### PR TITLE
feat(find): fall back to the events feed for restricted stargazer lists

### DIFF
--- a/packages/find/__tests__/stargazers.test.ts
+++ b/packages/find/__tests__/stargazers.test.ts
@@ -4,6 +4,9 @@ import { recentStargazers } from "../src/_stargazers.ts";
 function star(login: string, starredAt: string) {
   return { starred_at: starredAt, user: { login, html_url: `https://github.com/${login}` } };
 }
+function watchEvent(login: string, createdAt: string) {
+  return { type: "WatchEvent", created_at: createdAt, actor: { login } };
+}
 function res(rows: unknown[], link: string | null) {
   return {
     ok: true,
@@ -36,7 +39,10 @@ describe("recentStargazers", () => {
     const fetchMock = vi.fn(async (url: string) => {
       const page = Number(/[?&]page=(\d+)/.exec(String(url))?.[1] ?? "1");
       if (page === 1) {
-        return res([star("p1", "2020-01-01T00:00:00Z")], '<https://x?per_page=100&page=3>; rel="last"');
+        return res(
+          [star("p1", "2020-01-01T00:00:00Z")],
+          '<https://x?per_page=100&page=3>; rel="last"',
+        );
       }
       // Backward page → rate-limited.
       return { ok: false, status: 403, headers: { get: () => null }, json: async () => [] };
@@ -73,7 +79,7 @@ describe("recentStargazers", () => {
       "fetch",
       vi.fn(async () => ({
         ok: false,
-        status: 403,
+        status: 500,
         headers: { get: () => null },
         json: async () => [],
       })),
@@ -81,5 +87,66 @@ describe("recentStargazers", () => {
     const out = await recentStargazers("o/r", { sinceIso: "2026-01-01T00:00:00Z" });
     expect(out.error).toBeDefined();
     expect(out.stargazers).toEqual([]);
+  });
+
+  // July 2026: /stargazers is admin/collaborator-only for third-party repos.
+  it("falls back to the events feed when the list endpoint is restricted", async () => {
+    const fetchMock = vi.fn(async (url: string) => {
+      if (String(url).includes("/stargazers")) {
+        return { ok: false, status: 401, headers: { get: () => null }, json: async () => [] };
+      }
+      // events feed: newest-first, WatchEvents mixed with other event types
+      return res(
+        [
+          watchEvent("fresh", "2026-06-02T00:00:00Z"),
+          { type: "PushEvent", created_at: "2026-06-01T12:00:00Z", actor: { login: "pusher" } },
+          watchEvent("fresh", "2026-06-01T00:00:00Z"), // dup login → deduped
+          watchEvent("stale", "2020-01-01T00:00:00Z"), // outside window → newestSeen only
+        ],
+        null,
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { stargazers, error, newestSeen } = await recentStargazers("o/r", {
+      sinceIso: "2026-05-01T00:00:00Z",
+    });
+    expect(error).toBeUndefined();
+    expect(stargazers.map((s) => s.login)).toEqual(["fresh"]);
+    expect(stargazers[0]?.starredAt).toBe("2026-06-02T00:00:00Z");
+    expect(newestSeen).toBe("2026-06-02T00:00:00Z");
+    // one restricted /stargazers hit + one /events page (rows < 100 → stop)
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("surfaces an error when both list and events endpoints fail", async () => {
+    const fetchMock = vi.fn(async (url: string) => ({
+      ok: false,
+      status: String(url).includes("/stargazers") ? 403 : 429,
+      headers: { get: () => null },
+      json: async () => [],
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+    const out = await recentStargazers("o/r", { sinceIso: "2026-01-01T00:00:00Z" });
+    expect(out.error).toMatch(/events status 429/);
+    expect(out.stargazers).toEqual([]);
+  });
+
+  it("stops paging events once a page's oldest event predates the window", async () => {
+    const hundredEvents = Array.from({ length: 99 }, (_, i) => ({
+      type: "PushEvent",
+      created_at: "2026-06-01T00:00:00Z",
+      actor: { login: `p${i}` },
+    }));
+    const fetchMock = vi.fn(async (url: string) => {
+      if (String(url).includes("/stargazers")) {
+        return { ok: false, status: 404, headers: { get: () => null }, json: async () => [] };
+      }
+      // full page (100 rows) whose oldest row predates the window → no page 2
+      return res([...hundredEvents, watchEvent("old", "2020-01-01T00:00:00Z")], null);
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const { stargazers } = await recentStargazers("o/r", { sinceIso: "2026-05-01T00:00:00Z" });
+    expect(stargazers).toEqual([]);
+    expect(fetchMock).toHaveBeenCalledTimes(2); // 1 stargazers + 1 events page only
   });
 });

--- a/packages/find/src/_stargazers.ts
+++ b/packages/find/src/_stargazers.ts
@@ -22,6 +22,33 @@ function parseStarRow(raw: unknown): Stargazer | null {
   return { login, userUrl: userUrl ?? `https://github.com/${login}`, starredAt };
 }
 
+/**
+ * Parse one `/repos/{repo}/events` row into a Stargazer when it's a
+ * `WatchEvent` (= a star; `created_at` is the star time). Non-star events and
+ * malformed rows return null.
+ */
+function parseWatchEvent(raw: unknown): Stargazer | null {
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (r["type"] !== "WatchEvent") return null;
+  const createdAt = typeof r["created_at"] === "string" ? (r["created_at"] as string) : null;
+  const actor = r["actor"];
+  if (!createdAt || !actor || typeof actor !== "object") return null;
+  const login =
+    typeof (actor as Record<string, unknown>)["login"] === "string"
+      ? ((actor as Record<string, unknown>)["login"] as string)
+      : null;
+  if (!login) return null;
+  return { login, userUrl: `https://github.com/${login}`, starredAt: createdAt };
+}
+
+/** Read a GitHub event row's `created_at` (any event type), else null. */
+function eventCreatedAt(raw: unknown): string | null {
+  if (!raw || typeof raw !== "object") return null;
+  const v = (raw as Record<string, unknown>)["created_at"];
+  return typeof v === "string" ? v : null;
+}
+
 /** Read the `page=N>; rel="last"` page number from a GitHub `Link` header. */
 function parseLastPage(link: string | null): number {
   if (!link) return 1;
@@ -43,6 +70,75 @@ export interface StargazersResult {
 }
 
 /**
+ * Fallback path: recent stargazers via the public repo *events* feed.
+ *
+ * Since July 2026 GitHub restricts `/stargazers` to repo admins/collaborators
+ * (401 unauth, 403/404 authed) — but `WatchEvent`s still flow through
+ * `/repos/{repo}/events`, which stays public. The feed is newest-first and
+ * keeps at most ~90 days / 300 events per repo, so we walk forward up to
+ * 3 pages of 100 and stop once a page's oldest event predates the window
+ * (every later page is older still). Busy repos can wash stars out of the
+ * 300-event cap between poll ticks — a scheduler that ticks at least daily
+ * keeps the gap negligible for the repo sizes we watch.
+ */
+async function recentStargazersViaEvents(
+  repo: string,
+  opts: { sinceIso: string },
+): Promise<StargazersResult> {
+  const headers = githubHeaders();
+  const base = `https://api.github.com/repos/${repo}/events?per_page=100`;
+
+  const out: Stargazer[] = [];
+  let newestSeen: string | null = null;
+  const dedupe = (): Stargazer[] => {
+    const seen = new Set<string>();
+    return out.filter((s) => {
+      const key = s.login.toLowerCase();
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+  };
+
+  try {
+    for (let page = 1; page <= 3; page++) {
+      const res = await fetch(`${base}&page=${page}`, { headers });
+      if (!res.ok) {
+        logEvent(
+          "github.stargazers",
+          { repo, ok: false, mode: "events", status: res.status, page },
+          "warn",
+        );
+        return { stargazers: dedupe(), newestSeen, error: `events status ${res.status}` };
+      }
+      const rows = ((await res.json()) as unknown[]) ?? [];
+      let oldestOnPage: string | null = null;
+      for (const raw of rows) {
+        const at = eventCreatedAt(raw);
+        if (at && (!oldestOnPage || at < oldestOnPage)) oldestOnPage = at;
+        const s = parseWatchEvent(raw);
+        if (!s) continue;
+        if (!newestSeen || s.starredAt > newestSeen) newestSeen = s.starredAt;
+        if (s.starredAt >= opts.sinceIso) out.push(s);
+      }
+      if (rows.length < 100) break; // feed exhausted
+      if (oldestOnPage && oldestOnPage < opts.sinceIso) break; // rest is older
+    }
+    const stargazers = dedupe();
+    logEvent("github.stargazers", { repo, ok: true, mode: "events", fresh: stargazers.length });
+    return { stargazers, newestSeen };
+  } catch (err) {
+    const message = ((err as Error).message ?? "").slice(0, 120);
+    logEvent(
+      "github.stargazers",
+      { repo, ok: false, mode: "events", message_120: message },
+      "warn",
+    );
+    return { stargazers: dedupe(), newestSeen, error: message };
+  }
+}
+
+/**
  * Recent stargazers of a public repo. GitHub returns stargazers oldest-first,
  * so the newest stars live on the LAST page — we read the `Link: rel="last"`
  * page number, then page backward (newest → older), collecting stars with
@@ -52,6 +148,11 @@ export interface StargazersResult {
  * / parse failure so the caller logs + continues. A non-2xx on a BACKWARD page
  * surfaces as `error` (it usually means a rate-limit mid-walk) rather than
  * silently masquerading as "no recent stars".
+ *
+ * Since July 2026 the list endpoint only answers for repos the token owner
+ * admins/collaborates on; a 401/403/404 on the first page falls back to the
+ * public events feed (recentStargazersViaEvents). Own repos keep the richer
+ * full-history walk.
  *
  * Requires `GITHUB_TOKEN` for any real volume (5,000 req/hr core); without it
  * GitHub rate-limits hard at 60/hr — which a backward walk through a big repo
@@ -84,6 +185,11 @@ export async function recentStargazers(
     const firstRes = await fetch(`${base}&page=1`, { headers });
     if (!firstRes.ok) {
       logEvent("github.stargazers", { repo, ok: false, status: firstRes.status }, "warn");
+      // 401/403/404 here is the July-2026 access restriction (not-own-repo),
+      // not a transient failure — the events feed still publishes stars.
+      if ([401, 403, 404].includes(firstRes.status)) {
+        return recentStargazersViaEvents(repo, { sinceIso: opts.sinceIso });
+      }
       return { stargazers: [], newestSeen: null, error: `status ${firstRes.status}` };
     }
     const lastPage = parseLastPage(firstRes.headers.get("link"));
@@ -100,11 +206,7 @@ export async function recentStargazers(
         if (!res.ok) {
           // Surface it — a 403/429 mid-walk is almost always the rate limit,
           // NOT "no recent stars". Return what we have so far + the error.
-          logEvent(
-            "github.stargazers",
-            { repo, ok: false, status: res.status, page },
-            "warn",
-          );
+          logEvent("github.stargazers", { repo, ok: false, status: res.status, page }, "warn");
           return {
             stargazers: dedupe(),
             newestSeen,

--- a/packages/find/src/github-stars.ts
+++ b/packages/find/src/github-stars.ts
@@ -123,12 +123,15 @@ export async function runGitHubStarsFinder(opts: GitHubStarsFinderOpts): Promise
     // empty window, and when empty, say how stale the newest star is so the
     // founder knows to widen `sinceDays` rather than wonder what broke.
     if (firstError) {
+      // Both the stargazers list AND the events-feed fallback failed — that's
+      // a rate limit or outage, not the (handled) July-2026 access restriction.
       result.halted = `github fetch failed (${firstError}) — set GITHUB_TOKEN for higher rate limits`;
     } else if (newestSeen) {
       const ageDays = Math.floor((Date.now() - new Date(newestSeen).getTime()) / 86_400_000);
       result.halted = `no stars in last ${sinceDays}d — newest was ${ageDays}d ago; widen sinceDays`;
     } else {
-      result.halted = "no stargazers found (check repo names / GITHUB_TOKEN)";
+      result.halted =
+        "no stargazers found (check repo names — third-party repos only surface stars still in the public events feed, ~90d/300 events)";
     }
     logEvent("finder.done", { name: PLAY_NAME, candidates: 0, halted: result.halted });
     return result;


### PR DESCRIPTION
## Why

GitHub [restricted](https://github.blog/changelog/2026-06-30-upcoming-access-restrictions-to-public-api-endpoints-and-ui-views/) `/repos/{repo}/stargazers` (and watchers) in July 2026 to repo admins/collaborators — unauthenticated calls get **401**, authenticated non-collaborators get **404**. No token scope fixes it, so the github-stars finder halted on every third-party watched repo with a misleading "set GITHUB_TOKEN" hint.

## What

`WatchEvent`s (star actor + timestamp) still flow through the public `/repos/{repo}/events` feed, so:

- `recentStargazers` falls back to a new `recentStargazersViaEvents` when the list endpoint answers 401/403/404 on the first page. Own repos (where the token owner is admin/collaborator) keep the full-history list walk.
- The events walk is capped at the feed's own retention (~90 days / 300 events → 3 pages of 100) and stops early once a page's oldest event predates the `sinceIso` window. Same `StargazersResult` shape — the rest of the finder pipeline is untouched.
- Halt hints in `github-stars.ts` reworded: a fetch failure now means *both* endpoints failed (rate limit/outage), and an empty result explains the events-feed retention window.

## Caveat

The events feed only retains ~90d/300 events per repo, so very busy repos can wash stars out between poll ticks — daily-or-faster trigger cadence keeps the gap negligible.

## Testing

- 7 unit tests (3 new: restricted→fallback, both-endpoints-fail error surfacing, early page stop) — all pass
- Verified live: recovered 7 stargazers of `NousResearch/hermes-agent` with correct star timestamps via the fallback
- `tsc --noEmit`, oxlint, oxfmt clean

https://claude.ai/code/session_01Na1bf7452zdZvNTEJXm5g6

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fall back to the public events feed when the stargazer list returns 401/403/404
> - When `recentStargazers` hits a 401, 403, or 404 on page 1 of `/stargazers`, it now falls back to `recentStargazersViaEvents`, which pages through `/repos/{repo}/events` (up to 3 pages, 100 per page) collecting `WatchEvent` rows.
> - The fallback filters events to the requested time window, dedupes by login (case-insensitive), tracks `newestSeen`, and stops early when a page is under 100 rows or older than the window.
> - Halted-reason messages in [github-stars.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/18/files#diff-a4a9f739ccfb5162b59261228f66a399754c0d09283a0247ce810ad93f8a797d) are updated to distinguish events-feed failures from list failures and to surface the ~90-day/300-event retention limit of the public feed.
> - Behavioral Change: repos with restricted stargazer lists now return results (or a descriptive `'events status <code>'` error) instead of immediately failing.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized eae8568.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->