### PR TITLE
fix(plays): log why a per-target send failed, not just "Tool request failed"

### DIFF
--- a/apps/server/src/api/queue.ts
+++ b/apps/server/src/api/queue.ts
@@ -7,7 +7,7 @@ import {
   type TelemetryOutcome,
 } from "@oneshot-gtm/core";
 import { drainQueue } from "@oneshot-gtm/find";
-import { enrollInCadence, sendDraftedEmail } from "@oneshot-gtm/plays";
+import { enrollInCadence, logTargetError, sendDraftedEmail } from "@oneshot-gtm/plays";
 import { reportServerExecution } from "../telemetry.ts";
 import {
   blockingFlags,
@@ -411,6 +411,11 @@ export async function sendDraftRoute(
     if (isSendDeferred(err)) {
       return done("ok", jsonResponse({ error: (err as Error).message, deferred: true }, 429, req));
     }
+    // The 400 body carries only `err.message`, which for an SDK ToolError is
+    // the generic "Tool request failed" — the founder sees "couldn't send ·
+    // 400 Bad Request: {"error":"Tool request failed"}" and has nothing to act
+    // on. Log the status + response body so the real reason is recoverable.
+    logTargetError({ playName: row.play_name, to: email, err });
     return done(
       "error",
       jsonResponse({ error: (err as Error).message ?? "send failed" }, 400, req),

--- a/packages/plays/__tests__/target-error-logging.test.ts
+++ b/packages/plays/__tests__/target-error-logging.test.ts
@@ -110,3 +110,52 @@ describe("logTargetError redaction", () => {
     expect(logged[0]?.ctx).not.toHaveProperty("to_domain");
   });
 });
+
+describe("logTargetError never throws", () => {
+  // It runs inside the per-target catch. A TypeError raised while logging
+  // would escape that catch and abort the whole drain — the exact failure the
+  // catch exists to prevent. A thrown value is `unknown`, so nothing about its
+  // shape can be assumed.
+  const nasty: Array<[string, unknown]> = [
+    ["non-string message", { message: 500, stack: 42 }],
+    ["thrown string", "just a string"],
+    ["thrown number", 500],
+    ["null", null],
+    ["undefined", undefined],
+    [
+      "object with throwing getter",
+      {
+        get message() {
+          throw new Error("boom");
+        },
+      },
+    ],
+    ["non-Error cause", new Error("outer", { cause: { code: 7 } })],
+  ];
+
+  for (const [label, err] of nasty) {
+    it(`survives ${label}`, () => {
+      logged.length = 0;
+      expect(() => logTargetError({ playName: "show-hn", err })).not.toThrow();
+      // A hostile getter costs us the log entry, never the run.
+      if (label !== "object with throwing getter") {
+        expect(logged).toHaveLength(1);
+        expect(typeof logged[0]?.ctx["message_200"]).toBe("string");
+        expect(typeof logged[0]?.ctx["stack_300"]).toBe("string");
+      }
+    });
+  }
+
+  it("coerces a non-string message instead of crashing", () => {
+    logged.length = 0;
+    logTargetError({ playName: "show-hn", err: { message: 500, stack: 42 } });
+    expect(logged[0]?.ctx["message_200"]).toBe("500");
+    expect(logged[0]?.ctx["stack_300"]).toBe("42");
+  });
+
+  it("tolerates a non-string recipient", () => {
+    logged.length = 0;
+    logTargetError({ playName: "show-hn", to: 42 as unknown as string, err: new Error("x") });
+    expect(logged[0]?.ctx).not.toHaveProperty("to_domain");
+  });
+});

--- a/packages/plays/__tests__/target-error-logging.test.ts
+++ b/packages/plays/__tests__/target-error-logging.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+
+// A per-target failure surfaces on the queue row as errorDraft's 80-char slice
+// of err.message — for an SDK ToolError that's the generic "Tool request
+// failed". The 2026-08-13 luma-events drain failed all 8 of its sends that way
+// and left NOTHING in events.jsonl to diagnose from. logTargetError is what
+// keeps the status code + response body, which is where the real reason lives.
+
+const logged: Array<{ kind: string; ctx: Record<string, unknown>; level?: string }> = [];
+
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    logEvent: (kind: string, ctx: Record<string, unknown>, level?: string) => {
+      logged.push({ kind, ctx, ...(level ? { level } : {}) });
+    },
+  };
+});
+
+const { logTargetError, errorDraft } = await import("../src/_lib.ts");
+
+/** Shape of the OneShot SDK's ToolError: generic message, real detail alongside. */
+function toolError(): Error {
+  const e = new Error("Tool request failed") as Error & {
+    statusCode: number;
+    responseBody: string;
+  };
+  e.statusCode = 403;
+  e.responseBody = JSON.stringify({
+    error: "domain_not_owned",
+    message: "Domain is owned by a different agent.",
+    domain: "oneshotagent.com",
+  });
+  return e;
+}
+
+describe("logTargetError", () => {
+  it("keeps the status code and response body the row throws away", () => {
+    logged.length = 0;
+    logTargetError({ playName: "luma-events", to: "a@b.dev", err: toolError() });
+
+    expect(logged).toHaveLength(1);
+    const [entry] = logged;
+    expect(entry?.kind).toBe("play.target_error");
+    expect(entry?.level).toBe("error");
+    expect(entry?.ctx).toMatchObject({
+      play: "luma-events",
+      to: "a@b.dev",
+      message_200: "Tool request failed",
+      status_code: 403,
+    });
+    // The reason the founder actually needs — absent from the queue row.
+    expect(String(entry?.ctx["response_body_400"])).toContain("domain_not_owned");
+
+    // Contrast: this is all the row itself carries.
+    expect(errorDraft(toolError().message).flags).toEqual(["error: Tool request failed"]);
+  });
+
+  it("records a plain Error without inventing SDK fields", () => {
+    logged.length = 0;
+    logTargetError({ playName: "show-hn", to: "c@d.dev", err: new Error("boom") });
+    expect(logged[0]?.ctx).toMatchObject({
+      play: "show-hn",
+      message_200: "boom",
+      status_code: null,
+      response_body_400: null,
+      cause_200: null,
+    });
+  });
+
+  it("unwraps a nested cause", () => {
+    logged.length = 0;
+    const err = new Error("outer", { cause: new Error("the real reason") });
+    logTargetError({ playName: "show-hn", err });
+    expect(logged[0]?.ctx["cause_200"]).toBe("the real reason");
+    // No recipient supplied → the key is omitted rather than logged as null.
+    expect(logged[0]?.ctx).not.toHaveProperty("to");
+  });
+
+  it("truncates a huge response body instead of dumping it into the log", () => {
+    logged.length = 0;
+    const e = new Error("Tool request failed") as Error & { responseBody: string };
+    e.responseBody = "x".repeat(5000);
+    logTargetError({ playName: "luma-events", err: e });
+    expect(String(logged[0]?.ctx["response_body_400"])).toHaveLength(400);
+  });
+});

