### PR TITLE
fix(telemetry): code-review findings #1-#5

### DIFF
--- a/apps/server/__tests__/scheduler-outcome.test.ts
+++ b/apps/server/__tests__/scheduler-outcome.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import type { TriggerRunOutcome } from "@oneshot-gtm/find";
+import { triggerOutcome } from "../src/scheduler.ts";
+
+// triggerOutcome only reads `.error` and `.result?.halted`, so partial casts
+// are enough — no need to build a full FinderResult.
+function outcome(partial: Partial<TriggerRunOutcome>): TriggerRunOutcome {
+  return { name: "show-hn", fired: true, nextDueInMs: 0, ...partial } as TriggerRunOutcome;
+}
+
+describe("triggerOutcome", () => {
+  it("maps a clean run to ok", () => {
+    expect(triggerOutcome(outcome({ result: { candidates: 3, enqueued: 1 } as never }))).toBe("ok");
+  });
+
+  it("maps a thrown error to error", () => {
+    expect(triggerOutcome(outcome({ error: "boom" }))).toBe("error");
+  });
+
+  it("maps a halted finder (returned, but stopped early) to error", () => {
+    expect(triggerOutcome(outcome({ result: { halted: "max-cost cap" } as never }))).toBe("error");
+  });
+
+  it("maps a fired run with neither error nor result to ok", () => {
+    expect(triggerOutcome(outcome({}))).toBe("ok");
+  });
+});

--- a/apps/server/src/scheduler.ts
+++ b/apps/server/src/scheduler.ts
@@ -1,7 +1,22 @@
-import { logEvent } from "@oneshot-gtm/core";
-import { nextSleepMs, runDueTriggers, runPendingRetries } from "@oneshot-gtm/find";
+import { logEvent, type TelemetryOutcome } from "@oneshot-gtm/core";
+import {
+  nextSleepMs,
+  runDueTriggers,
+  runPendingRetries,
+  type TriggerRunOutcome,
+} from "@oneshot-gtm/find";
 import { pollInboxReplies } from "@oneshot-gtm/plays";
 import { reportServerExecution } from "./telemetry.ts";
+
+/**
+ * Map a fired trigger's outcome to a telemetry outcome. A thrown error is an
+ * error; so is a finder that returned but `halted` early (e.g. cost cap, all
+ * cohorts empty) — that's a degraded run, not a clean success, and lumping it
+ * into "ok" would understate the real failure rate. Exported for unit tests.
+ */
+export function triggerOutcome(o: TriggerRunOutcome): TelemetryOutcome {
+  return o.error || o.result?.halted ? "error" : "ok";
+}
 
 /**
  * Background scheduler that polls registered triggers on their interval and
@@ -48,7 +63,7 @@ export function startScheduler(): SchedulerHandle {
       for (const o of outcomes) {
         if (!o.fired) continue;
         void reportServerExecution(`server.trigger.${o.name}`, {
-          outcome: o.error ? "error" : "ok",
+          outcome: triggerOutcome(o),
           durationMs: o.duration_ms ?? 0,
           flags: ["scheduled"],
         });

--- a/apps/telemetry-ingest/src/sink.ts
+++ b/apps/telemetry-ingest/src/sink.ts
@@ -19,25 +19,31 @@ export class MemorySink implements Sink {
 
 /**
  * Streams one row per event into BigQuery via tabledata.insertAll. The
- * `@google-cloud/bigquery` client is imported lazily so the service (and the
- * local sink) boot even when the dep or GCP credentials are absent — the
- * import only fires when this sink is actually selected.
+ * `@google-cloud/bigquery` client is imported lazily ON FIRST INSERT — not in
+ * the constructor. An eager async IIFE in the constructor would be a floating
+ * promise: if the dynamic import or `new BigQuery()` rejected (missing dep, bad
+ * ADC) it would surface as an unhandledRejection and could crash the container
+ * at boot, before any request. Initializing inside `insert` means the init
+ * promise is always awaited where its rejection is handled (by the handler's
+ * catch → 204).
  */
 export class BigQuerySink implements Sink {
-  private table: Promise<{ insert(rows: unknown[]): Promise<unknown> }>;
+  private table?: Promise<{ insert(rows: unknown[]): Promise<unknown> }>;
 
-  constructor(opts: { projectId?: string; dataset: string; table: string }) {
-    this.table = (async () => {
+  constructor(private readonly opts: { projectId?: string; dataset: string; table: string }) {}
+
+  private getTable(): Promise<{ insert(rows: unknown[]): Promise<unknown> }> {
+    return (this.table ??= (async () => {
       const { BigQuery } = await import("@google-cloud/bigquery");
       // On Cloud Run, credentials + projectId come from the runtime service
       // account via ADC — no key file. projectId is optional override.
-      const bq = new BigQuery(opts.projectId ? { projectId: opts.projectId } : {});
-      return bq.dataset(opts.dataset).table(opts.table);
-    })();
+      const bq = new BigQuery(this.opts.projectId ? { projectId: this.opts.projectId } : {});
+      return bq.dataset(this.opts.dataset).table(this.opts.table);
+    })());
   }
 
   async insert(row: TelemetryRow): Promise<void> {
-    const table = await this.table;
+    const table = await this.getTable();
     await table.insert([row]);
   }
 }

--- a/packages/core/__tests__/telemetry.test.ts
+++ b/packages/core/__tests__/telemetry.test.ts
@@ -105,8 +105,10 @@ describe("telemetryUrl", () => {
     );
   });
 
