### PR TITLE
feat: Add Prospect from a LinkedIn/X URL + cadence quick-select

### DIFF
--- a/apps/server/src/api/plays.ts
+++ b/apps/server/src/api/plays.ts
@@ -67,6 +67,10 @@ const PLAY_CATALOG: PlayMeta[] = [
     name: "breakup-revive",
     cli: "oneshot-gtm motion breakup-revive --min-days 60 --max-days 90",
   },
+  {
+    name: "profile-intro",
+    cli: "added from the dashboard: Add Prospect → paste a LinkedIn or X/Twitter URL",
+  },
 ];
 
 /** Relative per-step dayOffsets → cumulative days from the day-0 initial send. */

--- a/apps/server/src/api/prospects.ts
+++ b/apps/server/src/api/prospects.ts
@@ -1,0 +1,44 @@
+import { createProspectResearchJob, runProspectResearch } from "@oneshot-gtm/plays";
+import type { AddProspectRequest, AddProspectResult } from "@oneshot-gtm/shared-types";
+import { jsonResponse } from "../server.ts";
+
+/**
+ * POST /api/prospects/add — manual add-prospect from a profile URL.
+ *
+ * Validates + enqueues a placeholder `profile-intro` queue row synchronously,
+ * then kicks off the ~2-5 min dossier research + draft in the background
+ * (`void runProspectResearch`) and returns 202 immediately. The drafted row
+ * fills in on `/queue` (which polls) when research completes.
+ */
+export async function addProspectRoute(req: Request): Promise<Response> {
+  let body: AddProspectRequest;
+  try {
+    body = (await req.json()) as AddProspectRequest;
+  } catch {
+    return jsonResponse({ error: "invalid JSON body" }, 400, req);
+  }
+  if (!body || typeof body.url !== "string" || body.url.trim() === "") {
+    return jsonResponse({ error: "url required" }, 400, req);
+  }
+  const email =
+    typeof body.email === "string" && body.email.trim() !== "" ? body.email.trim() : undefined;
+
+  let job: ReturnType<typeof createProspectResearchJob>;
+  try {
+    job = createProspectResearchJob({ url: body.url, ...(email ? { emailOverride: email } : {}) });
+  } catch (err) {
+    // parseProfileUrl throws a clear message on bad / unsupported URLs.
+    return jsonResponse({ error: (err as Error).message }, 400, req);
+  }
+
+  if ("duplicate" in job) {
+    const result: AddProspectResult = { queued: false, duplicate: true };
+    return jsonResponse(result, 200, req);
+  }
+
+  // Fire-and-forget the heavy research + draft. Errors land on the row's notes.
+  void runProspectResearch(job.queueId);
+
+  const result: AddProspectResult = { queued: true, queueId: job.queueId };
+  return jsonResponse(result, 202, req);
+}

--- a/apps/server/src/api/queue.ts
+++ b/apps/server/src/api/queue.ts
@@ -369,7 +369,10 @@ export async function sendDraftRoute(
         name: str("name") ?? str("founderName"),
         email,
         company: str("company"),
-        linkedin_url: str("linkedinUrl"),
+        // Falls back to twitterUrl so a profile-intro prospect added from an
+        // X/Twitter URL keeps its profile link (mirrors the play's own
+        // prospectMeta); the column is the de-facto social-profile URL.
+        linkedin_url: str("linkedinUrl") ?? str("twitterUrl"),
         phone: str("phone"),
         source: row.play_name,
       },

--- a/apps/server/src/api/queue.ts
+++ b/apps/server/src/api/queue.ts
@@ -369,10 +369,10 @@ export async function sendDraftRoute(
         name: str("name") ?? str("founderName"),
         email,
         company: str("company"),
-        // Falls back to twitterUrl so a profile-intro prospect added from an
-        // X/Twitter URL keeps its profile link (mirrors the play's own
+        // Falls back to twitter/github URL so a profile-intro prospect added
+        // from an X or GitHub URL keeps its profile link (mirrors the play's own
         // prospectMeta); the column is the de-facto social-profile URL.
-        linkedin_url: str("linkedinUrl") ?? str("twitterUrl"),
+        linkedin_url: str("linkedinUrl") ?? str("twitterUrl") ?? str("githubUrl"),
         phone: str("phone"),
         source: row.play_name,
       },

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -39,6 +39,7 @@ import {
   setTriggerConfigRoute,
   setTriggerEnabledRoute,
 } from "./api/triggers.ts";
