### PR TITLE
feat(telemetry): phase 1 anonymous distribution telemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,12 @@ tmp/
 temp/
 .tmp/
 
+# ── Maintainer ops tooling (not for the public repo) ──────────────────────────
+# Deploy/provisioning scripts for first-party infra (Cloud Run, BigQuery, …).
+# They describe our cloud topology and are maintainer-local; keep them out of
+# the public tree. See apps/telemetry-ingest/README.md for what lives here.
+/ops/
+
 # ── User-supplied target / cohort / transcript files (privacy) ────────────────
 # Real prospect lists shouldn't end up in git. Keep the example files,
 # ignore anything you write next to them.

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -8,7 +8,9 @@
 oneshot-gtm config telemetry off
 ```
 
-Or set `ONESHOT_GTM_TELEMETRY=0` in your environment. That's a hard kill at the call site — no payload is even constructed.
+Or set `ONESHOT_GTM_TELEMETRY=0` in your environment (`false`, `off`, and `no` work too). That's a hard kill at the call site — no payload is even constructed, and it overrides the persisted flag for that shell session.
+
+To point the CLI at a different ingest endpoint (e.g. a local receiver while developing), set `ONESHOT_GTM_TELEMETRY_URL`.
 
 ## What is collected (when telemetry is on)
 
@@ -21,7 +23,7 @@ Or set `ONESHOT_GTM_TELEMETRY=0` in your environment. That's a hard kill at the 
 | `version`              | `0.1.0`                         | Catch regressions on a release.                         |
 | `os`                   | `darwin` / `linux` / `win32`    | Reproducibility for bug reports.                        |
 | `bun_version`          | `1.3.10`                        | Same.                                                   |
-| `anonymous_machine_id` | `9f3...` (sha256, salted)       | Distinguish unique installs without identifying anyone. |
+| `anonymous_machine_id` | `9f3a…` (random UUID)           | Distinguish unique installs without identifying anyone. This is the per-install `clientId` (see below) — a random UUID minted on first run, **not** a hash of any machine identifier, so it carries nothing traceable to your hardware or account. |
 | `llm_provider`         | `openrouter`                    | Learn which providers founders pick.                    |
 
 ## What is NEVER collected
@@ -36,9 +38,9 @@ Or set `ONESHOT_GTM_TELEMETRY=0` in your environment. That's a hard kill at the 
 
 ## Where it goes
 
-Sent to a single endpoint owned by OneShot. Aggregated and used to prioritize the public roadmap. Never sold, never shared with third parties.
+Sent to a single first-party endpoint owned by OneShot: a Cloud Run service on our GCP project (`apps/telemetry-ingest`) that validates the payload against the whitelist above and writes one row to BigQuery. No third-party analytics SDK is bundled in the CLI — it's a plain `fetch` POST, so there's no vendor phoning home from your machine. Aggregated and used to prioritize the public roadmap. Never sold, never shared with third parties.
 
-This file is the authoritative spec. If telemetry is ever extended, this file is updated in the same PR. CI rejects PRs that change telemetry without updating this file.
+This file is the authoritative spec. If telemetry is ever extended, this file is updated in the same PR — both the client (`packages/core/src/telemetry.ts`) and the receiver (`apps/telemetry-ingest`) carry the same field whitelist deliberately, and all three must move together. (This is a maintainer convention; it is not yet enforced by CI.)
 
 ## Local development log (separate from telemetry)
 
@@ -56,4 +58,4 @@ Delete the file any time: `rm ~/.oneshot-gtm/events.jsonl`. Disable the dev mirr
 
 ## Anonymous `clientId`
 
-A UUID is generated on first run and persisted to `~/.oneshot-gtm/config.json`. It is never exposed to the web layer (filtered out of `/api/setup` responses) and never transmitted today. Reserved for opt-in distribution telemetry once that lands — having it now means pre-launch installs aren't attribution-orphaned later. Disabling telemetry leaves the UUID on disk but blocks any transmission.
+A UUID is generated on first run and persisted to `~/.oneshot-gtm/config.json`. It is never exposed to the web layer (filtered out of `/api/setup` responses). It is the `anonymous_machine_id` sent with each distribution telemetry event (above) — the only thing that distinguishes one install's events from another's, with nothing traceable back to a person or machine. Distribution telemetry is **opt-out** (on by default, disclosed on first run); disabling it leaves the UUID on disk but blocks any transmission.

--- a/apps/cli/__tests__/dispatch.test.ts
+++ b/apps/cli/__tests__/dispatch.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import { extractInvocation, toKebabCase } from "../src/dispatch.ts";
+
+/**
+ * Structural fakes for commander's Command — extractInvocation only touches
+ * name(), opts(), parent, and getOptionValueSource(), so we don't need a real
+ * commander program (and can pin option sources precisely).
+ */
+interface FakeOpts {
+  name: string;
+  parent?: unknown;
+  opts?: Record<string, unknown>;
+  sources?: Record<string, string>; // "cli" | "default" | "env" | "THROW"
+}
+
+function fakeCmd({ name, parent = null, opts = {}, sources = {} }: FakeOpts): unknown {
+  return {
+    name: () => name,
+    opts: () => opts,
+    parent,
+    getOptionValueSource: (k: string) => {
+      const v = sources[k];
+      if (v === "THROW") throw new Error("no such option");
+      return v ?? "default";
+    },
+  };
+}
+
+const program = fakeCmd({ name: "oneshot-gtm", parent: null });
+
+describe("toKebabCase", () => {
+  it.each([
+    ["dryRun", "dry-run"],
+    ["skipSms", "skip-sms"],
+    ["port", "port"],
+    ["fromFileName", "from-file-name"],
+  ])("%s → %s", (input, expected) => {
+    expect(toKebabCase(input)).toBe(expected);
+  });
+});
+
+describe("extractInvocation — command path", () => {
+  it("returns 'unknown' when no Command-like arg is present", () => {
+    expect(extractInvocation([{ dryRun: true }, "positional"])).toEqual({
+      command: "unknown",
+      flags: [],
+    });
+  });
+
+  it("resolves a top-level command name (stops before the root program)", () => {
+    const doctor = fakeCmd({ name: "doctor", parent: program });
+    expect(extractInvocation([{}, doctor]).command).toBe("doctor");
+  });
+
+  it("joins a nested group path like 'motion show-hn'", () => {
+    const motion = fakeCmd({ name: "motion", parent: program });
+    const showHn = fakeCmd({ name: "show-hn", parent: motion });
+    expect(extractInvocation([{}, showHn]).command).toBe("motion show-hn");
+  });
+
+  it("handles a three-level path 'discover icp interview-prep'", () => {
+    const discover = fakeCmd({ name: "discover", parent: program });
+    const icp = fakeCmd({ name: "icp", parent: discover });
+    const prep = fakeCmd({ name: "interview-prep", parent: icp });
+    expect(extractInvocation([prep]).command).toBe("discover icp interview-prep");
+  });
+
+  it("picks the LAST command-like arg (commander passes the Command last)", () => {
+    const a = fakeCmd({ name: "wrong", parent: program });
+    const b = fakeCmd({ name: "right", parent: program });
+    // options object (no name/opts fns) between them must be ignored
+    expect(extractInvocation([a, { some: "opts" }, b]).command).toBe("right");
+  });
+});
+
+describe("extractInvocation — flags (names only, cli-sourced)", () => {
+  it("keeps only flags whose source is 'cli', kebab-cased", () => {
+    const cmd = fakeCmd({
+      name: "show-hn",
+      parent: program,
+      opts: { dryRun: true, limit: 10, skipSms: false },
+      sources: { dryRun: "cli", limit: "default", skipSms: "cli" },
+    });
+    expect(extractInvocation([cmd]).flags).toEqual(["dry-run", "skip-sms"]);
+  });
+
+  it("excludes default- and env-sourced options", () => {
+    const cmd = fakeCmd({
+      name: "x",
+      parent: program,
+      opts: { fromEnv: "v", fromDefault: "d" },
+      sources: { fromEnv: "env", fromDefault: "default" },
+    });
+    expect(extractInvocation([cmd]).flags).toEqual([]);
+  });
+
+  it("drops a flag whose getOptionValueSource throws", () => {
+    const cmd = fakeCmd({
+      name: "x",
+      parent: program,
+      opts: { good: true, broken: true },
+      sources: { good: "cli", broken: "THROW" },
+    });
+    expect(extractInvocation([cmd]).flags).toEqual(["good"]);
+  });
+
+  it("returns no flags when the command has none", () => {
+    const cmd = fakeCmd({ name: "doctor", parent: program });
+    expect(extractInvocation([cmd]).flags).toEqual([]);
+  });
+});

--- a/apps/cli/src/commands/discover.ts
+++ b/apps/cli/src/commands/discover.ts
@@ -8,7 +8,7 @@ import {
 } from "@oneshot-gtm/plays";
 import { readFileSync, writeFileSync } from "node:fs";
 import prompts from "prompts";
-import { box, c, fail, header, note, ok, warn } from "../output.ts";
+import { bail, box, c, header, note, ok, warn } from "../output.ts";
 
 export async function commandIcpInterviewPrep(
   hypothesisArg: string | undefined,
@@ -17,10 +17,9 @@ export async function commandIcpInterviewPrep(
   header(`discover icp interview-prep`);
   const hypothesis = await resolveHypothesis(hypothesisArg, opts);
   if (!hypothesis) {
-    fail(
+    bail(
       "no hypothesis given. Pass it as an arg, with --from-file <path>, --stdin, or run with no args for an interactive prompt.",
     );
-    process.exit(1);
   }
   note(`Hypothesis: ${c.cyan(truncate(hypothesis, 120))}\n`);
   const md = await generateInterviewPrep(hypothesis);
@@ -99,8 +98,7 @@ export async function commandPmfClassify(): Promise<void> {
   );
 
   if (!answers["buyer"] || !answers["painInTheirWords"]) {
-    fail("required answers missing.");
-    process.exit(1);
+    bail("required answers missing.");
   }
 
   const result = await pmfClassify({
@@ -141,8 +139,7 @@ export async function commandPmfSurvey(opts: {
 }): Promise<void> {
   header(`discover pmf survey ${opts.dryRun ? c.dim("(dry-run)") : ""}`);
   if (!opts.cohortFile) {
-    fail("--cohort <file> is required (text file with one email per line, or JSON array)");
-    process.exit(1);
+    bail("--cohort <file> is required (text file with one email per line, or JSON array)");
   }
   const productName = opts.productName ?? (await askText("Product name (for the landing page)"));
   const productDescription =

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -1,5 +1,5 @@
 import { runDoctor } from "@oneshot-gtm/doctor";
-import { c, fail, header, ok, warn } from "../output.ts";
+import { bail, c, fail, header, ok, warn } from "../output.ts";
 
 export async function commandDoctor(): Promise<void> {
   header("oneshot-gtm doctor");
@@ -19,8 +19,7 @@ export async function commandDoctor(): Promise<void> {
   }
   process.stdout.write("\n");
   if (failed > 0) {
-    fail(`${failed} blocking issue(s). Fix before running paid plays.`);
-    process.exit(1);
+    bail(`${failed} blocking issue(s). Fix before running paid plays.`);
   }
   if (warned > 0) {
     warn(`${warned} warning(s). Plays will run but features may be missing.`);

--- a/apps/cli/src/commands/handoff.ts
+++ b/apps/cli/src/commands/handoff.ts
@@ -6,7 +6,7 @@ import {
 } from "@oneshot-gtm/plays";
 import { readFileSync } from "node:fs";
 import prompts from "prompts";
-import { box, c, fail, header, note, ok, warn } from "../output.ts";
+import { bail, box, c, fail, header, note, ok, warn } from "../output.ts";
 
 const VERDICT_COLOR: Record<"green" | "yellow" | "red", (s: string) => string> = {
   green: (s) => c.green(s),
@@ -118,8 +118,7 @@ export async function commandHandoffTemplatize(opts: {
     outcome?: "replied" | "no_reply";
   }>;
   if (!Array.isArray(emails) || emails.length === 0) {
-    fail("input file must be a JSON array of {subject, body, outcome?} objects");
-    process.exit(1);
+    bail("input file must be a JSON array of {subject, body, outcome?} objects");
   }
   note(
     `Extracting from ${emails.length} sent emails (${emails.filter((e) => e.outcome === "replied").length} replied)\n`,

--- a/apps/cli/src/commands/intel.ts
+++ b/apps/cli/src/commands/intel.ts
@@ -8,7 +8,7 @@ import {
 import { loadConfig } from "@oneshot-gtm/core";
 import { writeFileSync } from "node:fs";
 import prompts from "prompts";
-import { box, c, fail, header, note, ok, warn } from "../output.ts";
+import { bail, box, c, header, note, ok, warn } from "../output.ts";
 
 const EXIT_WORDS = new Set(["exit", "quit", "q", ":q", "bye", "done"]);
 
@@ -127,8 +127,7 @@ export async function commandIntelPersonalize(opts: {
   header("intel personalize");
   const cfg = loadConfig();
   if (!cfg.founderName || !cfg.productOneLiner) {
-    fail("founder profile incomplete. run: oneshot-gtm config founder");
-    process.exit(1);
+    bail("founder profile incomplete. run: oneshot-gtm config founder");
   }
   const out = await generateFirstLine({
     founderName: cfg.founderName,

--- a/apps/cli/src/commands/motion.ts
+++ b/apps/cli/src/commands/motion.ts
@@ -15,6 +15,7 @@ import {
   type PodcastGuestTarget,
   type PostFundingTarget,
 } from "@oneshot-gtm/plays";
+import { markTelemetryOutcome } from "@oneshot-gtm/core";
 import { readFileSync } from "node:fs";
 import { box, c, fail, header, note, ok, warn } from "../output.ts";
 
@@ -63,7 +64,12 @@ function printDrafts(drafts: DraftedView[], dryRun: boolean): void {
     }
     if (d.sent) ok(c.green("Sent."));
     else if (dryRun) note("(dry-run, not sent)");
-    else if (d.flags.length > 0) fail("Not sent — fix lint flags or rerun.");
+    else if (d.flags.length > 0) {
+      // The send was withheld by the anti-slop linter — not an error, but
+      // distinct from a clean "ok". Surface it as its own telemetry outcome.
+      markTelemetryOutcome("lint-blocked");
+      fail("Not sent — fix lint flags or rerun.");
+    }
   }
 }
 

--- a/apps/cli/src/commands/ui.ts
+++ b/apps/cli/src/commands/ui.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { c, fail, header, note, ok } from "../output.ts";
+import { CommandExit, c, fail, header, note, ok } from "../output.ts";
 
 interface UiOpts {
   port: number;
@@ -28,7 +28,8 @@ export async function commandUi(opts: UiOpts): Promise<void> {
     note(
       `Run: ${c.cyan("bun run --cwd apps/web build")} (one-time), or pass --dev to use the vite dev server.`,
     );
-    process.exit(1);
+    // message already printed above; abort through runOrFail so telemetry fires
+    throw new CommandExit();
   }
 
   const env: NodeJS.ProcessEnv = {

--- a/apps/cli/src/dispatch.ts
+++ b/apps/cli/src/dispatch.ts
@@ -1,0 +1,57 @@
+import type { Command } from "commander";
+
+/**
+ * Pure helpers for turning commander's action arguments into the small
+ * telemetry envelope (command path + flag names). Extracted from index.ts so
+ * they can be unit-tested without importing the CLI entrypoint, which runs
+ * `program.parseAsync` on import.
+ */
+
+export interface Invocation {
+  command: string;
+  flags: string[];
+}
+
+/** `dryRun` → `dry-run`, `skipSms` → `skip-sms`. Names only — never values. */
+export function toKebabCase(s: string): string {
+  return s.replace(/[A-Z]/g, (m) => "-" + m.toLowerCase());
+}
+
+/**
+ * Recover the command path and the flag names the user actually passed from
+ * commander's action arguments. The Command instance is the last action arg;
+ * we walk its parent chain (stopping before the root program) to build paths
+ * like "motion show-hn", and use getOptionValueSource to keep only flags set
+ * on the CLI — never their values.
+ */
+export function extractInvocation(args: unknown[]): Invocation {
+  const cmd = args.findLast(
+    (a): a is Command =>
+      !!a &&
+      typeof a === "object" &&
+      typeof (a as Command).name === "function" &&
+      typeof (a as Command).opts === "function",
+  );
+  if (!cmd) return { command: "unknown", flags: [] };
+
+  const parts: string[] = [];
+  let cur: Command | null = cmd;
+  while (cur && cur.parent) {
+    parts.unshift(cur.name());
+    cur = cur.parent;
+  }
+  const command = parts.join(" ") || cmd.name() || "unknown";
+
+  const opts = cmd.opts();
+  const flags = Object.keys(opts)
+    .filter((k) => {
+      try {
+        return cmd.getOptionValueSource(k) === "cli";
+      } catch {
+        return false;
+      }
+    })
+    .map(toKebabCase);
+
+  return { command, flags };
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -1,6 +1,19 @@
 #!/usr/bin/env bun
 import { Command } from "commander";
-import { fail } from "./output.ts";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  buildTelemetryPayload,
+  loadConfig,
+  reportCommand,
+  shouldSendTelemetry,
+  takeMarkedOutcome,
+  telemetryUrl,
+  type TelemetryOutcome,
+} from "@oneshot-gtm/core";
+import { CommandExit, fail } from "./output.ts";
+import { extractInvocation, type Invocation } from "./dispatch.ts";
 import { runInit } from "./commands/init.ts";
 import { configFounder, configKeys, configLlm, configTelemetry } from "./commands/config.ts";
 import { commandDoctor } from "./commands/doctor.ts";
@@ -41,6 +54,21 @@ import {
   commandMotionPostFunding,
 } from "./commands/motion.ts";
 
+// Read the real version from package.json so the `--version` output and the
+// telemetry `version` field can't drift from the published release (the old
+// hardcoded "0.1.0" had gone stale against 0.6.0).
+const CLI_VERSION: string = (() => {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url)); // apps/cli/src
+    const pkg = JSON.parse(readFileSync(join(here, "..", "package.json"), "utf8")) as {
+      version?: string;
+    };
+    return typeof pkg.version === "string" ? pkg.version : "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+})();
+
 const program = new Command();
 program
   .name("oneshot-gtm")
@@ -48,7 +76,7 @@ program
     "Open-source GTM agent for technical founders. Pay-per-result. Signed receipts.\n" +
       "The CLI is a thin headless layer; ad-hoc target discovery + review + send happens in the dashboard (oneshot-gtm ui).",
   )
-  .version("0.1.0");
+  .version(CLI_VERSION);
 
 // Bootstrap + launcher
 
@@ -438,13 +466,56 @@ program.parseAsync(process.argv).catch((err) => {
 
 function runOrFail<A extends unknown[]>(fn: (...args: A) => void | Promise<void>) {
   return async (...args: A) => {
+    const inv = extractInvocation(args);
+    const start = performance.now();
     try {
       await fn(...args);
     } catch (err) {
+      // Errors are valuable signal — record before exiting. A thrown error
+      // always wins over any outcome a command marked for itself.
+      await sendTelemetry(inv, "error", start);
+      // CommandExit already printed its message via bail(); a raw error hasn't.
+      if (err instanceof CommandExit) process.exit(err.code);
       fail((err as Error).message);
       process.exit(1);
     }
+    // Clean return: honor an explicit marker (e.g. "lint-blocked"), else "ok".
+    await sendTelemetry(inv, takeMarkedOutcome() ?? "ok", start);
   };
+}
+
+/**
+ * Build and transmit the anonymous summary event for one invocation. Gated on
+ * the opt-out flag + env kill switch, bounded by reportCommand's own timeout,
+ * and fully best-effort — a telemetry failure must never affect the command.
+ */
+async function sendTelemetry(
+  inv: Invocation,
+  outcome: TelemetryOutcome,
+  startMs: number,
+): Promise<void> {
+  try {
+    // No endpoint configured (default OSS build) ⇒ skip everything, including
+    // the config read. The maintainer's release sets the endpoint.
+    const url = telemetryUrl();
+    if (!url) return;
+    const cfg = loadConfig();
+    if (!shouldSendTelemetry(cfg, process.env)) return;
+    const payload = buildTelemetryPayload({
+      command: inv.command,
+      flags: inv.flags,
+      outcome,
+      durationMs: performance.now() - startMs,
+      version: CLI_VERSION,
+      clientId: cfg.clientId,
+      llmProvider: cfg.llmProvider,
+      platform: process.platform,
+      bunVersion: typeof Bun !== "undefined" ? Bun.version : "",
+    });
+    await reportCommand(payload, url);
+  } catch {
+    // never surface telemetry failures to the user
+  }
 }
 
 function attachHelpFallbacks(cmd: Command): void {

--- a/apps/cli/src/output.ts
+++ b/apps/cli/src/output.ts
@@ -30,6 +30,31 @@ export function fail(s: string): void {
   process.stdout.write(`  ${c.red("✗")} ${s}\n`);
 }
 
+/**
+ * Sentinel thrown by `bail()`: the command already printed its own message and
+ * wants to abort with a non-zero code. The dispatch wrapper (runOrFail)
+ * recognizes it, records telemetry, and exits WITHOUT re-printing.
+ */
+export class CommandExit extends Error {
+  readonly code: number;
+  constructor(code = 1) {
+    super("command-exit");
+    this.name = "CommandExit";
+    this.code = code;
+  }
+}
+
+/**
+ * Print a failure message and abort the command. Replaces the
+ * `fail(msg); process.exit(1)` pattern so every exit funnels through
+ * runOrFail — that's the single place that records telemetry, so a guard
+ * clause must not call process.exit() directly (it would skip the event).
+ */
+export function bail(message: string, code = 1): never {
+  fail(message);
+  throw new CommandExit(code);
+}
+
 export function note(s: string): void {
   process.stdout.write(`${c.dim(s)}\n`);
 }

--- a/apps/telemetry-ingest/.dockerignore
+++ b/apps/telemetry-ingest/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+.turbo
+dist
+*.log
+__tests__
+README.md

--- a/apps/telemetry-ingest/Dockerfile
+++ b/apps/telemetry-ingest/Dockerfile
@@ -1,0 +1,16 @@
+# Self-contained build — this service has no workspace deps, so the build
+# context is just this directory (no monorepo root needed).
+FROM oven/bun:1.3-slim
+
+WORKDIR /app
+
+# Install deps first for layer caching.
+COPY package.json ./
+RUN bun install --production
+
+COPY src ./src
+
+ENV PORT=8080
+EXPOSE 8080
+
+CMD ["bun", "run", "src/index.ts"]

--- a/apps/telemetry-ingest/README.md
+++ b/apps/telemetry-ingest/README.md
@@ -1,0 +1,73 @@
+# oneshot-gtm telemetry ingest
+
+First-party receiver for the anonymous, opt-out CLI telemetry described in the
+repo-root [`TELEMETRY.md`](../../TELEMETRY.md). The CLI POSTs one summary event
+per invocation here; the service validates it against a strict whitelist and
+streams a row into BigQuery.
+
+It deploys to **Cloud Run** as a single production service (`us-central1` by
+default). The target GCP project comes from your active `gcloud config` (or
+`PROJECT=<id>`) — no project id is baked into the repo. The client never talks
+to a third-party analytics vendor — only to this endpoint.
+
+## Endpoints
+
+- `GET /` — health check (Cloud Run liveness).
+- `POST /v1/cli` — ingest one event. Returns `204` on accept, `400` on a bad
+  payload. Storage failures are logged and still `204` (the client is
+  fire-and-forget).
+
+## Run locally
+
+```bash
+# in-memory sink, no GCP creds needed
+TELEMETRY_SINK=local PORT=8080 bun run src/index.ts
+
+# point the CLI at it
+ONESHOT_GTM_TELEMETRY_URL=http://localhost:8080/v1/cli oneshot-gtm doctor
+```
+
+## Provision + deploy (run by a maintainer with gcloud/bq access)
+
+The deploy/provision scripts (`bq-setup.sh`, `deploy.sh`, BigQuery schema) live
+in `ops/telemetry-ingest/`, which is **gitignored** — they describe first-party
+cloud topology and are kept out of this public repo. They build/deploy the app
+in this directory.
+
+```bash
+cd ops/telemetry-ingest
+
+# 1. one-time: create dataset telemetry + table cli_events (day-partitioned)
+./bq-setup.sh
+
+# 2. deploy the production service
+./deploy.sh
+
+# 3. one-time (only if the runtime SA lacks BigQuery write access):
+#    the deploy script prints the exact grant command
+```
+
+After deploy, set `DEFAULT_TELEMETRY_URL` in `packages/core/src/telemetry.ts`
+to a **stable custom domain** you map onto the service (e.g.
+`https://telemetry.yourdomain.com/v1/cli`) — prefer a domain you own over the
+raw `*.run.app` host so the public client doesn't pin a Cloud Run revision or
+leak the project number. For ad-hoc testing, point the CLI at the service URL
+via `ONESHOT_GTM_TELEMETRY_URL`.
+
+## Verify rows land
+
+```bash
+bq query --use_legacy_sql=false \
+  'SELECT command, outcome, duration_ms, version, ingest_ts
+   FROM telemetry.cli_events ORDER BY ingest_ts DESC LIMIT 10'
+```
+
+## Environment
+
+| Var              | Default      | Purpose                                  |
+| ---------------- | ------------ | ---------------------------------------- |
+| `PORT`           | `8080`       | Cloud Run injects this.                  |
+| `TELEMETRY_SINK` | `bigquery`   | Set `local` for the in-memory dev sink.  |
+| `GCP_PROJECT`    | (ADC)        | BigQuery project override.               |
+| `BQ_DATASET`     | `telemetry`  | Dataset name.                            |
+| `BQ_TABLE`       | `cli_events` | Table name.                              |