-  it("ignores a blank override", () => {
-    expect(telemetryUrl({ ONESHOT_GTM_TELEMETRY_URL: "   " })).toBe(DEFAULT_TELEMETRY_URL);
+  it("treats an explicitly-empty override as a no-op (empty string), not the default", () => {
+    // honors the documented `ONESHOT_GTM_TELEMETRY_URL=""` kill path
+    expect(telemetryUrl({ ONESHOT_GTM_TELEMETRY_URL: "" })).toBe("");
+    expect(telemetryUrl({ ONESHOT_GTM_TELEMETRY_URL: "   " })).toBe("");
   });
 });
 

--- a/packages/core/src/telemetry.ts
+++ b/packages/core/src/telemetry.ts
@@ -59,15 +59,24 @@ export interface TelemetryPayload {
  */
 export const DEFAULT_TELEMETRY_URL = "https://telemetry.oneshotagent.com/v1/cli";
 
-const TELEMETRY_TIMEOUT_MS = 1500;
+// Bounds the worst-case hang on a dead/captive network. The in-flight fetch
+// keeps the event loop alive until it settles, so on the CLI this is also the
+// ceiling on how long a command's exit can be delayed by telemetry. Kept tight:
+// a healthy send is ~100-300ms; past 1s we'd rather drop the event than make
+// the user wait.
+const TELEMETRY_TIMEOUT_MS = 1000;
 
 /**
- * Resolve the ingest URL. `ONESHOT_GTM_TELEMETRY_URL` overrides the default
- * so the receiver can be exercised locally / against staging.
+ * Resolve the ingest URL. `ONESHOT_GTM_TELEMETRY_URL` overrides the default so
+ * the receiver can be exercised locally / against staging. An *explicitly
+ * empty* override (`ONESHOT_GTM_TELEMETRY_URL=""`) resolves to `""` — a hard
+ * no-op (see reportCommand's `if (!url) return`) — honoring the documented kill
+ * path. Only an absent var falls back to the default endpoint.
  */
 export function telemetryUrl(env: NodeJS.ProcessEnv = process.env): string {
-  const override = env["ONESHOT_GTM_TELEMETRY_URL"]?.trim();
-  return override && override.length > 0 ? override : DEFAULT_TELEMETRY_URL;
+  const raw = env["ONESHOT_GTM_TELEMETRY_URL"];
+  if (raw === undefined) return DEFAULT_TELEMETRY_URL;
+  return raw.trim();
 }
 
 /**

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -18,6 +18,15 @@ import { join } from "node:path";
 const dir = mkdtempSync(join(tmpdir(), "oneshot-gtm-test-"));
 process.env["ONESHOT_GTM_HOME"] = dir;
 
+// Hard-disable distribution telemetry for the whole suite. Otherwise any test
+// that drives a server route / scheduler tick / CLI dispatch reaches
+// reportTelemetryEvent, which (telemetry defaults on) fires a real POST to the
+// production endpoint — synthetic events leaking into prod BigQuery, plus per-
+// test latency. The dedicated telemetry tests manage this var themselves
+// (explicit env args, or delete/set process.env per case), so their "enabled"
+// assertions are unaffected.
+process.env["ONESHOT_GTM_TELEMETRY"] = "0";
+
 process.on("exit", () => {
   try {
     rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
Remediation from the high-effort review of the telemetry work (PRs #2–#5). Lower-priority findings filed as #6–#10.

### #1 🔴 Tests phoned home to production
Route/scheduler/cadence tests reach `reportTelemetryEvent` with telemetry on by default → live POSTs to `telemetry.oneshotagent.com` (confirmed: 9 synthetic `server.cadence.*` rows had appeared in prod BigQuery). `vitest.setup.ts` now sets `ONESHOT_GTM_TELEMETRY=0` for the whole suite. The dedicated telemetry tests manage the var themselves, so their "enabled" assertions still hold. Prod table reset separately. **Proof:** ran the full suite after the fix → `SELECT COUNT(*) FROM telemetry.cli_events` stays `0`.

### #2 🟠 `telemetryUrl` fail-open
An explicitly-empty `ONESHOT_GTM_TELEMETRY_URL=""` fell back to the prod default, contradicting the documented `=""` kill path. Now: **absent → default; present (incl. `""`) → use it** (so `""` is a real no-op). Test updated.

### #3 🟠 CLI exit delay
`TELEMETRY_TIMEOUT_MS` 1500 → 1000. The in-flight `fetch` keeps the loop alive, so this caps how long telemetry can delay CLI exit on a dead/captive network (~100–300 ms healthy sends still go through).

### #4 🟠 `BigQuerySink` boot crash
Init was a floating async IIFE in the constructor — an import/ADC failure was an unhandledRejection that could crash the container at boot. Now lazy on first `insert`, so the init promise is always awaited where its rejection is handled.

### #5 🟡 Scheduler outcome
A finder that returns `fired:true` with `result.halted` (cost cap, empty cohorts) was logged `ok`. New exported `triggerOutcome()` helper maps `halted` → `error`; unit-tested.

## Verification
- typecheck + lint + fmt clean; full suite **1240** (+4 `triggerOutcome`).
- Confirmed the suite no longer writes to prod BigQuery (count stays 0).