+import { addProspectRoute } from "./api/prospects.ts";
 
 interface ServerOptions {
   port: number;
@@ -97,6 +98,7 @@ const routes: RouteEntry[] = [
   route("GET", "/api/doctor", doctor),
   route("POST", "/api/run/:playName", runPlay),
   route("GET", "/api/runs/:id", getRunRoute),
+  route("POST", "/api/prospects/add", addProspectRoute),
   route("GET", "/api/queue", listQueueRoute),
   route("POST", "/api/queue/approve-all", approveAllRoute),
   route("POST", "/api/queue/drain", drainQueueRoute),

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -1,4 +1,5 @@
 import type {
+  AddProspectResult,
   CadencesResult,
   CadenceView,
   DoctorCheck,
@@ -158,6 +159,10 @@ export const api = {
     }>("/setup"),
   setup: (req: SetupRequest) => postJson<{ ok: boolean }>("/setup", req),
   deriveIcp: (domain: string) => postJson<DeriveIcpResult>("/setup/derive-icp", { domain }),
+  // Manual add-prospect from a LinkedIn/X URL. Returns 202 immediately; the
+  // researched + drafted row appears on /queue when the background job finishes.
+  addProspect: (url: string, email?: string) =>
+    postJson<AddProspectResult>("/prospects/add", { url, ...(email ? { email } : {}) }),
   queue: (opts?: { play?: string; status?: QueueStatusView; limit?: number }) => {
     const q = new URLSearchParams();
     if (opts?.play) q.set("play", opts.play);

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,7 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
 import { Outlet, createRootRouteWithContext, Link } from "@tanstack/react-router";
 import type { QueryClient } from "@tanstack/react-query";
-import { Activity, BarChart3, Feather, Inbox, Layers, Mail, Receipt, Settings } from "lucide-react";
+import {
+  Activity,
+  BarChart3,
+  Feather,
+  Inbox,
+  Layers,
+  Mail,
+  Receipt,
+  Settings,
+  UserPlus,
+} from "lucide-react";
 import { useState, type ComponentType } from "react";
 import { Toaster } from "sonner";
 import { api } from "../api/client.ts";
@@ -22,7 +32,16 @@ export const Route = createRootRouteWithContext<RootContext>()({
 });
 
 interface NavItem {
-  to: "/" | "/queue" | "/inbox" | "/cadences" | "/receipts" | "/measure" | "/plays" | "/setup";
+  to:
+    | "/"
+    | "/add-prospect"
+    | "/queue"
+    | "/inbox"
+    | "/cadences"
+    | "/receipts"
+    | "/measure"
+    | "/plays"
+    | "/setup";
   label: string;
   icon: ComponentType<{ size?: number; className?: string }>;
   /** Which alert-data key, if any, lights a dot next to this nav item. */
@@ -31,6 +50,7 @@ interface NavItem {
 
 const NAV: NavItem[] = [
   { to: "/", label: "Today", icon: Activity },
+  { to: "/add-prospect", label: "Add Prospect", icon: UserPlus },
   { to: "/queue", label: "Queue", icon: Inbox, alert: "queue-pending" },
   { to: "/inbox", label: "Replies", icon: Mail },
   { to: "/cadences", label: "Cadences", icon: Layers },

--- a/apps/web/src/routes/add-prospect.tsx
+++ b/apps/web/src/routes/add-prospect.tsx
@@ -1,0 +1,138 @@
+import { useMutation } from "@tanstack/react-query";
+import { createFileRoute, Link } from "@tanstack/react-router";
+import { ArrowRight, UserPlus } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import type { AddProspectResult } from "@oneshot-gtm/shared-types";
+import { api } from "../api/client.ts";
+import { Button } from "../components/primitives/Button.tsx";
+import { Field, Input } from "../components/primitives/Field.tsx";
+
+export const Route = createFileRoute("/add-prospect")({
+  component: AddProspectPage,
+});
+
+function AddProspectPage() {
+  const [url, setUrl] = useState("");
+  const [email, setEmail] = useState("");
+  const [last, setLast] = useState<{ kind: "queued" | "duplicate" } | null>(null);
+
+  const add = useMutation({
+    mutationFn: (): Promise<AddProspectResult> =>
+      api.addProspect(url.trim(), email.trim() || undefined),
+    onSuccess: (res) => {
+      if (res.duplicate) {
+        setLast({ kind: "duplicate" });
+        toast.info("already in the queue — this profile was added before");
+        return;
+      }
+      setLast({ kind: "queued" });
+      setUrl("");
+      setEmail("");
+      toast.success("researching profile — it'll appear in the Queue with a draft shortly");
+    },
+    onError: (err) => toast.error(`couldn't add: ${err.message}`),
+  });
+
+  const canSubmit = url.trim() !== "" && !add.isPending;
+
+  return (
+    <div className="-mx-6 -my-6 flex flex-col">
+      {/* Masthead */}
+      <section className="flex items-end justify-between gap-4 border-b border-ink-rule px-6 pb-5 pt-6">
+        <div>
+          <div className="ln-eyebrow">The Ledger · Add Prospect</div>
+          <h1
+            className="mt-1 text-ink-cream"
+            style={{
+              fontFamily: "var(--font-display)",
+              fontSize: 44,
+              fontWeight: 600,
+              letterSpacing: "-0.025em",
+              lineHeight: 0.98,
+            }}
+          >
+            One profile, one draft.
+          </h1>
+        </div>
+      </section>
+
+      <section className="px-6 py-6">
+        <div className="max-w-xl">
+          <p className="mb-5 text-[13.5px] leading-relaxed text-ink-cream-2">
+            Paste a LinkedIn or X/Twitter profile. We research the person, pick the angle against
+            your ICP, draft a tailored intro, and queue a 4-touch cadence — ready for your review in
+            the{" "}
+            <Link to="/queue" className="text-ink-cream underline underline-offset-2">
+              Queue
+            </Link>
+            .
+          </p>
+
+          <form
+            className="flex flex-col gap-4"
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (canSubmit) add.mutate();
+            }}
+          >
+            <Field
+              label="Profile URL"
+              hint="LinkedIn, X/Twitter, or GitHub. e.g. https://www.linkedin.com/in/jane-doe"
+            >
+              <Input
+                type="url"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                placeholder="https://x.com/janedoe"
+                autoFocus
+                required
+              />
+            </Field>
+
+            <Field
+              label="Email (optional)"
+              hint="Only needed if research can't find one — sending is held until an email exists."
+            >
+              <Input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="jane@acme.com"
+              />
+            </Field>
+
+            <div className="flex items-center gap-3 pt-1">
+              <Button type="submit" variant="primary" size="md" disabled={!canSubmit}>
+                <UserPlus size={14} />
+                {add.isPending ? "Adding…" : "Research & draft"}
+              </Button>
+              <span className="text-[12px] text-ink-faint">research takes ~2–5 min</span>
+            </div>
+          </form>
+
+          {last && (
+            <div className="mt-6 rounded-[var(--radius-sm)] border border-ink-rule bg-ink-surface/40 px-4 py-3">
+              <div className="text-[13px] text-ink-cream-2">
+                {last.kind === "queued" ? (
+                  <>
+                    On it — researching the profile now. The drafted prospect will show up in the
+                    Queue when ready.
+                  </>
+                ) : (
+                  <>This profile is already in the queue.</>
+                )}
+              </div>
+              <Link
+                to="/queue"
+                className="mt-2 inline-flex items-center gap-1 text-[12px] text-ink-cream underline-offset-2 hover:underline"
+              >
+                Go to Queue <ArrowRight size={12} />
+              </Link>
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/routes/cadences.tsx
+++ b/apps/web/src/routes/cadences.tsx
@@ -266,6 +266,23 @@ function CadencesPage() {
     });
   };
 
+  // Quick-select presets. Active rows are already returned most-overdue-first
+  // (server: ORDER BY next_due_at ASC NULLS LAST), but re-sort a copy so the
+  // ordering is correct even in the "All" view where rows are status-grouped.
+  // Nulls (no schedule) sort last. Replaces the current selection.
+  const activeByDue = useMemo(
+    () =>
+      selectableActive.toSorted((a, b) => {
+        if (a.nextDueAt === b.nextDueAt) return 0;
+        if (a.nextDueAt === null) return 1;
+        if (b.nextDueAt === null) return -1;
+        return a.nextDueAt < b.nextDueAt ? -1 : 1;
+      }),
+    [selectableActive],
+  );
+  const selectNextN = (n: number): void =>
+    setSelected(new Set(activeByDue.slice(0, n).map(rowKey)));
+
   return (
     <div className="-mx-6 -my-6 flex flex-col">
       {/* Masthead */}
@@ -350,7 +367,19 @@ function CadencesPage() {
             <span className="text-ink-faint">…</span>
           )}
         </div>
-        <div className="font-mono text-[11px] text-ink-faint">refresh · 15s</div>
+        <div className="flex items-center gap-2">
+          {selectableActive.length > 0 && (
+            <div className="flex items-center gap-1.5">
+              <span className="font-mono text-[11px] text-ink-faint">select next</span>
+              {[10, 20, 30].map((n) => (
+                <Button key={n} variant="secondary" size="sm" onClick={() => selectNextN(n)}>
+                  {n}
+                </Button>
+              ))}
+            </div>
+          )}
+          <div className="font-mono text-[11px] text-ink-faint">refresh · 15s</div>
+        </div>
       </section>
 
       {/* Bulk-action bar — visible when at least one active row is selected. */}

--- a/apps/web/src/routes/plays.tsx
+++ b/apps/web/src/routes/plays.tsx
@@ -36,6 +36,10 @@ const RUNNABLE_PLAYS = new Set([
   "luma-events",
 ]);
 
+// Non-runnable plays that are driven from the dashboard (not the CLI). Tagged
+// "dashboard" instead of "CLI only" on the Plays page.
+const DASHBOARD_PLAYS = new Set(["profile-intro"]);
+
 /**
  * Per-play metadata the API doesn't expose yet — human description + day-
  * offset timeline. Values mirror the sequences defined in
@@ -298,7 +302,9 @@ function PlaysPage() {
                       )}
                     </Button>
                     {!runnable && (
-                      <span className="font-mono text-[10px] text-ink-faint">CLI only</span>
+                      <span className="font-mono text-[10px] text-ink-faint">
+                        {DASHBOARD_PLAYS.has(p.name) ? "dashboard" : "CLI only"}
+                      </span>
                     )}
                   </div>
                 </div>

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -2372,6 +2372,32 @@ export class Ledger {
       .run(json, draftedAtIso, input.id);
   }
 
+  /**
+   * Overwrite a queue row's `payload_json` (the per-target JSON the play
+   * drafts from). Used by the manual add-prospect flow: the row is enqueued
+   * immediately as a placeholder, then — once the async dossier research
+   * completes — its payload is rewritten to the full ProfileIntroTarget
+   * (identity + dossier + angle) so `/queue` regenerate re-drafts from the
+   * researched dossier instead of paying for research again.
+   */
+  updateQueuePayload(input: { id: number; payload: unknown }): void {
+    this.db
+      .prepare(`UPDATE target_queue SET payload_json = ? WHERE id = ?`)
+      .run(JSON.stringify(input.payload), input.id);
+  }
+
+  /**
+   * Set a queue row's `notes` without touching its status. Used by the manual
+   * add-prospect flow to update the transient "researching profile…" note to
+   * a "no email found" flag (or a research-failed message) once the async job
+   * settles. Pass an empty string to clear it.
+   */
+  setQueueNotes(input: { id: number; notes: string }): void {
+    this.db
+      .prepare(`UPDATE target_queue SET notes = ? WHERE id = ?`)
+      .run(input.notes === "" ? null : input.notes, input.id);
+  }
+
   close(): void {
     this.db.close();
   }

--- a/packages/plays/__tests__/profile-intro.test.ts
+++ b/packages/plays/__tests__/profile-intro.test.ts
@@ -17,6 +17,7 @@ const state: {
   extract: Record<string, unknown>;
   enqueueResult: number | null;
   existingRow: FakeRow | null;
+  throwOnDraft: boolean;
   calls: { deepResearchPerson: number; llm: number; setStatus: number };
 } = {
   row: {
@@ -33,6 +34,7 @@ const state: {
   extract: {},
   enqueueResult: 7,
   existingRow: null,
+  throwOnDraft: false,
   calls: { deepResearchPerson: 0, llm: 0, setStatus: 0 },
 };
 
@@ -97,7 +99,9 @@ vi.mock("@oneshot-gtm/intel", async () => {
       const user = input.messages.find((m) => m.role === "user")?.content ?? "";
       // The draft call's input block leads with FOUNDER:; the extract call is
       // ICP/PRODUCT/DOSSIER only.
-      const content = user.includes("FOUNDER:")
+      const isDraft = user.includes("FOUNDER:");
+      if (isDraft && state.throwOnDraft) throw new Error("LLM down");
+      const content = isDraft
         ? JSON.stringify({ subject: "first ninety", body: "Hey Jane, real intro. Founder" })
         : JSON.stringify(state.extract);
       return { content, provider: "test", model: "test" };
@@ -128,6 +132,7 @@ beforeEach(() => {
   state.extract = {};
   state.enqueueResult = 7;
   state.existingRow = null;
+  state.throwOnDraft = false;
 });
 
 afterEach(() => {
@@ -212,6 +217,31 @@ describe("runProspectResearch", () => {
     expect(state.calls.llm).toBe(0); // no extract, no draft
     expect(state.row.last_draft_json).toBeNull();
     expect(state.row.notes).toContain("couldn't research this profile");
+  });
+
+  it("does NOT persist a draft (and keeps a failure note) when the LLM draft call fails", async () => {
+    resetRow({ url: "https://x.com/jane", platform: "twitter" });
+    state.enrichment = { best_work_email: "jane@acme.com" };
+    state.extract = { name: "Jane", company: "Acme", angle: "x", email: null };
+    state.throwOnDraft = true; // draft LLM call throws → errorDraft envelope
+
+    await runProspectResearch(7);
+
+    // The error envelope must NOT be persisted as a ready-to-send draft.
+    expect(state.row.last_draft_json).toBeNull();
+    expect(state.row.notes).toContain("draft failed");
+  });
+
+  it("does not clobber a row the founder rejected mid-research", async () => {
+    resetRow({ url: "https://x.com/jane", platform: "twitter" });
+    state.row.status = "rejected"; // founder rejected the placeholder during research
+    state.enrichment = { best_work_email: "jane@acme.com" };
+    state.extract = { name: "Jane", company: "Acme", angle: "x", email: "jane@acme.com" };
+
+    await runProspectResearch(7);
+
+    // Draft is computed but NOT persisted onto the rejected row.
+    expect(state.row.last_draft_json).toBeNull();
   });
 
   it("researches, drafts, and persists the dossier + draft; clears the note when an email is found", async () => {

--- a/packages/plays/__tests__/profile-intro.test.ts
+++ b/packages/plays/__tests__/profile-intro.test.ts
@@ -146,22 +146,29 @@ describe("profile-intro play registration", () => {
 });
 
 describe("parseProfileUrl", () => {
-  it("classifies LinkedIn, X, Twitter, and GitHub", () => {
+  it("classifies LinkedIn, X, Twitter, and GitHub (incl. dotted subdomains)", () => {
     expect(parseProfileUrl("https://www.linkedin.com/in/jane/").platform).toBe("linkedin");
     expect(parseProfileUrl("https://x.com/jane").platform).toBe("twitter");
     expect(parseProfileUrl("https://twitter.com/jane").platform).toBe("twitter");
+    expect(parseProfileUrl("https://mobile.twitter.com/jane").platform).toBe("twitter");
     expect(parseProfileUrl("https://github.com/jane").platform).toBe("github");
   });
 
-  it("normalizes to a host/path dedupe key (drops www, query, trailing slash)", () => {
+  it("normalizes to a lowercased host/path dedupe key (drops www, query, trailing slash)", () => {
     expect(parseProfileUrl("https://www.linkedin.com/in/jane/?x=1").dedupeKey).toBe(
       "linkedin.com/in/jane",
     );
+    // Case-insensitive handle → same dedupe key (no double-enqueue).
+    expect(parseProfileUrl("https://www.linkedin.com/in/JohnDoe").dedupeKey).toBe(
+      parseProfileUrl("https://linkedin.com/in/johndoe").dedupeKey,
+    );
   });
 
-  it("rejects junk and unsupported hosts", () => {
+  it("rejects junk, unsupported hosts, and look-alike domains", () => {
     expect(() => parseProfileUrl("not a url")).toThrow();
     expect(() => parseProfileUrl("https://example.com/jane")).toThrow(/unsupported/);
+    // `endsWith` would have mis-classified this as LinkedIn.
+    expect(() => parseProfileUrl("https://evillinkedin.com/in/jane")).toThrow(/unsupported/);
   });
 });
 
@@ -286,6 +293,19 @@ describe("runProspectResearch", () => {
     // Draft still produced, but the row is flagged so it can't be sent yet.
     expect(state.row.last_draft_json).not.toBeNull();
     expect(state.row.notes).toBe("no email found — add an email before sending");
+  });
+
+  it("stores a GitHub URL under githubUrl, not linkedinUrl", async () => {
+    resetRow({ url: "https://github.com/jane", platform: "github" });
+    state.enrichment = { displayname: "Jane", best_work_email: "jane@acme.com" };
+    state.extract = { name: "Jane", company: "Acme", angle: "x", email: null };
+
+    await runProspectResearch(7);
+
+    const payload = JSON.parse(state.row.payload_json);
+    expect(payload.githubUrl).toBe("https://github.com/jane");
+    expect(payload.linkedinUrl).toBeUndefined();
+    expect(payload.twitterUrl).toBeUndefined();
   });
 
   it("prefers an explicit email override over researched emails", async () => {

--- a/packages/plays/__tests__/profile-intro.test.ts
+++ b/packages/plays/__tests__/profile-intro.test.ts
@@ -1,0 +1,275 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+interface FakeRow {
+  id: number;
+  play_name: string;
+  payload_json: string;
+  status: string;
+  send_started_at: string | null;
+  last_draft_json: string | null;
+  notes: string | null;
+}
+
+const state: {
+  row: FakeRow;
+  enrichment: Record<string, unknown>;
+  articles: unknown[];
+  extract: Record<string, unknown>;
+  enqueueResult: number | null;
+  existingRow: FakeRow | null;
+  calls: { deepResearchPerson: number; llm: number; setStatus: number };
+} = {
+  row: {
+    id: 7,
+    play_name: "profile-intro",
+    payload_json: "{}",
+    status: "pending",
+    send_started_at: null,
+    last_draft_json: null,
+    notes: "researching profile…",
+  },
+  enrichment: {},
+  articles: [],
+  extract: {},
+  enqueueResult: 7,
+  existingRow: null,
+  calls: { deepResearchPerson: 0, llm: 0, setStatus: 0 },
+};
+
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    loadConfig: () => ({
+      llmProvider: "anthropic",
+      llmModel: "test",
+      telemetryEnabled: false,
+      founderName: "Founder",
+      founderEmail: "f@x.dev",
+      productOneLiner: "TestProduct SDK",
+      icpOneLiner: "Engineers shipping AI agents",
+      clientId: "test",
+    }),
+    deepResearchPerson: async () => {
+      state.calls.deepResearchPerson++;
+      return {
+        result: { result: { enrichment: state.enrichment, articles: state.articles } },
+        receiptId: 9,
+      };
+    },
+    getLedger: () => ({
+      getQueueRow: () => state.row,
+      getQueueRowByDedupe: () => state.existingRow,
+      updateQueuePayload: ({ id: _id, payload }: { id: number; payload: unknown }) => {
+        state.row.payload_json = JSON.stringify(payload);
+        if (state.existingRow) state.existingRow.payload_json = JSON.stringify(payload);
+      },
+      setQueueDraft: ({ id: _id, draft }: { id: number; draft: unknown }) => {
+        state.row.last_draft_json = JSON.stringify(draft);
+      },
+      setQueueNotes: ({ id: _id, notes }: { id: number; notes: string }) => {
+        state.row.notes = notes;
+        if (state.existingRow) state.existingRow.notes = notes;
+      },
+      setQueueStatus: () => {
+        state.calls.setStatus++;
+      },
+      enqueueTarget: () => state.enqueueResult,
+      // runEmailPlay / sendDraftedEmail (dryRun path doesn't actually use these,
+      // but the play module reaches getLedger()).
+      upsertProspect: () => 1,
+      recordSequenceEvent: () => 1,
+      findProspectByEmail: () => null,
+      getCachedEnrichment: () => null,
+      setCachedEnrichment: () => {},
+    }),
+    receiptUrlForId: (id: number) => `oneshot://receipt/${id}`,
+  };
+});
+
+vi.mock("@oneshot-gtm/intel", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/intel")>("@oneshot-gtm/intel");
+  return {
+    ...actual,
+    loadPrompt: () => "system",
+    complete: async (input: { messages: Array<{ role: string; content: string }> }) => {
+      state.calls.llm++;
+      const user = input.messages.find((m) => m.role === "user")?.content ?? "";
+      // The draft call's input block leads with FOUNDER:; the extract call is
+      // ICP/PRODUCT/DOSSIER only.
+      const content = user.includes("FOUNDER:")
+        ? JSON.stringify({ subject: "first ninety", body: "Hey Jane, real intro. Founder" })
+        : JSON.stringify(state.extract);
+      return { content, provider: "test", model: "test" };
+    },
+  };
+});
+
+const { runProspectResearch, parseProfileUrl, createProspectResearchJob } =
+  await import("../src/add-prospect.ts");
+const { playFollowupCount } = await import("../src/_cadence.ts");
+
+function resetRow(payload: unknown): void {
+  state.row = {
+    id: 7,
+    play_name: "profile-intro",
+    payload_json: JSON.stringify(payload),
+    status: "pending",
+    send_started_at: null,
+    last_draft_json: null,
+    notes: "researching profile…",
+  };
+}
+
+beforeEach(() => {
+  state.calls = { deepResearchPerson: 0, llm: 0, setStatus: 0 };
+  state.enrichment = {};
+  state.articles = [];
+  state.extract = {};
+  state.enqueueResult = 7;
+  state.existingRow = null;
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("profile-intro play registration", () => {
+  it("registers a 3-step follow-up sequence (intro + 2 follow-ups + breakup)", () => {
+    expect(playFollowupCount("profile-intro")).toBe(3);
+  });
+});
+
+describe("parseProfileUrl", () => {
+  it("classifies LinkedIn, X, Twitter, and GitHub", () => {
+    expect(parseProfileUrl("https://www.linkedin.com/in/jane/").platform).toBe("linkedin");
+    expect(parseProfileUrl("https://x.com/jane").platform).toBe("twitter");
+    expect(parseProfileUrl("https://twitter.com/jane").platform).toBe("twitter");
+    expect(parseProfileUrl("https://github.com/jane").platform).toBe("github");
+  });
+
+  it("normalizes to a host/path dedupe key (drops www, query, trailing slash)", () => {
+    expect(parseProfileUrl("https://www.linkedin.com/in/jane/?x=1").dedupeKey).toBe(
+      "linkedin.com/in/jane",
+    );
+  });
+
+  it("rejects junk and unsupported hosts", () => {
+    expect(() => parseProfileUrl("not a url")).toThrow();
+    expect(() => parseProfileUrl("https://example.com/jane")).toThrow(/unsupported/);
+  });
+});
+
+describe("createProspectResearchJob", () => {
+  it("enqueues a new row and returns its id", () => {
+    state.enqueueResult = 42;
+    const res = createProspectResearchJob({ url: "https://x.com/jane" });
+    expect(res).toEqual({ queueId: 42 });
+  });
+
+  it("returns duplicate when an already-drafted row exists", () => {
+    state.enqueueResult = null; // unique-index collision
+    state.existingRow = {
+      id: 9,
+      play_name: "profile-intro",
+      payload_json: "{}",
+      status: "pending",
+      send_started_at: null,
+      last_draft_json: JSON.stringify({ subject: "s", body: "b" }), // has a draft
+      notes: null,
+    };
+    const res = createProspectResearchJob({ url: "https://x.com/jane" });
+    expect(res).toEqual({ duplicate: true });
+  });
+
+  it("reuses a stuck placeholder (no draft) so a re-add retries instead of blocking", () => {
+    state.enqueueResult = null;
+    state.existingRow = {
+      id: 9,
+      play_name: "profile-intro",
+      payload_json: "{}",
+      status: "pending",
+      send_started_at: null,
+      last_draft_json: null, // research never produced a draft
+      notes: "research failed: boom",
+    };
+    const res = createProspectResearchJob({ url: "https://x.com/jane" });
+    expect(res).toEqual({ queueId: 9 });
+    expect(state.calls.setStatus).toBe(1); // re-activated
+    expect(state.existingRow.notes).toBe("researching profile…");
+  });
+});
+
+describe("runProspectResearch", () => {
+  it("bails with a note when research turns up nothing (no fabricated draft)", async () => {
+    resetRow({ url: "https://x.com/ghost", platform: "twitter" });
+    state.enrichment = {}; // empty
+    state.articles = [];
+
+    await runProspectResearch(7);
+
+    expect(state.calls.deepResearchPerson).toBe(1);
+    expect(state.calls.llm).toBe(0); // no extract, no draft
+    expect(state.row.last_draft_json).toBeNull();
+    expect(state.row.notes).toContain("couldn't research this profile");
+  });
+
+  it("researches, drafts, and persists the dossier + draft; clears the note when an email is found", async () => {
+    resetRow({ url: "https://x.com/jane", platform: "twitter" });
+    state.enrichment = { displayname: "Jane Doe", best_work_email: "jane@acme.com" };
+    state.extract = { name: "Jane Doe", company: "Acme", angle: "ships an agent SDK", email: null };
+
+    await runProspectResearch(7);
+
+    expect(state.calls.deepResearchPerson).toBe(1);
+    // Two LLM calls: the ICP-grounded extract + the intro draft.
+    expect(state.calls.llm).toBe(2);
+
+    // Draft persisted.
+    expect(state.row.last_draft_json).not.toBeNull();
+    const draft = JSON.parse(state.row.last_draft_json!);
+    expect(draft.subject).toBe("first ninety");
+    expect(draft.dryRun).toBe(true);
+    expect(draft.sent).toBe(false);
+
+    // Payload rewritten to the full target incl. dossier + resolved email.
+    const payload = JSON.parse(state.row.payload_json);
+    expect(payload.email).toBe("jane@acme.com");
+    expect(payload.twitterUrl).toBe("https://x.com/jane");
+    expect(typeof payload.dossier).toBe("string");
+    expect(payload.dossier).toContain("jane@acme.com");
+
+    // Email found → note cleared.
+    expect(state.row.notes).toBe("");
+  });
+
+  it("flags 'no email found' when research + extract yield no email", async () => {
+    resetRow({ url: "https://www.linkedin.com/in/jane", platform: "linkedin" });
+    state.enrichment = { displayname: "Jane Doe" }; // no emails
+    state.extract = { name: "Jane Doe", company: "Acme", angle: "x", email: null };
+
+    await runProspectResearch(7);
+
+    const payload = JSON.parse(state.row.payload_json);
+    expect(payload.email).toBeNull();
+    expect(payload.linkedinUrl).toBe("https://www.linkedin.com/in/jane");
+    // Draft still produced, but the row is flagged so it can't be sent yet.
+    expect(state.row.last_draft_json).not.toBeNull();
+    expect(state.row.notes).toBe("no email found — add an email before sending");
+  });
+
+  it("prefers an explicit email override over researched emails", async () => {
+    resetRow({
+      url: "https://x.com/jane",
+      platform: "twitter",
+      emailOverride: "override@acme.com",
+    });
+    state.enrichment = { best_work_email: "found@acme.com" };
+    state.extract = { name: "Jane", company: "Acme", angle: "x", email: "extracted@acme.com" };
+
+    await runProspectResearch(7);
+
+    const payload = JSON.parse(state.row.payload_json);
+    expect(payload.email).toBe("override@acme.com");
+  });
+});

--- a/packages/plays/__tests__/registry.test.ts
+++ b/packages/plays/__tests__/registry.test.ts
@@ -16,6 +16,7 @@ const EXPECTED = [
   "repo-interest",
   "luma-events",
   "breakup-revive",
+  "profile-intro",
 ];
 
 describe("play registry", () => {

--- a/packages/plays/src/add-prospect.ts
+++ b/packages/plays/src/add-prospect.ts
@@ -34,14 +34,20 @@ export function parseProfileUrl(raw: string): ParsedProfileUrl {
   if (u.protocol !== "http:" && u.protocol !== "https:") {
     throw new Error("URL must be http(s)");
   }
+  // Match the registrable domain exactly or as a dotted subdomain — NOT a bare
+  // `endsWith("linkedin.com")`, which also matches `evillinkedin.com` (CodeQL:
+  // incomplete URL substring sanitization).
   const host = u.hostname.toLowerCase().replace(/^www\./, "");
+  const hostMatches = (domain: string): boolean => host === domain || host.endsWith(`.${domain}`);
   let platform: Platform;
-  if (host.endsWith("linkedin.com")) platform = "linkedin";
-  else if (host === "x.com" || host.endsWith("twitter.com")) platform = "twitter";
-  else if (host.endsWith("github.com")) platform = "github";
+  if (hostMatches("linkedin.com")) platform = "linkedin";
+  else if (hostMatches("x.com") || hostMatches("twitter.com")) platform = "twitter";
+  else if (hostMatches("github.com")) platform = "github";
   else throw new Error("unsupported URL — use a LinkedIn, X/Twitter, or GitHub profile");
 
-  const path = u.pathname.replace(/\/+$/, "");
+  // Lowercase the path too: profile handles are case-insensitive, so
+  // /in/JohnDoe and /in/johndoe are the same person and must dedupe to one key.
+  const path = u.pathname.toLowerCase().replace(/\/+$/, "");
   return { platform, url: trimmed, dedupeKey: `${host}${path}` };
 }
 
@@ -192,15 +198,21 @@ export async function runProspectResearch(queueId: number): Promise<void> {
       altEmails[0] ??
       null;
 
+    // Store the URL under the field matching its platform — a GitHub URL must
+    // NOT land in `linkedinUrl` (downstream enrichment treats that as LinkedIn).
+    const urlField: Pick<ProfileIntroTarget, "linkedinUrl" | "twitterUrl" | "githubUrl"> =
+      payload.platform === "twitter"
+        ? { twitterUrl: payload.url }
+        : payload.platform === "github"
+          ? { githubUrl: payload.url }
+          : { linkedinUrl: payload.url };
     const target: ProfileIntroTarget = {
       name: str(extracted.name) ?? str(enrichment["displayname"]) ?? "(unknown)",
       email,
       company: str(extracted.company),
       angle: str(extracted.angle),
       dossier,
-      ...(payload.platform === "twitter"
-        ? { twitterUrl: payload.url }
-        : { linkedinUrl: payload.url }),
+      ...urlField,
     };
 
     // 4. Draft the intro (dry-run: prepare→draft→lint, never sends).

--- a/packages/plays/src/add-prospect.ts
+++ b/packages/plays/src/add-prospect.ts
@@ -4,6 +4,9 @@ import { type ProfileIntroTarget, runProfileIntro } from "./profile-intro.ts";
 
 const PLAY_NAME = "profile-intro";
 
+/** Transient note on a placeholder row while its background research runs. */
+const RESEARCHING_NOTE = "researching profile…";
+
 export type Platform = "linkedin" | "twitter" | "github";
 
 /** Validated, normalized profile URL + which platform it points at. */
@@ -73,7 +76,7 @@ export function createProspectResearchJob(input: {
     payload,
     dedupeKey: parsed.dedupeKey,
     source: "manual",
-    notes: "researching profile…",
+    notes: RESEARCHING_NOTE,
   });
   if (id != null) return { queueId: id };
 
@@ -90,7 +93,7 @@ export function createProspectResearchJob(input: {
   ) {
     ledger.setQueueStatus({ id: existing.id, status: "pending" });
     ledger.updateQueuePayload({ id: existing.id, payload });
-    ledger.setQueueNotes({ id: existing.id, notes: "researching profile…" });
+    ledger.setQueueNotes({ id: existing.id, notes: RESEARCHING_NOTE });
     return { queueId: existing.id };
   }
   return { duplicate: true };
@@ -203,14 +206,34 @@ export async function runProspectResearch(queueId: number): Promise<void> {
     // 4. Draft the intro (dry-run: prepare→draft→lint, never sends).
     const { drafted } = await runProfileIntro({ dryRun: true, targets: [target] });
     const draft = drafted[0];
-    if (!draft) {
-      ledger.setQueueNotes({ id: queueId, notes: "research failed: no draft produced" });
+    // runEmailPlay never throws per-target: an LLM/provider failure comes back
+    // as an errorDraft ({subject:"(error)", body:"", flags:["error: …"]}), and a
+    // malformed LLM response yields an empty subject/body. Treat either as a
+    // failed draft — leave the note set (so a re-add retries) instead of
+    // persisting a broken "(error)"/blank draft that would look ready to send.
+    const errorFlag = draft?.flags.find((f) => f.startsWith("error:"));
+    if (!draft || errorFlag || draft.subject.trim() === "" || draft.body.trim() === "") {
+      ledger.setQueueNotes({
+        id: queueId,
+        notes: (errorFlag
+          ? `draft failed: ${errorFlag}`
+          : "draft came back empty — re-add to retry"
+        ).slice(0, 200),
+      });
       return;
     }
 
-    // 5. Persist — re-read first so a concurrent send/regenerate isn't clobbered.
+    // 5. Persist — re-read first so a concurrent reject/send isn't clobbered.
+    // Only an untouched placeholder (still pending/approved, not sending) gets
+    // the draft; a row the founder rejected mid-research stays rejected.
     const fresh = ledger.getQueueRow(queueId);
-    if (!fresh || fresh.status === "sent" || fresh.send_started_at != null) return;
+    if (
+      !fresh ||
+      (fresh.status !== "pending" && fresh.status !== "approved") ||
+      fresh.send_started_at != null
+    ) {
+      return;
+    }
     ledger.updateQueuePayload({ id: queueId, payload: target });
     ledger.setQueueDraft({
       id: queueId,

--- a/packages/plays/src/add-prospect.ts
+++ b/packages/plays/src/add-prospect.ts
@@ -1,0 +1,240 @@
+import { deepResearchPerson, getLedger, loadConfig } from "@oneshot-gtm/core";
+import { complete, loadPrompt, tryParseJsonObject } from "@oneshot-gtm/intel";
+import { type ProfileIntroTarget, runProfileIntro } from "./profile-intro.ts";
+
+const PLAY_NAME = "profile-intro";
+
+export type Platform = "linkedin" | "twitter" | "github";
+
+/** Validated, normalized profile URL + which platform it points at. */
+export interface ParsedProfileUrl {
+  platform: Platform;
+  /** The original URL, trimmed. */
+  url: string;
+  /** Stable `host/path` key for queue dedupe (lowercased, no query/trailing slash). */
+  dedupeKey: string;
+}
+
+/**
+ * Validate a pasted profile URL and classify the platform. Throws on an
+ * unparseable URL or an unsupported host — `deepResearchPerson` chases
+ * LinkedIn / X-Twitter / GitHub social URLs, so we gate to those.
+ */
+export function parseProfileUrl(raw: string): ParsedProfileUrl {
+  const trimmed = (raw ?? "").trim();
+  let u: URL;
+  try {
+    u = new URL(trimmed);
+  } catch {
+    throw new Error("not a valid URL — paste a full LinkedIn or X/Twitter profile link");
+  }
+  if (u.protocol !== "http:" && u.protocol !== "https:") {
+    throw new Error("URL must be http(s)");
+  }
+  const host = u.hostname.toLowerCase().replace(/^www\./, "");
+  let platform: Platform;
+  if (host.endsWith("linkedin.com")) platform = "linkedin";
+  else if (host === "x.com" || host.endsWith("twitter.com")) platform = "twitter";
+  else if (host.endsWith("github.com")) platform = "github";
+  else throw new Error("unsupported URL — use a LinkedIn, X/Twitter, or GitHub profile");
+
+  const path = u.pathname.replace(/\/+$/, "");
+  return { platform, url: trimmed, dedupeKey: `${host}${path}` };
+}
+
+interface PlaceholderPayload {
+  url: string;
+  platform: Platform;
+  emailOverride?: string;
+}
+
+export type CreateJobResult = { queueId: number } | { duplicate: true };
+
+/**
+ * Fast, synchronous step of the manual add-prospect flow: validate the URL and
+ * enqueue a placeholder `profile-intro` queue row immediately (so it shows on
+ * /queue right away), returning its id. The heavy dossier research + draft runs
+ * separately in `runProspectResearch`. Returns `{ duplicate:true }` when this
+ * profile is already queued for this play.
+ */
+export function createProspectResearchJob(input: {
+  url: string;
+  emailOverride?: string;
+}): CreateJobResult {
+  const parsed = parseProfileUrl(input.url);
+  const ledger = getLedger();
+  const payload: PlaceholderPayload = {
+    url: parsed.url,
+    platform: parsed.platform,
+    ...(input.emailOverride ? { emailOverride: input.emailOverride } : {}),
+  };
+  const id = ledger.enqueueTarget({
+    playName: PLAY_NAME,
+    payload,
+    dedupeKey: parsed.dedupeKey,
+    source: "manual",
+    notes: "researching profile…",
+  });
+  if (id != null) return { queueId: id };
+
+  // Already queued under (profile-intro, dedupeKey). If the prior attempt never
+  // produced a draft — research failed, or is still in flight — reuse that row
+  // so a re-add RETRIES instead of being blocked forever by the unique index.
+  // A row that already has a draft (or was sent) is a genuine duplicate.
+  const existing = ledger.getQueueRowByDedupe(PLAY_NAME, parsed.dedupeKey);
+  if (
+    existing &&
+    existing.last_draft_json == null &&
+    existing.send_started_at == null &&
+    existing.status !== "sent"
+  ) {
+    ledger.setQueueStatus({ id: existing.id, status: "pending" });
+    ledger.updateQueuePayload({ id: existing.id, payload });
+    ledger.setQueueNotes({ id: existing.id, notes: "researching profile…" });
+    return { queueId: existing.id };
+  }
+  return { duplicate: true };
+}
+
+interface ExtractResult {
+  name?: string | null;
+  company?: string | null;
+  role?: string | null;
+  email?: string | null;
+  angle?: string | null;
+  icpFit?: "strong" | "weak" | "none" | null;
+  reasoning?: string | null;
+}
+
+function str(v: unknown): string | null {
+  return typeof v === "string" && v.trim() !== "" ? v.trim() : null;
+}
+
+/**
+ * Async step: research the profile via the OneShot SDK (`deepResearchPerson`,
+ * which accepts any social URL — LinkedIn / X / GitHub — and returns a
+ * multi-source dossier incl. work/personal emails), have the LLM extract
+ * identity + an ICP-grounded angle, draft the intro via the profile-intro play
+ * (dry-run, no send), then persist the full target + draft onto the queue row.
+ * Never throws — failures are written to the row's notes so the founder sees
+ * what happened. Safe to call as `void runProspectResearch(id)`.
+ */
+export async function runProspectResearch(queueId: number): Promise<void> {
+  const ledger = getLedger();
+  try {
+    const row = ledger.getQueueRow(queueId);
+    if (!row) return;
+    let payload: PlaceholderPayload;
+    try {
+      payload = JSON.parse(row.payload_json) as PlaceholderPayload;
+    } catch {
+      ledger.setQueueNotes({ id: queueId, notes: "research failed: corrupt job payload" });
+      return;
+    }
+
+    // 1. Research the person from their social URL.
+    const research = await deepResearchPerson(
+      {
+        socialMediaUrl: payload.url,
+        ...(payload.emailOverride ? { email: payload.emailOverride } : {}),
+      },
+      { playName: PLAY_NAME, decisionContext: { source: "add-prospect", url: payload.url } },
+    );
+    const enrichment = (research.result?.result?.enrichment ?? {}) as Record<string, unknown>;
+    const articles = research.result?.result?.articles;
+    // Research came back empty (bad/private URL, no match). Don't draft from
+    // nothing — a fabricated intro is exactly what we're avoiding. Leave the
+    // row note so the founder can fix the URL and re-add (which retries).
+    const hasSignal =
+      Object.keys(enrichment).length > 0 || (Array.isArray(articles) && articles.length > 0);
+    if (!hasSignal) {
+      ledger.setQueueNotes({
+        id: queueId,
+        notes: "couldn't research this profile — verify the URL is a public LinkedIn/X profile",
+      });
+      return;
+    }
+    const dossier = JSON.stringify(research.result?.result ?? research.result, null, 2).slice(
+      0,
+      6000,
+    );
+
+    // 2. Extract identity + ICP-grounded angle.
+    const cfg = loadConfig();
+    const extractSystem = loadPrompt("profile-extract");
+    const extractUser = [
+      `ICP: ${cfg.icpOneLiner ?? "(not set)"}`,
+      `PRODUCT: ${cfg.productOneLiner ?? "(not set)"}`,
+      `DOSSIER:\n${dossier}`,
+    ].join("\n");
+    const extractRes = await complete({
+      messages: [
+        { role: "system", content: extractSystem },
+        { role: "user", content: extractUser },
+      ],
+      temperature: 0.3,
+      maxTokens: 500,
+    });
+    const extracted = tryParseJsonObject<ExtractResult>(extractRes.content, {});
+
+    // 3. Resolve the email: explicit override → extracted → SDK-found work/personal/alt.
+    const altEmails = Array.isArray(enrichment["altemails"])
+      ? (enrichment["altemails"] as unknown[]).map(str).filter((x): x is string => x != null)
+      : [];
+    const email =
+      str(payload.emailOverride) ??
+      str(extracted.email) ??
+      str(enrichment["best_work_email"]) ??
+      str(enrichment["best_personal_email"]) ??
+      altEmails[0] ??
+      null;
+
+    const target: ProfileIntroTarget = {
+      name: str(extracted.name) ?? str(enrichment["displayname"]) ?? "(unknown)",
+      email,
+      company: str(extracted.company),
+      angle: str(extracted.angle),
+      dossier,
+      ...(payload.platform === "twitter"
+        ? { twitterUrl: payload.url }
+        : { linkedinUrl: payload.url }),
+    };
+
+    // 4. Draft the intro (dry-run: prepare→draft→lint, never sends).
+    const { drafted } = await runProfileIntro({ dryRun: true, targets: [target] });
+    const draft = drafted[0];
+    if (!draft) {
+      ledger.setQueueNotes({ id: queueId, notes: "research failed: no draft produced" });
+      return;
+    }
+
+    // 5. Persist — re-read first so a concurrent send/regenerate isn't clobbered.
+    const fresh = ledger.getQueueRow(queueId);
+    if (!fresh || fresh.status === "sent" || fresh.send_started_at != null) return;
+    ledger.updateQueuePayload({ id: queueId, payload: target });
+    ledger.setQueueDraft({
+      id: queueId,
+      draft: {
+        subject: draft.subject,
+        body: draft.body,
+        flags: draft.flags,
+        sent: false,
+        receiptIds: [],
+        dryRun: true,
+      },
+    });
+    ledger.setQueueNotes({
+      id: queueId,
+      notes: email ? "" : "no email found — add an email before sending",
+    });
+  } catch (err) {
+    try {
+      ledger.setQueueNotes({
+        id: queueId,
+        notes: `research failed: ${(err as Error)?.message ?? "unknown error"}`.slice(0, 200),
+      });
+    } catch {
+      // best-effort — the row simply keeps its "researching…" note
+    }
+  }
+}

--- a/packages/plays/src/index.ts
+++ b/packages/plays/src/index.ts
@@ -7,6 +7,8 @@ export * from "./show-hn.ts";
 export * from "./icp.ts";
 export * from "./job-change.ts";
 export * from "./post-funding.ts";
+export * from "./profile-intro.ts";
+export * from "./add-prospect.ts";
 export * from "./accelerator-batch.ts";
 export * from "./pmf-classify.ts";
 export * from "./pmf-survey.ts";

--- a/packages/plays/src/profile-intro.ts
+++ b/packages/plays/src/profile-intro.ts
@@ -15,6 +15,7 @@ export interface ProfileIntroTarget {
   company?: string | null;
   linkedinUrl?: string | null;
   twitterUrl?: string | null;
+  githubUrl?: string | null;
   phone?: string | null;
   /** Pre-researched dossier text. When set, `prepare` returns it directly. */
   dossier?: string;
@@ -77,7 +78,9 @@ const profileIntroDef: EmailPlayDef<ProfileIntroTarget> = {
     name: t.name,
     email: t.email ?? null,
     company: t.company ?? null,
-    linkedin_url: t.linkedinUrl ?? t.twitterUrl ?? null,
+    // The prospects table has one social-URL column; store whichever profile
+    // link we have (LinkedIn / X / GitHub).
+    linkedin_url: t.linkedinUrl ?? t.twitterUrl ?? t.githubUrl ?? null,
     phone: t.phone ?? null,
     source: "manual",
   }),

--- a/packages/plays/src/profile-intro.ts
+++ b/packages/plays/src/profile-intro.ts
@@ -1,0 +1,131 @@
+import { type EmailPlayDef, type Prepared, runEmailPlay, standardEnrich } from "./_run-play.ts";
+import { buildFollowUpEmail, registerSequence } from "./_cadence.ts";
+
+/**
+ * A manually-added prospect researched from a LinkedIn or X/Twitter URL. Unlike
+ * the signal-specific plays, there's no external trigger artifact — the hook is
+ * the person's own dossier, and the LLM picks the angle. `dossier` is the
+ * pre-researched context (from deepResearchPerson); when present, `prepare`
+ * uses it verbatim instead of re-enriching (so X profiles with no email still
+ * draft, and `/queue` regenerate doesn't re-pay for research).
+ */
+export interface ProfileIntroTarget {
+  name: string;
+  email?: string | null;
+  company?: string | null;
+  linkedinUrl?: string | null;
+  twitterUrl?: string | null;
+  phone?: string | null;
+  /** Pre-researched dossier text. When set, `prepare` returns it directly. */
+  dossier?: string;
+  /** The single hook the draft should lead with, chosen against the ICP. */
+  angle?: string | null;
+}
+
+export interface ProfileIntroRunOptions {
+  dryRun: boolean;
+  targets: ProfileIntroTarget[];
+  onProgress?: (
+    index: number,
+    draft: { subject: string; body: string; flags: string[]; sent: boolean; receiptIds: number[] },
+  ) => void;
+}
+
+interface ProfileIntroDraft {
+  target: ProfileIntroTarget;
+  subject: string;
+  body: string;
+  receiptIds: number[];
+  sent: boolean;
+  flags: string[];
+}
+
+const PLAY_NAME = "profile-intro";
+
+const profileIntroDef: EmailPlayDef<ProfileIntroTarget> = {
+  playName: PLAY_NAME,
+  promptName: "profile-intro-email",
+  maxBodyWords: 100,
+  enrollCadence: true,
+  toEmail: (t) => t.email ?? "",
+  // The add-prospect flow does the heavy research up-front and passes the
+  // dossier in, so use it verbatim. The generic fallback (no dossier supplied)
+  // enriches by email/linkedin like the other plays.
+  prepare: (t, _dryRun): Promise<Prepared> =>
+    t.dossier != null
+      ? Promise.resolve({ receiptIds: [], dossier: t.dossier })
+      : standardEnrich({
+          playName: PLAY_NAME,
+          enrichInput: {
+            ...(t.email ? { email: t.email } : {}),
+            ...(t.linkedinUrl ? { linkedinUrl: t.linkedinUrl } : {}),
+            name: t.name,
+          },
+          enrichSlice: 5000,
+        }),
+  buildInputBlock: (t, prep, cfg) =>
+    [
+      `FOUNDER: ${cfg.founderName}`,
+      `PRODUCT: ${cfg.productOneLiner}`,
+      ...(cfg.icpOneLiner ? [`ICP: ${cfg.icpOneLiner}`] : []),
+      `PROSPECT: ${t.name}`,
+      `COMPANY: ${t.company ?? "(unknown)"}`,
+      `ANGLE: ${t.angle ?? "(none detected — keep it honest and narrow)"}`,
+      `DOSSIER:\n${prep.dossier || "(no dossier; rely on the angle only)"}`,
+    ].join("\n"),
+  prospectMeta: (t) => ({
+    name: t.name,
+    email: t.email ?? null,
+    company: t.company ?? null,
+    linkedin_url: t.linkedinUrl ?? t.twitterUrl ?? null,
+    phone: t.phone ?? null,
+    source: "manual",
+  }),
+};
+
+export function runProfileIntro(
+  opts: ProfileIntroRunOptions,
+): Promise<{ drafted: ProfileIntroDraft[] }> {
+  return runEmailPlay(profileIntroDef, opts);
+}
+
+registerSequence({
+  playName: PLAY_NAME,
+  steps: [
+    {
+      dayOffset: 4,
+      channel: "email",
+      breakOnReply: true,
+      label: "value follow-up",
+      builder: buildFollowUpEmail({
+        playName: PLAY_NAME,
+        promptName: "profile-intro-followup",
+        contextLines: [`CONTEXT: cold intro from their profile went unanswered ~4 days ago.`],
+      }),
+    },
+    {
+      dayOffset: 5, // ~9 days from enrollment
+      channel: "email",
+      breakOnReply: true,
+      label: "value follow-up",
+      builder: buildFollowUpEmail({
+        playName: PLAY_NAME,
+        promptName: "profile-intro-followup",
+        contextLines: [
+          `CONTEXT: second touch; still no reply. Keep it shorter than the first ping.`,
+        ],
+      }),
+    },
+    {
+      dayOffset: 9, // ~18 days from enrollment
+      channel: "email",
+      breakOnReply: true,
+      label: "breakup",
+      builder: buildFollowUpEmail({
+        playName: PLAY_NAME,
+        promptName: "breakup-email",
+        contextLines: [`PLAY: profile-intro. Sender is closing the file.`],
+      }),
+    },
+  ],
+});

--- a/packages/plays/src/registry.ts
+++ b/packages/plays/src/registry.ts
@@ -6,6 +6,7 @@ import { type JobChangeTarget, runJobChange } from "./job-change.ts";
 import { type LumaEventsTarget, runLumaEvents } from "./luma-events.ts";
 import { type PodcastGuestTarget, runPodcastGuest } from "./podcast-guest.ts";
 import { type PostFundingTarget, runPostFunding } from "./post-funding.ts";
+import { type ProfileIntroTarget, runProfileIntro } from "./profile-intro.ts";
 import { type RepoInterestTarget, runRepoInterest } from "./repo-interest.ts";
 import { type ShowHnTarget, runShowHn } from "./show-hn.ts";
 import { type StackConsolidationTarget, runStackConsolidation } from "./stack-consolidation.ts";
@@ -142,6 +143,14 @@ export const PLAYS: Record<string, PlayDispatch> = {
       runLumaEvents({
         dryRun: o.dryRun,
         targets: o.targets as LumaEventsTarget[],
+        ...progressOpt(o),
+      }),
+  },
+  "profile-intro": {
+    run: (o) =>
+      runProfileIntro({
+        dryRun: o.dryRun,
+        targets: o.targets as ProfileIntroTarget[],
         ...progressOpt(o),
       }),
   },

--- a/packages/prompts/profile-extract.md
+++ b/packages/prompts/profile-extract.md
@@ -1,0 +1,38 @@
+You read a researched dossier about ONE person (assembled from their LinkedIn or X/Twitter profile: bio, role/org history, recent posts, articles, social profiles, contact data) and extract the facts a cold-email writer needs. You also pick the single best ANGLE for a founder-to-founder cold email, judged against the founder's ICP. Inventing facts is worse than leaving them null.
+
+[See _humanizer.md — apply to the `angle` and `reasoning` fields only. The output schema is fixed.]
+
+## Inputs
+
+- `ICP`: a single sentence describing who the founder is trying to reach (may be empty).
+- `PRODUCT`: the founder's product one-liner (may be empty).
+- `DOSSIER`: a JSON/text dossier about the person.
+
+## Output
+
+A JSON object only:
+
+```json
+{
+  "name": string | null,
+  "company": string | null,
+  "role": string | null,
+  "email": string | null,
+  "angle": string | null,
+  "icpFit": "strong" | "weak" | "none",
+  "reasoning": string | null
+}
+```
+
+## Rules
+
+- `name`: the person's full name. Null if the dossier never states it.
+- `company`: their CURRENT company (the most recent / `is_current` organization). Null if unclear.
+- `role`: their current title. Strip filler. Null if unclear.
+- `email`: a deliverable address for THIS person if the dossier contains one (prefer a work email, then personal). Null if none — do not guess or construct one from a domain.
+- `angle`: ONE specific, true hook this outreach should lead with, drawn from the dossier and relevant to the founder's PRODUCT/ICP — e.g. "recently moved from Stripe to lead payments at Acme", "posts weekly about scaling on-call", "just shipped an open-source agent SDK". Name the concrete signal. NEVER fabricate a funding round, a launch, or a post that isn't in the dossier. Null if the dossier is too thin for any honest hook.
+- `icpFit`: `strong` if the person clearly matches the ICP; `weak` if plausibly adjacent; `none` if they don't fit or the ICP is empty and you can't tell. Tie-breakers go DOWN, not up.
+- `reasoning`: ONE short sentence (≤ 25 words) naming the signal that set the angle and fit. Specific over abstract.
+- Anything not supported by the dossier → null. Do not guess.
+
+Output ONLY the JSON object. No prose around it.

--- a/packages/prompts/profile-intro-email.md
+++ b/packages/prompts/profile-intro-email.md
@@ -1,0 +1,30 @@
+You write a founder-to-founder cold email to a prospect the founder hand-picked from their LinkedIn or X/Twitter profile. There is no single news trigger — the hook is who this person IS and what they're visibly working on, framed against the founder's product and ICP. ONE TOUCH ONLY in Phase 1 (the cadence engine handles follow-ups).
+
+[See _humanizer.md — binding. Follow the 4-step shape: Hook → Identity → Offer → CTA.]
+
+## Inputs
+
+- FOUNDER name and PRODUCT one-liner
+- ICP (only when set): one sentence on who the founder targets — use it to frame WHY this person, never quote it back
+- PROSPECT name and company
+- ANGLE: the single specific, true hook to lead with (pulled from their dossier)
+- DOSSIER: researched facts — bio, role history, recent posts, articles, social presence
+- SOCIAL PROOF (only when set): structured block with CREDENTIALS / PORTFOLIO / PARTNERS lines
+- PROSPECT_FIRST_NAME (only when set): occasionally open with "Hey {firstName},"
+
+## Email rules
+
+- Subject: 2-4 lowercase words, specific to the ANGLE. NEVER a generic "quick question" or anything with an exclamation mark.
+- Body: 4-6 short sentences, under 100 words. Follow the 4-step shape from _humanizer.md.
+  - Hook (1-2 sentences): open on the ANGLE — a concrete detail from the DOSSIER that proves you actually looked (a specific post, a role move, a thing they shipped). NEVER a generic "came across your profile" / "love what you're building".
+  - Identity (1 sentence): say what you ship. If SOCIAL PROOF is present, weave ONE concrete credential beat. Skip if no SOCIAL PROOF.
+  - Offer (1 sentence): a substantive peer-level observation that connects YOUR product to a SPECIFIC thing in their world (the problem their role/posts surface). Name the TOPIC, not a deliverable. NEVER frame as a doc you'd mail ("the teardown", "the benchmark") — see _humanizer.md → Banned: invented artifacts.
+  - CTA (1 sentence): a single yes/no question inviting a conversation. Name the TOPIC, not a deliverable.
+  - Sign-off: founder name.
+- Forbidden: fabricating any fact not in the DOSSIER (a funding round, a launch, a quote, a mutual connection); "I came across your profile", "love what you're building", "hope this finds you well", "I'd love to connect"; promising a doc you don't have.
+
+## Voice
+
+Another founder who did the reading. Specific, peer-level, useful. No flattery, no fanfare. If the DOSSIER is thin, stay honest and narrow rather than inventing color.
+
+Output as a JSON object only: { "subject": string, "body": string }.

--- a/packages/prompts/profile-intro-followup.md
+++ b/packages/prompts/profile-intro-followup.md
@@ -1,0 +1,19 @@
+You write a SHORT PING follow-up to a profile-intro cold email that has NOT been replied to. Sent a few days after the first email. No new pitch — just a light, specific re-touch.
+
+[See _humanizer.md — binding. Short pings only.]
+
+## Context you receive
+
+- FOUNDER name + PRODUCT one-liner
+- PROSPECT name, company
+- PRIOR EMAILS: the touches you already sent. Use to AVOID recycling.
+
+## Email rules
+
+- Subject: 1-3 lowercase words. Examples: "ping", "still curious?", the topic you raised.
+- Body: ≤ 30 words, 1-2 sentences.
+  - One sentence pinging the TOPIC you raised in the first email — pull the concrete topic from PRIOR EMAILS and re-invite the conversation. NOT a doc you'd send. No recap. See _humanizer.md → Banned: invented artifacts.
+  - Sign-off: founder name.
+- Forbidden: "following up", "circling back", "bumping this", "just wanted to make sure", restating your whole pitch.
+
+Output as a JSON object only: { "subject": string, "body": string }.

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -341,6 +341,30 @@ export interface QueueRowView {
 }
 
 /**
+ * Manual "Add Prospect": paste a LinkedIn or X/Twitter profile URL (optionally
+ * an email to use). The server researches the profile, has the LLM pick an
+ * ICP-grounded angle + draft the intro, and lands it as a reviewable row in the
+ * Queue under the `profile-intro` play.
+ */
+export interface AddProspectRequest {
+  /** A LinkedIn, X/Twitter, or GitHub profile URL. */
+  url: string;
+  /** Optional email to use when research can't find one. */
+  email?: string;
+}
+
+/**
+ * The add returns immediately (research runs ~2-5 min in the background). The
+ * drafted prospect appears on `/queue` when ready. `queued:false` with
+ * `duplicate:true` means this profile is already in the queue.
+ */
+export interface AddProspectResult {
+  queued: boolean;
+  duplicate?: boolean;
+  queueId?: number;
+}
+
+/**
  * Per-row draft envelope persisted after each /api/run dispatch. `dryRun`
  * distinguishes preview-only drafts from real-send attempts; `sent` is
  * true only when the SDK actually emitted the email (false for dryRun


### PR DESCRIPTION
Two related dashboard features for getting prospects into cadences faster.

## 1. Add Prospect from a profile URL
A new **Add Prospect** page (left nav). Paste a **LinkedIn, X/Twitter, or GitHub** profile URL (optionally an email) → the system researches the person, drafts a tailored intro, and lands it in the **Queue** for review.

- **Real dossier, not a scrape.** Uses the OneShot SDK's `deepResearchPerson`, which accepts any social URL and returns a multi-source dossier (org/role history, recent posts, articles, social profiles) **plus work/personal emails** — so the "no public email" case is rare.
- **ICP-grounded angle.** An LLM extract step picks the outreach angle against the founder's `icpOneLiner`; the intro is drafted only from real dossier facts (no fabricated funding rounds / posts).
- **New generic `profile-intro` play** — intro + 2 follow-ups + breakup (4 touches). Existing signal-specific plays need hard artifacts (Show HN URL, funding amount, cohort) a profile can't supply, so a dedicated play avoids forcing the LLM to invent facts.
- **Lands in the Queue**, reusing the existing preview / regenerate / send / drain pipeline; on send it auto-enrolls the cadence so follow-ups flow into Cadences.
- **Async** (`POST /api/prospects/add` returns `202`; research runs ~2-5 min in the background). A placeholder row appears immediately and fills in its draft when ready.

### Robustness
- **No email found** → row is queued + flagged ("no email found — add an email before sending"); send is held until one exists.
- **Failed / stuck research is retryable** — a placeholder row with no draft is reused on re-add instead of being permanently blocked by the `(play, dedupe_key)` unique index.
- **Empty research bails** with a clear note instead of fabricating a draft (and skips the wasted LLM calls).

## 2. Cadence quick-select (10/20/30)
On the Cadences page, "select next 10 / 20 / 30" buttons fill the existing bulk selection with the most-overdue-first active rows, then reuse the existing Preview/Send batch flow. Frontend-only.

## Files of note
- `packages/plays/src/profile-intro.ts`, `packages/plays/src/add-prospect.ts`
- `packages/prompts/profile-{extract,intro-email,intro-followup}.md`
- `packages/core/src/ledger.ts` (`updateQueuePayload`, `setQueueNotes`)
- `apps/server/src/api/prospects.ts` + route
- `apps/web/src/routes/add-prospect.tsx`, nav, `cadences.tsx`

## Testing
- `packages/plays/__tests__/profile-intro.test.ts`: play registration (3 follow-ups), URL parsing/classification, research→extract→draft→persist, email resolution + override precedence, retry of stuck rows, empty-research bail.
- Full suite green: typecheck, oxlint, oxfmt, **1241 tests pass**.

## Notes / follow-ups
- The OneShot SDK is pinned at `0.22.0` in package.json; `deepResearchPerson` is already wrapped in `packages/core/src/oneshot.ts`.
- Editing a missing email *after* queueing (inline on the Queue row) is out of scope here — the form's optional email field covers it up front.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add 'Add Prospect' flow for LinkedIn/X/GitHub URLs with cadence quick-select
> - Adds a new `/add-prospect` UI page and `POST /api/prospects/add` endpoint that accept a LinkedIn, X/Twitter, or GitHub profile URL and optional email, enqueue a `profile-intro` queue row, and run background research + email drafting.
> - Implements `parseProfileUrl`, `createProspectResearchJob`, and `runProspectResearch` in [`packages/plays/src/add-prospect.ts`](https://github.com/oneshot-agent/oneshot-gtm/pull/15/files#diff-d01d0307854aa979947f75f6784fbd12cbdeead598d6c4b457229c9f65362a6f) with dedupe logic, dossier-backed drafting, and notes for failure/no-email cases.
> - Adds the `profile-intro` play in [`packages/plays/src/profile-intro.ts`](https://github.com/oneshot-agent/oneshot-gtm/pull/15/files#diff-81978cc8f09084beeb59e1100c7d4f6d77af2cb48ca261bdd13c65c132438091) with a 4-touch cadence (intro + 2 follow-ups + breakup) and new LLM prompts for extraction, intro email, and follow-up.
> - Adds quick-select buttons (next 10/20/30) to the Cadences page, sorted by `nextDueAt` with nulls last, replacing the current selection on click.
> - Risk: Duplicate detection relies on a unique index in the queue; stuck placeholder rows are reactivated rather than creating a new entry, which changes behavior for in-progress jobs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 363941e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->