### PR TITLE
ci: lint/typecheck/test gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,44 @@
+name: ci
+
+# Lint / typecheck / test gate. Runs on every PR into main and on pushes to
+# main. Mirrors the local dev commands (Bun + the root package.json scripts) so
+# a green CI means the same thing as a green local run.
+#
+# Note: `fmt:check` is intentionally NOT gated yet — the repo carries
+# pre-existing oxfmt debt in unrelated files. Add it here once that's cleaned.
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+
+# A newer push to the same branch/PR cancels an in-flight run.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13" # match `packageManager` in root package.json
+
+      - name: Install workspace deps
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Test
+        run: bun run test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,5 +40,8 @@ jobs:
       - name: Lint
         run: bun run lint
 
+      # `--bun` forces the Bun runtime for vitest + its worker pool. Without it,
+      # CI runs vitest under Node, where `bun:sqlite` (imported by ledger.ts)
+      # doesn't exist and the suite errors with ERR_MODULE_NOT_FOUND.
       - name: Test
-        run: bun run test
+        run: bun --bun run test


### PR DESCRIPTION
Adds `.github/workflows/ci.yml` — runs `bun install --frozen-lockfile` then `typecheck` + `lint` + `test` on every PR into `main` and on pushes to `main`. Mirrors local dev; matches the Bun 1.3.13 setup from `release.yml`.

`fmt:check` is intentionally **not** gated yet — the repo carries pre-existing oxfmt debt in ~51 unrelated files that would make it red on day one. Add it here once that debt is cleaned.

This workflow runs on its own PR, so a green check here is the gate validating itself.

Note: making these checks **required** (block merge until green) + requiring a review are branch-protection settings, separate from this file.