### PR TITLE
feat: resume/pause OneShot sending domains (CLI + /setup + API)

### DIFF
--- a/apps/cli/src/commands/identities.ts
+++ b/apps/cli/src/commands/identities.ts
@@ -4,9 +4,11 @@ import {
   identityCapacities,
   listSendingDomains,
   loadConfig,
+  pauseSendingDomain,
   registerOneShotIdentity,
   removeIdentity,
   resolveIdentities,
+  resumeSendingDomain,
   WARMUP_DEFAULTS,
   type DomainPoolEntry,
 } from "@oneshot-gtm/core";
@@ -140,6 +142,45 @@ export async function commandIdentitiesAdd(): Promise<void> {
     : `warm-up ${WARMUP_DEFAULTS.warmup!.startPerDay}/day +${WARMUP_DEFAULTS.warmup!.incrementPerWeek}/wk, max ${WARMUP_DEFAULTS.maxPerDay}`;
   ok(`Identity ${c.cyan(identityId)} added to the rotation pool (${capMsg}).`);
   note("New prospects rotate across the pool; existing threads keep their original sender.");
+}
+
+/** Show just the wallet's provisioned domain pool with status + warmth + usage. */
+export async function commandDomainsList(): Promise<void> {
+  header("Provisioned domains");
+  const domains = await safeListDomains();
+  if (domains.length === 0) {
+    note("None found (or the pool couldn't be reached).");
+    return;
+  }
+  for (const d of domains) {
+    const tone = d.pool_status === "active" ? c.green : d.pool_status === "warming" ? c.cyan : c.red;
+    note(
+      `${d.domain}  ${tone(d.pool_status)}` +
+        (d.warmup_score != null ? `  warmth ${d.warmup_score}` : "") +
+        `  sent ${d.daily_sent_count}/${d.daily_send_limit}/day`,
+    );
+  }
+  if (domains.some((d) => d.pool_status === "paused" || d.pool_status === "removed")) {
+    note("Resume a paused domain: oneshot-gtm domains resume <domain>");
+  }
+}
+
+/** Resume a paused sending domain in the wallet's pool. */
+export async function commandDomainsResume(domain: string): Promise<void> {
+  const result = await resumeSendingDomain(domain);
+  ok(`${c.cyan(result.domain)} → ${result.pool_status}`);
+  if (result.pool_status !== "active") {
+    warn(
+      "Still not active — the pause may be account- or platform-level (not per-domain). " +
+        "Check `oneshot-gtm doctor` and OneShot's status.",
+    );
+  }
+}
+
+/** Pause a sending domain in the wallet's pool (stop sending from it). */
+export async function commandDomainsPause(domain: string): Promise<void> {
+  const result = await pauseSendingDomain(domain);
+  ok(`${c.cyan(result.domain)} → ${result.pool_status}`);
 }
 
 /** Drop an identity from the pool by id. */

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -32,6 +32,9 @@ import {
 import { commandCadenceAdvance } from "./commands/cadence.ts";
 import { commandGmailAuth } from "./commands/gmail.ts";
 import {
+  commandDomainsList,
+  commandDomainsPause,
+  commandDomainsResume,
   commandIdentitiesAdd,
   commandIdentitiesList,
   commandIdentitiesRemove,
@@ -129,6 +132,25 @@ identities
   .command("remove <id>")
   .description("Remove an identity from the pool (e.g. oneshot:sales@acme.com)")
   .action(runOrFail(commandIdentitiesRemove));
+
+// Domains: manage the wallet's provisioned OneShot sending-domain pool. A domain
+// gets paused (by reputation, or account/platform-level) → no sends from it
+// until resumed. `doctor` flags a paused domain; these resume/pause it.
+const domains = program
+  .command("domains")
+  .description("Manage the wallet's provisioned OneShot sending-domain pool");
+domains
+  .command("list")
+  .description("Show provisioned domains with pool status, warmth, and daily usage")
+  .action(runOrFail(commandDomainsList));
+domains
+  .command("resume <domain>")
+  .description("Resume a paused sending domain (e.g. oneshotagents.com)")
+  .action(runOrFail(commandDomainsResume));
+domains
+  .command("pause <domain>")
+  .description("Pause a sending domain (stop sending from it)")
+  .action(runOrFail(commandDomainsPause));
 
 // Find: scheduled / cron-able only. Ad-hoc finder runs are in the dashboard.
 const find = program

--- a/apps/server/__tests__/domains-route.test.ts
+++ b/apps/server/__tests__/domains-route.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const resumeMock = vi.fn();
+const pauseMock = vi.fn();
+
+// Mock the core wrappers — the route's job is request validation + status
+// mapping, not the live SDK call (covered by the wrappers themselves).
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    resumeSendingDomain: (domain: string) => resumeMock(domain),
+    pauseSendingDomain: (domain: string) => pauseMock(domain),
+  };
+});
+
+const { resumeDomainRoute, pauseDomainRoute } = await import("../src/api/domains.ts");
+
+function jsonReq(body: unknown): Request {
+  return new Request("http://localhost/api/domains/resume", {
+    method: "POST",
+    headers: { "content-type": "application/json", host: "127.0.0.1:3030" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  resumeMock.mockReset();
+  pauseMock.mockReset();
+});
+afterEach(() => vi.clearAllMocks());
+
+describe("resumeDomainRoute", () => {
+  it("400s on invalid JSON", async () => {
+    const res = await resumeDomainRoute(jsonReq("{not-json"));
+    expect(res.status).toBe(400);
+    expect(resumeMock).not.toHaveBeenCalled();
+  });
+
+  it("400s when domain is missing / blank", async () => {
+    expect((await resumeDomainRoute(jsonReq({}))).status).toBe(400);
+    expect((await resumeDomainRoute(jsonReq({ domain: "   " }))).status).toBe(400);
+    expect(resumeMock).not.toHaveBeenCalled();
+  });
+
+  it("normalizes (trim+lowercase) and returns the new pool status on success", async () => {
+    resumeMock.mockResolvedValue({ domain: "acme.com", pool_status: "active" });
+    const res = await resumeDomainRoute(jsonReq({ domain: "  ACME.com " }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ domain: "acme.com", poolStatus: "active" });
+    expect(resumeMock).toHaveBeenCalledWith("acme.com");
+  });
+
+  it("maps a platform 5xx to 502 with the OneShot status folded into the message", async () => {
+    resumeMock.mockRejectedValue(
+      Object.assign(new Error("Failed to resume domain"), { statusCode: 500 }),
+    );
+    const res = await resumeDomainRoute(jsonReq({ domain: "acme.com" }));
+    expect(res.status).toBe(502);
+    expect(await res.json()).toMatchObject({ error: /Failed to resume domain \(OneShot HTTP 500\)/ });
+  });
+
+  it("passes a client 4xx (bad/unowned domain) through as 4xx, not 502", async () => {
+    resumeMock.mockRejectedValue(
+      Object.assign(new Error("domain not owned"), { statusCode: 404 }),
+    );
+    const res = await resumeDomainRoute(jsonReq({ domain: "notmine.com" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("defaults to 502 when the error carries no statusCode (e.g. network)", async () => {
+    resumeMock.mockRejectedValue(new Error("fetch failed"));
+    const res = await resumeDomainRoute(jsonReq({ domain: "acme.com" }));
+    expect(res.status).toBe(502);
+  });
+});
+
+describe("pauseDomainRoute", () => {
+  it("returns the paused status on success", async () => {
+    pauseMock.mockResolvedValue({ domain: "acme.com", pool_status: "paused" });
+    const res = await pauseDomainRoute(jsonReq({ domain: "acme.com" }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ domain: "acme.com", poolStatus: "paused" });
+    expect(pauseMock).toHaveBeenCalledWith("acme.com");
+  });
+});

--- a/apps/server/src/api/domains.ts
+++ b/apps/server/src/api/domains.ts
@@ -1,0 +1,59 @@
+import { logEvent, pauseSendingDomain, resumeSendingDomain } from "@oneshot-gtm/core";
+import type { DomainActionResult } from "@oneshot-gtm/shared-types";
+import { jsonResponse } from "../server.ts";
+
+/**
+ * Resume / pause a wallet-owned sending domain in the OneShot pool. The /setup
+ * UI calls these to act on a paused domain (the doctor flags one); the CLI
+ * (`oneshot-gtm domains resume/pause`) hits the same core wrappers.
+ *
+ * Errors are surfaced verbatim (incl. the platform HTTP status) rather than
+ * swallowed — a paused domain that won't resume because OneShot is returning
+ * 500s is exactly what the founder needs to see, not a silent no-op.
+ */
+async function domainActionRoute(
+  req: Request,
+  action: "resume" | "pause",
+): Promise<Response> {
+  let body: { domain?: unknown };
+  try {
+    body = (await req.json()) as { domain?: unknown };
+  } catch {
+    return jsonResponse({ error: "invalid JSON body" }, 400, req);
+  }
+  if (typeof body.domain !== "string" || body.domain.trim().length === 0) {
+    return jsonResponse({ error: "domain (string) required" }, 400, req);
+  }
+  const domain = body.domain.trim().toLowerCase();
+
+  try {
+    const result =
+      action === "resume" ? await resumeSendingDomain(domain) : await pauseSendingDomain(domain);
+    const out: DomainActionResult = { domain: result.domain, poolStatus: result.pool_status };
+    return jsonResponse(out, 200, req);
+  } catch (err) {
+    const e = err as Error & { statusCode?: number };
+    logEvent(
+      `domains.${action}_failed`,
+      { domain, status_code: typeof e?.statusCode === "number" ? e.statusCode : null },
+      "warn",
+    );
+    // Mirror the run-route style: include the platform HTTP status so a 500
+    // (OneShot outage) reads differently from a 4xx (bad domain / not owned).
+    const sc = typeof e?.statusCode === "number" ? e.statusCode : null;
+    const msg = e?.message ?? `${action} failed`;
+    const detail = sc != null ? ` (OneShot HTTP ${sc})` : "";
+    // Pass a client error (bad/unowned domain) through as 4xx; treat a platform
+    // 5xx / unknown failure as 502 (we're the gateway to OneShot here).
+    const httpStatus = sc != null && sc >= 400 && sc < 500 ? sc : 502;
+    return jsonResponse({ error: `${msg}${detail}` }, httpStatus, req);
+  }
+}
+
+export function resumeDomainRoute(req: Request): Promise<Response> {
+  return domainActionRoute(req, "resume");
+}
+
+export function pauseDomainRoute(req: Request): Promise<Response> {
+  return domainActionRoute(req, "pause");
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -21,6 +21,7 @@ import { gmailAuthCallbackRoute, startGmailAuthRoute } from "./api/gmail-auth.ts
 import { deriveIcpRoute } from "./api/derive-icp.ts";
 import { strategistRoute } from "./api/strategist.ts";
 import { doctor } from "./api/doctor.ts";
+import { pauseDomainRoute, resumeDomainRoute } from "./api/domains.ts";
 import { runPlay } from "./api/run.ts";
 import { getRunRoute } from "./api/runs.ts";
 import {
@@ -87,6 +88,8 @@ const routes: RouteEntry[] = [
   route("POST", "/api/measure/outcome", recordOutcome),
   route("GET", "/api/setup", getSetupStatus),
   route("POST", "/api/setup", setup),
+  route("POST", "/api/domains/resume", resumeDomainRoute),
+  route("POST", "/api/domains/pause", pauseDomainRoute),
   route("GET", "/api/gmail/auth/start", startGmailAuthRoute),
   route("GET", "/api/gmail/auth/callback", gmailAuthCallbackRoute),
   route("POST", "/api/setup/derive-icp", deriveIcpRoute),

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -17,6 +17,7 @@ import type {
   OutcomeByPlay,
   OutcomeRequest,
   PlayDescriptor,
+  DomainActionResult,
   DomainPoolView,
   QueueCounts,
   QueueRowView,
@@ -129,6 +130,8 @@ export const api = {
     ),
   recordOutcome: (req: OutcomeRequest) => postJson<{ id: number }>("/measure/outcome", req),
   doctor: () => getJson<{ checks: DoctorCheck[] }>("/doctor"),
+  resumeDomain: (domain: string) => postJson<DomainActionResult>("/domains/resume", { domain }),
+  pauseDomain: (domain: string) => postJson<DomainActionResult>("/domains/pause", { domain }),
   setupStatus: () =>
     getJson<{
       identities: SenderIdentityView[];

--- a/apps/web/src/routes/setup.tsx
+++ b/apps/web/src/routes/setup.tsx
@@ -106,6 +106,20 @@ function SetupPage() {
     },
   });
 
+  // Resume / pause a provisioned sending domain in the OneShot pool. Refetches
+  // the setup status (and doctor) so the status badge + warning update. Errors
+  // surface verbatim — incl. the OneShot HTTP status during a platform outage.
+  const domainAction = useMutation({
+    mutationFn: (vars: { domain: string; action: "resume" | "pause" }) =>
+      vars.action === "resume" ? api.resumeDomain(vars.domain) : api.pauseDomain(vars.domain),
+    onSuccess: (res) => {
+      void qc.invalidateQueries({ queryKey: ["setup"] });
+      void qc.invalidateQueries({ queryKey: ["doctor"] });
+      toast.success(`${res.domain} → ${res.poolStatus}`);
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
   // Elapsed counter so the ~30–60s derive feels alive instead of frozen.
   // Server doesn't stream progress; we cycle a phase label by elapsed time.
   const [deriveElapsed, setDeriveElapsed] = useState(0);
@@ -638,6 +652,53 @@ function SetupPage() {
                   . Cap and removal changes apply on Save. Removing an identity blocks sends to
                   prospects pinned to it until it's restored.
                 </span>
+
+                {/* Provisioned domains: the wallet's OneShot sending-domain pool
+                    with live status. A paused domain sends nothing until resumed
+                    (doctor flags it); resume/pause act on it in place. */}
+                {provisionedDomains.length > 0 && (
+                  <div className="mt-3 flex flex-col gap-2 border-t border-ink-rule pt-3">
+                    <span className="ln-eyebrow">Provisioned domains</span>
+                    {provisionedDomains.map((d) => {
+                      const paused = d.poolStatus === "paused" || d.poolStatus === "removed";
+                      const tone =
+                        d.poolStatus === "active"
+                          ? "receipt"
+                          : d.poolStatus === "warming"
+                            ? "spend"
+                            : "blocked";
+                      const busy =
+                        domainAction.isPending && domainAction.variables?.domain === d.domain;
+                      return (
+                        <div
+                          key={d.domain}
+                          className="flex items-center gap-3 border border-ink-rule rounded-[var(--radius-sm)] px-3 py-2"
+                        >
+                          <Badge tone={tone}>{d.poolStatus}</Badge>
+                          <span className="truncate text-[13px] text-ink-cream">{d.domain}</span>
+                          <span className="ln-mono text-[11px] text-ink-muted">
+                            sent {d.dailySentCount}/{d.dailySendLimit}/day
+                            {d.warmupScore != null ? ` · warmth ${d.warmupScore}` : ""}
+                          </span>
+                          <Button
+                            type="button"
+                            variant="secondary"
+                            disabled={busy}
+                            className="ml-auto h-7 px-2 text-[11px]"
+                            onClick={() =>
+                              domainAction.mutate({
+                                domain: d.domain,
+                                action: paused ? "resume" : "pause",
+                              })
+                            }
+                          >
+                            {busy ? "…" : paused ? "Resume" : "Pause"}
+                          </Button>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
 
                 {/* Add OneShot sender: a wallet-owned domain + a mailbox local-part.
                     Multiple domains, and multiple mailboxes within one domain, all

--- a/packages/core/src/oneshot.ts
+++ b/packages/core/src/oneshot.ts
@@ -3,6 +3,7 @@ import {
   type BrowserResult,
   type DeepResearchPersonResult,
   type DomainPoolEntry,
+  type DomainPoolStatusResult,
   type EmailResult,
   type EnrichProfileResult,
   type FindEmailResult,
@@ -26,7 +27,7 @@ import { isTransientToolError, resolveSenderIdentity } from "./send-routing.ts";
 import type { EmailIdentity } from "./types.ts";
 
 /** Re-exported so callers don't reach into the SDK for the domain-pool shape. */
-export type { DomainPoolEntry } from "@oneshot-agent/sdk";
+export type { DomainPoolEntry, DomainPoolStatusResult } from "@oneshot-agent/sdk";
 
 export interface SendEmailInput {
   to: string;
@@ -166,6 +167,27 @@ export async function listSendingDomains(): Promise<DomainPoolEntry[]> {
     }
     throw err;
   }
+}
+
+/**
+ * Resume a paused sending domain in the wallet's pool (SDK `resumeDomain`).
+ * Unlike `listSendingDomains`, errors PROPAGATE — this is an explicit operator
+ * action, so a transient/auth failure must be surfaced (and retried), never
+ * swallowed into a false "done". Returns the domain's new pool status.
+ */
+export async function resumeSendingDomain(domain: string): Promise<DomainPoolStatusResult> {
+  const agent = await getAgent();
+  const result = await agent.resumeDomain(domain.trim().toLowerCase());
+  logEvent("domains.resume", { domain: domain.trim().toLowerCase(), status: result.pool_status });
+  return result;
+}
+
+/** Pause a sending domain in the wallet's pool (SDK `pauseDomain`). Errors propagate (see resumeSendingDomain). */
+export async function pauseSendingDomain(domain: string): Promise<DomainPoolStatusResult> {
+  const agent = await getAgent();
+  const result = await agent.pauseDomain(domain.trim().toLowerCase());
+  logEvent("domains.pause", { domain: domain.trim().toLowerCase(), status: result.pool_status });
+  return result;
 }
 
 /**

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -277,6 +277,12 @@ export interface DomainPoolView {
   dailySentCount: number;
 }
 
+/** Result of POST /api/domains/{resume,pause} — the domain's new pool status. */
+export interface DomainActionResult {
+  domain: string;
+  poolStatus: "active" | "paused";
+}
+
 /** One sender identity as shown on /setup: pool entry + today's usage. */
 export interface SenderIdentityView {
   id: string;


### PR DESCRIPTION
## What
A paused sending domain blocks all sends from it (doctor flags it), but there was no way to act on it. This adds resume/pause across all three surfaces.

- **core** — `resumeSendingDomain` / `pauseSendingDomain` wrappers (SDK `resumeDomain`/`pauseDomain`; errors propagate, unlike the read path)
- **CLI** — `oneshot-gtm domains list|resume|pause <domain>`
- **Web** — `/setup` → Sender → "Provisioned domains" list with status badge + Resume/Pause buttons
- **API** — `POST /api/domains/{resume,pause}` → `DomainActionResult`. Client 4xx (bad/unowned domain) passes through as-is; platform 5xx/unknown → 502, with the OneShot HTTP status folded into the message.

## Tests
`apps/server/__tests__/domains-route.test.ts` — validation (400), success + trim/lowercase normalization, 4xx passthrough, 5xx→502, no-statusCode→502.

tsc clean · oxlint 0 warnings · full suite green (1230 tests).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add resume/pause sending domain support to CLI, API, and Setup page
> - Adds `resumeSendingDomain` and `pauseSendingDomain` core wrappers in [`packages/core/src/oneshot.ts`](https://github.com/oneshot-agent/oneshot-gtm/pull/14/files#diff-a75653098eb1094047ae1458ce831158ed4abd7e08122279a6827b46c0c2e9db) that normalize input, call the SDK, and propagate errors.
> - Exposes `POST /api/domains/resume` and `POST /api/domains/pause` endpoints in [`apps/server/src/api/domains.ts`](https://github.com/oneshot-agent/oneshot-gtm/pull/14/files#diff-99e4031d737d23dbc859fe606dc799888ac200ac30d4e46474e5fcc5a0970f2f), with 4xx pass-through and 5xx mapped to 502.
> - Adds `domains list`, `domains resume <domain>`, and `domains pause <domain>` CLI subcommands in [`apps/cli/src/index.ts`](https://github.com/oneshot-agent/oneshot-gtm/pull/14/files#diff-4565ec586fe8103913bc7f7abc9b548cb8f4d8403669752a5f10874118093bce).
> - Updates the Setup page in [`apps/web/src/routes/setup.tsx`](https://github.com/oneshot-agent/oneshot-gtm/pull/14/files#diff-8d426675a915adf798c40f7640497bf825ab5522167c3359604e391a1b54fcf3) to display provisioned domains with status badges and Pause/Resume buttons, invalidating setup and doctor queries on success.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e05b48d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->