### PR TITLE
feat(server): telemetry for dashboard play executions

### DIFF
--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -3,15 +3,7 @@ import { Command } from "commander";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import {
-  buildTelemetryPayload,
-  loadConfig,
-  reportCommand,
-  shouldSendTelemetry,
-  takeMarkedOutcome,
-  telemetryUrl,
-  type TelemetryOutcome,
-} from "@oneshot-gtm/core";
+import { reportTelemetryEvent, takeMarkedOutcome, type TelemetryOutcome } from "@oneshot-gtm/core";
 import { CommandExit, fail } from "./output.ts";
 import { extractInvocation, type Invocation } from "./dispatch.ts";
 import { runInit } from "./commands/init.ts";
@@ -494,28 +486,13 @@ async function sendTelemetry(
   outcome: TelemetryOutcome,
   startMs: number,
 ): Promise<void> {
-  try {
-    // No endpoint configured (default OSS build) ⇒ skip everything, including
-    // the config read. The maintainer's release sets the endpoint.
-    const url = telemetryUrl();
-    if (!url) return;
-    const cfg = loadConfig();
-    if (!shouldSendTelemetry(cfg, process.env)) return;
-    const payload = buildTelemetryPayload({
-      command: inv.command,
-      flags: inv.flags,
-      outcome,
-      durationMs: performance.now() - startMs,
-      version: CLI_VERSION,
-      clientId: cfg.clientId,
-      llmProvider: cfg.llmProvider,
-      platform: process.platform,
-      bunVersion: typeof Bun !== "undefined" ? Bun.version : "",
-    });
-    await reportCommand(payload, url);
-  } catch {
-    // never surface telemetry failures to the user
-  }
+  await reportTelemetryEvent({
+    command: inv.command,
+    flags: inv.flags,
+    outcome,
+    durationMs: performance.now() - startMs,
+    version: CLI_VERSION,
+  });
 }
 
 function attachHelpFallbacks(cmd: Command): void {

--- a/apps/server/__tests__/telemetry.test.ts
+++ b/apps/server/__tests__/telemetry.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { reportServerExecution } from "../src/telemetry.ts";
+
+// reportServerExecution reaches the real telemetry endpoint via global fetch,
+// so every test that exercises the send path must spy on fetch — otherwise it
+// would phone home. Tests run under ONESHOT_GTM_HOME = a temp dir (see
+// vitest.setup.ts), so loadConfig() reads a fresh config with telemetry on by
+// default.
+
+const ENV_KEY = "ONESHOT_GTM_TELEMETRY";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env[ENV_KEY];
+});
+
+describe("reportServerExecution — gate", () => {
+  it("is a no-op when the env kill-switch is set (no fetch)", async () => {
+    process.env[ENV_KEY] = "0";
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await reportServerExecution("server.run.show-hn", { outcome: "ok", durationMs: 5 });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("reportServerExecution — transport", () => {
+  it("POSTs a server.-prefixed payload with the right command/flags/outcome", async () => {
+    delete process.env[ENV_KEY];
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 204 }));
+
+    await reportServerExecution("server.run.show-hn", {
+      outcome: "ok",
+      durationMs: 1234,
+      flags: ["dry-run", "from-queue"],
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const init = fetchSpy.mock.calls[0]![1];
+    expect(init?.method).toBe("POST");
+    const payload = JSON.parse(init?.body as string) as Record<string, unknown>;
+    expect(payload["command"]).toBe("server.run.show-hn");
+    expect(payload["flags"]).toEqual(["dry-run", "from-queue"]);
+    expect(payload["outcome"]).toBe("ok");
+    expect(payload["duration_ms"]).toBe(1234);
+    // Server build carries a real version + platform — proves it's a server
+    // event, not a CLI one.
+    expect(typeof payload["version"]).toBe("string");
+    expect(payload["os"]).toBe(process.platform);
+  });
+
+  it("defaults flags to an empty array when omitted", async () => {
+    delete process.env[ENV_KEY];
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    await reportServerExecution("server.trigger.show-hn", { outcome: "error", durationMs: 0 });
+    const payload = JSON.parse(fetchSpy.mock.calls[0]![1]?.body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(payload["flags"]).toEqual([]);
+    expect(payload["outcome"]).toBe("error");
+  });
+
+  it("never throws when fetch rejects (endpoint down must not break a request)", async () => {
+    delete process.env[ENV_KEY];
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+    await expect(
+      reportServerExecution("server.queue.drain", { outcome: "ok", durationMs: 9 }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/apps/server/src/api/cadences.ts
+++ b/apps/server/src/api/cadences.ts
@@ -17,6 +17,7 @@ import type {
   CadenceView,
 } from "@oneshot-gtm/shared-types";
 import { jsonResponse } from "../server.ts";
+import { reportServerExecution } from "../telemetry.ts";
 
 /**
  * In-flight cadence sends are tracked on the cadence_state row's
@@ -314,12 +315,21 @@ export async function sendCadenceStepRoute(
       req,
     );
   }
+  const sendStartedAt = performance.now();
   void (async () => {
     try {
       await sendCadenceStep(parsed);
       // Success path: advanceCadence inside sendCadenceStep already cleared
       // sending_started_at as part of its UPDATE. Nothing to do here.
+      void reportServerExecution("server.cadence.send", {
+        outcome: "ok",
+        durationMs: performance.now() - sendStartedAt,
+      });
     } catch (err) {
+      void reportServerExecution("server.cadence.send", {
+        outcome: "error",
+        durationMs: performance.now() - sendStartedAt,
+      });
       logEvent(
         "cadence.send.failed",
         {
@@ -403,6 +413,7 @@ export async function sendCadenceBatchRoute(req: Request): Promise<Response> {
       req,
     );
   }
+  const batchStartedAt = performance.now();
   void (async () => {
     try {
       // Per-item callback: clear the marker on each settled row. The serial
@@ -416,7 +427,15 @@ export async function sendCadenceBatchRoute(req: Request): Promise<Response> {
           /* sweeper safety net */
         }
       });
+      void reportServerExecution("server.cadence.batch", {
+        outcome: "ok",
+        durationMs: performance.now() - batchStartedAt,
+      });
     } catch (err) {
+      void reportServerExecution("server.cadence.batch", {
+        outcome: "error",
+        durationMs: performance.now() - batchStartedAt,
+      });
       // Belt-and-suspenders: the wrapper catches per-item; this catch only
       // fires if the wrapper itself throws. Release everything so the founder
       // can retry without waiting for the sweep.

--- a/apps/server/src/api/queue.ts
+++ b/apps/server/src/api/queue.ts
@@ -4,9 +4,11 @@ import {
   isSendDeferred,
   type QueueRow,
   type QueueStatus,
+  type TelemetryOutcome,
 } from "@oneshot-gtm/core";
 import { drainQueue } from "@oneshot-gtm/find";
 import { enrollInCadence, sendDraftedEmail } from "@oneshot-gtm/plays";
+import { reportServerExecution } from "../telemetry.ts";
 import {
   blockingFlags,
   type DrainRequest,
@@ -134,19 +136,32 @@ export async function drainQueueRoute(req: Request): Promise<Response> {
     return jsonResponse({ error: "invalid JSON body" }, 400, req);
   }
   if (!body.playName) return jsonResponse({ error: "playName required" }, 400, req);
-  const result = await drainQueue({
-    playName: body.playName,
-    limit: body.limit ?? 10,
-    dryRun: !!body.dryRun,
-    ...(body.senderCohort ? { senderCohort: body.senderCohort } : {}),
-    ...(body.freeForCohortOffer ? { freeForCohortOffer: body.freeForCohortOffer } : {}),
-  });
-  const view: DrainResult = {
-    drained: result.drained,
-    sent: result.sent,
-    errors: result.errors,
-  };
-  return jsonResponse(view, 200, req);
+  const t0 = performance.now();
+  let outcome: TelemetryOutcome = "ok";
+  try {
+    const result = await drainQueue({
+      playName: body.playName,
+      limit: body.limit ?? 10,
+      dryRun: !!body.dryRun,
+      ...(body.senderCohort ? { senderCohort: body.senderCohort } : {}),
+      ...(body.freeForCohortOffer ? { freeForCohortOffer: body.freeForCohortOffer } : {}),
+    });
+    const view: DrainResult = {
+      drained: result.drained,
+      sent: result.sent,
+      errors: result.errors,
+    };
+    return jsonResponse(view, 200, req);
+  } catch (err) {
+    outcome = "error";
+    throw err;
+  } finally {
+    void reportServerExecution("server.queue.drain", {
+      outcome,
+      durationMs: performance.now() - t0,
+      flags: body.dryRun ? ["dry-run"] : [],
+    });
+  }
 }
 
 /**
@@ -216,11 +231,7 @@ export async function regenerateDraftRoute(
   // body + wipe the receiptIds list.
   const fresh = ledger.getQueueRow(id);
   if (!fresh || fresh.status === "sent" || fresh.send_started_at != null) {
-    return jsonResponse(
-      { error: "send completed (or started) during regenerate" },
-      409,
-      req,
-    );
+    return jsonResponse({ error: "send completed (or started) during regenerate" }, 409, req);
   }
 
   ledger.setQueueDraft({
@@ -331,6 +342,18 @@ export async function sendDraftRoute(
   const email = str("email") ?? str("founderEmail");
   if (!email) return jsonResponse({ error: "row has no recipient email" }, 400, req);
 
+  // Telemetry: emit exactly one event for this send attempt, regardless of
+  // which terminal path we take. Declared here (after pre-send validation) so
+  // bad-request / not-found returns above don't count as executions.
+  const t0 = performance.now();
+  const done = (outcome: TelemetryOutcome, res: Response): Response => {
+    void reportServerExecution("server.queue.send", {
+      outcome,
+      durationMs: performance.now() - t0,
+    });
+    return res;
+  };
+
   // sendDraftedEmail pushes dedup outcomes ("already-enrolled" / "already-
   // contacted") onto this array, so we can tell a deliberate skip apart from a
   // genuine send failure below.
@@ -364,9 +387,12 @@ export async function sendDraftRoute(
     // Daily caps exhausted — not a failure. Row stays approved with its
     // reviewed draft; 429 tells the UI "try again tomorrow".
     if (isSendDeferred(err)) {
-      return jsonResponse({ error: (err as Error).message, deferred: true }, 429, req);
+      return done("ok", jsonResponse({ error: (err as Error).message, deferred: true }, 429, req));
     }
-    return jsonResponse({ error: (err as Error).message ?? "send failed" }, 400, req);
+    return done(
+      "error",
+      jsonResponse({ error: (err as Error).message ?? "send failed" }, 400, req),
+    );
   }
   if (!result.sent) {
     try {
@@ -385,9 +411,12 @@ export async function sendDraftRoute(
           ? "already contacted via another play"
           : "already sent this play";
       ledger.setQueueStatus({ id, status: "rejected", notes: `auto: ${reason} — not re-sent` });
-      return jsonResponse({ error: `${reason} — not re-sent`, skipped: true, reason: dedup }, 409, req);
+      return done(
+        "ok",
+        jsonResponse({ error: `${reason} — not re-sent`, skipped: true, reason: dedup }, 409, req),
+      );
     }
-    return jsonResponse({ error: "send did not complete" }, 500, req);
+    return done("error", jsonResponse({ error: "send did not complete" }, 500, req));
   }
 
   const prospect = ledger.findProspectByEmail(email);
@@ -398,5 +427,5 @@ export async function sendDraftRoute(
     draft: { subject, body, flags: [], sent: true, receiptIds: result.receiptIds, dryRun: false },
   });
 
-  return jsonResponse({ sent: true, receiptIds: result.receiptIds }, 200, req);
+  return done("ok", jsonResponse({ sent: true, receiptIds: result.receiptIds }, 200, req));
 }

--- a/apps/server/src/api/run.ts
+++ b/apps/server/src/api/run.ts
@@ -1,7 +1,8 @@
-import { getLedger, logEvent } from "@oneshot-gtm/core";
+import { getLedger, logEvent, type TelemetryOutcome } from "@oneshot-gtm/core";
 import { verifyAndFilterTargets } from "@oneshot-gtm/plays";
 import type { RunPlayEvent, RunPlayRequest } from "@oneshot-gtm/shared-types";
 import { jsonResponse } from "../server.ts";
+import { reportServerExecution } from "../telemetry.ts";
 import { dispatchPlay, type DraftedView } from "./_play-dispatch.ts";
 
 const SUPPORTED = new Set([
@@ -57,6 +58,10 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
     async start(controller) {
       const encoder = new TextEncoder();
       const ledger = getLedger();
+      // Telemetry bookkeeping for this run — emitted once in `finally`.
+      const t0 = performance.now();
+      let runOutcome: TelemetryOutcome = "ok";
+      let fromQueue = false;
       const send = (event: RunPlayEvent): void => {
         // Persist FIRST — even if the client has disconnected, the resume
         // view needs every event. SSE write second; swallow if the client
@@ -101,7 +106,7 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
         // verified at finder-enqueue time, so re-verifying just adds latency.
         // The verify event tells the UI which rows were dropped + why.
         const inputCount = body.targets.length;
-        const fromQueue =
+        fromQueue =
           Array.isArray(body.dedupeKeys) && body.dedupeKeys.length === body.targets.length;
         let verify: Awaited<ReturnType<typeof verifyAndFilterTargets>>;
         if (fromQueue) {
@@ -170,6 +175,7 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
           });
         }
       } catch (err) {
+        runOutcome = "error";
         // Log the full error server-side — the SSE error event only carries a
         // short message (e.g. the SDK's generic "Tool request failed"), which
         // is useless for diagnosis. The stack reveals which call failed
@@ -229,6 +235,14 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
         } catch {
           // already closed (client disconnected) — ignore
         }
+        const flags: string[] = [];
+        if (body.dryRun) flags.push("dry-run");
+        if (fromQueue) flags.push("from-queue");
+        void reportServerExecution(`server.run.${playName}`, {
+          outcome: runOutcome,
+          durationMs: performance.now() - t0,
+          flags,
+        });
       }
     },
   });

--- a/apps/server/src/scheduler.ts
+++ b/apps/server/src/scheduler.ts
@@ -1,6 +1,7 @@
 import { logEvent } from "@oneshot-gtm/core";
 import { nextSleepMs, runDueTriggers, runPendingRetries } from "@oneshot-gtm/find";
 import { pollInboxReplies } from "@oneshot-gtm/plays";
+import { reportServerExecution } from "./telemetry.ts";
 
 /**
  * Background scheduler that polls registered triggers on their interval and
@@ -41,6 +42,17 @@ export function startScheduler(): SchedulerHandle {
     try {
       const outcomes = await runDueTriggers();
       const fired = outcomes.filter((o) => o.fired).length;
+      // One anonymous telemetry event per trigger that actually ran this tick.
+      // Best-effort and detached — must not delay the next tick or the reply
+      // poll below.
+      for (const o of outcomes) {
+        if (!o.fired) continue;
+        void reportServerExecution(`server.trigger.${o.name}`, {
+          outcome: o.error ? "error" : "ok",
+          durationMs: o.duration_ms ?? 0,
+          flags: ["scheduled"],
+        });
+      }
       // Reply detection is isolated: an inbox outage must not skip trigger
       // scheduling (or vice-versa), and it never sends, so it can't double-spend.
       let repliesDetected = 0;

--- a/apps/server/src/telemetry.ts
+++ b/apps/server/src/telemetry.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { reportTelemetryEvent, type TelemetryOutcome } from "@oneshot-gtm/core";
+
+/**
+ * Server-side telemetry — the dashboard analogue of the CLI's per-command
+ * event (see apps/cli/src/index.ts `sendTelemetry`). The server executes the
+ * same kinds of work (plays, cadence sends, queue drains, scheduled triggers)
+ * but never passes through the CLI's `runOrFail`, so it reports here instead.
+ *
+ * Delegates the gate + payload + send to `reportTelemetryEvent` in core (the
+ * shared path the CLI also uses); this wrapper only supplies the server's own
+ * `version` and an empty-flags default. Two deliberate differences from the
+ * CLI path:
+ *
+ *  1. `outcome` is passed in explicitly rather than read from the
+ *     `markTelemetryOutcome` global — that singleton is unsafe in a concurrent
+ *     server where many executions overlap.
+ *  2. `command` is prefixed `server.` so the BigQuery table can separate CLI
+ *     and server channels (`WHERE command LIKE 'server.%'`).
+ *
+ * Best-effort and non-blocking: `reportTelemetryEvent` never throws and has its
+ * own timeout, so a telemetry failure can't affect a request or the scheduler.
+ */
+
+const SERVER_VERSION: string = (() => {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url)); // apps/server/src
+    const pkg = JSON.parse(readFileSync(join(here, "..", "package.json"), "utf8")) as {
+      version?: string;
+    };
+    return typeof pkg.version === "string" ? pkg.version : "0.0.0";
+  } catch {
+    return "0.0.0";
+  }
+})();
+
+export interface ServerExecutionOpts {
+  outcome: TelemetryOutcome;
+  durationMs: number;
+  /** Flag-style labels only (e.g. "scheduled", "dry-run") — never values. */
+  flags?: string[];
+}
+
+/**
+ * Emit one anonymous telemetry event for a server-initiated execution.
+ * `command` should already carry the `server.` prefix (e.g. `server.run.show-hn`).
+ */
+export async function reportServerExecution(
+  command: string,
+  opts: ServerExecutionOpts,
+): Promise<void> {
+  // Defensive: every call site `void`s this, so it must never reject —
+  // `reportTelemetryEvent` is already best-effort, but this guards the
+  // delegation itself (e.g. a partially-mocked core in tests).
+  try {
+    await reportTelemetryEvent({
+      command,
+      flags: opts.flags ?? [],
+      outcome: opts.outcome,
+      durationMs: opts.durationMs,
+      version: SERVER_VERSION,
+    });
+  } catch {
+    // never surface to a request or the scheduler loop
+  }
+}

--- a/apps/telemetry-ingest/README.md
+++ b/apps/telemetry-ingest/README.md
@@ -64,10 +64,10 @@ bq query --use_legacy_sql=false \
 
 ## Environment
 
-| Var              | Default      | Purpose                                  |
-| ---------------- | ------------ | ---------------------------------------- |
-| `PORT`           | `8080`       | Cloud Run injects this.                  |
-| `TELEMETRY_SINK` | `bigquery`   | Set `local` for the in-memory dev sink.  |
-| `GCP_PROJECT`    | (ADC)        | BigQuery project override.               |
-| `BQ_DATASET`     | `telemetry`  | Dataset name.                            |
-| `BQ_TABLE`       | `cli_events` | Table name.                              |
+| Var              | Default      | Purpose                                 |
+| ---------------- | ------------ | --------------------------------------- |
+| `PORT`           | `8080`       | Cloud Run injects this.                 |
+| `TELEMETRY_SINK` | `bigquery`   | Set `local` for the in-memory dev sink. |
+| `GCP_PROJECT`    | (ADC)        | BigQuery project override.              |
+| `BQ_DATASET`     | `telemetry`  | Dataset name.                           |
+| `BQ_TABLE`       | `cli_events` | Table name.                             |

--- a/apps/telemetry-ingest/__tests__/handler.test.ts
+++ b/apps/telemetry-ingest/__tests__/handler.test.ts
@@ -150,7 +150,6 @@ describe("validateEvent — caps + coercion", () => {
     expect(r.ok && r.row.llm_provider).toBe("");
   });
 
-
   it("caps flags count and element length", () => {
     const flags = Array.from({ length: 50 }, (_, i) => "f".repeat(100) + i);
     const r = validateEvent({ command: "x", outcome: "ok", flags }, NOW);

--- a/apps/telemetry-ingest/src/handler.ts
+++ b/apps/telemetry-ingest/src/handler.ts
@@ -21,7 +21,11 @@ function json(status: number, body: unknown): Response {
  * transient BigQuery hiccup doesn't turn into client-visible 5xx retries
  * (the client is fire-and-forget anyway).
  */
-export async function handleTelemetry(req: Request, sink: Sink, now: () => string): Promise<Response> {
+export async function handleTelemetry(
+  req: Request,
+  sink: Sink,
+  now: () => string,
+): Promise<Response> {
   const url = new URL(req.url);
 
   if (req.method === "GET" && url.pathname === "/") {

--- a/apps/telemetry-ingest/src/index.ts
+++ b/apps/telemetry-ingest/src/index.ts
@@ -11,4 +11,6 @@ Bun.serve({
   fetch: (req) => handleTelemetry(req, sink, now),
 });
 
-console.log(`oneshot-gtm telemetry ingest listening on :${port} (sink=${process.env["TELEMETRY_SINK"] ?? "bigquery"})`);
+console.log(
+  `oneshot-gtm telemetry ingest listening on :${port} (sink=${process.env["TELEMETRY_SINK"] ?? "bigquery"})`,
+);

--- a/packages/core/__tests__/telemetry.test.ts
+++ b/packages/core/__tests__/telemetry.test.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_TELEMETRY_URL,
   markTelemetryOutcome,
   reportCommand,
+  reportTelemetryEvent,
   shouldSendTelemetry,
   takeMarkedOutcome,
   telemetryUrl,
@@ -135,6 +136,44 @@ describe("reportCommand — transport", () => {
   it("never throws when fetch rejects (endpoint down)", async () => {
     vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
     await expect(reportCommand(payload, "http://ingest.local/v1/cli")).resolves.toBeUndefined();
+  });
+});
+
+describe("reportTelemetryEvent — shared send path (gate + payload)", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  const event = {
+    command: "motion show-hn",
+    flags: ["dry-run"],
+    outcome: "ok" as const,
+    durationMs: 12,
+    version: "9.9.9",
+  };
+
+  it("is a no-op when the env kill-switch disables telemetry", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    await reportTelemetryEvent(event, { ONESHOT_GTM_TELEMETRY: "0" });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("builds and POSTs a payload (caller's version, host-stamped os) when enabled", async () => {
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(null, { status: 204 }));
+    await reportTelemetryEvent(event, {}); // empty env → not disabled, default URL
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const payload = JSON.parse(fetchSpy.mock.calls[0]![1]?.body as string) as Record<
+      string,
+      unknown
+    >;
+    expect(payload["command"]).toBe("motion show-hn");
+    expect(payload["version"]).toBe("9.9.9");
+    expect(payload["os"]).toBe(process.platform);
+  });
+
+  it("never throws when fetch rejects", async () => {
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("ECONNREFUSED"));
+    await expect(reportTelemetryEvent(event, {})).resolves.toBeUndefined();
   });
 });
 

--- a/packages/core/src/telemetry.ts
+++ b/packages/core/src/telemetry.ts
@@ -1,3 +1,4 @@
+import { loadConfig } from "./config.ts";
 import type { OneShotConfig } from "./types.ts";
 
 /**
@@ -141,6 +142,50 @@ export async function reportCommand(
     // swallowed — telemetry must never surface to the user (see header)
   } finally {
     clearTimeout(timer);
+  }
+}
+
+/** One telemetry event, minus the host-resolved fields the helper fills in. */
+export interface TelemetryEventInput {
+  command: string;
+  flags: string[];
+  outcome: TelemetryOutcome;
+  durationMs: number;
+  /** Caller-supplied so each emitter reports its own package version. */
+  version: string;
+}
+
+/**
+ * The single send path shared by every emitter (CLI dispatch, server
+ * executions). Resolves the endpoint + opt-out gate, reads the anonymous
+ * install id / provider from config, stamps host fields (os, bun), and fires.
+ * Best-effort: never throws, never blocks the caller. Centralizing this keeps
+ * the CLI and server channels from drifting as the payload evolves.
+ */
+export async function reportTelemetryEvent(
+  input: TelemetryEventInput,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  try {
+    const url = telemetryUrl(env);
+    // No endpoint configured ⇒ skip everything, including the config read.
+    if (!url) return;
+    const cfg = loadConfig();
+    if (!shouldSendTelemetry(cfg, env)) return;
+    const payload = buildTelemetryPayload({
+      command: input.command,
+      flags: input.flags,
+      outcome: input.outcome,
+      durationMs: input.durationMs,
+      version: input.version,
+      clientId: cfg.clientId,
+      llmProvider: cfg.llmProvider,
+      platform: process.platform,
+      bunVersion: typeof Bun !== "undefined" ? Bun.version : "",
+    });
+    await reportCommand(payload, url);
+  } catch {
+    // never surface telemetry failures to the caller
   }
 }
 

--- a/packages/find/src/registry.ts
+++ b/packages/find/src/registry.ts
@@ -523,6 +523,10 @@ export interface TriggerRunOutcome {
   fired: boolean;
   result?: FinderResult;
   error?: string;
+  /** Wall-clock of the run, present only when `fired`. Surfaced so callers
+   * (e.g. the dashboard scheduler's telemetry) can attribute duration without
+   * re-deriving it. */
+  duration_ms?: number;
   /** ms until this trigger is next due */
   nextDueInMs: number;
 }
@@ -821,10 +825,11 @@ export async function runDueTriggers(): Promise<TriggerRunOutcome[]> {
     logEvent("trigger.run.start", { name: spec.name, source: "watch" });
     try {
       const result = await spec.run(config);
+      const durationMs = Date.now() - startedAt;
       ledger.updateTriggerLastPoll({ name: spec.name, summary: result });
       logEvent("trigger.run.done", {
         name: spec.name,
-        duration_ms: Date.now() - startedAt,
+        duration_ms: durationMs,
         candidates: result.candidates,
         enqueued: result.enqueued,
         dropped_icp: result.droppedIcp,
@@ -833,8 +838,15 @@ export async function runDueTriggers(): Promise<TriggerRunOutcome[]> {
         cost_usd: result.costUsd,
         halted: result.halted ?? null,
       });
-      outcomes.push({ name: spec.name, fired: true, result, nextDueInMs: intervalMs });
+      outcomes.push({
+        name: spec.name,
+        fired: true,
+        result,
+        duration_ms: durationMs,
+        nextDueInMs: intervalMs,
+      });
     } catch (err) {
+      const durationMs = Date.now() - startedAt;
       const message = (err as Error).message ?? "unknown error";
       ledger.updateTriggerLastPoll({
         name: spec.name,
@@ -844,7 +856,7 @@ export async function runDueTriggers(): Promise<TriggerRunOutcome[]> {
         "trigger.run.error",
         {
           name: spec.name,
-          duration_ms: Date.now() - startedAt,
+          duration_ms: durationMs,
           message_120: message.slice(0, 120),
         },
         "error",
@@ -853,6 +865,7 @@ export async function runDueTriggers(): Promise<TriggerRunOutcome[]> {
         name: spec.name,
         fired: true,
         error: message,
+        duration_ms: durationMs,
         nextDueInMs: intervalMs,
       });
     }


### PR DESCRIPTION
Follow-up to #2 (CLI telemetry). The dashboard server runs the same work — plays, cadence sends, queue drains, scheduled triggers — through a separate `Bun.serve` entrypoint that never hits the CLI's `runOrFail`, so none of it was reported. This instruments it.

## core
- Extract **`reportTelemetryEvent`** — the single gate + payload + send path now shared by the CLI and the server, so the two channels can't drift as the payload evolves. `sendTelemetry` (CLI) delegates to it.

## server (`apps/server`)
- New `src/telemetry.ts` `reportServerExecution(command, {flags, outcome, durationMs})`:
  - **outcome passed explicitly** — the `markTelemetryOutcome` global is unsafe under server concurrency.
  - **`command` prefixed `server.`** so BigQuery separates CLI vs server channels (`WHERE command LIKE 'server.%'`).
  - defensive `try/catch` — every call site `void`s it; a fire-and-forget wrapper must never reject.
- Emit at **server-only chokepoints** (CLI-unreachable → no double-count with `runOrFail`):
  - scheduler, per fired trigger → `server.trigger.<name>`
  - `runPlay` → `server.run.<play>`
  - cadence send + batch → `server.cadence.send` / `server.cadence.batch`
  - queue drain + send → `server.queue.drain` / `server.queue.send`
- `packages/find/src/registry.ts`: surface `duration_ms` on `TriggerRunOutcome` (data only, no emit) so scheduled triggers report accurate durations.

**Out of scope:** manual trigger fire (`/api/triggers/:name/run`) — fire-and-forget with its outcome resolving in shared code; scheduled runs cover the recurring bulk.

## chore
- oxfmt the `apps/telemetry-ingest/*` files that landed unformatted in #2.

## Verification
- +7 tests (core shared `reportTelemetryEvent`; server `reportServerExecution`: gate / payload / never-throws). Full suite **1236/1236**; typecheck + lint + fmt clean.
- E2E: server `drain` (dry-run) emits `server.queue.drain` and a CLI command emits `config telemetry` — one event each, separate channels, no double-count.