--- a/apps/telemetry-ingest/__tests__/handler.test.ts
+++ b/apps/telemetry-ingest/__tests__/handler.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from "vitest";
+import { handleTelemetry, INGEST_PATH } from "../src/handler.ts";
+import { BigQuerySink, MemorySink, sinkFromEnv } from "../src/sink.ts";
+import { validateEvent } from "../src/schema.ts";
+
+const NOW = "2026-06-21T00:00:00.000Z";
+const URL = `http://ingest.local${INGEST_PATH}`;
+
+function post(body: unknown): Request {
+  return new Request(URL, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+const VALID = {
+  command: "motion show-hn",
+  flags: ["dry-run"],
+  outcome: "ok",
+  duration_ms: 42,
+  version: "0.6.0",
+  os: "darwin",
+  bun_version: "1.3.13",
+  anonymous_machine_id: "cid-1",
+  llm_provider: "openrouter",
+};
+
+describe("handleTelemetry — routing", () => {
+  it("GET / is a health check", async () => {
+    const res = await handleTelemetry(
+      new Request("http://ingest.local/"),
+      new MemorySink(),
+      () => NOW,
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true });
+  });
+
+  it("unknown path is 404", async () => {
+    const res = await handleTelemetry(
+      new Request("http://ingest.local/nope"),
+      new MemorySink(),
+      () => NOW,
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("non-POST to the ingest path is 405", async () => {
+    const res = await handleTelemetry(
+      new Request(URL, { method: "PUT" }),
+      new MemorySink(),
+      () => NOW,
+    );
+    expect(res.status).toBe(405);
+  });
+
+  it("invalid JSON body is 400", async () => {
+    const res = await handleTelemetry(post("{not json"), new MemorySink(), () => NOW);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("handleTelemetry — ingest", () => {
+  it("accepts a valid payload, records one row, returns 204", async () => {
+    const sink = new MemorySink();
+    const res = await handleTelemetry(post(VALID), sink, () => NOW);
+    expect(res.status).toBe(204);
+    expect(sink.rows).toHaveLength(1);
+    expect(sink.rows[0]).toMatchObject({
+      command: "motion show-hn",
+      flags: ["dry-run"],
+      outcome: "ok",
+      duration_ms: 42,
+      anonymous_machine_id: "cid-1",
+      ingest_ts: NOW,
+    });
+  });
+
+  it("strips fields outside the whitelist", async () => {
+    const sink = new MemorySink();
+    await handleTelemetry(post({ ...VALID, SNEAKY: "x", email: "a@b.com" }), sink, () => NOW);
+    expect(sink.rows[0]).not.toHaveProperty("SNEAKY");
+    expect(sink.rows[0]).not.toHaveProperty("email");
+  });
+
+  it("rejects a missing command with 400 and stores nothing", async () => {
+    const sink = new MemorySink();
+    const res = await handleTelemetry(post({ outcome: "ok" }), sink, () => NOW);
+    expect(res.status).toBe(400);
+    expect(sink.rows).toHaveLength(0);
+  });
+
+  it("rejects an invalid outcome with 400", async () => {
+    const sink = new MemorySink();
+    const res = await handleTelemetry(post({ command: "x", outcome: "boom" }), sink, () => NOW);
+    expect(res.status).toBe(400);
+  });
+
+  it("still ACKs (204) when the sink throws — fire-and-forget client must not retry", async () => {
+    const failing = {
+      async insert() {
+        throw new Error("bq down");
+      },
+    };
+    const res = await handleTelemetry(post(VALID), failing, () => NOW);
+    expect(res.status).toBe(204);
+  });
+});
+
+describe("sinkFromEnv — sink selection", () => {
+  it("returns the in-memory sink when TELEMETRY_SINK=local", () => {
+    expect(sinkFromEnv({ TELEMETRY_SINK: "local" })).toBeInstanceOf(MemorySink);
+    expect(sinkFromEnv({ TELEMETRY_SINK: "LOCAL" })).toBeInstanceOf(MemorySink);
+  });
+
+  it("returns the BigQuery sink by default (no creds touched until first insert)", () => {
+    // Construction is lazy — selecting it must not require GCP credentials.
+    expect(sinkFromEnv({ BQ_DATASET: "telemetry", BQ_TABLE: "cli_events" })).toBeInstanceOf(
+      BigQuerySink,
+    );
+  });
+});
+
+describe("validateEvent — caps + coercion", () => {
+  it("rejects a non-object body", () => {
+    expect(validateEvent(null, NOW).ok).toBe(false);
+    expect(validateEvent("nope", NOW).ok).toBe(false);
+    expect(validateEvent(42, NOW).ok).toBe(false);
+  });
+
+  it("rejects an empty / non-string command", () => {
+    expect(validateEvent({ command: "", outcome: "ok" }, NOW).ok).toBe(false);
+    expect(validateEvent({ command: 123, outcome: "ok" }, NOW).ok).toBe(false);
+  });
+
+  it.each(["ok", "error", "lint-blocked"])("accepts the valid outcome %s", (outcome) => {
+    expect(validateEvent({ command: "x", outcome }, NOW).ok).toBe(true);
+  });
+
+  it("stamps ingest_ts from the supplied clock", () => {
+    const r = validateEvent({ command: "x", outcome: "ok" }, NOW);
+    expect(r.ok && r.row.ingest_ts).toBe(NOW);
+  });
+
+  it("defaults a null anonymous_machine_id and missing optional strings to empty", () => {
+    const r = validateEvent({ command: "x", outcome: "ok" }, NOW);
+    expect(r.ok && r.row.anonymous_machine_id).toBeNull();
+    expect(r.ok && r.row.version).toBe("");
+    expect(r.ok && r.row.llm_provider).toBe("");
+  });
+
+
+  it("caps flags count and element length", () => {
+    const flags = Array.from({ length: 50 }, (_, i) => "f".repeat(100) + i);
+    const r = validateEvent({ command: "x", outcome: "ok", flags }, NOW);
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.row.flags.length).toBeLessThanOrEqual(32);
+      expect(r.row.flags.every((f) => f.length <= 60)).toBe(true);
+    }
+  });
+
+  it("coerces a non-numeric duration to 0 and clamps absurd durations", () => {
+    const bad = validateEvent({ command: "x", outcome: "ok", duration_ms: "huge" }, NOW);
+    expect(bad.ok && bad.row.duration_ms).toBe(0);
+    const big = validateEvent({ command: "x", outcome: "ok", duration_ms: 1e15 }, NOW);
+    expect(big.ok && big.row.duration_ms).toBe(24 * 60 * 60 * 1000);
+  });
+
+  it("drops non-string flags", () => {
+    const r = validateEvent({ command: "x", outcome: "ok", flags: ["a", 1, null, "b"] }, NOW);
+    expect(r.ok && r.row.flags).toEqual(["a", "b"]);
+  });
+});

--- a/apps/telemetry-ingest/package.json
+++ b/apps/telemetry-ingest/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "oneshot-gtm-telemetry-ingest",
+  "version": "0.6.0",
+  "private": true,
+  "description": "First-party ingest endpoint for oneshot-gtm anonymous CLI telemetry. Deploys to Cloud Run; writes to BigQuery.",
+  "license": "MIT",
+  "type": "module",
+  "main": "./src/index.ts",
+  "scripts": {
+    "start": "bun run src/index.ts",
+    "dev": "TELEMETRY_SINK=local bun run --watch src/index.ts"
+  },
+  "dependencies": {
+    "@google-cloud/bigquery": "^7.9.0"
+  }
+}

--- a/apps/telemetry-ingest/src/handler.ts
+++ b/apps/telemetry-ingest/src/handler.ts
@@ -1,0 +1,55 @@
+import { validateEvent } from "./schema.ts";
+import type { Sink } from "./sink.ts";
+
+/** Path the CLI posts to (see DEFAULT_TELEMETRY_URL in packages/core). */
+export const INGEST_PATH = "/v1/cli";
+
+const JSON_HEADERS = { "content-type": "application/json" } as const;
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), { status, headers: JSON_HEADERS });
+}
+
+/**
+ * Runtime-agnostic request handler (web-standard Request/Response, so it runs
+ * under Bun, Node, or any edge runtime and is trivially unit-testable).
+ *
+ * - GET  /            → health check (Cloud Run liveness)
+ * - POST {INGEST_PATH}→ validate + insert one event
+ *
+ * Never throws: a sink failure is logged and swallowed with a 204 so a
+ * transient BigQuery hiccup doesn't turn into client-visible 5xx retries
+ * (the client is fire-and-forget anyway).
+ */
+export async function handleTelemetry(req: Request, sink: Sink, now: () => string): Promise<Response> {
+  const url = new URL(req.url);
+
+  if (req.method === "GET" && url.pathname === "/") {
+    return json(200, { ok: true, service: "oneshot-gtm-telemetry-ingest" });
+  }
+
+  if (url.pathname !== INGEST_PATH) return json(404, { error: "not found" });
+  if (req.method !== "POST") return json(405, { error: "method not allowed" });
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return json(400, { error: "invalid json" });
+  }
+
+  const result = validateEvent(body, now());
+  if (!result.ok) return json(400, { error: result.reason });
+
+  try {
+    await sink.insert(result.row);
+    if (process.env["INGEST_DEBUG"]) {
+      console.log("ingest:", result.row.command, result.row.outcome, `${result.row.duration_ms}ms`);
+    }
+  } catch (err) {
+    // Don't surface storage errors to the fire-and-forget client; record for
+    // our own logs (Cloud Run captures stderr) and ack.
+    console.error("telemetry insert failed:", (err as Error).message);
+  }
+  return new Response(null, { status: 204 });
+}

--- a/apps/telemetry-ingest/src/index.ts
+++ b/apps/telemetry-ingest/src/index.ts
@@ -1,0 +1,14 @@
+import { handleTelemetry } from "./handler.ts";
+import { sinkFromEnv } from "./sink.ts";
+
+// Cloud Run injects PORT (default 8080). The sink is chosen once at boot.
+const port = Number.parseInt(process.env["PORT"] ?? "8080", 10);
+const sink = sinkFromEnv();
+const now = () => new Date().toISOString();
+
+Bun.serve({
+  port,
+  fetch: (req) => handleTelemetry(req, sink, now),
+});
+
+console.log(`oneshot-gtm telemetry ingest listening on :${port} (sink=${process.env["TELEMETRY_SINK"] ?? "bigquery"})`);

--- a/apps/telemetry-ingest/src/schema.ts
+++ b/apps/telemetry-ingest/src/schema.ts
@@ -1,0 +1,88 @@
+/**
+ * The ingest contract — intentionally a SEPARATE definition from the client's
+ * `TelemetryPayload` (packages/core/src/telemetry.ts). This is the trust
+ * boundary: the receiver accepts unauthenticated public traffic, so it
+ * validates and whitelists rather than trusting the shape. Keeping the field
+ * list here in lockstep with TELEMETRY.md (and the client) is deliberate
+ * duplication, not an abstraction to share.
+ */
+
+export const OUTCOMES = ["ok", "error", "lint-blocked"] as const;
+export type Outcome = (typeof OUTCOMES)[number];
+
+/** Caps — defense against a malformed or hostile client stuffing the table. */
+const MAX_STR = 120;
+const MAX_FLAGS = 32;
+const MAX_FLAG_LEN = 60;
+const MAX_DURATION_MS = 24 * 60 * 60 * 1000; // a CLI run over a day is noise
+
+/** One validated row, ready for insert. `ingest_ts` is stamped server-side. */
+export interface TelemetryRow {
+  command: string;
+  flags: string[];
+  outcome: Outcome;
+  duration_ms: number;
+  version: string;
+  os: string;
+  bun_version: string;
+  anonymous_machine_id: string | null;
+  llm_provider: string;
+  ingest_ts: string;
+}
+
+function clampStr(v: unknown, max = MAX_STR): string {
+  return typeof v === "string" ? v.slice(0, max) : "";
+}
+
+/**
+ * Validate + whitelist an incoming body into a row, or return an error reason.
+ * Strips every field not on the whitelist. Requires only the two load-bearing
+ * fields (`command`, `outcome`); everything else is best-effort so a newer or
+ * older client never gets rejected over a peripheral field.
+ */
+export function validateEvent(
+  body: unknown,
+  now: string,
+): { ok: true; row: TelemetryRow } | { ok: false; reason: string } {
+  if (!body || typeof body !== "object") return { ok: false, reason: "body is not an object" };
+  const b = body as Record<string, unknown>;
+
+  const command = clampStr(b["command"]);
+  if (!command) return { ok: false, reason: "missing command" };
+
+  const outcome = b["outcome"];
+  if (typeof outcome !== "string" || !(OUTCOMES as readonly string[]).includes(outcome)) {
+    return { ok: false, reason: "invalid outcome" };
+  }
+
+  const rawFlags = Array.isArray(b["flags"]) ? b["flags"] : [];
+  const flags = rawFlags
+    .filter((f): f is string => typeof f === "string")
+    .slice(0, MAX_FLAGS)
+    .map((f) => f.slice(0, MAX_FLAG_LEN));
+
+  const rawDuration = b["duration_ms"];
+  const duration_ms =
+    typeof rawDuration === "number" && Number.isFinite(rawDuration)
+      ? Math.min(MAX_DURATION_MS, Math.max(0, Math.round(rawDuration)))
+      : 0;
+
+  const machineId = b["anonymous_machine_id"];
+  const anonymous_machine_id = typeof machineId === "string" ? machineId.slice(0, MAX_STR) : null;
+
+  return {
+    ok: true,
+    row: {
+      command,
+      flags,
+      outcome: outcome as Outcome,
+      duration_ms,
+      version: clampStr(b["version"]),
+      os: clampStr(b["os"]),
+      bun_version: clampStr(b["bun_version"]),
+      anonymous_machine_id,
+      llm_provider: clampStr(b["llm_provider"]),
+      ingest_ts: now,
+    },
+  };
+}

--- a/apps/telemetry-ingest/src/sink.ts
+++ b/apps/telemetry-ingest/src/sink.ts
@@ -1,0 +1,59 @@
+import type { TelemetryRow } from "./schema.ts";
+
+/**
+ * Where validated rows go. Two implementations: BigQuery (production) and an
+ * in-memory list (local dev + tests). The handler depends only on this
+ * interface so the wire/validation path can be exercised without GCP creds.
+ */
+export interface Sink {
+  insert(row: TelemetryRow): Promise<void>;
+}
+
+/** Holds rows in process memory. Used by `TELEMETRY_SINK=local` and by tests. */
+export class MemorySink implements Sink {
+  readonly rows: TelemetryRow[] = [];
+  async insert(row: TelemetryRow): Promise<void> {
+    this.rows.push(row);
+  }
+}
+
+/**
+ * Streams one row per event into BigQuery via tabledata.insertAll. The
+ * `@google-cloud/bigquery` client is imported lazily so the service (and the
+ * local sink) boot even when the dep or GCP credentials are absent — the
+ * import only fires when this sink is actually selected.
+ */
+export class BigQuerySink implements Sink {
+  private table: Promise<{ insert(rows: unknown[]): Promise<unknown> }>;
+
+  constructor(opts: { projectId?: string; dataset: string; table: string }) {
+    this.table = (async () => {
+      const { BigQuery } = await import("@google-cloud/bigquery");
+      // On Cloud Run, credentials + projectId come from the runtime service
+      // account via ADC — no key file. projectId is optional override.
+      const bq = new BigQuery(opts.projectId ? { projectId: opts.projectId } : {});
+      return bq.dataset(opts.dataset).table(opts.table);
+    })();
+  }
+
+  async insert(row: TelemetryRow): Promise<void> {
+    const table = await this.table;
+    await table.insert([row]);
+  }
+}
+
+/**
+ * Pick a sink from the environment. Defaults to BigQuery; set
+ * `TELEMETRY_SINK=local` for dev/tests. Dataset/table are overridable so the
+ * stg and prod services can point at the same or distinct tables.
+ */
+export function sinkFromEnv(env: NodeJS.ProcessEnv = process.env): Sink {
+  if ((env["TELEMETRY_SINK"] ?? "").toLowerCase() === "local") {
+    return new MemorySink();
+  }
+  return new BigQuerySink({
+    projectId: env["GCP_PROJECT"] || env["GOOGLE_CLOUD_PROJECT"] || undefined,
+    dataset: env["BQ_DATASET"] || "telemetry",
+    table: env["BQ_TABLE"] || "cli_events",
+  });
+}

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/cli": {
       "name": "oneshot-gtm",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "bin": {
         "oneshot-gtm": "./src/index.ts",
       },
@@ -37,7 +37,7 @@
     },
     "apps/server": {
       "name": "oneshot-gtm-server",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "bin": {
         "oneshot-gtm-server": "./dist/bin.mjs",
       },
@@ -55,9 +55,16 @@
         "tsdown": "^0.21.10",
       },
     },