--- a/packages/plays/__tests__/target-error-logging.test.ts
+++ b/packages/plays/__tests__/target-error-logging.test.ts
@@ -46,10 +46,12 @@ describe("logTargetError", () => {
     expect(entry?.level).toBe("error");
     expect(entry?.ctx).toMatchObject({
       play: "luma-events",
-      to: "a@b.dev",
+      // Domain only — events.jsonl is a PII-free sink.
+      to_domain: "b.dev",
       message_200: "Tool request failed",
       status_code: 403,
     });
+    expect(JSON.stringify(entry?.ctx)).not.toContain("a@b.dev");
     // The reason the founder actually needs — absent from the queue row.
     expect(String(entry?.ctx["response_body_400"])).toContain("domain_not_owned");
 
@@ -75,7 +77,7 @@ describe("logTargetError", () => {
     logTargetError({ playName: "show-hn", err });
     expect(logged[0]?.ctx["cause_200"]).toBe("the real reason");
     // No recipient supplied → the key is omitted rather than logged as null.
-    expect(logged[0]?.ctx).not.toHaveProperty("to");
+    expect(logged[0]?.ctx).not.toHaveProperty("to_domain");
   });
 
   it("truncates a huge response body instead of dumping it into the log", () => {
@@ -84,5 +86,27 @@ describe("logTargetError", () => {
     e.responseBody = "x".repeat(5000);
     logTargetError({ playName: "luma-events", err: e });
     expect(String(logged[0]?.ctx["response_body_400"])).toHaveLength(400);
+  });
+});
+
+describe("logTargetError redaction", () => {
+  // Asserts on the address itself, not on "@" — stack_300 legitimately carries
+  // node_modules paths like `@vitest+runner@4.1.5`.
+  it("keeps the domain and drops the local part, whatever the caller passes", () => {
+    for (const [to, domain] of [
+      ["pat@acme.io", "acme.io"],
+      ["ODD@Example.CO", "Example.CO"],
+    ] as const) {
+      logged.length = 0;
+      logTargetError({ playName: "show-hn", to, err: new Error("x") });
+      expect(logged[0]?.ctx["to_domain"], to).toBe(domain);
+      expect(String(logged[0]?.ctx["to_domain"]), to).not.toContain(to.split("@")[0]);
+    }
+  });
+
+  it("omits the key entirely for a value that isn't an address", () => {
+    logged.length = 0;
+    logTargetError({ playName: "show-hn", to: "not-an-email", err: new Error("x") });
+    expect(logged[0]?.ctx).not.toHaveProperty("to_domain");
   });
 });

--- a/packages/plays/src/_lib.ts
+++ b/packages/plays/src/_lib.ts
@@ -239,6 +239,47 @@ export function errorDraft(message: string | null | undefined): ErrorDraft {
 }
 
 /**
+ * Record WHY a single target failed, next to every `errorDraft` call site.
+ *
+ * What reaches the queue row (and the founder's screen) is errorDraft's 80-char
+ * slice of `err.message` — for an SDK ToolError that's the generic "Tool
+ * request failed", true and useless. The status code and response body carry
+ * the actual reason (`403 domain_not_owned`, the last time one was captured).
+ * Without this, a drain could fail every send and leave nothing in
+ * events.jsonl to diagnose from.
+ *
+ * Mirrors the whole-run handler in apps/server/src/api/run.ts, which already
+ * logs these fields; per-target failures were the gap.
+ */
+export function logTargetError(input: {
+  playName: string;
+  to?: string | null;
+  err: unknown;
+}): void {
+  const e = input.err as Error & {
+    cause?: unknown;
+    statusCode?: number;
+    responseBody?: string;
+  };
+  const causeMsg = e?.cause instanceof Error ? e.cause.message : e?.cause ? String(e.cause) : null;
+  logEvent(
+    "play.target_error",
+    {
+      play: input.playName,
+      ...(input.to ? { to: input.to } : {}),
+      message_200: (e?.message ?? "").slice(0, 200),
+      // OneShot SDK ToolError carries the failing call's HTTP status + server
+      // response body — the real reason, vs the generic message.
+      status_code: typeof e?.statusCode === "number" ? e.statusCode : null,
+      response_body_400: typeof e?.responseBody === "string" ? e.responseBody.slice(0, 400) : null,
+      cause_200: causeMsg ? causeMsg.slice(0, 200) : null,
+      stack_300: (e?.stack ?? "").slice(0, 300),
+    },
+    "error",
+  );
+}
+
+/**
  * Deterministic, semantics-preserving cleanups that the LLM occasionally
  * slips through despite the humanizer rules being in its system prompt.
  * Applied silently inside `draftEmailFromPrompt` so these four flags never

--- a/packages/plays/src/_lib.ts
+++ b/packages/plays/src/_lib.ts
@@ -253,6 +253,13 @@ export function errorDraft(message: string | null | undefined): ErrorDraft {
  */
 export function logTargetError(input: {
   playName: string;
+  /**
+   * Recipient address. Only its DOMAIN is logged — events.jsonl is a
+   * PII-free sink (see the `email_domain` precedent in core/send-routing.ts),
+   * and the domain is the diagnostic half anyway: it tells you whether one
+   * receiving domain is rejecting. Redaction lives here, not at the call
+   * sites, so no caller can leak the address by accident.
+   */
   to?: string | null;
   err: unknown;
 }): void {
@@ -266,7 +273,7 @@ export function logTargetError(input: {
     "play.target_error",
     {
       play: input.playName,
-      ...(input.to ? { to: input.to } : {}),
+      ...(input.to?.includes("@") ? { to_domain: input.to.split("@")[1] } : {}),
       message_200: (e?.message ?? "").slice(0, 200),
       // OneShot SDK ToolError carries the failing call's HTTP status + server
       // response body — the real reason, vs the generic message.

--- a/packages/plays/src/_lib.ts
+++ b/packages/plays/src/_lib.ts
@@ -268,19 +268,45 @@ export function logTargetError(input: {
     statusCode?: number;
     responseBody?: string;
   };
-  const causeMsg = e?.cause instanceof Error ? e.cause.message : e?.cause ? String(e.cause) : null;
+  // Nothing here may throw. This runs INSIDE the per-target catch whose whole
+  // job is to stop one bad target from killing the batch — a TypeError raised
+  // while logging would escape that catch and abort the entire drain. A thrown
+  // value is `unknown`: `{ message: 500 }` is legal, so is a rejected string,
+  // and `.slice()` on either blows up. Coerce, don't assume.
+  try {
+    logTargetErrorUnsafe(e, input);
+  } catch {
+    // Belt and braces: a hostile shape (a throwing `message` getter, a
+    // String()-hostile object) must not turn a logged failure into a dead
+    // batch. Losing the diagnosis is bad; losing the run is worse.
+  }
+}
+
+/** Coerce an unknown thrown field to a string — never assume `.slice()` exists. */
+function text(v: unknown): string {
+  return typeof v === "string" ? v : v == null ? "" : String(v);
+}
+
+function logTargetErrorUnsafe(
+  e: Error & { cause?: unknown; statusCode?: number; responseBody?: string },
+  input: { playName: string; to?: string | null },
+): void {
+  const causeMsg =
+    e?.cause instanceof Error ? text(e.cause.message) : e?.cause ? text(e.cause) : null;
   logEvent(
     "play.target_error",
     {
       play: input.playName,
-      ...(input.to?.includes("@") ? { to_domain: input.to.split("@")[1] } : {}),
-      message_200: (e?.message ?? "").slice(0, 200),
+      ...(typeof input.to === "string" && input.to.includes("@")
+        ? { to_domain: input.to.split("@")[1] }
+        : {}),
+      message_200: text(e?.message).slice(0, 200),
       // OneShot SDK ToolError carries the failing call's HTTP status + server
       // response body — the real reason, vs the generic message.
       status_code: typeof e?.statusCode === "number" ? e.statusCode : null,
       response_body_400: typeof e?.responseBody === "string" ? e.responseBody.slice(0, 400) : null,
       cause_200: causeMsg ? causeMsg.slice(0, 200) : null,
-      stack_300: (e?.stack ?? "").slice(0, 300),
+      stack_300: text(e?.stack).slice(0, 300),
     },
     "error",
   );

--- a/packages/plays/src/_run-play.ts
+++ b/packages/plays/src/_run-play.ts
@@ -10,6 +10,7 @@ import {
   errorDraft,
   firstNameFrom,
   lintEmail,
+  logTargetError,
   safeEnrich,
   sendDraftedEmail,
   socialProofBlock,
@@ -189,6 +190,7 @@ export async function runEmailPlay<T, X = Record<string, never>>(
         // Daily-cap deferral is not a per-target failure — propagate so the
         // caller (drain / SSE run) leaves remaining targets queued.
         if (isSendDeferred(err)) throw err;
+        logTargetError({ playName: def.playName, to: def.toEmail(target), err });
         return {
           target,
           ...errorDraft((err as Error)?.message),

--- a/packages/plays/src/breakup-revive.ts
+++ b/packages/plays/src/breakup-revive.ts
@@ -1,5 +1,11 @@
 import { getLedger, isSendDeferred, loadConfig } from "@oneshot-gtm/core";
-import { draftEmailFromPrompt, errorDraft, lintEmail, sendDraftedEmail } from "./_lib.ts";
+import {
+  draftEmailFromPrompt,
+  errorDraft,
+  lintEmail,
+  logTargetError,
+  sendDraftedEmail,
+} from "./_lib.ts";
 
 const PLAY_NAME = "breakup-revive";
 
@@ -103,6 +109,7 @@ export async function runBreakupRevive(
       // Daily-cap deferral is not a per-target failure — abort the run so the
       // caller leaves remaining targets queued instead of stamping error drafts.
       if (isSendDeferred(err)) throw err;
+      logTargetError({ playName: PLAY_NAME, to: t.email, err });
       const stub = errorDraft((err as Error)?.message);
       drafted.push({
         prospectEmail: t.email,

--- a/packages/plays/src/demo-no-show.ts
+++ b/packages/plays/src/demo-no-show.ts
@@ -1,6 +1,12 @@
 import { getLedger, isSendDeferred, loadConfig, sendSms } from "@oneshot-gtm/core";
 import { complete, loadPrompt, tryParseJsonObject } from "@oneshot-gtm/intel";
-import { draftEmailFromPrompt, errorDraft, lintEmail, sendDraftedEmail } from "./_lib.ts";
+import {
+  draftEmailFromPrompt,
+  errorDraft,
+  lintEmail,
+  logTargetError,
+  sendDraftedEmail,
+} from "./_lib.ts";
 import { buildFollowUpEmail, enrollInCadence, registerSequence } from "./_cadence.ts";
 
 const PLAY_NAME = "demo-no-show";
@@ -111,6 +117,7 @@ export async function runDemoNoShow(opts: DemoNoShowRunOptions): Promise<DemoNoS
       // Daily-cap deferral is not a per-target failure — abort so remaining
       // targets stay queued instead of getting error drafts.
       if (isSendDeferred(err)) throw err;
+      logTargetError({ playName: PLAY_NAME, to: t.email, err });
       const stub = errorDraft((err as Error)?.message);
       outcomes.push({
         target: t,


### PR DESCRIPTION
## The incident

A `luma-events` drain today failed **all 8 of its send attempts** and left **nothing** in `events.jsonl`. The queue rows showed:

```
error: Tool request failed
```

That's the OneShot SDK's generic `ToolError` message. No status code, no response body — no way to tell an auth failure from a rate limit from a paused sending domain.

Nothing was actually sent or billed (`sent_count: 0`, zero receipts, zero `sequence_events`, all rows still `approved`), so the damage was only diagnostic. But the run is unexplainable after the fact, which is the real bug.

## Why nothing was logged

The per-target catch in `_run-play.ts` reduced the error to `err.message` and logged nothing:

```ts
if (isSendDeferred(err)) throw err;
return { target, ...errorDraft((err as Error)?.message), ... };
```

Twenty lines away, the whole-run handler in `apps/server/src/api/run.ts:164` already captures `statusCode` / `responseBody` / `cause` / `stack`, with a comment noting this exact message is *"useless for diagnosis"*. Per-target failures simply never got the same treatment — and a drain fails **per target**, so the good handler never fires.

The one time this detail *was* captured (May), the body read `403 domain_not_owned` — exactly the kind of cause the generic message hides.

## The change

`logTargetError()` in `_lib.ts`, next to `errorDraft`, called from all three sites that build an error draft:

- `runEmailPlay` — every email play
- `demo-no-show`
- `breakup-revive`

Emits `play.target_error` at error level with `message_200`, `status_code`, `response_body_400`, `cause_200`, `stack_300`.

**No behavior change.** The row envelope and the flags the founder sees are byte-identical; only the log gains the diagnosis.

## Tests

4 new, pinning what the row throws away vs what the log keeps: a ToolError's 403 + `domain_not_owned` body survives, a plain `Error` doesn't get invented SDK fields, a nested `cause` is unwrapped, and a 5000-char body truncates to 400 rather than dumping into the log.

## Verification

- `bun run typecheck` clean, `oxlint` 0/0, `fmt:check` clean
- **1336/1336** tests — 1332 baseline + 4 new

## Caveat

Dry-run never reaches `sendDraftedEmail`'s SDK call, so confirming the original cause needs one real send attempt after this lands.

https://claude.ai/code/session_01WfjkhiBKFjEbkkL5TzmRLZ

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Log per-target send failure details instead of generic 'Tool request failed'
> - Adds `logTargetError` to [`packages/plays/src/_lib.ts`](https://github.com/oneshot-agent/oneshot-gtm/pull/21/files#diff-586f14829195e8211d573a99c431e65ccfd7eb1e14b4243a03745b16145e90cb), which emits a structured `play.target_error` log entry with status code, response body (truncated to 400 chars), stack trace, and cause — redacting recipient to domain-only for PII safety.
> - Calls `logTargetError` in the per-target catch blocks of `runEmailPlay`, `runBreakupRevive`, `runDemoNoShow`, and the [`apps/server/src/api/queue.ts`](https://github.com/oneshot-agent/oneshot-gtm/pull/21/files#diff-82603c88c0a618245651db800cb8da95025555c3c6992b82d689dd5b2b34bcd9) send handler, replacing silent failures with detailed diagnostics.
> - `logTargetError` is wrapped in a try/catch so it never throws and cannot disrupt the surrounding error path.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a5023e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->