### PR TITLE
docs: 'built with' badge → oneshot-sdk

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ bun run cli -- init         # one-time setup
 bun run cli -- ui           # opens http://127.0.0.1:3030
 ```
 
-[![Built with oneshot-gtm](https://img.shields.io/badge/built%20with-oneshot--gtm-0a0a0a?style=flat&labelColor=18181b&color=22c55e)](https://github.com/oneshot-agent/oneshot-gtm) [![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE) [![Bun](https://img.shields.io/badge/runtime-Bun%201.3+-fbf0df?logo=bun&logoColor=black)](https://bun.sh) [![TypeScript](https://img.shields.io/badge/typed-TypeScript%206-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org)
+[![Built with oneshot-sdk](https://img.shields.io/badge/built%20with-oneshot--sdk-0a0a0a?style=flat&labelColor=18181b&color=22c55e)](https://www.npmjs.com/package/@oneshot-agent/sdk) [![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE) [![Bun](https://img.shields.io/badge/runtime-Bun%201.3+-fbf0df?logo=bun&logoColor=black)](https://bun.sh) [![TypeScript](https://img.shields.io/badge/typed-TypeScript%206-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org)
 
 ---
 


### PR DESCRIPTION
The README badge read **"built with oneshot-gtm"**, but `oneshot-gtm` *is* this tool — it's built on the **OneShot SDK** (`@oneshot-agent/sdk`). Relabels the badge to `oneshot-sdk` and points the link at the SDK package instead of this repo. Badge styling unchanged.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update 'Built with' badge in README to reference oneshot-sdk
> Replaces the 'Built with oneshot-gtm' badge in [README.md](https://github.com/oneshot-agent/oneshot-gtm/pull/13/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) with a 'Built with oneshot-sdk' badge, updating both the image slug and the link target to point to the `@oneshot-agent/sdk` NPM package.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 54a24e1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->