### PR TITLE
feat(web,server,core): one drain button on /queue, plus drain-selected

### DIFF
--- a/apps/server/__tests__/queue-list-route.test.ts
+++ b/apps/server/__tests__/queue-list-route.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it, vi } from "vitest";
+
+// GET /api/queue carries `approvedByPlay` — whole-queue approved counts per
+// play — alongside the filtered `rows`. /queue's drain button reads it, so the
+// contract that matters is: the counts must NOT be narrowed by the request's
+// status/play filters (the button has to work from the default `pending` view).
+
+const listQueueCalls: Array<Record<string, unknown>> = [];
+
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    getLedger: () => ({
+      listQueue: (args: Record<string, unknown>) => {
+        listQueueCalls.push(args);
+        return [];
+      },
+      queueCounts: () => ({ pending: 0, approved: 220, rejected: 0, sent: 0, expired: 0 }),
+      approvedCountsByPlay: () => ({ "luma-events": 145, "repo-interest": 35 }),
+    }),
+  };
+});
+
+const { listQueueRoute } = await import("../src/api/queue.ts");
+
+async function body(url: string): Promise<Record<string, unknown>> {
+  const res = listQueueRoute(new Request(url));
+  return (await res.json()) as Record<string, unknown>;
+}
+
+describe("listQueueRoute", () => {
+  it("returns per-play approved counts", async () => {
+    const out = await body("http://x/api/queue");
+    expect(out["approvedByPlay"]).toEqual({ "luma-events": 145, "repo-interest": 35 });
+  });
+
+  it("passes an explicit ?ids= pick through to the row query", async () => {
+    listQueueCalls.length = 0;
+    await body("http://x/api/queue?ids=7,9,11&play=luma-events&status=approved");
+    expect(listQueueCalls[0]).toMatchObject({
+      ids: [7, 9, 11],
+      playName: "luma-events",
+      status: "approved",
+    });
+  });
+
+  it("drops junk ids and raises the limit to cover the pick", async () => {
+    listQueueCalls.length = 0;
+    await body("http://x/api/queue?ids=7,abc,,-3,0,9&limit=1");
+    // Only the two usable ids survive; limit can't be lower than the pick or
+    // the tail of a big selection would silently vanish.
+    expect(listQueueCalls[0]).toMatchObject({ ids: [7, 9], limit: 2 });
+  });
+
+  it("keeps those counts whole-queue even when rows are filtered", async () => {
+    listQueueCalls.length = 0;
+    const out = await body("http://x/api/queue?status=pending&play=show-hn");
+    // The filters reach the row query…
+    expect(listQueueCalls[0]).toMatchObject({ status: "pending", playName: "show-hn" });
+    expect(out["rows"]).toEqual([]);
+    // …but not the counts, which is the whole point.
+    expect(out["approvedByPlay"]).toEqual({ "luma-events": 145, "repo-interest": 35 });
+  });
+});

--- a/apps/server/__tests__/queue-list-route.test.ts
+++ b/apps/server/__tests__/queue-list-route.test.ts
@@ -53,6 +53,23 @@ describe("listQueueRoute", () => {
     expect(listQueueCalls[0]).toMatchObject({ ids: [7, 9], limit: 2 });
   });
 
