### PR TITLE
chore(doctor): point paused-domain hint at the resume UI/CLI

### DIFF
--- a/packages/doctor/src/check.ts
+++ b/packages/doctor/src/check.ts
@@ -187,7 +187,7 @@ export async function runDoctor(): Promise<CheckResult[]> {
             name,
             severity: "warn",
             message: `${localpart}${domain} is ${entry.status} in the pool · ${usage}`,
-            hint: "Resume it (agent.resumeDomain) before relying on it.",
+            hint: `Resume it on /setup (Sender → Provisioned domains) or run: oneshot-gtm domains resume ${domain}`,
           });
         } else {
           const warmth =


### PR DESCRIPTION
The doctor's paused-domain warning said `Resume it (agent.resumeDomain)` — a raw SDK method a founder can't easily call. Now that resume is shipped on `/setup` (Sender → Provisioned domains) and the CLI (`oneshot-gtm domains resume <domain>`, #14), point the hint at those, with the domain interpolated.

One-line hint text change; no test asserted the old string. tsc clean · oxlint 0 warnings · 1230 tests pass.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update paused-domain hint in `runDoctor` to include domain and resume instructions
> The hint shown when an identity pool entry has a `paused` or `removed` status now includes the specific domain name and directs users to resume it via `/setup (Sender → Provisioned domains)` or by running `oneshot-gtm domains resume <domain>`. The previous hint referenced `agent.resumeDomain` which no longer reflects the current UI or CLI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4ed121c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->