+    "apps/telemetry-ingest": {
+      "name": "oneshot-gtm-telemetry-ingest",
+      "version": "0.6.0",
+      "dependencies": {
+        "@google-cloud/bigquery": "^7.9.0",
+      },
+    },
     "apps/web": {
       "name": "@oneshot-gtm/web",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@assistant-ui/react": "^0.12.25",
         "@base-ui/react": "^1.2.0",
@@ -89,21 +96,21 @@
     },
     "packages/core": {
       "name": "@oneshot-gtm/core",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@oneshot-agent/sdk": "0.22.0",
       },
     },
     "packages/doctor": {
       "name": "@oneshot-gtm/doctor",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@oneshot-gtm/core": "workspace:*",
       },
     },
     "packages/find": {
       "name": "@oneshot-gtm/find",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@oneshot-gtm/core": "workspace:*",
         "@oneshot-gtm/intel": "workspace:*",
@@ -112,14 +119,14 @@
     },
     "packages/intel": {
       "name": "@oneshot-gtm/intel",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@oneshot-gtm/core": "workspace:*",
       },
     },
     "packages/plays": {
       "name": "@oneshot-gtm/plays",
-      "version": "0.5.0",
+      "version": "0.6.0",
       "dependencies": {
         "@oneshot-gtm/core": "workspace:*",
         "@oneshot-gtm/intel": "workspace:*",
@@ -127,11 +134,11 @@
     },
     "packages/prompts": {
       "name": "@oneshot-gtm/prompts",
-      "version": "0.5.0",
+      "version": "0.6.0",
     },
     "packages/shared-types": {
       "name": "@oneshot-gtm/shared-types",
-      "version": "0.5.0",
+      "version": "0.6.0",
     },
   },
   "catalog": {
@@ -265,6 +272,18 @@
     "@fontsource/ibm-plex-mono": ["@fontsource/ibm-plex-mono@5.2.7", "", {}, "sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w=="],
 
     "@fontsource/ibm-plex-sans": ["@fontsource/ibm-plex-sans@5.2.8", "", {}, "sha512-eztSXjDhPhcpxNIiGTgMebdLP9qS4rWkysuE1V7c+DjOR0qiezaiDaTwQE7bTnG5HxAY/8M43XKDvs3cYq6ZYQ=="],
+
+    "@google-cloud/bigquery": ["@google-cloud/bigquery@7.9.4", "", { "dependencies": { "@google-cloud/common": "^5.0.0", "@google-cloud/paginator": "^5.0.2", "@google-cloud/precise-date": "^4.0.0", "@google-cloud/promisify": "4.0.0", "arrify": "^2.0.1", "big.js": "^6.0.0", "duplexify": "^4.0.0", "extend": "^3.0.2", "is": "^3.3.0", "stream-events": "^1.0.5", "uuid": "^9.0.0" } }, "sha512-C7jeI+9lnCDYK3cRDujcBsPgiwshWKn/f0BiaJmClplfyosCLfWE83iGQ0eKH113UZzjR9c9q7aZQg0nU388sw=="],
+
+    "@google-cloud/common": ["@google-cloud/common@5.0.2", "", { "dependencies": { "@google-cloud/projectify": "^4.0.0", "@google-cloud/promisify": "^4.0.0", "arrify": "^2.0.1", "duplexify": "^4.1.1", "extend": "^3.0.2", "google-auth-library": "^9.0.0", "html-entities": "^2.5.2", "retry-request": "^7.0.0", "teeny-request": "^9.0.0" } }, "sha512-V7bmBKYQyu0eVG2BFejuUjlBt+zrya6vtsKdY+JxMM/dNntPF41vZ9+LhOshEUH01zOHEqBSvI7Dad7ZS6aUeA=="],
+
+    "@google-cloud/paginator": ["@google-cloud/paginator@5.0.2", "", { "dependencies": { "arrify": "^2.0.0", "extend": "^3.0.2" } }, "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg=="],
+
+    "@google-cloud/precise-date": ["@google-cloud/precise-date@4.0.0", "", {}, "sha512-1TUx3KdaU3cN7nfCdNf+UVqA/PSX29Cjcox3fZZBtINlRrXVTmUkQnCKv2MbBUbCopbK4olAT1IHl76uZyCiVA=="],
+
+    "@google-cloud/projectify": ["@google-cloud/projectify@4.0.0", "", {}, "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA=="],
+
+    "@google-cloud/promisify": ["@google-cloud/promisify@4.0.0", "", {}, "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -586,6 +605,8 @@
 
     "@tanstack/virtual-file-routes": ["@tanstack/virtual-file-routes@1.161.7", "", { "bin": { "intent": "bin/intent.js" } }, "sha512-olW33+Cn+bsCsZKPwEGhlkqS6w3M2slFv11JIobdnCFKMLG97oAI2kWKdx5/zsywTL8flpnoIgaZZPlQTFYhdQ=="],
 
+    "@tootallnate/once": ["@tootallnate/once@2.0.1", "", {}, "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ=="],
+
     "@turbo/darwin-64": ["@turbo/darwin-64@2.9.6", "", { "os": "darwin", "cpu": "x64" }, "sha512-X/56SnVXIQZBLKwniGTwEQTGmtE5brSACnKMBWpY3YafuxVYefrC2acamfjgxP7BG5w3I+6jf0UrLoSzgPcSJg=="],
 
     "@turbo/darwin-arm64": ["@turbo/darwin-arm64@2.9.6", "", { "os": "darwin", "cpu": "arm64" }, "sha512-aalBeSl4agT/QtYGDyf/XLajedWzUC9Vg/pm/YO6QQ93vkQ91Vz5uK1ta5RbVRDozQSz4njxUNqRNmOXDzW+qw=="],
@@ -602,6 +623,8 @@
 
     "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
 
+    "@types/caseless": ["@types/caseless@0.12.5", "", {}, "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg=="],
+
     "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
 
     "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
@@ -617,6 +640,10 @@
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
+
+    "@types/request": ["@types/request@2.48.13", "", { "dependencies": { "@types/caseless": "*", "@types/node": "*", "@types/tough-cookie": "*", "form-data": "^2.5.5" } }, "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg=="],
+
+    "@types/tough-cookie": ["@types/tough-cookie@4.0.5", "", {}, "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA=="],
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.1", "", { "dependencies": { "@rolldown/pluginutils": "1.0.0-rc.7" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ=="],
 
@@ -638,11 +665,15 @@
 
     "aes-js": ["aes-js@4.0.0-beta.5", "", {}, "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="],
 
+    "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
+
     "ansis": ["ansis@4.2.0", "", {}, "sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
 
     "aria-hidden": ["aria-hidden@1.2.6", "", { "dependencies": { "tslib": "^2.0.0" } }, "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA=="],
+
+    "arrify": ["arrify@2.0.1", "", {}, "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
 
@@ -652,9 +683,17 @@
 
     "ast-kit": ["ast-kit@3.0.0-beta.1", "", { "dependencies": { "@babel/parser": "^8.0.0-beta.4", "estree-walker": "^3.0.3", "pathe": "^2.0.3" } }, "sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw=="],
 
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
     "babel-dead-code-elimination": ["babel-dead-code-elimination@1.0.12", "", { "dependencies": { "@babel/core": "^7.23.7", "@babel/parser": "^7.23.6", "@babel/traverse": "^7.23.7", "@babel/types": "^7.23.6" } }, "sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig=="],
 
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.21", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-Q+rUQ7Uz8AHM7DEaNdwvfFCTq7a43lNTzuS94eiWqwyxfV/wJv+oUivef51T91mmRY4d4A1u9rcSvkeufCVXlA=="],
+
+    "big.js": ["big.js@6.2.2", "", {}, "sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ=="],
+
+    "bignumber.js": ["bignumber.js@9.3.1", "", {}, "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ=="],
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
@@ -664,11 +703,15 @@
 
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
+    "buffer-equal-constant-time": ["buffer-equal-constant-time@1.0.1", "", {}, "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA=="],
+
     "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
 
     "cac": ["cac@7.0.0", "", {}, "sha512-tixWYgm5ZoOD+3g6UTea91eow5z6AAHaho3g0V9CNSNb45gM8SmflpAc+GRd1InC4AqN/07Unrgp56Y94N9hJQ=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001790", "", {}, "sha512-bOoxfJPyYo+ds6W0YfptaCWbFnJYjh2Y1Eow5lRv+vI2u8ganPZqNm1JwNh0t2ELQCqIWg4B3dWEusgAmsoyOw=="],
 
@@ -681,6 +724,8 @@
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "cmdk": ["cmdk@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "^1.1.1", "@radix-ui/react-dialog": "^1.1.6", "@radix-ui/react-id": "^1.1.0", "@radix-ui/react-primitive": "^2.0.2" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "react-dom": "^18 || ^19 || ^19.0.0-rc" } }, "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
 
@@ -700,6 +745,8 @@
 
     "defu": ["defu@6.1.7", "", {}, "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ=="],
 
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
@@ -708,13 +755,29 @@
 
     "dts-resolver": ["dts-resolver@2.1.3", "", { "peerDependencies": { "oxc-resolver": ">=11.0.0" }, "optionalPeers": ["oxc-resolver"] }, "sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw=="],
 
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
+    "duplexify": ["duplexify@4.1.3", "", { "dependencies": { "end-of-stream": "^1.4.1", "inherits": "^2.0.3", "readable-stream": "^3.1.1", "stream-shift": "^1.0.2" } }, "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA=="],
+
+    "ecdsa-sig-formatter": ["ecdsa-sig-formatter@1.0.11", "", { "dependencies": { "safe-buffer": "^5.0.1" } }, "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.344", "", {}, "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg=="],
 
     "empathic": ["empathic@2.0.0", "", {}, "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA=="],
 
+    "end-of-stream": ["end-of-stream@1.4.5", "", { "dependencies": { "once": "^1.4.0" } }, "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg=="],
+
     "enhanced-resolve": ["enhanced-resolve@5.21.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA=="],
 
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
     "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "esbuild": ["esbuild@0.27.7", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.7", "@esbuild/android-arm": "0.27.7", "@esbuild/android-arm64": "0.27.7", "@esbuild/android-x64": "0.27.7", "@esbuild/darwin-arm64": "0.27.7", "@esbuild/darwin-x64": "0.27.7", "@esbuild/freebsd-arm64": "0.27.7", "@esbuild/freebsd-x64": "0.27.7", "@esbuild/linux-arm": "0.27.7", "@esbuild/linux-arm64": "0.27.7", "@esbuild/linux-ia32": "0.27.7", "@esbuild/linux-loong64": "0.27.7", "@esbuild/linux-mips64el": "0.27.7", "@esbuild/linux-ppc64": "0.27.7", "@esbuild/linux-riscv64": "0.27.7", "@esbuild/linux-s390x": "0.27.7", "@esbuild/linux-x64": "0.27.7", "@esbuild/netbsd-arm64": "0.27.7", "@esbuild/netbsd-x64": "0.27.7", "@esbuild/openbsd-arm64": "0.27.7", "@esbuild/openbsd-x64": "0.27.7", "@esbuild/openharmony-arm64": "0.27.7", "@esbuild/sunos-x64": "0.27.7", "@esbuild/win32-arm64": "0.27.7", "@esbuild/win32-ia32": "0.27.7", "@esbuild/win32-x64": "0.27.7" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w=="],
 
@@ -726,27 +789,65 @@
 
     "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
 
+    "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "form-data": ["form-data@2.5.6", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.4", "mime-types": "^2.1.35", "safe-buffer": "^5.2.1" } }, "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA=="],
 
     "framer-motion": ["framer-motion@12.38.0", "", { "dependencies": { "motion-dom": "^12.38.0", "motion-utils": "^12.36.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
+    "function-bind": ["function-bind@1.1.2", "", {}, "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA=="],
+
+    "gaxios": ["gaxios@6.7.1", "", { "dependencies": { "extend": "^3.0.2", "https-proxy-agent": "^7.0.1", "is-stream": "^2.0.0", "node-fetch": "^2.6.9", "uuid": "^9.0.1" } }, "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ=="],
+
+    "gcp-metadata": ["gcp-metadata@6.1.1", "", { "dependencies": { "gaxios": "^6.1.1", "google-logging-utils": "^0.0.2", "json-bigint": "^1.0.0" } }, "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A=="],
+
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "google-auth-library": ["google-auth-library@9.15.1", "", { "dependencies": { "base64-js": "^1.3.0", "ecdsa-sig-formatter": "^1.0.11", "gaxios": "^6.1.1", "gcp-metadata": "^6.1.0", "gtoken": "^7.0.0", "jws": "^4.0.0" } }, "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng=="],
+
+    "google-logging-utils": ["google-logging-utils@0.0.2", "", {}, "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ=="],
+
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
+
+    "gtoken": ["gtoken@7.1.0", "", { "dependencies": { "gaxios": "^6.0.0", "jws": "^4.0.0" } }, "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
+
+    "hasown": ["hasown@2.0.4", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A=="],
 
     "hookable": ["hookable@6.1.1", "", {}, "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ=="],
 
+    "html-entities": ["html-entities@2.6.0", "", {}, "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@5.0.0", "", { "dependencies": { "@tootallnate/once": "2", "agent-base": "6", "debug": "4" } }, "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w=="],
+
+    "https-proxy-agent": ["https-proxy-agent@5.0.1", "", { "dependencies": { "agent-base": "6", "debug": "4" } }, "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA=="],
+
     "import-without-cache": ["import-without-cache@0.3.3", "", {}, "sha512-bDxwDdF04gm550DfZHgffvlX+9kUlcz32UD0AeBTmVPFiWkrexF2XVmiuFFbDhiFuP8fQkrkvI2KdSNPYWAXkQ=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "is": ["is@3.3.2", "", {}, "sha512-a2xr4E3s1PjDS8ORcGgXpWx6V+liNs+O3JRD2mb9aeugD7rtkkZ0zgLdYgw0tWsKhsdiezGYptSiMlVazCBTuQ=="],
 
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
 
@@ -762,6 +863,8 @@
 
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
+    "is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
+
     "is-wsl": ["is-wsl@3.1.1", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw=="],
 
     "isbot": ["isbot@5.1.39", "", {}, "sha512-obH0yYahGXdzNxo+djmHhBYThUKDkz565cxkIlt2L9hXfv1NlaLKoDBHo6KxXsYrIXx2RK3x5vY36CfZcobxEw=="],
@@ -772,7 +875,13 @@
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
+    "json-bigint": ["json-bigint@1.0.0", "", { "dependencies": { "bignumber.js": "^9.0.0" } }, "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ=="],
+
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "jwa": ["jwa@2.0.1", "", { "dependencies": { "buffer-equal-constant-time": "^1.0.1", "ecdsa-sig-formatter": "1.0.11", "safe-buffer": "^5.0.1" } }, "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg=="],
+
+    "jws": ["jws@4.0.1", "", { "dependencies": { "jwa": "^2.0.1", "safe-buffer": "^5.0.1" } }, "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA=="],
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
@@ -806,6 +915,12 @@
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
+
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
     "motion": ["motion@12.38.0", "", { "dependencies": { "framer-motion": "^12.38.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w=="],
 
     "motion-dom": ["motion-dom@12.38.0", "", { "dependencies": { "motion-utils": "^12.36.0" } }, "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA=="],
@@ -816,15 +931,21 @@
 
     "nanoid": ["nanoid@5.1.9", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw=="],
 
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
     "node-releases": ["node-releases@2.0.38", "", {}, "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
 
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
     "oneshot-gtm": ["oneshot-gtm@workspace:apps/cli"],
 
     "oneshot-gtm-server": ["oneshot-gtm-server@workspace:apps/server"],
+
+    "oneshot-gtm-telemetry-ingest": ["oneshot-gtm-telemetry-ingest@workspace:apps/telemetry-ingest"],
 
     "open": ["open@11.0.0", "", { "dependencies": { "default-browser": "^5.4.0", "define-lazy-prop": "^3.0.0", "is-in-ssh": "^1.0.0", "is-inside-container": "^1.0.0", "powershell-utils": "^0.1.0", "wsl-utils": "^0.3.0" } }, "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw=="],
 
@@ -862,17 +983,23 @@
 
     "react-textarea-autosize": ["react-textarea-autosize@8.5.9", "", { "dependencies": { "@babel/runtime": "^7.20.13", "use-composed-ref": "^1.3.0", "use-latest": "^1.2.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A=="],
 
+    "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
+
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
     "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
+    "retry-request": ["retry-request@7.0.2", "", { "dependencies": { "@types/request": "^2.48.8", "extend": "^3.0.2", "teeny-request": "^9.0.0" } }, "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w=="],
+
     "rolldown": ["rolldown@1.0.0-rc.17", "", { "dependencies": { "@oxc-project/types": "=0.127.0", "@rolldown/pluginutils": "1.0.0-rc.17" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-arm64": "1.0.0-rc.17", "@rolldown/binding-darwin-x64": "1.0.0-rc.17", "@rolldown/binding-freebsd-x64": "1.0.0-rc.17", "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.17", "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.17", "@rolldown/binding-linux-x64-musl": "1.0.0-rc.17", "@rolldown/binding-openharmony-arm64": "1.0.0-rc.17", "@rolldown/binding-wasm32-wasi": "1.0.0-rc.17", "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.17", "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.17" }, "bin": { "rolldown": "bin/cli.mjs" } }, "sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA=="],
 
     "rolldown-plugin-dts": ["rolldown-plugin-dts@0.23.2", "", { "dependencies": { "@babel/generator": "8.0.0-rc.3", "@babel/helper-validator-identifier": "8.0.0-rc.3", "@babel/parser": "8.0.0-rc.3", "@babel/types": "8.0.0-rc.3", "ast-kit": "^3.0.0-beta.1", "birpc": "^4.0.0", "dts-resolver": "^2.1.3", "get-tsconfig": "^4.13.7", "obug": "^2.1.1", "picomatch": "^4.0.4" }, "peerDependencies": { "@ts-macro/tsc": "^0.3.6", "@typescript/native-preview": ">=7.0.0-dev.20260325.1", "rolldown": "^1.0.0-rc.12", "typescript": "^5.0.0 || ^6.0.0", "vue-tsc": "~3.2.0" }, "optionalPeers": ["@ts-macro/tsc", "@typescript/native-preview", "typescript", "vue-tsc"] }, "sha512-PbSqLawLgZBGcOGT3yqWBGn4cX+wh2nt5FuBGdcMHyOhoukmjbhYAl8NT9sE4U38Cm9tqLOIQeOrvzeayM0DLQ=="],
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
@@ -896,11 +1023,21 @@
 
     "std-env": ["std-env@4.1.0", "", {}, "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ=="],
 
+    "stream-events": ["stream-events@1.0.5", "", { "dependencies": { "stubs": "^3.0.0" } }, "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg=="],
+
+    "stream-shift": ["stream-shift@1.0.3", "", {}, "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
+
+    "stubs": ["stubs@3.0.0", "", {}, "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw=="],
+
     "tailwind-merge": ["tailwind-merge@3.5.0", "", {}, "sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A=="],
 
     "tailwindcss": ["tailwindcss@4.2.4", "", {}, "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA=="],
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
+
+    "teeny-request": ["teeny-request@9.0.0", "", { "dependencies": { "http-proxy-agent": "^5.0.0", "https-proxy-agent": "^5.0.0", "node-fetch": "^2.6.9", "stream-events": "^1.0.5", "uuid": "^9.0.0" } }, "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g=="],
 
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
@@ -913,6 +1050,8 @@
     "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
 
     "tree-kill": ["tree-kill@1.2.2", "", { "bin": { "tree-kill": "cli.js" } }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
 
@@ -950,13 +1089,23 @@
 
     "use-sync-external-store": ["use-sync-external-store@1.6.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w=="],
 
+    "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
+
+    "uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
+
     "vite": ["vite@8.0.10", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.10", "rolldown": "1.0.0-rc.17", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw=="],
 
     "vitest": ["vitest@4.1.5", "", { "dependencies": { "@vitest/expect": "4.1.5", "@vitest/mocker": "4.1.5", "@vitest/pretty-format": "4.1.5", "@vitest/runner": "4.1.5", "@vitest/snapshot": "4.1.5", "@vitest/spy": "4.1.5", "@vitest/utils": "4.1.5", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.5", "@vitest/browser-preview": "4.1.5", "@vitest/browser-webdriverio": "4.1.5", "@vitest/coverage-istanbul": "4.1.5", "@vitest/coverage-v8": "4.1.5", "@vitest/ui": "4.1.5", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-9Xx1v3/ih3m9hN+SbfkUyy0JAs72ap3r7joc87XL6jwF0jGg6mFBvQ1SrwaX+h8BlkX6Hz9shdd1uo6AF+ZGpg=="],
 
+    "webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
+    "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
     "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "ws": ["ws@8.17.1", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ=="],
 
@@ -1152,6 +1301,8 @@
 
     "ethers/tslib": ["tslib@2.7.0", "", {}, "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="],
 
+    "gaxios/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
     "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "prompts/kleur": ["kleur@3.0.3", "", {}, "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="],
@@ -1245,6 +1396,8 @@
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/wasi-threads/tslib": ["tslib@2.7.0", "", {}, "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA=="],
 
     "ast-kit/@babel/parser/@babel/types": ["@babel/types@8.0.0-rc.3", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.3", "@babel/helper-validator-identifier": "^8.0.0-rc.3" } }, "sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q=="],
+
+    "gaxios/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "rolldown-plugin-dts/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@8.0.0-rc.3", "", {}, "sha512-AmwWFx1m8G/a5cXkxLxTiWl+YEoWuoFLUCwqMlNuWO1tqAYITQAbCRPUkyBHv1VOFgfjVOqEj6L3u15J5ZCzTA=="],
 

--- a/packages/core/__tests__/telemetry.test.ts
+++ b/packages/core/__tests__/telemetry.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  buildTelemetryPayload,
+  DEFAULT_TELEMETRY_URL,
+  markTelemetryOutcome,
+  reportCommand,
+  shouldSendTelemetry,
+  takeMarkedOutcome,
+  telemetryUrl,
+  type TelemetryInputs,
+} from "../src/telemetry.ts";
+
+const BASE: TelemetryInputs = {
+  command: "motion show-hn",
+  flags: ["dry-run"],
+  outcome: "ok",
+  durationMs: 2840.6,
+  version: "0.6.0",
+  clientId: "cid-123",
+  llmProvider: "openrouter",
+  platform: "darwin",
+  bunVersion: "1.3.13",
+};
+
+describe("buildTelemetryPayload — exactly the TELEMETRY.md whitelist", () => {
+  it("maps inputs onto the documented field names", () => {
+    const p = buildTelemetryPayload(BASE);
+    expect(p).toEqual({
+      command: "motion show-hn",
+      flags: ["dry-run"],
+      outcome: "ok",
+      duration_ms: 2841, // rounded
+      version: "0.6.0",
+      os: "darwin",
+      bun_version: "1.3.13",
+      anonymous_machine_id: "cid-123",
+      llm_provider: "openrouter",
+    });
+  });
+
+  it("carries no field outside the whitelist", () => {
+    const keys = Object.keys(buildTelemetryPayload(BASE)).toSorted();
+    expect(keys).toEqual([
+      "anonymous_machine_id",
+      "bun_version",
+      "command",
+      "duration_ms",
+      "flags",
+      "llm_provider",
+      "os",
+      "outcome",
+      "version",
+    ]);
+  });
+
+  it("passes flags through as-is (names only — caller never puts values here)", () => {
+    const p = buildTelemetryPayload({ ...BASE, flags: ["dry-run", "skip-sms"] });
+    expect(p.flags).toEqual(["dry-run", "skip-sms"]);
+  });
+
+  it("rounds and floors duration to a non-negative integer", () => {
+    expect(buildTelemetryPayload({ ...BASE, durationMs: -5 }).duration_ms).toBe(0);
+    expect(buildTelemetryPayload({ ...BASE, durationMs: 12.4 }).duration_ms).toBe(12);
+  });
+
+  it("preserves a null anonymous id (install without a clientId yet)", () => {
+    expect(buildTelemetryPayload({ ...BASE, clientId: null }).anonymous_machine_id).toBeNull();
+  });
+});
+
+describe("shouldSendTelemetry — gate", () => {
+  it("is on by default when the flag is true and no env override", () => {
+    expect(shouldSendTelemetry({ telemetryEnabled: true }, {})).toBe(true);
+  });
+
+  it("is off when the persisted flag is false", () => {
+    expect(shouldSendTelemetry({ telemetryEnabled: false }, {})).toBe(false);
+  });
+
+  it.each(["0", "false", "off", "no", "FALSE", "Off"])(
+    "env kill switch ONESHOT_GTM_TELEMETRY=%s wins over flag=true",
+    (val) => {
+      expect(shouldSendTelemetry({ telemetryEnabled: true }, { ONESHOT_GTM_TELEMETRY: val })).toBe(
+        false,
+      );
+    },
+  );
+
+  it("a truthy-looking env value (e.g. '1') does not force-disable", () => {
+    expect(shouldSendTelemetry({ telemetryEnabled: true }, { ONESHOT_GTM_TELEMETRY: "1" })).toBe(
+      true,
+    );
+  });
+});
+
+describe("telemetryUrl", () => {
+  it("defaults to the first-party endpoint", () => {
+    expect(telemetryUrl({})).toBe(DEFAULT_TELEMETRY_URL);
+  });
+
+  it("honors ONESHOT_GTM_TELEMETRY_URL override", () => {
+    expect(telemetryUrl({ ONESHOT_GTM_TELEMETRY_URL: "http://localhost:9/x" })).toBe(
+      "http://localhost:9/x",
+    );
+  });
+
+  it("ignores a blank override", () => {
+    expect(telemetryUrl({ ONESHOT_GTM_TELEMETRY_URL: "   " })).toBe(DEFAULT_TELEMETRY_URL);
+  });
+});
+
+describe("reportCommand — transport", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  const payload = buildTelemetryPayload(BASE);
+
+  it("is a no-op when the URL is empty (unconfigured / forked build)", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await reportCommand(payload, "");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("POSTs JSON to the configured URL", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    await reportCommand(payload, "http://ingest.local/v1/cli");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0]!;
+    expect(url).toBe("http://ingest.local/v1/cli");
+    expect(init?.method).toBe("POST");
+    expect(JSON.parse(init?.body as string)).toMatchObject({ command: "motion show-hn" });
+  });
+
+  it("never throws when fetch rejects (endpoint down)", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+    await expect(reportCommand(payload, "http://ingest.local/v1/cli")).resolves.toBeUndefined();
+  });
+});
+
+describe("markTelemetryOutcome / takeMarkedOutcome", () => {
+  it("returns null when nothing was marked", () => {
+    takeMarkedOutcome(); // clear any residue
+    expect(takeMarkedOutcome()).toBeNull();
+  });
+
+  it("returns the marked outcome once, then clears", () => {
+    markTelemetryOutcome("lint-blocked");
+    expect(takeMarkedOutcome()).toBe("lint-blocked");
+    expect(takeMarkedOutcome()).toBeNull();
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export * from "./inflight.ts";
 export * from "./ledger.ts";
 export * from "./config.ts";
 export * from "./events.ts";
+export * from "./telemetry.ts";
 export * from "./json.ts";
 export * from "./gmail.ts";
 export * from "./identities.ts";

--- a/packages/core/src/telemetry.ts
+++ b/packages/core/src/telemetry.ts
@@ -1,0 +1,171 @@
+import type { OneShotConfig } from "./types.ts";
+
+/**
+ * Anonymous distribution telemetry — ONE summary event per CLI invocation.
+ *
+ * This is a separate channel from the verbose local `events.jsonl`
+ * (see events.ts). That log is for the developer and never leaves the
+ * machine; this is the opt-out, off-device signal documented in
+ * TELEMETRY.md. The two share a privacy boundary (primitives, counters,
+ * category labels — never user-typed values, prospect data, or content)
+ * but emit different shapes to different sinks.
+ *
+ * TELEMETRY.md is the authoritative spec for the payload below. The field
+ * set here must stay in lockstep with that file.
+ *
+ * ## Hard rules
+ *
+ * - `ONESHOT_GTM_TELEMETRY=0` / `false` is a kill switch checked BEFORE a
+ *   payload is constructed (`shouldSendTelemetry`). No payload, no request.
+ * - `cfg.telemetryEnabled === false` (the `config telemetry off` flag) does
+ *   the same.
+ * - Transmission never throws and never blocks process exit — a telemetry
+ *   bug or an unreachable endpoint must be invisible to the user.
+ * - No telemetry SDK: a plain `fetch` POST keeps the OSS client dependency
+ *   free and transparent. The receiver (Cloud Run + BigQuery) is first-party.
+ */
+
+/** Outcome of a single CLI invocation. Mirrors the TELEMETRY.md `outcome` column. */
+export type TelemetryOutcome = "ok" | "error" | "lint-blocked";
+
+/**
+ * The exact wire shape. Field set is the TELEMETRY.md whitelist — do not add
+ * fields here without updating that file in the same change.
+ */
+export interface TelemetryPayload {
+  command: string;
+  flags: string[];
+  outcome: TelemetryOutcome;
+  duration_ms: number;
+  version: string;
+  os: string;
+  bun_version: string;
+  /**
+   * Anonymous per-install id. Satisfied by the existing `clientId` UUID
+   * (config.json) rather than a machine fingerprint — random-per-install,
+   * already persisted, and carries nothing PII-adjacent.
+   */
+  anonymous_machine_id: string | null;
+  llm_provider: string;
+}
+
+/**
+ * Default first-party ingest endpoint. Intentionally EMPTY in the public
+ * source so no internal infrastructure identifier (GCP project, Cloud Run
+ * host) ships in the OSS client, and so a fork/local build sends nowhere by
+ * default. A maintainer sets this to a stable custom domain they control
+ * (e.g. "https://telemetry.example.com/v1/cli") for a release; operators can
+ * override per-run with ONESHOT_GTM_TELEMETRY_URL. Empty ⇒ telemetry is a
+ * no-op (nothing is constructed or sent).
+ */
+export const DEFAULT_TELEMETRY_URL = "";
+
+const TELEMETRY_TIMEOUT_MS = 1500;
+
+/**
+ * Resolve the ingest URL. `ONESHOT_GTM_TELEMETRY_URL` overrides the default
+ * so the receiver can be exercised locally / against staging.
+ */
+export function telemetryUrl(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env["ONESHOT_GTM_TELEMETRY_URL"]?.trim();
+  return override && override.length > 0 ? override : DEFAULT_TELEMETRY_URL;
+}
+
+/**
+ * Pure gate. Returns false — meaning "construct nothing, send nothing" — when
+ * either the persisted flag is off or the env kill switch is set. Env wins so
+ * a single shell-session export reliably silences telemetry regardless of
+ * what's on disk.
+ */
+export function shouldSendTelemetry(
+  cfg: Pick<OneShotConfig, "telemetryEnabled">,
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  const raw = env["ONESHOT_GTM_TELEMETRY"]?.trim().toLowerCase();
+  if (raw === "0" || raw === "false" || raw === "off" || raw === "no") return false;
+  return cfg.telemetryEnabled !== false;
+}
+
+export interface TelemetryInputs {
+  command: string;
+  flags: string[];
+  outcome: TelemetryOutcome;
+  durationMs: number;
+  version: string;
+  clientId: string | null;
+  llmProvider: string;
+  platform: string;
+  bunVersion: string;
+}
+
+/**
+ * Pure builder — no I/O, no clock, no globals. The caller supplies every
+ * value so tests can pin them (mirrors `buildEventLine`). Strips nothing:
+ * the field set IS the whitelist, so anything not listed simply can't be
+ * carried.
+ */
+export function buildTelemetryPayload(input: TelemetryInputs): TelemetryPayload {
+  return {
+    command: input.command,
+    flags: input.flags,
+    outcome: input.outcome,
+    duration_ms: Math.max(0, Math.round(input.durationMs)),
+    version: input.version,
+    os: input.platform,
+    bun_version: input.bunVersion,
+    anonymous_machine_id: input.clientId,
+    llm_provider: input.llmProvider,
+  };
+}
+
+/**
+ * Fire-and-forget POST. Resolves either way — a network error, a non-2xx, or
+ * the timeout all resolve to undefined. Bounded by an AbortController so a
+ * hung endpoint can't delay CLI exit beyond TELEMETRY_TIMEOUT_MS.
+ */
+export async function reportCommand(
+  payload: TelemetryPayload,
+  url: string = telemetryUrl(),
+): Promise<void> {
+  // No endpoint configured ⇒ no-op. Keeps unconfigured/forked builds silent
+  // and avoids a guaranteed-failing fetch on every command.
+  if (!url) return;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), TELEMETRY_TIMEOUT_MS);
+  try {
+    await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(payload),
+      signal: controller.signal,
+    });
+  } catch {
+    // swallowed — telemetry must never surface to the user (see header)
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-invocation outcome marker.
+//
+// Most commands map cleanly: a thrown error => "error", a clean return =>
+// "ok". But the anti-slop path prints "Not sent — fix lint flags" and returns
+// normally (printDrafts in motion.ts), so "lint-blocked" can't be inferred
+// from control flow. A command signals it explicitly via markTelemetryOutcome;
+// the dispatch wrapper reads it back with takeMarkedOutcome.
+// ---------------------------------------------------------------------------
+
+let markedOutcome: TelemetryOutcome | null = null;
+
+/** Override the inferred outcome for the current invocation (e.g. "lint-blocked"). */
+export function markTelemetryOutcome(outcome: TelemetryOutcome): void {
+  markedOutcome = outcome;
+}
+
+/** Read and clear the marked outcome. Returns null if nothing was marked. */
+export function takeMarkedOutcome(): TelemetryOutcome | null {
+  const o = markedOutcome;
+  markedOutcome = null;
+  return o;
+}

--- a/packages/core/src/telemetry.ts
+++ b/packages/core/src/telemetry.ts
@@ -50,15 +50,13 @@ export interface TelemetryPayload {
 }
 
 /**
- * Default first-party ingest endpoint. Intentionally EMPTY in the public
- * source so no internal infrastructure identifier (GCP project, Cloud Run
- * host) ships in the OSS client, and so a fork/local build sends nowhere by
- * default. A maintainer sets this to a stable custom domain they control
- * (e.g. "https://telemetry.example.com/v1/cli") for a release; operators can
- * override per-run with ONESHOT_GTM_TELEMETRY_URL. Empty ⇒ telemetry is a
- * no-op (nothing is constructed or sent).
+ * Default first-party ingest endpoint. A stable custom domain we own (mapped
+ * onto a Cloud Run service) rather than the raw `*.run.app` host — so the
+ * backend can move without re-shipping the client, and no GCP project number
+ * leaks into the OSS source. Operators can override per-run with
+ * ONESHOT_GTM_TELEMETRY_URL; set it to "" to make telemetry a hard no-op.
  */
-export const DEFAULT_TELEMETRY_URL = "";
+export const DEFAULT_TELEMETRY_URL = "https://telemetry.oneshotagent.com/v1/cli";
 
 const TELEMETRY_TIMEOUT_MS = 1500;
 


### PR DESCRIPTION
## What

Phase 1 of distribution telemetry per `TELEMETRY.md`: one anonymous, opt-out summary event per CLI invocation, sent to a first-party endpoint. Nothing was transmitted before this.

## Client (`packages/core/src/telemetry.ts`)
- Pure `buildTelemetryPayload` + `shouldSendTelemetry` gate (`ONESHOT_GTM_TELEMETRY` hard-kill before any payload is built; honors the `telemetryEnabled` flag).
- Fire-and-forget `reportCommand` — `AbortController` timeout, never throws, never blocks exit.
- `DEFAULT_TELEMETRY_URL` is **empty** in the public source (empty ⇒ no-op). No `*.run.app` host or GCP project id is committed; a maintainer sets a custom domain at release.
- `anonymous_machine_id` reuses the existing per-install `clientId` UUID — no machine fingerprinting.

## CLI dispatch (`apps/cli`)
- `runOrFail` captures command path, cli-set flag **names** (never values), duration, and outcome.
- `bail()` / `CommandExit` funnels guard-clause exits (doctor/discover/handoff/intel/ui) through the telemetry path as `error` instead of bypassing it via `process.exit`.
- `motion` marks the `lint-blocked` outcome.
- Fixed the stale `--version` (now read from `package.json`).
- Pure dispatch helpers extracted to `dispatch.ts` for testability.

## Receiver (`apps/telemetry-ingest`) — Cloud Run + BigQuery
- Whitelist-validating handler (strips unknown fields), pluggable BigQuery / in-memory sinks.
- Deploy/provision scripts live in gitignored `ops/` (not in this public repo).
- **Deployed**: `oneshot-telemetry-prod` (single env, no staging); BigQuery `telemetry.cli_events` created and verified end-to-end.

## Docs / tests
- `TELEMETRY.md`: fixed the opt-in/opt-out contradiction, documented the now-wired env vars and `anonymous_machine_id == clientId`.
- +56 tests (client transport + gate, dispatch parsing, receiver validation). Full suite: 1229 passing; typecheck + lint clean.

## Follow-up (not in this PR)
Map a custom domain onto the prod service and set `DEFAULT_TELEMETRY_URL` to it — until then the client is a no-op.