+  it("keeps a present-but-empty ?ids= as an explicit empty pick", async () => {
+    // Regression: `?ids=` used to read as absent, so the route dropped the
+    // filter and returned the ordinary batch — a mangled drain-selected URL
+    // would hydrate rows the founder never picked.
+    for (const url of ["http://x/api/queue?ids=", "http://x/api/queue?ids=abc"]) {
+      listQueueCalls.length = 0;
+      await body(url);
+      expect(listQueueCalls[0], url).toHaveProperty("ids", []);
+    }
+  });
+
+  it("still lists normally when ?ids= is absent entirely", async () => {
+    listQueueCalls.length = 0;
+    await body("http://x/api/queue?status=approved");
+    expect(listQueueCalls[0]).not.toHaveProperty("ids");
+  });
+
   it("keeps those counts whole-queue even when rows are filtered", async () => {
     listQueueCalls.length = 0;
     const out = await body("http://x/api/queue?status=pending&play=show-hn");

--- a/apps/server/src/api/queue.ts
+++ b/apps/server/src/api/queue.ts
@@ -15,6 +15,7 @@ import {
   type DrainResult,
   type LastDraft,
   type QueueCounts,
+  type QueueListResponse,
   type QueueRowView,
   type RunPlayRequest,
 } from "@oneshot-gtm/shared-types";
@@ -72,14 +73,39 @@ export function listQueueRoute(req: Request): Response {
   const url = new URL(req.url);
   const playName = url.searchParams.get("play") ?? undefined;
   const status = (url.searchParams.get("status") ?? undefined) as QueueStatus | undefined;
+  // `?ids=1,2,3` — an explicit row pick (the /queue "drain selected" path).
+  // Non-numeric entries are dropped rather than 400ing: the caller is a URL,
+  // and a partial pick is still a valid, visible outcome. Capped at the same
+  // 500 as `limit` so a hand-crafted URL can't build unbounded SQL.
+  const idsParam = url.searchParams.get("ids");
+  const ids = idsParam
+    ? idsParam
+        .split(",")
+        .map((s) => Number.parseInt(s.trim(), 10))
+        .filter((n) => Number.isSafeInteger(n) && n > 0)
+        .slice(0, 500)
+    : undefined;
   const limit = Math.min(500, Number.parseInt(url.searchParams.get("limit") ?? "200", 10) || 200);
   const ledger = getLedger();
-  const filterArgs: { playName?: string; status?: QueueStatus; limit?: number } = { limit };
+  const filterArgs: {
+    playName?: string;
+    status?: QueueStatus;
+    limit?: number;
+    ids?: number[];
+  } = { limit: ids ? Math.max(limit, ids.length) : limit };
   if (playName) filterArgs.playName = playName;
   if (status) filterArgs.status = status;
+  if (ids) filterArgs.ids = ids;
   const rows = ledger.listQueue(filterArgs);
   const counts: QueueCounts = ledger.queueCounts();
-  return jsonResponse({ rows: rows.map(toView), counts }, 200, req);
+  // Unfiltered on purpose — the drain button needs per-play approved counts
+  // even while the page is showing, say, only pending rows.
+  const body: QueueListResponse = {
+    rows: rows.map(toView),
+    counts,
+    approvedByPlay: ledger.approvedCountsByPlay(),
+  };
+  return jsonResponse(body, 200, req);
 }
 
 export async function approveQueueRoute(

--- a/apps/server/src/api/queue.ts
+++ b/apps/server/src/api/queue.ts
@@ -14,6 +14,7 @@ import {
   type DrainRequest,
   type DrainResult,
   type LastDraft,
+  parseQueueIds,
   type QueueCounts,
   type QueueListResponse,
   type QueueRowView,
@@ -74,17 +75,9 @@ export function listQueueRoute(req: Request): Response {
   const playName = url.searchParams.get("play") ?? undefined;
   const status = (url.searchParams.get("status") ?? undefined) as QueueStatus | undefined;
   // `?ids=1,2,3` — an explicit row pick (the /queue "drain selected" path).
-  // Non-numeric entries are dropped rather than 400ing: the caller is a URL,
-  // and a partial pick is still a valid, visible outcome. Capped at the same
-  // 500 as `limit` so a hand-crafted URL can't build unbounded SQL.
-  const idsParam = url.searchParams.get("ids");
-  const ids = idsParam
-    ? idsParam
-        .split(",")
-        .map((s) => Number.parseInt(s.trim(), 10))
-        .filter((n) => Number.isSafeInteger(n) && n > 0)
-        .slice(0, 500)
-    : undefined;
+  // A present-but-unusable value yields `[]`, NOT `undefined`: falling back to
+  // the unscoped batch would hand the caller rows it never picked.
+  const ids = parseQueueIds(url.searchParams.get("ids"));
   const limit = Math.min(500, Number.parseInt(url.searchParams.get("limit") ?? "200", 10) || 200);
   const ledger = getLedger();
   const filterArgs: {

--- a/apps/server/src/api/run.ts
+++ b/apps/server/src/api/run.ts
@@ -1,26 +1,13 @@
 import { getLedger, logEvent, type TelemetryOutcome } from "@oneshot-gtm/core";
 import { verifyAndFilterTargets } from "@oneshot-gtm/plays";
-import type { RunPlayEvent, RunPlayRequest } from "@oneshot-gtm/shared-types";
+import { isRunnablePlay, type RunPlayEvent, type RunPlayRequest } from "@oneshot-gtm/shared-types";
 import { jsonResponse } from "../server.ts";
 import { reportServerExecution } from "../telemetry.ts";
 import { dispatchPlay, type DraftedView } from "./_play-dispatch.ts";
 
-const SUPPORTED = new Set([
-  "show-hn",
-  "job-change",
-  "post-funding",
-  "accelerator-batch",
-  "hiring-signal",
-  "podcast-guest",
-  "competitor-switch",
-  "stack-consolidation",
-  "repo-interest",
-  "luma-events",
-]);
-
 export async function runPlay(req: Request, params: Record<string, string>): Promise<Response> {
   const playName = params["playName"] ?? "";
-  if (!SUPPORTED.has(playName)) {
+  if (!isRunnablePlay(playName)) {
     return jsonResponse(
       { error: `play '${playName}' is not exposed in the UI; use the CLI` },
       400,

--- a/apps/web/__tests__/drainButton.test.ts
+++ b/apps/web/__tests__/drainButton.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import { drainButtonState, drainSelectionState } from "../src/lib/drainButton";
+
+const RUNNABLE = new Set(["luma-events", "repo-interest", "show-hn"]);
+const state = (playFilter: string, approvedByPlay: Record<string, number> = {}) =>
+  drainButtonState({ playFilter, approvedByPlay, isRunnable: (p) => RUNNABLE.has(p) });
+
+describe("drainButtonState", () => {
+  it("asks for a play when the filter is 'all'", () => {
+    const out = state("all", { "luma-events": 145 });
+    expect(out.enabled).toBe(false);
+    expect(out.playName).toBeNull();
+    expect(out.label).toBe("drain — pick a play above");
+  });
+
+  it("enables with the whole-queue count for the filtered play", () => {
+    const out = state("luma-events", { "luma-events": 145, "repo-interest": 35 });
+    expect(out).toEqual({
+      playName: "luma-events",
+      approvedCount: 145,
+      enabled: true,
+      label: "drain luma-events · 145",
+    });
+  });
+
+  it("says why it's disabled when the play has nothing approved", () => {
+    // Absent from the map (the server omits zero-count plays) reads as 0.
+    const out = state("show-hn", { "luma-events": 145 });
+    expect(out.enabled).toBe(false);
+    expect(out.label).toBe("drain show-hn · nothing approved");
+  });
+
+  it("refuses a play with no /run schema, even when rows are approved", () => {
+    const out = state("concierge", { concierge: 12 });
+    expect(out.enabled).toBe(false);
+    expect(out.label).toBe("drain concierge · not runnable here");
+  });
+});
+
+describe("drainSelectionState", () => {
+  const sel = (rows: Array<[number, string, string]>) =>
+    drainSelectionState({
+      selected: rows.map(([id, playName, status]) => ({ id, playName, status })),
+      isRunnable: (p) => RUNNABLE.has(p),
+    });
+
+  it("drains a single-play approved selection", () => {
+    const out = sel([
+      [1, "luma-events", "approved"],
+      [2, "luma-events", "approved"],
+    ]);
+    expect(out).toEqual({
+      playName: "luma-events",
+      ids: [1, 2],
+      enabled: true,
+      label: "drain 2 selected",
+    });
+  });
+
+  it("ignores non-approved rows in the selection", () => {
+    const out = sel([
+      [1, "luma-events", "approved"],
+      [2, "luma-events", "pending"],
+      [3, "luma-events", "sent"],
+    ]);
+    expect(out.ids).toEqual([1]);
+    expect(out.label).toBe("drain 1 selected");
+  });
+
+  it("refuses a selection spanning plays rather than draining a subset", () => {
+    const out = sel([
+      [1, "luma-events", "approved"],
+      [2, "repo-interest", "approved"],
+    ]);
+    expect(out.enabled).toBe(false);
+    expect(out.ids).toEqual([]);
+    expect(out.label).toBe("drain selected · spans 2 plays");
+  });
+
+  it("counts only approved rows when deciding whether plays are mixed", () => {
+    // The repo-interest row is pending, so this is NOT a mixed batch.
+    const out = sel([
+      [1, "luma-events", "approved"],
+      [2, "repo-interest", "pending"],
+    ]);
+    expect(out).toMatchObject({ playName: "luma-events", ids: [1], enabled: true });
+  });
+
+  it("disables when nothing selected is approved", () => {
+    expect(sel([[1, "luma-events", "pending"]])).toMatchObject({
+      enabled: false,
+      label: "drain selected · none approved",
+    });
+  });
+
+  it("disables for a play /run can't drive", () => {
+    expect(sel([[1, "concierge", "approved"]])).toMatchObject({
+      enabled: false,
+      label: "drain selected · not runnable here",
+    });
+  });
+});

--- a/apps/web/__tests__/drainButton.test.ts
+++ b/apps/web/__tests__/drainButton.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { drainButtonState, drainSelectionState } from "../src/lib/drainButton";
+import { drainButtonState, drainSelectionState, mergeRowMeta } from "../src/lib/drainButton";
 
 const RUNNABLE = new Set(["luma-events", "repo-interest", "show-hn"]);
+const rows = (...r: Array<[number, string, string]>) =>
+  r.map(([id, playName, status]) => ({ id, playName, status }));
 const state = (playFilter: string, approvedByPlay: Record<string, number> = {}) =>
   drainButtonState({ playFilter, approvedByPlay, isRunnable: (p) => RUNNABLE.has(p) });
 
@@ -98,5 +100,38 @@ describe("drainSelectionState", () => {
       enabled: false,
       label: "drain selected · not runnable here",
     });
+  });
+});
+
+describe("mergeRowMeta", () => {
+  it("remembers rows that later filters hide", () => {
+    // Founder selects across plays, then filters to one of them: the hidden
+    // row must still count, or "drain selected" would act on the visible subset.
+    let meta = mergeRowMeta(
+      new Map(),
+      rows([1, "luma-events", "approved"], [2, "repo-interest", "approved"]),
+    );
+    meta = mergeRowMeta(meta, rows([1, "luma-events", "approved"])); // filtered to luma-events
+    const out = drainSelectionState({
+      selected: [1, 2].map((id) => {
+        const m = meta.get(id) as { playName: string; status: string };
+        return { id, playName: m.playName, status: m.status };
+      }),
+      isRunnable: (p) => RUNNABLE.has(p),
+    });
+    expect(out.enabled).toBe(false);
+    expect(out.label).toBe("drain selected · spans 2 plays");
+  });
+
+  it("picks up a status that moved on", () => {
+    let meta = mergeRowMeta(new Map(), rows([1, "luma-events", "approved"]));
+    meta = mergeRowMeta(meta, rows([1, "luma-events", "sent"]));
+    expect(meta.get(1)).toEqual({ playName: "luma-events", status: "sent" });
+  });
+
+  it("returns the same map when nothing changed (safe to call from an effect)", () => {
+    const meta = mergeRowMeta(new Map(), rows([1, "luma-events", "approved"]));
+    expect(mergeRowMeta(meta, rows([1, "luma-events", "approved"]))).toBe(meta);
+    expect(mergeRowMeta(meta, [])).toBe(meta);
   });
 });

--- a/apps/web/__tests__/playSchemas.test.ts
+++ b/apps/web/__tests__/playSchemas.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { RUNNABLE_PLAYS } from "@oneshot-gtm/shared-types";
+import { PLAY_SCHEMAS } from "../src/lib/playSchemas";
+
+// The list and the schemas are edited in different files by different features,
+// and they drifted twice before this test existed: /queue's drain list lost
+// luma-events, the Plays page's copy lost competitor-switch. RUNNABLE_PLAYS is
+// now the single source of truth (the server's /api/run gate reads it), so a
+// play in the list with no form schema would render "not supported" after the
+// founder clicks through, and a schema with no listing would 400 at the server.
+describe("PLAY_SCHEMAS vs RUNNABLE_PLAYS", () => {
+  it("covers exactly the runnable plays", () => {
+    expect(Object.keys(PLAY_SCHEMAS).toSorted()).toEqual([...RUNNABLE_PLAYS].toSorted());
+  });
+
+  it("gives every schema at least one field and a default row", () => {
+    for (const [name, schema] of Object.entries(PLAY_SCHEMAS)) {
+      expect(schema.fields.length, `${name} has no fields`).toBeGreaterThan(0);
+      // Every field must be addressable from defaultRow, else hydration from a
+      // queue row silently drops it.
+      for (const f of schema.fields) {
+        expect(schema.defaultRow, `${name}.${f.key} missing from defaultRow`).toHaveProperty(f.key);
+      }
+    }
+  });
+});

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -20,8 +20,7 @@ import type {
   PlayDescriptor,
   DomainActionResult,
   DomainPoolView,
-  QueueCounts,
-  QueueRowView,
+  QueueListResponse,
   QueueStatusView,
   DeriveIcpResult,
   ReceiptDetail,
@@ -163,13 +162,20 @@ export const api = {
   // researched + drafted row appears on /queue when the background job finishes.
   addProspect: (url: string, email?: string) =>
     postJson<AddProspectResult>("/prospects/add", { url, ...(email ? { email } : {}) }),
-  queue: (opts?: { play?: string; status?: QueueStatusView; limit?: number }) => {
+  queue: (opts?: {
+    play?: string;
+    status?: QueueStatusView;
+    limit?: number;
+    /** Explicit row pick — the "drain selected" path. */
+    ids?: number[];
+  }) => {
     const q = new URLSearchParams();
     if (opts?.play) q.set("play", opts.play);
     if (opts?.status) q.set("status", opts.status);
     if (opts?.limit != null) q.set("limit", String(opts.limit));
+    if (opts?.ids?.length) q.set("ids", opts.ids.join(","));
     const qs = q.toString();
-    return getJson<{ rows: QueueRowView[]; counts: QueueCounts }>(`/queue${qs ? `?${qs}` : ""}`);
+    return getJson<QueueListResponse>(`/queue${qs ? `?${qs}` : ""}`);
   },
   approveQueue: (id: number) => postJson<{ ok: boolean }>(`/queue/${id}/approve`, {}),
   rejectQueue: (id: number, reason?: string) =>

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -173,7 +173,10 @@ export const api = {
     if (opts?.play) q.set("play", opts.play);
     if (opts?.status) q.set("status", opts.status);
     if (opts?.limit != null) q.set("limit", String(opts.limit));
-    if (opts?.ids?.length) q.set("ids", opts.ids.join(","));
+    // Note the `!= null`, not a length check: an empty array is an explicit
+    // "nothing picked" and must reach the server as `ids=`, or the server would
+    // read it as absent and return the unscoped batch instead of no rows.
+    if (opts?.ids != null) q.set("ids", opts.ids.join(","));
     const qs = q.toString();
     return getJson<QueueListResponse>(`/queue${qs ? `?${qs}` : ""}`);
   },

--- a/apps/web/src/lib/drainButton.ts
+++ b/apps/web/src/lib/drainButton.ts
@@ -1,0 +1,101 @@
+/**
+ * State of /queue's single drain button, derived from the PLAY filter chips
+ * above it. One button instead of one-per-play: the play is already chosen by
+ * the filter, and a disabled button should say *why* it's disabled rather than
+ * just dimming out.
+ *
+ *   { playFilter: "all" }                        → "drain — pick a play above"
+ *   { playFilter: "luma-events", approved: 145 } → "drain luma-events · 145"
+ *   { playFilter: "show-hn", approved: 0 }       → "drain show-hn · nothing approved"
+ *   { playFilter: "concierge" } (not runnable)   → "drain concierge · not runnable here"
+ */
+export interface DrainButtonState {
+  /** Play to drain, or null when the button can't act. */
+  playName: string | null;
+  approvedCount: number;
+  enabled: boolean;
+  label: string;
+}
+
+export function drainButtonState(input: {
+  playFilter: string;
+  approvedByPlay: Record<string, number>;
+  /** Usually `isRunnablePlay` from shared-types; injected so this stays pure. */
+  isRunnable: (playName: string) => boolean;
+}): DrainButtonState {
+  const { playFilter, approvedByPlay, isRunnable } = input;
+  if (playFilter === "all") {
+    return { playName: null, approvedCount: 0, enabled: false, label: "drain — pick a play above" };
+  }
+  const approvedCount = approvedByPlay[playFilter] ?? 0;
+  // Runnability first: "not runnable here" is the more useful complaint even
+  // when the play also happens to have nothing approved.
+  if (!isRunnable(playFilter)) {
+    return {
+      playName: playFilter,
+      approvedCount,
+      enabled: false,
+      label: `drain ${playFilter} · not runnable here`,
+    };
+  }
+  if (approvedCount === 0) {
+    return {
+      playName: playFilter,
+      approvedCount: 0,
+      enabled: false,
+      label: `drain ${playFilter} · nothing approved`,
+    };
+  }
+  return {
+    playName: playFilter,
+    approvedCount,
+    enabled: true,
+    label: `drain ${playFilter} · ${approvedCount}`,
+  };
+}
+
+/**
+ * State of the selection bar's "drain selected" button.
+ *
+ * Draining runs through /run, which is per-play and only accepts approved
+ * rows — so a selection that spans two plays, or holds nothing approved, can't
+ * be drained as one batch. Rather than silently draining a subset, the button
+ * disables and names the reason.
+ *
+ *   3 approved luma-events rows          → "drain 3 selected"
+ *   2 luma-events + 1 repo-interest      → "drain selected · spans 2 plays"
+ *   3 pending rows                       → "drain selected · none approved"
+ */
+export interface DrainSelectionState {
+  playName: string | null;
+  /** Row ids that would actually be drained (approved, single play). */
+  ids: number[];
+  enabled: boolean;
+  label: string;
+}
+
+export function drainSelectionState(input: {
+  /** The selected rows, as loaded in the table. */
+  selected: Array<{ id: number; playName: string; status: string }>;
+  isRunnable: (playName: string) => boolean;
+}): DrainSelectionState {
+  const approved = input.selected.filter((r) => r.status === "approved");
+  if (approved.length === 0) {
+    return { playName: null, ids: [], enabled: false, label: "drain selected · none approved" };
+  }
+  const plays = Array.from(new Set(approved.map((r) => r.playName)));
+  if (plays.length > 1) {
+    return {
+      playName: null,
+      ids: [],
+      enabled: false,
+      label: `drain selected · spans ${plays.length} plays`,
+    };
+  }
+  const playName = plays[0] as string;
+  const ids = approved.map((r) => r.id);
+  if (!input.isRunnable(playName)) {
+    return { playName, ids, enabled: false, label: "drain selected · not runnable here" };
+  }
+  return { playName, ids, enabled: true, label: `drain ${ids.length} selected` };
+}

--- a/apps/web/src/lib/drainButton.ts
+++ b/apps/web/src/lib/drainButton.ts
@@ -99,3 +99,30 @@ export function drainSelectionState(input: {
   }
   return { playName, ids, enabled: true, label: `drain ${ids.length} selected` };
 }
+
+/**
+ * Fold the currently-visible rows into the session's id → {play, status} map.
+ *
+ * /queue's selection is a Set of row ids that survives filter changes, but
+ * `rows` only ever holds the current filtered page. Without this memory, a
+ * selection spanning two plays looks single-play the moment you filter to one
+ * of them — and "drain selected" would quietly act on the visible subset.
+ *
+ * Returns the previous map unchanged when nothing moved, so it's safe to call
+ * from an effect keyed on `rows`.
+ */
+export type RowMeta = ReadonlyMap<number, { playName: string; status: string }>;
+
+export function mergeRowMeta(
+  prev: RowMeta,
+  rows: ReadonlyArray<{ id: number; playName: string; status: string }>,
+): RowMeta {
+  let next: Map<number, { playName: string; status: string }> | null = null;
+  for (const r of rows) {
+    const cur = prev.get(r.id);
+    if (cur && cur.playName === r.playName && cur.status === r.status) continue;
+    next ??= new Map(prev);
+    next.set(r.id, { playName: r.playName, status: r.status });
+  }
+  return next ?? prev;
+}

--- a/apps/web/src/lib/playSchemas.ts
+++ b/apps/web/src/lib/playSchemas.ts
@@ -1,0 +1,413 @@
+/**
+ * Per-play form schemas for the /run page — the fields a founder fills in (or
+ * that get hydrated from an approved queue row) before dispatching a play.
+ *
+ * Lives in lib/ rather than inside the route so it can be unit-tested and so
+ * other pages can reason about it without importing a route module (which drags
+ * the whole table into the entry bundle).
+ *
+ * The key set must match RUNNABLE_PLAYS in @oneshot-gtm/shared-types — the
+ * server's run gate keys off that list, and playSchemas.test.ts pins the two
+ * together so a play can never be runnable-but-formless (or vice versa).
+ */
+export interface FieldSpec {
+  key: string;
+  label: string;
+  type: "text" | "email" | "number" | "url" | "textarea";
+  required?: boolean;
+  placeholder?: string;
+  hint?: string;
+}
+
+export interface PlaySchema {
+  fields: FieldSpec[];
+  defaultRow: Record<string, string>;
+  description: string;
+  /** Extra non-target options surfaced as form fields above the rows. */
+  extras?: FieldSpec[];
+}
+
+export const PLAY_SCHEMAS: Record<string, PlaySchema> = {
+  "show-hn": {
+    description:
+      "One-touch founder-to-founder reply to a recent Show HN post. References a specific comment thread.",
+    fields: [
+      { key: "founderName", label: "Founder name", type: "text", required: true },
+      { key: "founderEmail", label: "Founder email", type: "email", required: true },
+      {
+        key: "postTitle",
+        label: "Show HN title",
+        type: "text",
+        required: true,
+        placeholder: "Show HN: Acme — open-source durable workflows",
+      },
+      { key: "postUrl", label: "Show HN URL", type: "url", required: true },
+      {
+        key: "hookSummary",
+        label: "Hook (specific comment thread / detail to reference)",
+        type: "textarea",
+        required: true,
+      },
+    ],
+    defaultRow: {
+      founderName: "",
+      founderEmail: "",
+      postTitle: "",
+      postUrl: "",
+      hookSummary: "",
+    },
+  },
+  "job-change": {
+    description:
+      "Triggered by a prospect starting a new role at a target company. Day-0 only here; cadence engine fires the day-5 follow-up automatically.",
+    fields: [
+      { key: "name", label: "Prospect name", type: "text", required: true },
+      { key: "email", label: "Prospect email", type: "email", required: true },
+      { key: "newRole", label: "New role", type: "text", required: true },
+      { key: "newCompany", label: "New company", type: "text", required: true },
+      { key: "previousRole", label: "Previous role", type: "text" },
+      { key: "previousCompany", label: "Previous company", type: "text" },
+      { key: "linkedinUrl", label: "LinkedIn URL (optional)", type: "url" },
+    ],
+    defaultRow: {
+      name: "",
+      email: "",
+      newRole: "",
+      newCompany: "",
+      previousRole: "",
+      previousCompany: "",
+      linkedinUrl: "",
+    },
+  },
+  "accelerator-batch": {
+    description:
+      "Founder-to-founder outreach within or across accelerator batches (YC, On Deck, SPC, Antler, Techstars).",
+    fields: [
+      { key: "name", label: "Prospect name", type: "text", required: true },
+      { key: "email", label: "Prospect email", type: "email", required: true },
+      { key: "company", label: "Company", type: "text", required: true },
+      {
+        key: "cohort",
+        label: "Cohort tag",
+        type: "text",
+        required: true,
+        placeholder: "e.g. yc-w26 · tx-s26 · antler-ldn-12",
+      },
+      { key: "launchUrl", label: "Launch URL (optional)", type: "url" },
+      { key: "productOneLiner", label: "Their product one-liner", type: "text" },
+      { key: "linkedinUrl", label: "LinkedIn URL (optional)", type: "url" },
+    ],
+    defaultRow: {
+      name: "",
+      email: "",
+      company: "",
+      cohort: "",
+      launchUrl: "",
+      productOneLiner: "",
+      linkedinUrl: "",
+    },
+    extras: [
+      {
+        key: "senderCohort",
+        label: "Your cohort tag (sender)",
+        type: "text",
+        required: true,
+        placeholder: "e.g. yc-w23 · od-2 · (leave blank)",
+      },
+      {
+        key: "freeForCohortOffer",
+        label: "Free-for-cohort offer (optional)",
+        type: "text",
+        placeholder: "e.g. Free for your batch through demo day — reply with your cohort.",
+      },
+    ],
+  },
+  "post-funding": {
+    description:
+      "Triggered by a recent funding announcement. Day-0 here; cadence engine fires the day-9 follow-up and day-18 breakup automatically.",
+    fields: [
+      { key: "name", label: "Founder name", type: "text", required: true },
+      { key: "email", label: "Founder email", type: "email", required: true },
+      { key: "company", label: "Company", type: "text", required: true },
+      {
+        key: "round",
+        label: "Round",
+        type: "text",
+        required: true,
+        placeholder: "Seed / Series A / Series B",
+      },
+      {
+        key: "amountUsd",
+        label: "Amount (USD)",
+        type: "number",
+        required: true,
+        placeholder: "5000000",
+      },
+      { key: "leadInvestor", label: "Lead investor (optional)", type: "text" },
+      { key: "sourceUrl", label: "Announcement URL", type: "url", required: true },
+      { key: "linkedinUrl", label: "LinkedIn URL (optional)", type: "url" },
+    ],
+    defaultRow: {
+      name: "",
+      email: "",
+      company: "",
+      round: "",
+      amountUsd: "",
+      leadInvestor: "",
+      sourceUrl: "",
+      linkedinUrl: "",
+    },
+  },
+  "hiring-signal": {
+    description:
+      "Triggered by a job post at a target company. One-touch email to the hiring manager with your ramp-time claim.",
+    fields: [
+      { key: "name", label: "Hiring manager name", type: "text", required: true },
+      { key: "email", label: "Hiring manager email", type: "email", required: true },
+      { key: "company", label: "Company", type: "text", required: true },
+      { key: "jobTitle", label: "Job title they're hiring for", type: "text", required: true },
+      { key: "jobPostUrl", label: "Job post URL (optional)", type: "url" },
+      {
+        key: "yourClaim",
+        label: "Your ramp-time claim",
+        type: "textarea",
+        required: true,
+        placeholder:
+          "We cut new-hire ramp time by ~30% on the team they're hiring for — happy to share how.",
+      },
+    ],
+    defaultRow: {
+      name: "",
+      email: "",
+      company: "",
+      jobTitle: "",
+      jobPostUrl: "",
+      yourClaim: "",
+    },
+  },
+  "podcast-guest": {
+    description:
+      "One-touch reply to a recent podcast guest referencing a specific moment from the episode.",
+    fields: [
+      { key: "name", label: "Guest name", type: "text", required: true },
+      { key: "email", label: "Guest email", type: "email", required: true },
+      { key: "company", label: "Guest company", type: "text", required: true },
+      {
+        key: "podcast",
+        label: "Podcast",
+        type: "text",
+        required: true,
+        placeholder: "Latent Space",
+      },
+      { key: "episodeTitle", label: "Episode title", type: "text", required: true },
+      {
+        key: "hookQuote",
+        label: "Specific quote or moment",
+        type: "textarea",
+        required: true,
+      },
+      {
+        key: "bridge",
+        label: "Why the moment matters to your work (one sentence)",
+        type: "text",
+      },
+    ],
+    defaultRow: {
+      name: "",
+      email: "",
+      company: "",
+      podcast: "",
+      episodeTitle: "",
+      hookQuote: "",
+      bridge: "",
+    },
+  },
+  "competitor-switch": {
+    description:
+      "Migration-honesty pitch to a prospect using a vendor you replace. Cites a specific evidence URL or claim, includes one yourEdge fact.",
+    fields: [
+      { key: "name", label: "Prospect name", type: "text", required: true },
+      { key: "email", label: "Prospect email", type: "email", required: true },
+      { key: "company", label: "Company", type: "text", required: true },
+      {
+        key: "competitor",
+        label: "Competitor (incumbent)",
+        type: "text",
+        required: true,
+        placeholder: "e.g. Salesforce · QuickBooks · Mailchimp",
+      },
+      {
+        key: "yourEdge",
+        label: "Your edge (one sentence)",
+        type: "textarea",
+        required: true,
+        hint: "One specific advantage, not a feature list. e.g. 'setup takes an afternoon, not a quarter'.",
+      },
+      {
+        key: "evidenceUrl",
+        label: "Evidence URL (optional)",
+        type: "url",
+        placeholder: "https://...",
+      },
+      {
+        key: "evidenceText",
+        label: "Evidence text (optional — paste a quote/snippet)",
+        type: "textarea",
+      },
+      { key: "linkedinUrl", label: "LinkedIn URL (optional)", type: "url" },
+    ],
+    defaultRow: {
+      name: "",
+      email: "",
+      company: "",
+      competitor: "",
+      yourEdge: "",
+      evidenceUrl: "",
+      evidenceText: "",
+      linkedinUrl: "",
+    },
+  },
+  "stack-consolidation": {
+    description:
+      "Consolidation-honesty pitch to a developer whose repo wires up several separate API vendors. One SDK collapses the sprawl; cites the detected stack and one yourEdge fact.",
+    fields: [
+      { key: "name", label: "Prospect name", type: "text", required: true },
+      { key: "email", label: "Prospect email", type: "email", required: true },
+      { key: "company", label: "Company", type: "text", required: true },
+      {
+        key: "vendorStack",
+        label: "Vendor stack (comma-separated)",
+        type: "textarea",
+        required: true,
+        placeholder: "e.g. auth0, stripe, sendgrid, datadog",
+        hint: "API vendors detected in their repo. Comma-separated.",
+      },
+      {
+        key: "yourEdge",
+        label: "Your edge (one sentence)",
+        type: "textarea",
+        required: true,
+        hint: "One specific way you collapse the sprawl. e.g. 'one integration replaces three separate vendors'.",
+      },
+      {
+        key: "evidenceUrl",
+        label: "Repo URL (optional)",
+        type: "url",
+        placeholder: "https://github.com/...",
+      },
+      { key: "linkedinUrl", label: "LinkedIn URL (optional)", type: "url" },
+    ],
+    defaultRow: {
+      name: "",
+      email: "",
+      company: "",
+      vendorStack: "",
+      yourEdge: "",
+      evidenceUrl: "",
+      linkedinUrl: "",
+    },
+  },
+  "repo-interest": {
+    description:
+      "Complementary intro to someone who starred a repo in your space (an adjacent tool, not a competitor). References the repo + one fact about how your product helps. One touch, no follow-up.",
+    fields: [
+      { key: "name", label: "Prospect name", type: "text", required: true },
+      { key: "email", label: "Prospect email", type: "email", required: true },
+      { key: "company", label: "Company", type: "text", required: true },
+      {
+        key: "repo",
+        label: "Repo they starred (owner/name)",
+        type: "text",
+        required: true,
+        placeholder: "e.g. modelcontextprotocol/servers",
+      },
+      {
+        key: "yourEdge",
+        label: "Your edge (one sentence)",
+        type: "textarea",
+        required: true,
+        hint: "How your product helps someone working in this space. e.g. 'one SDK for the tools they're already wiring up'.",
+      },
+      {
+        key: "evidenceUrl",
+        label: "Repo URL (optional)",
+        type: "url",
+        placeholder: "https://github.com/...",
+      },
+      { key: "linkedinUrl", label: "LinkedIn URL (optional)", type: "url" },
+    ],
+    defaultRow: {
+      name: "",
+      email: "",
+      company: "",
+      repo: "",
+      yourEdge: "",
+      evidenceUrl: "",
+      linkedinUrl: "",
+    },
+  },
+  "luma-events": {
+    description:
+      "Forward-looking pitch to a publicly-visible attendee of an upcoming Luma event. Hook references the specific event + city + date. One touch, no follow-up.",
+    fields: [
+      { key: "name", label: "Attendee name", type: "text", required: true },
+      { key: "email", label: "Attendee email", type: "email", required: true },
+      { key: "company", label: "Company (optional)", type: "text" },
+      {
+        key: "attendeeBio",
+        label: "Attendee bio / role (optional)",
+        type: "text",
+        placeholder: 'e.g. "Founder @ AcmeAI"',
+      },
+      {
+        key: "eventTitle",
+        label: "Event title",
+        type: "text",
+        required: true,
+        placeholder: "e.g. SF AI Builders Meetup",
+      },
+      {
+        key: "eventDate",
+        label: "Event date (ISO)",
+        type: "text",
+        required: true,
+        placeholder: "2026-06-10",
+        hint: "ISO date or datetime; prompt humanizes to 'tomorrow' / 'next Tuesday'.",
+      },
+      {
+        key: "eventCity",
+        label: "Event city",
+        type: "text",
+        required: true,
+        placeholder: "San Francisco",
+      },
+      {
+        key: "eventUrl",
+        label: "Luma event URL",
+        type: "url",
+        required: true,
+        placeholder: "https://luma.com/...",
+      },
+      {
+        key: "yourEdge",
+        label: "Your edge (one sentence)",
+        type: "textarea",
+        required: true,
+        hint: "How your product helps people going to events like this. e.g. 'a teardown of how X handles Y for hosts/attendees'.",
+      },
+      { key: "linkedinUrl", label: "LinkedIn URL (optional)", type: "url" },
+    ],
+    defaultRow: {
+      name: "",
+      email: "",
+      company: "",
+      attendeeBio: "",
+      eventTitle: "",
+      eventDate: "",
+      eventCity: "",
+      eventUrl: "",
+      yourEdge: "",
+      linkedinUrl: "",
+    },
+  },
+};

--- a/apps/web/src/routes/plays.tsx
+++ b/apps/web/src/routes/plays.tsx
@@ -3,7 +3,7 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { Check, Clock, Copy, Mail, MessageSquare, Phone, Play } from "lucide-react";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
-import type { PlayDescriptor } from "@oneshot-gtm/shared-types";
+import { isRunnablePlay, type PlayDescriptor } from "@oneshot-gtm/shared-types";
 import { api } from "../api/client.ts";
 import { Button } from "../components/primitives/Button.tsx";
 import { Input } from "../components/primitives/Field.tsx";
@@ -21,20 +21,6 @@ const CHANNEL_ICON = {
   voice: Phone,
   linkedin: MessageSquare,
 } as const;
-
-// Mirror of apps/server/src/api/run.ts SUPPORTED — plays whose targets the
-// SSE /api/run endpoint knows how to dispatch.
-const RUNNABLE_PLAYS = new Set([
-  "show-hn",
-  "job-change",
-  "post-funding",
-  "accelerator-batch",
-  "hiring-signal",
-  "podcast-guest",
-  "stack-consolidation",
-  "repo-interest",
-  "luma-events",
-]);
 
 // Non-runnable plays that are driven from the dashboard (not the CLI). Tagged
 // "dashboard" instead of "CLI only" on the Plays page.
@@ -193,7 +179,7 @@ function PlaysPage() {
           <div>
             {plays.data?.plays.map((p, i) => {
               const meta = PLAY_META[p.name];
-              const runnable = RUNNABLE_PLAYS.has(p.name);
+              const runnable = isRunnablePlay(p.name);
               const count = receiptCounts.get(p.name) ?? 0;
               return (
                 <div

--- a/apps/web/src/routes/queue.tsx
+++ b/apps/web/src/routes/queue.tsx
@@ -34,7 +34,12 @@ import { useMask } from "../lib/privacy.tsx";
 import { SkeletonRow } from "../components/primitives/Skeleton.tsx";
 import { Toggle } from "../components/primitives/Toggle.tsx";
 import { cn, eventIsPast, humanizeEventDate, timeAgo } from "../lib/cn.ts";
-import { drainButtonState, drainSelectionState } from "../lib/drainButton.ts";
+import {
+  drainButtonState,
+  drainSelectionState,
+  mergeRowMeta,
+  type RowMeta,
+} from "../lib/drainButton.ts";
 import { humanInterval } from "../lib/humanInterval.ts";
 import { INTERVAL_PRESETS_MS, withIntervalOverride } from "../lib/triggerInterval.ts";
 import {
@@ -55,6 +60,9 @@ import {
 export const Route = createFileRoute("/queue")({
   component: QueuePage,
 });
+
+/** Stable empty page — see `fetchedRows` below. */
+const EMPTY_ROWS: QueueRowView[] = [];
 
 const STATUSES: Array<QueueStatusView | "all"> = [
   "all",
@@ -225,10 +233,22 @@ function QueuePage() {
     sent: 0,
     expired: 0,
   };
-  const rows = queueQuery.data?.rows ?? [];
+  // Keep the fetched array's identity around: `?? []` allocates a fresh array
+  // every render, which would re-fire the rowMeta effect on each one.
+  const fetchedRows = queueQuery.data?.rows;
+  const rows = fetchedRows ?? EMPTY_ROWS;
   // Whole-queue approved counts per play — NOT scoped to the current filters,
   // so the drain button works from the default `pending` view too.
   const approvedByPlay = queueQuery.data?.approvedByPlay ?? {};
+  // Play/status of every row seen this session. Rows can only be selected while
+  // visible, so every selected id has an entry — and it stays correct after the
+  // filters hide the row. Refreshed whenever a row reappears in a fetch, so a
+  // status that moved on (someone else sent it) is picked up.
+  const [rowMeta, setRowMeta] = useState<RowMeta>(new Map());
+  useEffect(() => {
+    if (!fetchedRows) return;
+    setRowMeta((prev) => mergeRowMeta(prev, fetchedRows));
+  }, [fetchedRows]);
   const mask = useMask();
 
   // Per-row "generating draft" spinners, reconstructed from localStorage so they
@@ -246,8 +266,14 @@ function QueuePage() {
     new Set([...rows.map((r) => r.playName), ...Object.keys(approvedByPlay)]),
   ).toSorted();
   const drain = drainButtonState({ playFilter, approvedByPlay, isRunnable: isRunnablePlay });
+  // Selection outlives the filters, so read each selected row from the session
+  // map rather than the visible page — otherwise filtering to one play makes a
+  // cross-play selection look single-play and drains only what's on screen.
   const drainSelected = drainSelectionState({
-    selected: rows.filter((r) => selected.has(r.id)),
+    selected: [...selected].map((id) => {
+      const meta = rowMeta.get(id);
+      return { id, playName: meta?.playName ?? "", status: meta?.status ?? "" };
+    }),
     isRunnable: isRunnablePlay,
   });
 

--- a/apps/web/src/routes/queue.tsx
+++ b/apps/web/src/routes/queue.tsx
@@ -18,6 +18,7 @@ import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import {
   blockingFlags,
+  isRunnablePlay,
   type QueueRowView,
   type QueueStatusView,
   type TriggerView,
@@ -33,6 +34,7 @@ import { useMask } from "../lib/privacy.tsx";
 import { SkeletonRow } from "../components/primitives/Skeleton.tsx";
 import { Toggle } from "../components/primitives/Toggle.tsx";
 import { cn, eventIsPast, humanizeEventDate, timeAgo } from "../lib/cn.ts";
+import { drainButtonState, drainSelectionState } from "../lib/drainButton.ts";
 import { humanInterval } from "../lib/humanInterval.ts";
 import { INTERVAL_PRESETS_MS, withIntervalOverride } from "../lib/triggerInterval.ts";
 import {
@@ -63,21 +65,6 @@ const STATUSES: Array<QueueStatusView | "all"> = [
   "expired",
 ];
 
-// Finder-fed plays whose queue rows can be drained. github-topics routes
-// candidates to stack-consolidation (vendor sprawl) or competitor-switch
-// (when a detected vendor is on its directCompetitors list), so both appear.
-const DRAINABLE_PLAYS = [
-  "show-hn",
-  "job-change",
-  "post-funding",
-  "accelerator-batch",
-  "hiring-signal",
-  "podcast-guest",
-  "competitor-switch",
-  "stack-consolidation",
-  "repo-interest",
-];
-
 function statusTone(
   status: QueueStatusView,
 ): "receipt" | "spend" | "blocked" | "signal" | "neutral" {
@@ -103,6 +90,11 @@ interface RejectModalState {
 interface DrainModalState {
   playName: string;
   approvedCount: number;
+  /**
+   * Set when draining an explicit selection — /run hydrates exactly these rows
+   * and the modal's limit field steps aside (the pick IS the limit).
+   */
+  ids?: number[];
 }
 
 interface EditingState {
@@ -213,9 +205,10 @@ function QueuePage() {
     if (!drainModal) return;
     const search: Record<string, string> = {
       fromQueue: "1",
-      limit: String(drainLimit),
+      limit: String(drainModal.ids ? drainModal.ids.length : drainLimit),
       dryRun: drainDryRun ? "1" : "0",
     };
+    if (drainModal.ids) search["ids"] = drainModal.ids.join(",");
     if (drainSenderCohort.trim()) search["senderCohort"] = drainSenderCohort.trim();
     if (drainOffer.trim()) search["freeForCohortOffer"] = drainOffer.trim();
     void navigate({
@@ -233,6 +226,9 @@ function QueuePage() {
     expired: 0,
   };
   const rows = queueQuery.data?.rows ?? [];
+  // Whole-queue approved counts per play — NOT scoped to the current filters,
+  // so the drain button works from the default `pending` view too.
+  const approvedByPlay = queueQuery.data?.approvedByPlay ?? {};
   const mask = useMask();
 
   // Per-row "generating draft" spinners, reconstructed from localStorage so they
@@ -243,7 +239,17 @@ function QueuePage() {
     new Map(rows.map((r) => [r.id, r.lastDraftedAt])),
   );
 
-  const playList = Array.from(new Set(rows.map((r) => r.playName))).toSorted();
+  // Plays on the visible page, plus any play holding approved rows anywhere —
+  // the chip both filters the table and scopes the drain button, so a play with
+  // drainable rows must stay selectable even when the page shows none of them.
+  const playList = Array.from(
+    new Set([...rows.map((r) => r.playName), ...Object.keys(approvedByPlay)]),
+  ).toSorted();
+  const drain = drainButtonState({ playFilter, approvedByPlay, isRunnable: isRunnablePlay });
+  const drainSelected = drainSelectionState({
+    selected: rows.filter((r) => selected.has(r.id)),
+    isRunnable: isRunnablePlay,
+  });
 
   // Selection derived state — stable across renders even if rows refetch.
   const someSelected = selected.size > 0;
@@ -333,9 +339,9 @@ function QueuePage() {
           ))}
         </div>
 
-        {/* Bulk actions — approve-all + per-play drain. Colocated with the
-            table they act on; respects the current play filter so clicking
-            "approve all pending" while a play is selected scopes down. */}
+        {/* Bulk actions — approve-all + drain. Colocated with the table they
+            act on; both respect the current play filter, so the chips above
+            are the only play selector on the page. */}
         <div className="flex flex-wrap items-center gap-2 border-b border-ink-rule/60 bg-ink-surface/30 px-6 py-3">
           <Button
             variant="secondary"
@@ -346,27 +352,17 @@ function QueuePage() {
             <Check size={12} /> approve all pending
             {playFilter !== "all" ? ` (${playFilter})` : ""}
           </Button>
-          {DRAINABLE_PLAYS.map((p) => (
-            <Button
-              key={p}
-              variant="ghost"
-              size="sm"
-              disabled={
-                counts.approved === 0 ||
-                (playFilter !== "all" && playFilter !== p) ||
-                !rows.some((r) => r.playName === p && r.status === "approved")
-              }
-              onClick={() =>
-                setDrainModal({
-                  playName: p,
-                  approvedCount: rows.filter((r) => r.playName === p && r.status === "approved")
-                    .length,
-                })
-              }
-            >
-              <Send size={12} /> drain {p}
-            </Button>
-          ))}
+          <Button
+            variant="ghost"
+            size="sm"
+            disabled={!drain.enabled}
+            onClick={() => {
+              if (!drain.playName) return;
+              setDrainModal({ playName: drain.playName, approvedCount: drain.approvedCount });
+            }}
+          >
+            <Send size={12} /> {drain.label}
+          </Button>
         </div>
 
         {/* 7-day signal strip — enqueues per day from the rows in memory. */}
@@ -472,6 +468,21 @@ function QueuePage() {
             >
               <X size={12} /> reject {selected.size}
             </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={!drainSelected.enabled}
+              onClick={() => {
+                if (!drainSelected.playName) return;
+                setDrainModal({
+                  playName: drainSelected.playName,
+                  approvedCount: drainSelected.ids.length,
+                  ids: drainSelected.ids,
+                });
+              }}
+            >
+              <Send size={12} /> {drainSelected.label}
+            </Button>
           </div>
         </div>
       )}
@@ -511,7 +522,11 @@ function QueuePage() {
       <Modal
         open={drainModal != null}
         onClose={() => setDrainModal(null)}
-        title={`Drain ${drainModal?.playName ?? ""} (${drainModal?.approvedCount ?? 0} approved)`}
+        title={
+          drainModal?.ids
+            ? `Drain ${drainModal.playName} (${drainModal.ids.length} selected)`
+            : `Drain ${drainModal?.playName ?? ""} (${drainModal?.approvedCount ?? 0} approved)`
+        }
         footer={
           <>
             <Button variant="ghost" onClick={() => setDrainModal(null)}>
@@ -519,20 +534,34 @@ function QueuePage() {
             </Button>
             <Button onClick={submitDrainViaRun}>
               <Send size={12} />
-              {drainDryRun ? "Preview drafts (no send)" : `Send up to ${drainLimit}`}
+              {drainDryRun
+                ? "Preview drafts (no send)"
+                : `Send ${drainModal?.ids ? `the ${drainModal.ids.length} selected` : `up to ${drainLimit}`}`}
             </Button>
           </>
         }
       >
         <div className="flex flex-col gap-3">
-          <Field label="Limit">
-            <Input
-              type="number"
-              min={1}
-              value={drainLimit}
-              onChange={(e) => setDrainLimit(Math.max(1, Number.parseInt(e.target.value, 10) || 1))}
-            />
-          </Field>
+          {/* A selection IS the limit — showing a second, contradictory number
+              here would just invite "limit 10 of my 3 selected rows". */}
+          {drainModal?.ids ? (
+            <p className="text-[13px] text-ink-cream-2">
+              Draining the {drainModal.ids.length} approved{" "}
+              {drainModal.ids.length === 1 ? "row" : "rows"} you selected — nothing else in the
+              queue is touched.
+            </p>
+          ) : (
+            <Field label="Limit">
+              <Input
+                type="number"
+                min={1}
+                value={drainLimit}
+                onChange={(e) =>
+                  setDrainLimit(Math.max(1, Number.parseInt(e.target.value, 10) || 1))
+                }
+              />
+            </Field>
+          )}
           {drainModal?.playName === "accelerator-batch" && (
             <>
               <Field

--- a/apps/web/src/routes/run.$playName.tsx
+++ b/apps/web/src/routes/run.$playName.tsx
@@ -8,6 +8,7 @@ import { Badge } from "../components/primitives/Badge.tsx";
 import { Button } from "../components/primitives/Button.tsx";
 import { Field, Input, Textarea } from "../components/primitives/Field.tsx";
 import { cn } from "../lib/cn.ts";
+import { PLAY_SCHEMAS } from "../lib/playSchemas.ts";
 import { useMask } from "../lib/privacy.tsx";
 import { pruneSentRows } from "../lib/pruneSentRows.ts";
 
@@ -22,6 +23,11 @@ interface RunSearch {
   dryRun?: "0" | "1";
   senderCohort?: string;
   freeForCohortOffer?: string;
+  /**
+   * Explicit queue-row ids ("drain selected"). When present, hydration loads
+   * exactly these rows instead of the play's newest `limit` approved ones.
+   */
+  ids?: number[];
   /**
    * In-progress / done / interrupted mode: fetch GET /api/runs/:runId and render
    * server-side per-target state, polling every 2s while running. Survives
@@ -39,6 +45,13 @@ export const Route = createFileRoute("/run/$playName")({
     else if (typeof search["limit"] === "string" && /^\d+$/.test(search["limit"])) {
       out.limit = Number.parseInt(search["limit"], 10);
     }
+    if (typeof search["ids"] === "string" && search["ids"].trim().length > 0) {
+      const ids = search["ids"]
+        .split(",")
+        .map((s) => Number.parseInt(s.trim(), 10))
+        .filter((n) => Number.isSafeInteger(n) && n > 0);
+      if (ids.length > 0) out.ids = ids;
+    }
     if (search["dryRun"] === "0" || search["dryRun"] === "1") out.dryRun = search["dryRun"];
     if (typeof search["senderCohort"] === "string") out.senderCohort = search["senderCohort"];
     if (typeof search["freeForCohortOffer"] === "string") {
@@ -51,408 +64,6 @@ export const Route = createFileRoute("/run/$playName")({
     return out;
   },
 });
-
-interface FieldSpec {
-  key: string;
-  label: string;
-  type: "text" | "email" | "number" | "url" | "textarea";
-  required?: boolean;
-  placeholder?: string;
-  hint?: string;
-}
-
-interface PlaySchema {
-  fields: FieldSpec[];
-  defaultRow: Record<string, string>;
-  description: string;
-  /** Extra non-target options surfaced as form fields above the rows. */
-  extras?: FieldSpec[];
-}
-
-const PLAY_SCHEMAS: Record<string, PlaySchema> = {
-  "show-hn": {
-    description:
-      "One-touch founder-to-founder reply to a recent Show HN post. References a specific comment thread.",
-    fields: [
-      { key: "founderName", label: "Founder name", type: "text", required: true },
-      { key: "founderEmail", label: "Founder email", type: "email", required: true },
-      {
-        key: "postTitle",
-        label: "Show HN title",
-        type: "text",
-        required: true,
-        placeholder: "Show HN: Acme — open-source durable workflows",
-      },
-      { key: "postUrl", label: "Show HN URL", type: "url", required: true },
-      {
-        key: "hookSummary",
-        label: "Hook (specific comment thread / detail to reference)",
-        type: "textarea",
-        required: true,
-      },
-    ],
-    defaultRow: {
-      founderName: "",
-      founderEmail: "",
-      postTitle: "",
-      postUrl: "",
-      hookSummary: "",
-    },
-  },
-  "job-change": {
-    description:
-      "Triggered by a prospect starting a new role at a target company. Day-0 only here; cadence engine fires the day-5 follow-up automatically.",
-    fields: [
-      { key: "name", label: "Prospect name", type: "text", required: true },
-      { key: "email", label: "Prospect email", type: "email", required: true },
-      { key: "newRole", label: "New role", type: "text", required: true },
-      { key: "newCompany", label: "New company", type: "text", required: true },
-      { key: "previousRole", label: "Previous role", type: "text" },
-      { key: "previousCompany", label: "Previous company", type: "text" },
-      { key: "linkedinUrl", label: "LinkedIn URL (optional)", type: "url" },
-    ],
-    defaultRow: {
-      name: "",
-      email: "",
-      newRole: "",
-      newCompany: "",
-      previousRole: "",
-      previousCompany: "",
-      linkedinUrl: "",
-    },
-  },
-  "accelerator-batch": {
-    description:
-      "Founder-to-founder outreach within or across accelerator batches (YC, On Deck, SPC, Antler, Techstars).",
-    fields: [
-      { key: "name", label: "Prospect name", type: "text", required: true },
-      { key: "email", label: "Prospect email", type: "email", required: true },
-      { key: "company", label: "Company", type: "text", required: true },
-      {
-        key: "cohort",
-        label: "Cohort tag",
-        type: "text",
-        required: true,
-        placeholder: "e.g. yc-w26 · tx-s26 · antler-ldn-12",
-      },
-      { key: "launchUrl", label: "Launch URL (optional)", type: "url" },
-      { key: "productOneLiner", label: "Their product one-liner", type: "text" },
-      { key: "linkedinUrl", label: "LinkedIn URL (optional)", type: "url" },
-    ],
-    defaultRow: {
-      name: "",
-      email: "",
-      company: "",
-      cohort: "",
-      launchUrl: "",
-      productOneLiner: "",
-      linkedinUrl: "",
-    },
-    extras: [
-      {
-        key: "senderCohort",
-        label: "Your cohort tag (sender)",
-        type: "text",
-        required: true,
-        placeholder: "e.g. yc-w23 · od-2 · (leave blank)",
-      },
-      {
-        key: "freeForCohortOffer",
-        label: "Free-for-cohort offer (optional)",
-        type: "text",
-        placeholder: "e.g. Free for your batch through demo day — reply with your cohort.",
-      },
-    ],
-  },
-  "post-funding": {
-    description:
-      "Triggered by a recent funding announcement. Day-0 here; cadence engine fires the day-9 follow-up and day-18 breakup automatically.",
-    fields: [
-      { key: "name", label: "Founder name", type: "text", required: true },
-      { key: "email", label: "Founder email", type: "email", required: true },
-      { key: "company", label: "Company", type: "text", required: true },
-      {
-        key: "round",
-        label: "Round",
-        type: "text",
-        required: true,
-        placeholder: "Seed / Series A / Series B",
-      },
-      {
-        key: "amountUsd",
-        label: "Amount (USD)",
-        type: "number",
-        required: true,
-        placeholder: "5000000",
-      },
-      { key: "leadInvestor", label: "Lead investor (optional)", type: "text" },
-      { key: "sourceUrl", label: "Announcement URL", type: "url", required: true },
-      { key: "linkedinUrl", label: "LinkedIn URL (optional)", type: "url" },
-    ],
-    defaultRow: {
-      name: "",
-      email: "",
-      company: "",
-      round: "",
-      amountUsd: "",
-      leadInvestor: "",
-      sourceUrl: "",
-      linkedinUrl: "",
-    },
-  },
-  "hiring-signal": {
-    description:
-      "Triggered by a job post at a target company. One-touch email to the hiring manager with your ramp-time claim.",
-    fields: [
-      { key: "name", label: "Hiring manager name", type: "text", required: true },
-      { key: "email", label: "Hiring manager email", type: "email", required: true },
-      { key: "company", label: "Company", type: "text", required: true },
-      { key: "jobTitle", label: "Job title they're hiring for", type: "text", required: true },
-      { key: "jobPostUrl", label: "Job post URL (optional)", type: "url" },
-      {
-        key: "yourClaim",
-        label: "Your ramp-time claim",
-        type: "textarea",
-        required: true,
-        placeholder:
-          "We cut new-hire ramp time by ~30% on the team they're hiring for — happy to share how.",
-      },
-    ],
-    defaultRow: {
-      name: "",
-      email: "",
-      company: "",
-      jobTitle: "",
-      jobPostUrl: "",
-      yourClaim: "",
-    },
-  },
-  "podcast-guest": {
-    description:
-      "One-touch reply to a recent podcast guest referencing a specific moment from the episode.",
-    fields: [
-      { key: "name", label: "Guest name", type: "text", required: true },
-      { key: "email", label: "Guest email", type: "email", required: true },
-      { key: "company", label: "Guest company", type: "text", required: true },
-      {
-        key: "podcast",
-        label: "Podcast",
-        type: "text",
-        required: true,
-        placeholder: "Latent Space",
-      },
-      { key: "episodeTitle", label: "Episode title", type: "text", required: true },
-      {
-        key: "hookQuote",
-        label: "Specific quote or moment",
-        type: "textarea",
-        required: true,
-      },
-      {
-        key: "bridge",
-        label: "Why the moment matters to your work (one sentence)",
-        type: "text",
-      },
-    ],
-    defaultRow: {
-      name: "",
-      email: "",
-      company: "",
-      podcast: "",
-      episodeTitle: "",
-      hookQuote: "",
-      bridge: "",
-    },
-  },
-  "competitor-switch": {
-    description:
-      "Migration-honesty pitch to a prospect using a vendor you replace. Cites a specific evidence URL or claim, includes one yourEdge fact.",
-    fields: [
-      { key: "name", label: "Prospect name", type: "text", required: true },
-      { key: "email", label: "Prospect email", type: "email", required: true },
-      { key: "company", label: "Company", type: "text", required: true },
-      {
-        key: "competitor",
-        label: "Competitor (incumbent)",
-        type: "text",
-        required: true,
-        placeholder: "e.g. Salesforce · QuickBooks · Mailchimp",
-      },
-      {
-        key: "yourEdge",
-        label: "Your edge (one sentence)",
-        type: "textarea",
-        required: true,
-        hint: "One specific advantage, not a feature list. e.g. 'setup takes an afternoon, not a quarter'.",
-      },
-      {
-        key: "evidenceUrl",
-        label: "Evidence URL (optional)",
-        type: "url",
-        placeholder: "https://...",
-      },
-      {
-        key: "evidenceText",
-        label: "Evidence text (optional — paste a quote/snippet)",
-        type: "textarea",
-      },
-      { key: "linkedinUrl", label: "LinkedIn URL (optional)", type: "url" },
-    ],
-    defaultRow: {
-      name: "",
-      email: "",
-      company: "",
-      competitor: "",
-      yourEdge: "",
-      evidenceUrl: "",
-      evidenceText: "",
-      linkedinUrl: "",
-    },
-  },
-  "stack-consolidation": {
-    description:
-      "Consolidation-honesty pitch to a developer whose repo wires up several separate API vendors. One SDK collapses the sprawl; cites the detected stack and one yourEdge fact.",
-    fields: [
-      { key: "name", label: "Prospect name", type: "text", required: true },
-      { key: "email", label: "Prospect email", type: "email", required: true },
-      { key: "company", label: "Company", type: "text", required: true },
-      {
-        key: "vendorStack",
-        label: "Vendor stack (comma-separated)",
-        type: "textarea",
-        required: true,
-        placeholder: "e.g. auth0, stripe, sendgrid, datadog",
-        hint: "API vendors detected in their repo. Comma-separated.",
-      },
-      {
-        key: "yourEdge",
-        label: "Your edge (one sentence)",
-        type: "textarea",
-        required: true,
-        hint: "One specific way you collapse the sprawl. e.g. 'one integration replaces three separate vendors'.",
-      },
-      {
-        key: "evidenceUrl",
-        label: "Repo URL (optional)",
-        type: "url",
-        placeholder: "https://github.com/...",
-      },
-      { key: "linkedinUrl", label: "LinkedIn URL (optional)", type: "url" },
-    ],
-    defaultRow: {
-      name: "",
-      email: "",
-      company: "",
-      vendorStack: "",
-      yourEdge: "",
-      evidenceUrl: "",
-      linkedinUrl: "",
-    },
-  },
-  "repo-interest": {
-    description:
-      "Complementary intro to someone who starred a repo in your space (an adjacent tool, not a competitor). References the repo + one fact about how your product helps. One touch, no follow-up.",
-    fields: [
-      { key: "name", label: "Prospect name", type: "text", required: true },
-      { key: "email", label: "Prospect email", type: "email", required: true },
-      { key: "company", label: "Company", type: "text", required: true },
-      {
-        key: "repo",
-        label: "Repo they starred (owner/name)",
-        type: "text",
-        required: true,
-        placeholder: "e.g. modelcontextprotocol/servers",
-      },
-      {
-        key: "yourEdge",
-        label: "Your edge (one sentence)",
-        type: "textarea",
-        required: true,
-        hint: "How your product helps someone working in this space. e.g. 'one SDK for the tools they're already wiring up'.",
-      },
-      {
-        key: "evidenceUrl",
-        label: "Repo URL (optional)",
-        type: "url",
-        placeholder: "https://github.com/...",
-      },
-      { key: "linkedinUrl", label: "LinkedIn URL (optional)", type: "url" },
-    ],
-    defaultRow: {
-      name: "",
-      email: "",
-      company: "",
-      repo: "",
-      yourEdge: "",
-      evidenceUrl: "",
-      linkedinUrl: "",
-    },
-  },
-  "luma-events": {
-    description:
-      "Forward-looking pitch to a publicly-visible attendee of an upcoming Luma event. Hook references the specific event + city + date. One touch, no follow-up.",
-    fields: [
-      { key: "name", label: "Attendee name", type: "text", required: true },
-      { key: "email", label: "Attendee email", type: "email", required: true },
-      { key: "company", label: "Company (optional)", type: "text" },
-      {
-        key: "attendeeBio",
-        label: "Attendee bio / role (optional)",
-        type: "text",
-        placeholder: 'e.g. "Founder @ AcmeAI"',
-      },
-      {
-        key: "eventTitle",
-        label: "Event title",
-        type: "text",
-        required: true,
-        placeholder: "e.g. SF AI Builders Meetup",
-      },
-      {
-        key: "eventDate",
-        label: "Event date (ISO)",
-        type: "text",
-        required: true,
-        placeholder: "2026-06-10",
-        hint: "ISO date or datetime; prompt humanizes to 'tomorrow' / 'next Tuesday'.",
-      },
-      {
-        key: "eventCity",
-        label: "Event city",
-        type: "text",
-        required: true,
-        placeholder: "San Francisco",
-      },
-      {
-        key: "eventUrl",
-        label: "Luma event URL",
-        type: "url",
-        required: true,
-        placeholder: "https://luma.com/...",
-      },
-      {
-        key: "yourEdge",
-        label: "Your edge (one sentence)",
-        type: "textarea",
-        required: true,
-        hint: "How your product helps people going to events like this. e.g. 'a teardown of how X handles Y for hosts/attendees'.",
-      },
-      { key: "linkedinUrl", label: "LinkedIn URL (optional)", type: "url" },
-    ],
-    defaultRow: {
-      name: "",
-      email: "",
-      company: "",
-      attendeeBio: "",
-      eventTitle: "",
-      eventDate: "",
-      eventCity: "",
-      eventUrl: "",
-      yourEdge: "",
-      linkedinUrl: "",
-    },
-  },
-};
 
 function RunPage() {
   const { playName } = Route.useParams();
@@ -540,10 +151,15 @@ function RunPage() {
     async (cancelledRef?: { cancelled: boolean }): Promise<void> => {
       if (!schema) return;
       try {
+        // `ids` (drain-selected) narrows to exactly the founder's pick. play +
+        // status stay on as a guard: a hand-edited URL can't pull another
+        // play's rows into this play's form, and a row that got sent between
+        // the click and the load drops out instead of being re-sent.
         const res = await api.queue({
           play: playName,
           status: "approved",
-          limit: search.limit ?? 50,
+          ...(search.ids ? { ids: search.ids } : {}),
+          limit: search.ids ? search.ids.length : (search.limit ?? 50),
         });
         if (cancelledRef?.cancelled) return;
         const pairs = res.rows
@@ -592,7 +208,7 @@ function RunPage() {
         setError(`failed to load approved targets from queue: ${(err as Error).message}`);
       }
     },
-    [playName, schema, search.limit],
+    [playName, schema, search.limit, search.ids],
   );
 
   useEffect(() => {

--- a/apps/web/src/routes/run.$playName.tsx
+++ b/apps/web/src/routes/run.$playName.tsx
@@ -2,7 +2,12 @@ import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { ArrowLeft, CheckCircle2, Loader2, Play, Plus, RefreshCw, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import type { RunPlayEvent, RunPlayRequest, RunRecord } from "@oneshot-gtm/shared-types";
+import {
+  parseQueueIds,
+  type RunPlayEvent,
+  type RunPlayRequest,
+  type RunRecord,
+} from "@oneshot-gtm/shared-types";
 import { api } from "../api/client.ts";
 import { Badge } from "../components/primitives/Badge.tsx";
 import { Button } from "../components/primitives/Button.tsx";
@@ -45,13 +50,11 @@ export const Route = createFileRoute("/run/$playName")({
     else if (typeof search["limit"] === "string" && /^\d+$/.test(search["limit"])) {
       out.limit = Number.parseInt(search["limit"], 10);
     }
-    if (typeof search["ids"] === "string" && search["ids"].trim().length > 0) {
-      const ids = search["ids"]
-        .split(",")
-        .map((s) => Number.parseInt(s.trim(), 10))
-        .filter((n) => Number.isSafeInteger(n) && n > 0);
-      if (ids.length > 0) out.ids = ids;
-    }
+    // Keep an explicit-but-empty pick (`?ids=`, `?ids=abc`) as `[]` rather than
+    // dropping the field — hydration must load nothing, not silently widen to
+    // the play's whole approved batch.
+    const ids = parseQueueIds(typeof search["ids"] === "string" ? search["ids"] : null);
+    if (ids) out.ids = ids;
     if (search["dryRun"] === "0" || search["dryRun"] === "1") out.dryRun = search["dryRun"];
     if (typeof search["senderCohort"] === "string") out.senderCohort = search["senderCohort"];
     if (typeof search["freeForCohortOffer"] === "string") {
@@ -159,7 +162,7 @@ function RunPage() {
           play: playName,
           status: "approved",
           ...(search.ids ? { ids: search.ids } : {}),
-          limit: search.ids ? search.ids.length : (search.limit ?? 50),
+          limit: search.ids ? Math.max(1, search.ids.length) : (search.limit ?? 50),
         });
         if (cancelledRef?.cancelled) return;
         const pairs = res.rows

--- a/packages/core/__tests__/ledger-extra.test.ts
+++ b/packages/core/__tests__/ledger-extra.test.ts
@@ -218,6 +218,65 @@ describe("isEmailPendingInQueue (cross-play pending dedup)", () => {
   });
 });
 
+describe("approvedCountsByPlay", () => {
+  it("counts approved rows per play and omits plays with none", () => {
+    const enqueue = (playName: string, key: string, status?: "approved" | "sent"): void => {
+      const id = ledger.enqueueTarget({ playName, payload: {}, dedupeKey: key, source: "x" });
+      if (status) ledger.setQueueStatus({ id: id!, status });
+    };
+    enqueue("luma-events", "l1", "approved");
+    enqueue("luma-events", "l2", "approved");
+    enqueue("repo-interest", "r1", "approved");
+    // Non-approved rows of an otherwise-approved play don't inflate the count…
+    enqueue("repo-interest", "r2");
+    enqueue("repo-interest", "r3", "sent");
+    // …and a play with no approved row at all is absent, not zero.
+    enqueue("show-hn", "s1");
+
+    expect(ledger.approvedCountsByPlay()).toEqual({ "luma-events": 2, "repo-interest": 1 });
+  });
+
+  it("returns an empty map on an empty queue", () => {
+    expect(ledger.approvedCountsByPlay()).toEqual({});
+  });
+});
+
+describe("listQueue({ ids })", () => {
+  it("returns only the requested rows, still honouring the other filters", () => {
+    const a = ledger.enqueueTarget({
+      playName: "luma-events",
+      payload: {},
+      dedupeKey: "a",
+      source: "x",
+    })!;
+    const b = ledger.enqueueTarget({
+      playName: "luma-events",
+      payload: {},
+      dedupeKey: "b",
+      source: "x",
+    })!;
+    const c = ledger.enqueueTarget({
+      playName: "luma-events",
+      payload: {},
+      dedupeKey: "c",
+      source: "x",
+    })!;
+    for (const id of [a, b, c]) ledger.setQueueStatus({ id, status: "approved" });
+    // A selected row that moved on since the founder ticked it must drop out.
+    ledger.setQueueStatus({ id: c, status: "sent" });
+
+    const got = ledger.listQueue({ ids: [a, b, c], status: "approved" });
+    expect(got.map((r) => r.id).toSorted()).toEqual([a, b].toSorted());
+  });
+
+  it("returns nothing for an empty pick (never the whole table)", () => {
+    ledger.enqueueTarget({ playName: "show-hn", payload: {}, dedupeKey: "z", source: "x" });
+    expect(ledger.listQueue({ ids: [] })).toEqual([]);
+    // Sanity: the same call without `ids` does list rows.
+    expect(ledger.listQueue({}).length).toBe(1);
+  });
+});
+
 describe("expirePendingOlderThan", () => {
   it("flips only pending rows older than the cutoff", () => {
     // Fresh pending row — should NOT be expired.

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -1755,7 +1755,9 @@ export class Ledger {
     );
   }
 
-  listQueue(opts: { playName?: string; status?: QueueStatus; limit?: number } = {}): QueueRow[] {
+  listQueue(
+    opts: { playName?: string; status?: QueueStatus; limit?: number; ids?: number[] } = {},
+  ): QueueRow[] {
     const where: string[] = [];
     const args: unknown[] = [];
     if (opts.playName) {
@@ -1765,6 +1767,15 @@ export class Ledger {
     if (opts.status) {
       where.push("status = ?");
       args.push(opts.status);
+    }
+    // Explicit row picks (the /queue "drain selected" path). An empty array
+    // would compile to `IN ()` — a syntax error in SQLite — and semantically
+    // means "nothing selected", so return early rather than silently listing
+    // every row.
+    if (opts.ids) {
+      if (opts.ids.length === 0) return [];
+      where.push(`id IN (${opts.ids.map(() => "?").join(",")})`);
+      args.push(...opts.ids);
     }
     const sql = `
       SELECT * FROM target_queue
@@ -1962,6 +1973,23 @@ export class Ledger {
       expired: 0,
     };
     for (const r of rows) out[r.status] = r.n;
+    return out;
+  }
+
+  /**
+   * Approved-row count per play, across the whole queue. Deliberately ignores
+   * any status/play filter the caller is showing: /queue's drain button needs
+   * to know a play has drainable rows even when the visible page is filtered
+   * to `pending`. Plays with zero approved rows are absent from the map.
+   */
+  approvedCountsByPlay(): Record<string, number> {
+    const rows = this.db
+      .query(
+        "SELECT play_name, COUNT(*) AS n FROM target_queue WHERE status = 'approved' GROUP BY play_name",
+      )
+      .all() as Array<{ play_name: string; n: number }>;
+    const out: Record<string, number> = {};
+    for (const r of rows) out[r.play_name] = r.n;
     return out;
   }
 

--- a/packages/shared-types/__tests__/queueIds.test.ts
+++ b/packages/shared-types/__tests__/queueIds.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { parseQueueIds } from "../src/index";
+
+// The distinction this function exists to preserve: "no pick" (undefined →
+// list normally) vs "a pick that resolved to nothing" ([] → list nothing).
+// Collapsing the second into the first turns a drain-selected URL into an
+// unscoped drain of rows the founder never selected — which they could then send.
+describe("parseQueueIds", () => {
+  it("returns undefined only when the parameter is absent", () => {
+    expect(parseQueueIds(null)).toBeUndefined();
+    expect(parseQueueIds(undefined)).toBeUndefined();
+  });
+
+  it("returns an explicit empty pick for a present-but-empty value", () => {
+    expect(parseQueueIds("")).toEqual([]);
+    expect(parseQueueIds("   ")).toEqual([]);
+    expect(parseQueueIds(",,")).toEqual([]);
+  });
+
+  it("returns an explicit empty pick when every token is junk", () => {
+    expect(parseQueueIds("abc")).toEqual([]);
+    expect(parseQueueIds("-1,0,abc")).toEqual([]);
+  });
+
+  it("rejects numeric-prefixed tokens instead of truncating them", () => {
+    // parseInt("123abc") would yield 123 and load an unintended row.
+    expect(parseQueueIds("123abc")).toEqual([]);
+    expect(parseQueueIds("12.9")).toEqual([]);
+    expect(parseQueueIds("7,123abc,9")).toEqual([7, 9]);
+  });
+
+  it("parses a normal pick, trimming whitespace", () => {
+    expect(parseQueueIds("7,9,11")).toEqual([7, 9, 11]);
+    expect(parseQueueIds(" 7 , 9 ")).toEqual([7, 9]);
+  });
+
+  it("caps the pick so a hand-crafted URL can't build unbounded SQL", () => {
+    const raw = Array.from({ length: 600 }, (_, i) => i + 1).join(",");
+    expect(parseQueueIds(raw)).toHaveLength(500);
+  });
+});

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -404,6 +404,35 @@ export function blockingFlags(flags: string[]): string[] {
   return flags.filter((f) => !SOFT_REVIEW_FLAGS.includes(f));
 }
 
+/**
+ * Plays the SSE `/api/run/:playName` endpoint can dispatch — i.e. the ones
+ * drivable from the dashboard rather than the CLI. Canonical: the server's run
+ * gate, /queue's drain button and the Plays page all read THIS, because three
+ * hand-copied mirrors of the list had already drifted apart (the queue's copy
+ * was missing luma-events, the Plays page's was missing competitor-switch).
+ *
+ * Adding a play here also requires a form schema in the web app's
+ * `lib/playSchemas.ts`; a test pins the two together.
+ */
+export const RUNNABLE_PLAYS: readonly string[] = [
+  "show-hn",
+  "job-change",
+  "post-funding",
+  "accelerator-batch",
+  "hiring-signal",
+  "podcast-guest",
+  "competitor-switch",
+  "stack-consolidation",
+  "repo-interest",
+  "luma-events",
+];
+
+const RUNNABLE_PLAY_SET = new Set(RUNNABLE_PLAYS);
+
+export function isRunnablePlay(playName: string): boolean {
+  return RUNNABLE_PLAY_SET.has(playName);
+}
+
 /** A single inbox email (reply to outreach), with prospect/play context when matched. */
 export interface InboxReplyView {
   id: string;
@@ -508,6 +537,18 @@ export interface QueueCounts {
   rejected: number;
   sent: number;
   expired: number;
+}
+
+export interface QueueListResponse {
+  rows: QueueRowView[];
+  counts: QueueCounts;
+  /**
+   * Approved rows per play across the WHOLE queue, unaffected by the `status` /
+   * `play` filters that scoped `rows`. /queue's drain button reads this so it
+   * can offer a play whose rows aren't on the visible page. Plays with nothing
+   * approved are omitted.
+   */
+  approvedByPlay: Record<string, number>;
 }
 
 export interface DrainRequest {

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -427,6 +427,28 @@ export const RUNNABLE_PLAYS: readonly string[] = [
   "luma-events",
 ];
 
+/**
+ * Parse a `?ids=1,2,3` queue-row pick (the "drain selected" path).
+ *
+ * Returns `undefined` only when the parameter is ABSENT. A present-but-unusable
+ * value (`?ids=`, `?ids=abc`) returns `[]` — an explicit empty pick — because
+ * collapsing it to "absent" would silently downgrade a scoped drain into an
+ * unscoped one and hydrate rows the founder never selected, which they could
+ * then send. Tokens must be whole decimal integers: `123abc` is rejected
+ * outright rather than parsed as `123`, which would load an unintended row.
+ * Capped at 500 to match the list endpoint's own limit.
+ */
+export function parseQueueIds(raw: string | null | undefined): number[] | undefined {
+  if (raw == null) return undefined;
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => /^\d+$/.test(s))
+    .map((s) => Number.parseInt(s, 10))
+    .filter((n) => Number.isSafeInteger(n) && n > 0)
+    .slice(0, 500);
+}
+
 const RUNNABLE_PLAY_SET = new Set(RUNNABLE_PLAYS);
 
 export function isRunnablePlay(playName: string): boolean {


### PR DESCRIPTION
## Why

The `/queue` bulk bar rendered **nine** `drain <play>` buttons from a hand-kept array — and `luma-events` was never added to it. That stranded **145 of the 220 approved rows** (two-thirds of the drainable queue) with no way to drain them from the UI. The per-play buttons also duplicated the PLAY chip row directly above them, so eight of the nine were dead at any moment.

There was a second, quieter trap: the enabled-check read the *currently filtered page* of rows, while the counts it sat next to were global. Under the default `pending` status filter, no approved rows are loaded — so **every** drain button was disabled even with a full queue, until you happened to switch the status filter.

## What changed

**One button, scoped to the PLAY filter.** The chips above already pick the play; the button follows them. Disabled states name their reason instead of just dimming:

| condition | label |
|---|---|
| PLAY = all | `drain — pick a play above` |
| nothing approved | `drain show-hn · nothing approved` |
| no /run schema | `drain concierge · not runnable here` |
| otherwise | `drain luma-events · 145` |

**Drain selected.** The selection bar gains a drain button beside approve/reject. Approved-only and single-play, since `/run` is per-play and won't send unapproved rows — a mixed pick disables with `drain selected · spans 2 plays` rather than silently draining a subset.

**Counts come from the ledger, not the page.** New `ledger.approvedCountsByPlay()`, surfaced as `approvedByPlay` on `GET /api/queue`, deliberately ignoring the request's `status`/`play` filters. That kills the default-filter trap.

**One list instead of four.** The set of dashboard-runnable plays lived in three hand-copied mirrors that had already drifted — `/queue`'s was missing `luma-events`, `/plays`' was missing `competitor-switch`, and `plays.tsx` literally carried a `// Mirror of apps/server/src/api/run.ts SUPPORTED` comment. `RUNNABLE_PLAYS` / `isRunnablePlay()` now live in `shared-types` and the server's run gate, the drain button and the Plays page all read it. Side effect: `competitor-switch` stops being mislabelled CLI-only on `/plays`.

**`?ids=` filter.** `GET /api/queue?ids=1,2,3` (via `listQueue({ids})`) and a matching `?ids=` on `/run`, which hydrates exactly those rows. An empty or all-junk pick returns **nothing**, never a fallback to listing everything. `play` + `status=approved` stay on the `/run` fetch as a guard, so a hand-edited URL can't pull another play's rows into this play's form, and a row sent between click and load drops out instead of being re-sent.

**`PLAY_SCHEMAS` moved to `lib/playSchemas.ts`.** Importing it from the route module dragged the whole ~400-line table into the always-loaded entry chunk (measured: 396,102 B → 405,159 B). Now back to baseline, and a test pins its keys to `RUNNABLE_PLAYS` so a play can't be runnable-but-formless.

## Verification

- Typecheck clean, oxlint 0/0, **1264/1264** tests (12 new: ledger counts + ids filter, route contract, both button state machines, schema/list parity).
- Live against the real ledger: `approvedByPlay` = `{luma-events: 145, repo-interest: 35, stack-consolidation: 40}` and stays identical under `?status=pending` and `?play=…&status=sent`.
- `?ids=7686,7619,7618&play=luma-events` → exactly those rows; the same ids under `play=repo-interest` → 0 rows; `?ids=abc,,-1` → 200 with 0 rows.
- Run gate: `/api/run/concierge` → rejected; `/api/run/competitor-switch` → passes the gate, fails on empty targets.
- Entry bundle back to 396 kB, no duplicated schema table.

**Not verified:** the UI was never clicked — the Chrome extension isn't connected in this environment. Button logic is unit-tested and the API is confirmed live, but a human should eyeball `/queue` before merge.

https://claude.ai/code/session_01WfjkhiBKFjEbkkL5TzmRLZ

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add a single drain button and drain-selected support to the queue page
> - Replaces per-play drain buttons on `/queue` with a single drain button driven by whole-queue `approvedByPlay` counts, computed by the new `Ledger.approvedCountsByPlay` method and returned in `QueueListResponse`.
> - Adds a "drain selected" action in the selection bar that filters to approved rows from a single play; selection state persists across filter changes via `mergeRowMeta` in [drainButton.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/19/files#diff-77617687af73a5c2e1e4194bed004bd7a89a3a92ebec3b6f1721f6b8f0496ef6).
> - Extends `Ledger.listQueue` and `GET /api/queue` to accept an `ids` parameter; an empty `ids=` is treated as an explicit empty pick (returns no rows) rather than no filter.
> - The `/run` route now accepts `ids` in search params to scope hydration to those specific approved queue rows.
> - Centralizes runnability checks into `isRunnablePlay` and `RUNNABLE_PLAYS` in `shared-types`, removing local copies in the server and web app.
> - Risk: `ids=` present but empty now returns zero rows from `listQueue`; callers that previously sent an empty param expecting all rows will get none.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d235845.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->