### PR TITLE
feat(deliverability): harvest bounces and test inbox placement

### DIFF
--- a/apps/cli/src/commands/gmail.ts
+++ b/apps/cli/src/commands/gmail.ts
@@ -6,11 +6,15 @@ import {
   GMAIL_IDENTITY_DEFAULTS,
   gmailConsentUrl,
   registerGmailIdentity,
+  resolveCanaryPair,
+  runPlacementCanary,
+  SAME_DOMAIN_WARNING,
   saveSecrets,
   secretsPath,
+  SINGLE_SEED_CAVEAT,
 } from "@oneshot-gtm/core";
 import prompts from "prompts";
-import { c, header, note, ok, warn } from "../output.ts";
+import { bail, box, c, fail, header, note, ok, warn } from "../output.ts";
 
 const AUTH_TIMEOUT_MS = 5 * 60 * 1000;
 
@@ -148,4 +152,81 @@ export async function commandGmailAuth(): Promise<void> {
   } finally {
     server.stop(true);
   }
+}
+
+/**
+ * Inbox-placement canary. Sends one real email between two authorized
+ * mailboxes and reports where the receiving account filed it, plus the
+ * SPF/DKIM/DMARC verdicts the receiving server recorded on the delivered copy.
+ *
+ * Interactive confirmation by design: this SENDS, so it can't be something a
+ * founder triggers by accident while poking at diagnostics.
+ */
+export async function commandGmailPlacement(opts: {
+  from?: string;
+  to?: string;
+  play?: string;
+  yes?: boolean;
+}): Promise<void> {
+  header("Inbox placement test");
+
+  let pair: ReturnType<typeof resolveCanaryPair>;
+  try {
+    pair = resolveCanaryPair({
+      ...(opts.from ? { fromIdentityId: opts.from } : {}),
+      ...(opts.to ? { toIdentityId: opts.to } : {}),
+    });
+  } catch (err) {
+    bail((err as Error).message);
+  }
+
+  note(`Sends one real email: ${c.cyan(pair.from.id)} → ${c.cyan(pair.to.id)}`);
+  note(SINGLE_SEED_CAVEAT);
+
+  if (!opts.yes) {
+    const { go } = await prompts(
+      { type: "confirm", name: "go", message: "Send the canary now?", initial: true },
+      { onCancel: () => process.exit(0) },
+    );
+    if (!go) return;
+  }
+
+  note("Sending, then polling the receiving mailbox (up to 2 min)…");
+  const result = await runPlacementCanary({
+    ...(opts.from ? { fromIdentityId: opts.from } : {}),
+    ...(opts.to ? { toIdentityId: opts.to } : {}),
+    ...(opts.play ? { playName: opts.play } : {}),
+  });
+
+  const line = result.placement === "inbox" ? ok : result.placement === "spam" ? fail : warn;
+  const latency = result.latencyMs != null ? ` in ${Math.round(result.latencyMs / 1000)}s` : "";
+  line(`Landed in ${c.bold(result.placement.toUpperCase())}${latency}`);
+
+  const body = [
+    `from        ${result.fromAddress}`,
+    `to          ${result.toAddress}`,
+    `subject     ${result.subject}`,
+    // Naming the source matters: a verdict on generic filler says little about
+    // the copy that actually ships, and the founder should know which they got.
+    `copy        ${result.sourcePlay ? `replayed real send from '${result.sourcePlay}'` : "GENERIC SAMPLE (no prior send to replay)"}`,
+    `labels      ${result.labelIds.join(", ") || "—"}`,
+    `spf         ${result.auth.spf}`,
+    `dkim        ${result.auth.dkim}`,
+    `dmarc       ${result.auth.dmarc}`,
+  ].join("\n");
+  box("Result", body);
+
+  if (result.sameDomain) warn(SAME_DOMAIN_WARNING);
+  if (result.placement === "not_delivered") {
+    warn(
+      "Never arrived within the deadline — inconclusive, not proof it was dropped. Re-run to confirm.",
+    );
+  }
+  if (result.placement === "promotions" || result.placement === "tab") {
+    note("Delivered, but tab-binned — for cold outreach that's close to invisible.");
+  }
+  if (!result.sameDomain && result.auth.spf === "unknown" && result.auth.dkim === "unknown") {
+    note("No Authentication-Results header — the receiving server recorded no verdict.");
+  }
+  note("Recorded — `doctor` reports this result until you run another.");
 }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -30,7 +30,7 @@ import {
   commandHandoffTemplatize,
 } from "./commands/handoff.ts";
 import { commandCadenceAdvance } from "./commands/cadence.ts";
-import { commandGmailAuth } from "./commands/gmail.ts";
+import { commandGmailAuth, commandGmailPlacement } from "./commands/gmail.ts";
 import {
   commandDomainsList,
   commandDomainsPause,
@@ -114,6 +114,16 @@ gmail
     "Authorize Gmail via OAuth and store the refresh token (chmod 600 ~/.oneshot-gtm/.env)",
   )
   .action(runOrFail(commandGmailAuth));
+gmail
+  .command("placement")
+  .description(
+    "Send one real email between two authorized mailboxes and report inbox vs spam vs tab",
+  )
+  .option("--from <identityId>", "sending identity (default: first Gmail identity)")
+  .option("--to <identityId>", "receiving identity (default: first other Gmail identity)")
+  .option("--play <name>", "replay this play's most recent real email as the canary body")
+  .option("-y, --yes", "skip the send confirmation")
+  .action(runOrFail(commandGmailPlacement));
 
 // Identities: manage the OneShot sender rotation pool (multiple wallet-owned
 // domains + multiple mailboxes per domain). Gmail accounts join via `gmail auth`.

--- a/apps/server/src/api/cadences.ts
+++ b/apps/server/src/api/cadences.ts
@@ -187,6 +187,7 @@ function tallyCounts(
     breakup: 0,
     completed: 0,
     paused: 0,
+    bounced: 0,
     overdue: 0,
   };
   for (const r of rows) {
@@ -195,7 +196,8 @@ function tallyCounts(
       r.status === "replied" ||
       r.status === "breakup" ||
       r.status === "completed" ||
-      r.status === "paused"
+      r.status === "paused" ||
+      r.status === "bounced"
     ) {
       counts[r.status]++;
       if (r.status === "active" && r.next_due_at && new Date(r.next_due_at).getTime() <= now) {

--- a/apps/server/src/api/queue.ts
+++ b/apps/server/src/api/queue.ts
@@ -7,7 +7,7 @@ import {
   type TelemetryOutcome,
 } from "@oneshot-gtm/core";
 import { drainQueue } from "@oneshot-gtm/find";
-import { enrollInCadence, sendDraftedEmail } from "@oneshot-gtm/plays";
+import { enrollInCadence, logTargetError, sendDraftedEmail } from "@oneshot-gtm/plays";
 import { reportServerExecution } from "../telemetry.ts";
 import {
   blockingFlags,
@@ -411,6 +411,11 @@ export async function sendDraftRoute(
     if (isSendDeferred(err)) {
       return done("ok", jsonResponse({ error: (err as Error).message, deferred: true }, 429, req));
     }
+    // The 400 body carries only `err.message`, which for an SDK ToolError is
+    // the generic "Tool request failed" — the founder sees "couldn't send ·
+    // 400 Bad Request: {"error":"Tool request failed"}" and has nothing to act
+    // on. Log the status + response body so the real reason is recoverable.
+    logTargetError({ playName: row.play_name, to: email, err });
     return done(
       "error",
       jsonResponse({ error: (err as Error).message ?? "send failed" }, 400, req),

--- a/apps/server/src/scheduler.ts
+++ b/apps/server/src/scheduler.ts
@@ -5,7 +5,7 @@ import {
   runPendingRetries,
   type TriggerRunOutcome,
 } from "@oneshot-gtm/find";
-import { pollInboxReplies } from "@oneshot-gtm/plays";
+import { pollInboxBounces, pollInboxReplies } from "@oneshot-gtm/plays";
 import { reportServerExecution } from "./telemetry.ts";
 
 /**
@@ -34,11 +34,13 @@ export function triggerOutcome(o: TriggerRunOutcome): TelemetryOutcome {
  *   the orphaned `running_started_at` markers on the next start.
  *
  * The tick also polls the inbox for prospect replies and stops their cadences
- * (`pollInboxReplies`). That detection otherwise only ran when the founder
- * manually advanced a cadence, so a reply could sit unrecognized for days while
- * the sequence kept emailing. It's read-only apart from the status flip — no
- * step is sent — so it never spends. Tick cadence is clamped to REPLY_POLL_MAX
- * so replies surface within minutes even when no trigger is due for an hour.
+ * (`pollInboxReplies`), and for delivery failures (`pollInboxBounces`). Both
+ * otherwise only ran when the founder manually advanced a cadence, so a reply
+ * could sit unrecognized — or a dead address keep receiving paid sends — for
+ * days while the sequence kept emailing. Both are read-only apart from the
+ * status flip — no step is sent — so neither spends. Tick cadence is clamped to
+ * REPLY_POLL_MAX so both surface within minutes even when no trigger is due for
+ * an hour.
  */
 export interface SchedulerHandle {
   stop(): void;
@@ -47,10 +49,20 @@ export interface SchedulerHandle {
 const FIRST_TICK_DELAY_MS = 5_000;
 const ERROR_BACKOFF_MS = 60_000;
 const REPLY_POLL_MAX_MS = 5 * 60_000;
+/**
+ * Bounces are swept far less often than replies. A reply is time-sensitive —
+ * every minute it goes unnoticed is a minute the cadence might send again. A
+ * bounce has already happened and the sweep re-reads a 30-day window, so
+ * running it at reply cadence would re-fetch and re-parse the same DSNs a
+ * couple of hundred times a day for no new information.
+ */
+const BOUNCE_POLL_INTERVAL_MS = 30 * 60_000;
 
 export function startScheduler(): SchedulerHandle {
   let cancelled = false;
   let timer: ReturnType<typeof setTimeout> | null = null;
+  // 0 = never polled, so the first tick always sweeps.
+  let lastBouncePollAt = 0;
 
   const tick = async (): Promise<void> => {
     if (cancelled) return;
@@ -80,6 +92,25 @@ export function startScheduler(): SchedulerHandle {
           "warn",
         );
       }
+      // Bounce detection, isolated for the same reasons as the reply poll.
+      // Also non-spending: it records delivery failures and stops the cadences
+      // of hard-bounced addresses, so the founder stops paying to email
+      // mailboxes the receiving server has already refused.
+      let bouncesRecorded = 0;
+      if (Date.now() - lastBouncePollAt >= BOUNCE_POLL_INTERVAL_MS) {
+        // Stamped before the await, not after: a slow or failing sweep must not
+        // let ticks queue up behind it and then all fire at once.
+        lastBouncePollAt = Date.now();
+        try {
+          bouncesRecorded = (await pollInboxBounces()).recorded;
+        } catch (err) {
+          logEvent(
+            "scheduler.bounce_poll.failed",
+            { message_120: ((err as Error).message ?? "").slice(0, 120) },
+            "warn",
+          );
+        }
+      }
       // Drain outage-deferred candidates (time-windowed finders) now the
       // backend may be healthy again. Isolated like the reply poll — its
       // failure must not skip trigger scheduling.
@@ -92,7 +123,12 @@ export function startScheduler(): SchedulerHandle {
           "warn",
         );
       }
-      logEvent("scheduler.tick.done", { fired, repliesDetected, source: "server" });
+      logEvent("scheduler.tick.done", {
+        fired,
+        repliesDetected,
+        bouncesRecorded,
+        source: "server",
+      });
       if (cancelled) return;
       const sleepMs = Math.min(nextSleepMs(outcomes), REPLY_POLL_MAX_MS);
       timer = setTimeout(() => void tick(), sleepMs);

--- a/apps/web/src/routes/cadences.tsx
+++ b/apps/web/src/routes/cadences.tsx
@@ -42,7 +42,7 @@ function earlyByCopy(iso: string | null | undefined): string {
   return `${days}d early`;
 }
 
-function statusTone(status: string): "receipt" | "signal" | "spend" | "neutral" {
+function statusTone(status: string): "receipt" | "signal" | "spend" | "blocked" | "neutral" {
   switch (status) {
     case "active":
       return "receipt";
@@ -52,6 +52,8 @@ function statusTone(status: string): "receipt" | "signal" | "spend" | "neutral" 
       return "spend";
     case "completed":
       return "neutral";
+    case "bounced":
+      return "blocked";
     default:
       return "neutral";
   }
@@ -333,8 +335,16 @@ function CadencesPage() {
         </section>
       )}
 
-      {/* Aggregate strip — 4 columns divided by vertical hairlines. */}
-      <section className="grid grid-cols-2 divide-x divide-ink-rule border-b border-ink-rule md:grid-cols-4">
+      {/* Aggregate strip — 4 columns divided by vertical hairlines, 5 once any
+          cadence has bounced. The bounced tile only appears when there's
+          something to report: a permanent 0 would read as reassurance on
+          installs that have never had bounce detection run at all. */}
+      <section
+        className={cn(
+          "grid grid-cols-2 divide-x divide-ink-rule border-b border-ink-rule",
+          counts.bounced > 0 ? "md:grid-cols-5" : "md:grid-cols-4",
+        )}
+      >
         <CadenceSummary
           label="Active"
           value={counts.active}
@@ -354,6 +364,14 @@ function CadencesPage() {
           tone="spend"
         />
         <CadenceSummary label="Completed" value={counts.completed} caption="full cadence done" />
+        {counts.bounced > 0 && (
+          <CadenceSummary
+            label="Bounced"
+            value={counts.bounced}
+            caption="address dead · suppressed"
+            tone="blocked"
+          />
+        )}
       </section>
 
       {/* Meta strip */}
@@ -568,7 +586,9 @@ function CadencesPage() {
                                 ? "signal"
                                 : c.status === "breakup"
                                   ? "spend"
-                                  : "receipt"
+                                  : c.status === "bounced"
+                                    ? "blocked"
+                                    : "receipt"
                             }
                           />
                           <span className="font-mono text-[11px] text-ink-faint">
@@ -693,7 +713,7 @@ function CadencesPage() {
                               );
                             })()}
                           {/* Chevron also for NON-active rows that still have history
-                            (breakup / replied / completed / paused). The active-status
+                            (breakup / replied / completed / paused / bounced). The active-status
                             block already renders its own chevron above when there's a
                             draft OR history; this one covers the non-active case. */}
                           {c.status !== "active" &&
@@ -1065,7 +1085,7 @@ function CadenceSummary({
   label: string;
   value: number;
   caption?: string;
-  tone?: "neutral" | "receipt" | "signal" | "spend";
+  tone?: "neutral" | "receipt" | "signal" | "spend" | "blocked";
 }) {
   const captionColor =
     tone === "spend"
@@ -1074,7 +1094,9 @@ function CadenceSummary({
         ? "var(--ink-receipt-2)"
         : tone === "signal"
           ? "var(--ink-signal-2)"
-          : "var(--ink-faint)";
+          : tone === "blocked"
+            ? "var(--ink-blocked-2)"
+            : "var(--ink-faint)";
   return (
     <div className="px-5 py-4">
       <div className="ln-eyebrow">{label}</div>
@@ -1099,5 +1121,6 @@ const EMPTY_COUNTS: CadenceCounts = {
   breakup: 0,
   completed: 0,
   paused: 0,
+  bounced: 0,
   overdue: 0,
 };

--- a/apps/web/src/routes/inbox.tsx
+++ b/apps/web/src/routes/inbox.tsx
@@ -35,6 +35,8 @@ function statusTone(status: string | null): "receipt" | "spend" | "blocked" | "s
       return "blocked";
     case "completed":
       return "receipt";
+    case "bounced":
+      return "blocked";
     default:
       return "neutral";
   }

--- a/packages/core/__tests__/bounces.test.ts
+++ b/packages/core/__tests__/bounces.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { Ledger } from "../src/ledger.ts";
+import type { BounceKind } from "../src/types.ts";
+
+let dbPath: string;
+let ledger: Ledger;
+
+beforeEach(() => {
+  dbPath = join(
+    tmpdir(),
+    `oneshot-gtm-bounce-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`,
+  );
+  ledger = new Ledger(dbPath);
+});
+
+afterEach(() => {
+  ledger.close();
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      rmSync(`${dbPath}${suffix}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+function record(over: Partial<Parameters<Ledger["recordBounce"]>[0]> = {}): boolean {
+  return ledger.recordBounce({
+    messageId: "dsn-1",
+    recipient: "jane@dead.example",
+    identityId: "gmail:me@corp.example",
+    kind: "hard" as BounceKind,
+    statusCode: "5.1.1",
+    diagnostic: "smtp; 550 user unknown",
+    prospectId: null,
+    bouncedAt: "2026-08-01T10:00:00.000Z",
+    ...over,
+  });
+}
+
+describe("recordBounce", () => {
+  it("reports the first sighting as new and every re-sighting as not", () => {
+    // The sweep re-reads a 30-day window on every scheduler tick, so the same
+    // DSN comes back dozens of times. Only the first may act on the cadence.
+    expect(record()).toBe(true);
+    expect(record()).toBe(false);
+    expect(record()).toBe(false);
+    expect(ledger.listRecentBounces()).toHaveLength(1);
+  });
+
+  it("keeps one row per recipient when a single report names several", () => {
+    expect(record({ recipient: "a@dead.example" })).toBe(true);
+    expect(record({ recipient: "b@dead.example" })).toBe(true);
+    expect(ledger.listRecentBounces()).toHaveLength(2);
+  });
+
+  it("canonicalizes the recipient so casing can't create a duplicate", () => {
+    expect(record({ recipient: "Jane@Dead.Example" })).toBe(true);
+    expect(record({ recipient: "jane@dead.example" })).toBe(false);
+  });
+
+  it("truncates an overlong diagnostic rather than storing the whole SMTP dump", () => {
+    record({ diagnostic: "x".repeat(1000) });
+    expect(ledger.listRecentBounces()[0]?.diagnostic).toHaveLength(300);
+  });
+});
+
+describe("suppressionFor", () => {
+  it("suppresses an address that hard-bounced", () => {
+    record({ kind: "hard" });
+    expect(ledger.suppressionFor("jane@dead.example")).toMatchObject({
+      recipient: "jane@dead.example",
+      status_code: "5.1.1",
+    });
+  });
+
+  it("matches case-insensitively", () => {
+    record({ kind: "hard" });
+    expect(ledger.suppressionFor("  JANE@DEAD.EXAMPLE ")).not.toBeNull();
+  });
+
+  it("does NOT suppress on a policy block", () => {
+    // A 5.7.x is the receiving server refusing a message, not evidence the
+    // mailbox is dead — suppressing would permanently burn a live prospect
+    // over one spam-filter verdict.
+    record({ kind: "block", statusCode: "5.7.1" });
+    expect(ledger.suppressionFor("jane@dead.example")).toBeNull();
+  });
+
+  it("does NOT suppress on a soft bounce", () => {
+    record({ kind: "soft", statusCode: "4.2.2" });
+    expect(ledger.suppressionFor("jane@dead.example")).toBeNull();
+  });
+
+  it("returns null for an address that has never bounced", () => {
+    expect(ledger.suppressionFor("fine@corp.example")).toBeNull();
+  });
+
+  it("suppresses once a soft bounce is followed by a hard one", () => {
+    record({ messageId: "dsn-soft", kind: "soft", statusCode: "4.2.2" });
+    expect(ledger.suppressionFor("jane@dead.example")).toBeNull();
+    record({ messageId: "dsn-hard", kind: "hard", statusCode: "5.1.1" });
+    expect(ledger.suppressionFor("jane@dead.example")).not.toBeNull();
+  });
+});
+
+describe("bounceStatsByIdentity", () => {
+  it("counts each kind per identity", () => {
+    record({ messageId: "a", recipient: "1@x.example", kind: "hard" });
+    record({ messageId: "b", recipient: "2@x.example", kind: "hard" });
+    record({ messageId: "c", recipient: "3@x.example", kind: "block" });
+    record({ messageId: "d", recipient: "4@x.example", kind: "soft" });
+    record({ messageId: "e", recipient: "5@x.example", kind: "hard", identityId: "gmail:other" });
+
+    const stats = ledger.bounceStatsByIdentity({ sinceIso: "2026-01-01T00:00:00.000Z" });
+    expect(stats.get("gmail:me@corp.example")).toEqual({ hard: 2, block: 1, soft: 1 });
+    expect(stats.get("gmail:other")).toEqual({ hard: 1, block: 0, soft: 0 });
+  });
+
+  it("excludes bounces older than the window", () => {
+    record({ messageId: "old", recipient: "1@x.example", bouncedAt: "2026-01-01T00:00:00.000Z" });
+    record({ messageId: "new", recipient: "2@x.example", bouncedAt: "2026-08-01T00:00:00.000Z" });
+    const stats = ledger.bounceStatsByIdentity({ sinceIso: "2026-07-01T00:00:00.000Z" });
+    expect(stats.get("gmail:me@corp.example")).toEqual({ hard: 1, block: 0, soft: 0 });
+  });
+
+  it("skips rows with no identity attribution", () => {
+    record({ identityId: null });
+    expect(ledger.bounceStatsByIdentity({ sinceIso: "2026-01-01T00:00:00.000Z" }).size).toBe(0);
+  });
+
+  it("is empty before anything bounces", () => {
+    expect(ledger.bounceStatsByIdentity({ sinceIso: "2026-01-01T00:00:00.000Z" }).size).toBe(0);
+  });
+});
+
+describe("bounced cadence status", () => {
+  it("clears the draft and send-failure markers like other terminal states", () => {
+    const prospectId = ledger.upsertProspect({
+      name: "J",
+      email: "jane@dead.example",
+      source: "t",
+    });
+    ledger.enrollCadence({ prospectId, playName: "p", nextDueAt: "2026-08-01T00:00:00.000Z" });
+    ledger.setCadenceDraft({
+      prospectId,
+      playName: "p",
+      draft: { subject: "s", body: "b", flags: [], payload: null },
+    });
+    ledger.recordCadenceSendError({ prospectId, playName: "p", error: "boom" });
+
+    ledger.setCadenceStatus({ prospectId, playName: "p", status: "bounced" });
+
+    const cad = ledger.getCadence(prospectId, "p");
+    expect(cad?.status).toBe("bounced");
+    // A stale "send failed · retrying" marker on a dead address is actively
+    // misleading — no retry can ever succeed.
+    expect(cad?.last_send_error).toBeNull();
+    expect(ledger.getCadenceDraft({ prospectId, playName: "p" })).toBeNull();
+  });
+});

--- a/packages/core/__tests__/canary-ledger.test.ts
+++ b/packages/core/__tests__/canary-ledger.test.ts
@@ -203,6 +203,14 @@ describe("latestSentEmailCopy", () => {
     expect(ledger.latestSentEmailCopy()?.subject).toBe("third");
   });
 
+  it("finds usable copy behind a long run of bodyless rows", () => {
+    // Unusable rows are discarded in SQL, so a fixed candidate bound can't be
+    // exhausted by them — copy this far back is still found.
+    seedSent("post-funding", { subject: "buried", body: "the real copy" });
+    for (let i = 0; i < 60; i++) seedSent("post-funding", { label: `no body ${i}` });
+    expect(ledger.latestSentEmailCopy()?.subject).toBe("buried");
+  });
+
   it("ignores non-email channels and unsent steps", () => {
     const prospectId = ledger.upsertProspect({ name: "P", email: "p@x.example", source: "t" });
     ledger.recordSequenceEvent({

--- a/packages/core/__tests__/canary-ledger.test.ts
+++ b/packages/core/__tests__/canary-ledger.test.ts
@@ -185,6 +185,24 @@ describe("latestSentEmailCopy", () => {
     expect(ledger.latestSentEmailCopy()?.subject).toBe("delivered one");
   });
 
+  it("picks the newest row when several share a timestamp", () => {
+    // created_at is second-precision and a cadence batch writes several rows
+    // within one second, so without an id tie-break the "most recent" copy is
+    // whichever row SQLite happens to return first.
+    const prospectId = ledger.upsertProspect({ name: "P", email: "t@x.example", source: "t" });
+    for (const n of ["first", "second", "third"]) {
+      ledger.recordSequenceEvent({
+        prospectId,
+        playName: "post-funding",
+        stepIndex: 0,
+        channel: "email",
+        status: "sent",
+        metadata: { subject: n, body: `${n} body` },
+      });
+    }
+    expect(ledger.latestSentEmailCopy()?.subject).toBe("third");
+  });
+
   it("ignores non-email channels and unsent steps", () => {
     const prospectId = ledger.upsertProspect({ name: "P", email: "p@x.example", source: "t" });
     ledger.recordSequenceEvent({

--- a/packages/core/__tests__/canary-ledger.test.ts
+++ b/packages/core/__tests__/canary-ledger.test.ts
@@ -154,6 +154,37 @@ describe("latestSentEmailCopy", () => {
     expect(ledger.latestSentEmailCopy()?.subject).toBe("real");
   });
 
+  it("includes copy whose step later flipped to replied", () => {
+    // markLatestStepReplied UPDATEs a 'sent' row in place. Matching only
+    // status='sent' would skip every prospect who answered — i.e. the
+    // best-performing copy there is — and silently replay something older.
+    const prospectId = ledger.upsertProspect({ name: "P", email: "r@x.example", source: "t" });
+    ledger.recordSequenceEvent({
+      prospectId,
+      playName: "post-funding",
+      stepIndex: 0,
+      channel: "email",
+      status: "sent",
+      metadata: { subject: "the winner", body: "copy that got a reply" },
+    });
+    ledger.markLatestStepReplied({ prospectId, playName: "post-funding" });
+
+    expect(ledger.latestSentEmailCopy()?.subject).toBe("the winner");
+  });
+
+  it("includes copy whose step is marked delivered", () => {
+    const prospectId = ledger.upsertProspect({ name: "P", email: "d@x.example", source: "t" });
+    ledger.recordSequenceEvent({
+      prospectId,
+      playName: "post-funding",
+      stepIndex: 0,
+      channel: "email",
+      status: "delivered",
+      metadata: { subject: "delivered one", body: "body" },
+    });
+    expect(ledger.latestSentEmailCopy()?.subject).toBe("delivered one");
+  });
+
   it("ignores non-email channels and unsent steps", () => {
     const prospectId = ledger.upsertProspect({ name: "P", email: "p@x.example", source: "t" });
     ledger.recordSequenceEvent({

--- a/packages/core/__tests__/canary-ledger.test.ts
+++ b/packages/core/__tests__/canary-ledger.test.ts
@@ -1,0 +1,177 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Database } from "bun:sqlite";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { Ledger } from "../src/ledger.ts";
+
+let dbPath: string;
+let ledger: Ledger;
+
+beforeEach(() => {
+  dbPath = join(
+    tmpdir(),
+    `oneshot-gtm-canary-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`,
+  );
+  ledger = new Ledger(dbPath);
+});
+
+afterEach(() => {
+  ledger.close();
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      rmSync(`${dbPath}${suffix}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+function canary(over: Partial<Parameters<Ledger["recordCanaryResult"]>[0]> = {}): number {
+  return ledger.recordCanaryResult({
+    fromIdentity: "gmail:a@one.example",
+    toIdentity: "gmail:b@two.example",
+    placement: "inbox",
+    labelIds: ["INBOX", "CATEGORY_PERSONAL"],
+    auth: { spf: "pass", dkim: "pass", dmarc: "pass" },
+    subject: "quick question",
+    sourcePlay: "post-funding",
+    sameDomain: false,
+    latencyMs: 4200,
+    ...over,
+  });
+}
+
+describe("canary results", () => {
+  it("returns null before any test has run", () => {
+    expect(ledger.latestCanaryResult()).toBeNull();
+  });
+
+  it("round-trips a result", () => {
+    canary();
+    expect(ledger.latestCanaryResult()).toMatchObject({
+      from_identity: "gmail:a@one.example",
+      to_identity: "gmail:b@two.example",
+      placement: "inbox",
+      spf: "pass",
+      source_play: "post-funding",
+      same_domain: 0,
+      latency_ms: 4200,
+    });
+  });
+
+  it("keeps history and returns the newest", () => {
+    // Append-only so a reputation trend stays visible, not just the last verdict.
+    canary({ placement: "inbox" });
+    canary({ placement: "spam" });
+    expect(ledger.latestCanaryResult()?.placement).toBe("spam");
+  });
+
+  it("preserves the raw labels so a placement call can be re-litigated", () => {
+    canary({ labelIds: ["INBOX", "CATEGORY_PROMOTIONS"], placement: "promotions" });
+    const labels = JSON.parse(ledger.latestCanaryResult()?.labels_json ?? "[]") as string[];
+    expect(labels).toContain("CATEGORY_PROMOTIONS");
+  });
+
+  it("stores the same-domain flag", () => {
+    canary({ sameDomain: true });
+    expect(ledger.latestCanaryResult()?.same_domain).toBe(1);
+  });
+
+  it("stores a never-arrived result with a null latency", () => {
+    canary({ placement: "not_delivered", latencyMs: null, labelIds: [] });
+    expect(ledger.latestCanaryResult()).toMatchObject({
+      placement: "not_delivered",
+      latency_ms: null,
+    });
+  });
+});
+
+describe("latestSentEmailCopy", () => {
+  function seedSent(playName: string, meta: unknown): void {
+    const prospectId = ledger.upsertProspect({
+      name: "P",
+      email: `${Math.random().toString(36).slice(2)}@x.example`,
+      source: "t",
+    });
+    ledger.recordSequenceEvent({
+      prospectId,
+      playName,
+      stepIndex: 0,
+      channel: "email",
+      status: "sent",
+      metadata: meta,
+    });
+  }
+
+  it("returns null with no send history", () => {
+    expect(ledger.latestSentEmailCopy()).toBeNull();
+  });
+
+  it("returns the most recent sent email's real subject and body", () => {
+    seedSent("post-funding", { subject: "your Series A", body: "Hey — saw the round." });
+    expect(ledger.latestSentEmailCopy()).toEqual({
+      subject: "your Series A",
+      body: "Hey — saw the round.",
+      playName: "post-funding",
+    });
+  });
+
+  it("can be scoped to one play", () => {
+    seedSent("post-funding", { subject: "a", body: "a-body" });
+    seedSent("hiring-signal", { subject: "b", body: "b-body" });
+    expect(ledger.latestSentEmailCopy({ playName: "post-funding" })?.subject).toBe("a");
+  });
+
+  it("skips rows with no persisted body instead of giving up", () => {
+    // Pre-v8 rows and non-email payloads carry no subject/body. Reading only
+    // the newest row would return null whenever one of those happened to be on
+    // top, and the canary would silently fall back to generic filler.
+    seedSent("post-funding", { subject: "real", body: "real body" });
+    seedSent("post-funding", { label: "no body here" });
+    seedSent("post-funding", { subject: "also no body" });
+    expect(ledger.latestSentEmailCopy()?.subject).toBe("real");
+  });
+
+  it("skips a row whose body is blank", () => {
+    seedSent("post-funding", { subject: "real", body: "real body" });
+    seedSent("post-funding", { subject: "empty", body: "   " });
+    expect(ledger.latestSentEmailCopy()?.subject).toBe("real");
+  });
+
+  it("survives malformed metadata JSON", () => {
+    seedSent("post-funding", { subject: "real", body: "real body" });
+    // Written through a second connection: metadata_json is only ever produced
+    // by JSON.stringify, so there's no ledger API that can create this row.
+    const raw = new Database(dbPath);
+    raw
+      .prepare(
+        `INSERT INTO sequence_events(prospect_id, play_name, step_index, channel, status, metadata_json)
+         VALUES(1, 'post-funding', 1, 'email', 'sent', '{not json')`,
+      )
+      .run();
+    raw.close();
+    expect(ledger.latestSentEmailCopy()?.subject).toBe("real");
+  });
+
+  it("ignores non-email channels and unsent steps", () => {
+    const prospectId = ledger.upsertProspect({ name: "P", email: "p@x.example", source: "t" });
+    ledger.recordSequenceEvent({
+      prospectId,
+      playName: "p",
+      stepIndex: 0,
+      channel: "sms",
+      status: "sent",
+      metadata: { subject: "sms", body: "sms body" },
+    });
+    ledger.recordSequenceEvent({
+      prospectId,
+      playName: "p",
+      stepIndex: 1,
+      channel: "email",
+      status: "queued",
+      metadata: { subject: "queued", body: "queued body" },
+    });
+    expect(ledger.latestSentEmailCopy()).toBeNull();
+  });
+});

--- a/packages/core/__tests__/canary.test.ts
+++ b/packages/core/__tests__/canary.test.ts
@@ -255,6 +255,24 @@ describe("runPlacementCanary", () => {
     expect(sentMessages[0]?.htmlBody).toContain("saw the round");
   });
 
+  it("escapes HTML in replayed copy with the real send path's encoder", async () => {
+    // Unescaped & < > would reach the filter as different content from what
+    // ships — the canary would then be measuring the wrong message.
+    realCopy = {
+      subject: "Q&A",
+      body: "Tips & tricks for <founders>\nsecond line",
+      playName: "post-funding",
+    };
+    pollResults = [placed(["INBOX"])];
+    await runPlacementCanary({ sleep: noSleep });
+
+    const html = sentMessages[0]?.htmlBody ?? "";
+    expect(html).toContain("&amp;");
+    expect(html).toContain("&lt;founders&gt;");
+    expect(html).not.toContain("<founders>");
+    expect(html).toContain("<br>");
+  });
+
   it("flags a generic sample when there is no real send to replay", async () => {
     realCopy = null;
     pollResults = [placed(["INBOX"])];

--- a/packages/core/__tests__/canary.test.ts
+++ b/packages/core/__tests__/canary.test.ts
@@ -1,0 +1,298 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Drives the inbox-placement canary: pick two mailboxes, send a real message,
+// then look up where the RECEIVING account filed it. This is the only path that
+// can distinguish "accepted" from "accepted and filtered into spam".
+
+type Identity = {
+  id: string;
+  provider: string;
+  address: string | null;
+  maxPerDay: number | null;
+  warmup: null;
+};
+
+let identities: Identity[] = [];
+/** Queue of findPlacedMessage results — one shift per poll. */
+let pollResults: Array<null | {
+  id: string;
+  labelIds: string[];
+  placement: string;
+  auth: { spf: string; dkim: string; dmarc: string };
+  receivedAt: string;
+}> = [];
+let sentMessages: Array<{ to: string; fromEmail: string; subject: string; htmlBody: string }> = [];
+let recordedCanaries: unknown[] = [];
+let realCopy: { subject: string; body: string; playName: string } | null = null;
+let sentMessageIdResult: string | null = "<CAB123@mail.gmail.com>";
+let lastQuery = "";
+let pollCount = 0;
+
+vi.mock("../src/config.ts", async () => {
+  const actual = await vi.importActual<typeof import("../src/config.ts")>("../src/config.ts");
+  return {
+    ...actual,
+    loadConfig: () => ({
+      ...actual.loadConfig(),
+      founderName: "Jane Doe",
+      productOneLiner: "a thing",
+    }),
+  };
+});
+
+vi.mock("../src/identities.ts", async () => {
+  const actual =
+    await vi.importActual<typeof import("../src/identities.ts")>("../src/identities.ts");
+  return {
+    ...actual,
+    resolveIdentities: () => identities,
+    gmailAccountFor: (i: Identity) => ({ id: i.id, refreshToken: "rt" }),
+  };
+});
+
+vi.mock("../src/gmail.ts", async () => {
+  const actual = await vi.importActual<typeof import("../src/gmail.ts")>("../src/gmail.ts");
+  return {
+    ...actual,
+    sendGmailMessage: async (input: {
+      to: string;
+      fromEmail: string;
+      subject: string;
+      htmlBody: string;
+    }) => {
+      sentMessages.push(input);
+      return { id: "sent-1", threadId: "t-1" };
+    },
+    getSentMessageId: async () => sentMessageIdResult,
+    findPlacedMessage: async (query: string) => {
+      lastQuery = query;
+      pollCount++;
+      return pollResults.shift() ?? null;
+    },
+    getGmailProfile: async () => ({ emailAddress: "fallback@corp.example" }),
+  };
+});
+
+vi.mock("../src/ledger.ts", async () => {
+  const actual = await vi.importActual<typeof import("../src/ledger.ts")>("../src/ledger.ts");
+  return {
+    ...actual,
+    getLedger: () => ({
+      latestSentEmailCopy: () => realCopy,
+      recordCanaryResult: (r: unknown) => {
+        recordedCanaries.push(r);
+        return 1;
+      },
+    }),
+  };
+});
+
+const { runPlacementCanary, resolveCanaryPair } = await import("../src/canary.ts");
+const { classifyPlacement } = await import("../src/gmail.ts");
+
+const noSleep = async (): Promise<void> => undefined;
+
+function gmailIdentity(id: string, address: string): Identity {
+  return { id, provider: "gmail", address, maxPerDay: 40, warmup: null };
+}
+
+function placed(labelIds: string[], auth = { spf: "pass", dkim: "pass", dmarc: "pass" }) {
+  return {
+    id: "recv-1",
+    labelIds,
+    placement: classifyPlacement(labelIds),
+    auth,
+    receivedAt: "2026-08-13T10:00:00.000Z",
+  };
+}
+
+beforeEach(() => {
+  identities = [
+    gmailIdentity("gmail:a@one.example", "a@one.example"),
+    gmailIdentity("gmail:b@two.example", "b@two.example"),
+  ];
+  pollResults = [];
+  sentMessages = [];
+  recordedCanaries = [];
+  realCopy = null;
+  sentMessageIdResult = "<CAB123@mail.gmail.com>";
+  lastQuery = "";
+  pollCount = 0;
+});
+
+describe("resolveCanaryPair", () => {
+  it("refuses when only one Gmail account is connected", () => {
+    // A self-send is never filtered, so a single account would always read
+    // "inbox" and mean nothing.
+    identities = [gmailIdentity("gmail:a@one.example", "a@one.example")];
+    expect(() => resolveCanaryPair()).toThrow(/two authorized Gmail accounts/);
+  });
+
+  it("refuses when no Gmail account is connected", () => {
+    identities = [];
+    expect(() => resolveCanaryPair()).toThrow(/two authorized Gmail accounts/);
+  });
+
+  it("ignores non-Gmail identities when counting", () => {
+    identities = [
+      gmailIdentity("gmail:a@one.example", "a@one.example"),
+      { id: "oneshot:x", provider: "oneshot", address: null, maxPerDay: null, warmup: null },
+    ];
+    expect(() => resolveCanaryPair()).toThrow(/found 1/);
+  });
+
+  it("defaults to the first two identities", () => {
+    const { from, to } = resolveCanaryPair();
+    expect(from.id).toBe("gmail:a@one.example");
+    expect(to.id).toBe("gmail:b@two.example");
+  });
+
+  it("honours explicit ids", () => {
+    const { from, to } = resolveCanaryPair({
+      fromIdentityId: "gmail:b@two.example",
+      toIdentityId: "gmail:a@one.example",
+    });
+    expect(from.id).toBe("gmail:b@two.example");
+    expect(to.id).toBe("gmail:a@one.example");
+  });
+
+  it("refuses an explicit self-send", () => {
+    expect(() =>
+      resolveCanaryPair({
+        fromIdentityId: "gmail:a@one.example",
+        toIdentityId: "gmail:a@one.example",
+      }),
+    ).toThrow(/self-send/);
+  });
+
+  it("rejects an unknown identity id", () => {
+    expect(() => resolveCanaryPair({ fromIdentityId: "gmail:nope" })).toThrow(/no Gmail identity/);
+  });
+});
+
+describe("runPlacementCanary", () => {
+  it("reports a clean inbox delivery", async () => {
+    pollResults = [placed(["INBOX", "CATEGORY_PERSONAL"])];
+    const result = await runPlacementCanary({ sleep: noSleep });
+
+    expect(result.placement).toBe("inbox");
+    expect(result.fromAddress).toBe("a@one.example");
+    expect(result.toAddress).toBe("b@two.example");
+    expect(result.auth).toEqual({ spf: "pass", dkim: "pass", dmarc: "pass" });
+  });
+
+  it("reports spam — the outcome the test exists to catch", async () => {
+    pollResults = [placed(["SPAM"], { spf: "fail", dkim: "none", dmarc: "fail" })];
+    const result = await runPlacementCanary({ sleep: noSleep });
+
+    expect(result.placement).toBe("spam");
+    expect(result.auth.dmarc).toBe("fail");
+  });
+
+  it("reports Promotions rather than calling a tab-binned message delivered", async () => {
+    pollResults = [placed(["INBOX", "CATEGORY_PROMOTIONS"])];
+    expect((await runPlacementCanary({ sleep: noSleep })).placement).toBe("promotions");
+  });
+
+  it("searches by the Message-ID Gmail actually assigned", async () => {
+    // Gmail rewrites any Message-ID we supply, so the id must be read back off
+    // the sent copy or the receiving-side lookup matches nothing.
+    pollResults = [placed(["INBOX"])];
+    await runPlacementCanary({ sleep: noSleep });
+    expect(lastQuery).toBe("rfc822msgid:CAB123@mail.gmail.com");
+  });
+
+  it("falls back to a subject+sender query when the Message-ID can't be read", async () => {
+    sentMessageIdResult = null;
+    pollResults = [placed(["INBOX"])];
+    await runPlacementCanary({ sleep: noSleep });
+    expect(lastQuery).toContain("from:a@one.example");
+    expect(lastQuery).toContain("subject:");
+  });
+
+  it("bounds the fallback query to this run, so an earlier canary can't match", async () => {
+    // The subject is REPLAYED copy, so a previous canary of the same play is a
+    // valid match for it — an unbounded query would report that older run's
+    // placement as if it were this one's.
+    sentMessageIdResult = null;
+    realCopy = { subject: "your Series A", body: "b", playName: "post-funding" };
+    pollResults = [placed(["INBOX"])];
+    const before = Math.floor(Date.now() / 1000);
+    await runPlacementCanary({ sleep: noSleep });
+
+    const after = lastQuery.match(/after:(\d+)/)?.[1];
+    expect(after).toBeDefined();
+    // Bounded to roughly now, not an open-ended window.
+    expect(Number(after)).toBeGreaterThan(before - 120);
+    expect(lastQuery).not.toContain("newer_than");
+  });
+
+  it("keeps polling until the message shows up", async () => {
+    pollResults = [null, null, placed(["INBOX"])];
+    const result = await runPlacementCanary({ sleep: noSleep, deadlineMs: 60_000 });
+    expect(result.placement).toBe("inbox");
+    expect(pollCount).toBe(3);
+  });
+
+  it("reports not_delivered rather than guessing when nothing arrives", async () => {
+    // Silence is ambiguous — dropped, or just slow. Calling it "spam" would be
+    // a fabricated verdict.
+    pollResults = [];
+    const result = await runPlacementCanary({ sleep: noSleep, deadlineMs: 0 });
+    expect(result.placement).toBe("not_delivered");
+    expect(result.latencyMs).toBeNull();
+    expect(result.auth).toEqual({ spf: "unknown", dkim: "unknown", dmarc: "unknown" });
+  });
+
+  it("replays real shipping copy when the ledger has any", async () => {
+    // Filters judge CONTENT — a verdict on invented filler wouldn't transfer.
+    realCopy = { subject: "your Series A", body: "Hey — saw the round.", playName: "post-funding" };
+    pollResults = [placed(["INBOX"])];
+    const result = await runPlacementCanary({ sleep: noSleep });
+
+    expect(result.sourcePlay).toBe("post-funding");
+    expect(result.subject).toBe("your Series A");
+    expect(sentMessages[0]?.htmlBody).toContain("saw the round");
+  });
+
+  it("flags a generic sample when there is no real send to replay", async () => {
+    realCopy = null;
+    pollResults = [placed(["INBOX"])];
+    const result = await runPlacementCanary({ sleep: noSleep });
+    expect(result.sourcePlay).toBeNull();
+  });
+
+  it("flags a same-domain pair, whose result can't be trusted", async () => {
+    // Internal Workspace routing skips filtering and authentication, so this
+    // would read clean no matter how a stranger's server would treat us.
+    identities = [
+      gmailIdentity("gmail:a@corp.example", "a@corp.example"),
+      gmailIdentity("gmail:b@corp.example", "b@corp.example"),
+    ];
+    pollResults = [placed(["INBOX"])];
+    expect((await runPlacementCanary({ sleep: noSleep })).sameDomain).toBe(true);
+  });
+
+  it("does not flag cross-domain pairs", async () => {
+    pollResults = [placed(["INBOX"])];
+    expect((await runPlacementCanary({ sleep: noSleep })).sameDomain).toBe(false);
+  });
+
+  it("sends from the chosen identity to the chosen one", async () => {
+    pollResults = [placed(["INBOX"])];
+    await runPlacementCanary({ sleep: noSleep });
+    expect(sentMessages).toHaveLength(1);
+    expect(sentMessages[0]).toMatchObject({ to: "b@two.example", fromEmail: "a@one.example" });
+  });
+
+  it("records the result so doctor can report it without re-sending", async () => {
+    pollResults = [placed(["INBOX", "CATEGORY_PROMOTIONS"])];
+    await runPlacementCanary({ sleep: noSleep });
+    expect(recordedCanaries).toHaveLength(1);
+    expect(recordedCanaries[0]).toMatchObject({
+      fromIdentity: "gmail:a@one.example",
+      toIdentity: "gmail:b@two.example",
+      placement: "promotions",
+    });
+  });
+});

--- a/packages/core/__tests__/gmail-bounce-paging.test.ts
+++ b/packages/core/__tests__/gmail-bounce-paging.test.ts
@@ -1,0 +1,125 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { _resetGmailCache, listGmailBounces } from "../src/gmail.ts";
+
+// Pagination for the bounce sweep. Stopping at the first Gmail results page
+// leaves hard-bounced recipients unsuppressed AND reports a falsely low bounce
+// rate — a silent undercount, the worst failure mode for a check whose job is
+// to notice trouble.
+
+const GMAIL_KEYS = ["GMAIL_CLIENT_ID", "GMAIL_CLIENT_SECRET", "GMAIL_REFRESH_TOKEN"] as const;
+let envSnapshot: Record<string, string | undefined> = {};
+let listCalls: string[] = [];
+
+/** A DSN payload naming one dead address, keyed by message id. */
+function dsnMessage(id: string) {
+  const report = [
+    `Final-Recipient: rfc822; dead-${id}@corp.example`,
+    "Action: failed",
+    "Status: 5.1.1",
+  ].join("\r\n");
+  return {
+    id,
+    threadId: `t-${id}`,
+    internalDate: "1755000000000",
+    payload: {
+      mimeType: "multipart/report",
+      headers: [{ name: "From", value: "mailer-daemon@googlemail.com" }],
+      parts: [
+        {
+          mimeType: "message/delivery-status",
+          body: { data: Buffer.from(report).toString("base64url") },
+        },
+      ],
+    },
+  };
+}
+
+/** Serves `pages` of ids, each page linking to the next. */
+function stubGmail(pages: string[][]): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string | URL) => {
+      const u = String(url);
+      if (u.includes("oauth2.googleapis.com")) {
+        return new Response(JSON.stringify({ access_token: "at", expires_in: 3600 }), {
+          status: 200,
+        });
+      }
+      if (u.includes("/messages?")) {
+        listCalls.push(u);
+        const token = new URL(u).searchParams.get("pageToken");
+        const index = token ? Number(token) : 0;
+        const ids = pages[index] ?? [];
+        const hasNext = index + 1 < pages.length;
+        return new Response(
+          JSON.stringify({
+            messages: ids.map((id) => ({ id })),
+            ...(hasNext ? { nextPageToken: String(index + 1) } : {}),
+          }),
+          { status: 200 },
+        );
+      }
+      const id = u.split("/messages/")[1]?.split("?")[0] ?? "x";
+      return new Response(JSON.stringify(dsnMessage(id)), { status: 200 });
+    }),
+  );
+}
+
+beforeEach(() => {
+  envSnapshot = {};
+  for (const k of GMAIL_KEYS) {
+    envSnapshot[k] = process.env[k];
+    process.env[k] = "test";
+  }
+  listCalls = [];
+  _resetGmailCache();
+});
+
+afterEach(() => {
+  for (const k of GMAIL_KEYS) {
+    if (envSnapshot[k] === undefined) delete process.env[k];
+    else process.env[k] = envSnapshot[k];
+  }
+  _resetGmailCache();
+  vi.unstubAllGlobals();
+});
+
+describe("listGmailBounces pagination", () => {
+  it("follows nextPageToken across every page", async () => {
+    stubGmail([["a1", "a2"], ["b1", "b2"], ["c1"]]);
+    const bounces = await listGmailBounces(undefined, { id: "acct", refreshToken: "rt" });
+
+    expect(bounces).toHaveLength(5);
+    expect(bounces.map((b) => b.messageId).toSorted()).toEqual(["a1", "a2", "b1", "b2", "c1"]);
+    expect(listCalls).toHaveLength(3);
+  });
+
+  it("stops after a single page when there is no next token", async () => {
+    stubGmail([["only1", "only2"]]);
+    const bounces = await listGmailBounces(undefined, { id: "acct", refreshToken: "rt" });
+
+    expect(bounces).toHaveLength(2);
+    expect(listCalls).toHaveLength(1);
+  });
+
+  it("handles an empty mailbox without paging", async () => {
+    stubGmail([[]]);
+    expect(await listGmailBounces(undefined, { id: "acct", refreshToken: "rt" })).toEqual([]);
+    expect(listCalls).toHaveLength(1);
+  });
+
+  it("honours the total limit rather than walking an endless mailbox", async () => {
+    // Every page advertises a next token; the cap is what terminates the walk.
+    stubGmail([["a"], ["b"], ["c"], ["d"], ["e"], ["f"]]);
+    const bounces = await listGmailBounces({ limit: 3 }, { id: "acct", refreshToken: "rt" });
+    expect(bounces.length).toBeLessThanOrEqual(3);
+    expect(listCalls.length).toBeLessThanOrEqual(3);
+  });
+
+  it("never requests a page larger than the Gmail per-page maximum", async () => {
+    stubGmail([["a"]]);
+    await listGmailBounces({ limit: 5000 }, { id: "acct", refreshToken: "rt" });
+    const maxResults = new URL(listCalls[0]!).searchParams.get("maxResults");
+    expect(Number(maxResults)).toBeLessThanOrEqual(100);
+  });
+});

--- a/packages/core/__tests__/gmail-bounce-paging.test.ts
+++ b/packages/core/__tests__/gmail-bounce-paging.test.ts
@@ -40,14 +40,18 @@ function stubGmail(pages: string[][]): void {
     "fetch",
     vi.fn(async (url: string | URL) => {
       const u = String(url);
-      if (u.includes("oauth2.googleapis.com")) {
+      const parsed = new URL(u);
+      // Matched on the parsed hostname, not a substring: `includes()` would
+      // also match a URL that merely mentions the host elsewhere in its path
+      // or query, which is exactly the routing bug this stub would then hide.
+      if (parsed.hostname === "oauth2.googleapis.com") {
         return new Response(JSON.stringify({ access_token: "at", expires_in: 3600 }), {
           status: 200,
         });
       }
-      if (u.includes("/messages?")) {
+      if (parsed.pathname.endsWith("/messages")) {
         listCalls.push(u);
-        const token = new URL(u).searchParams.get("pageToken");
+        const token = parsed.searchParams.get("pageToken");
         const index = token ? Number(token) : 0;
         const ids = pages[index] ?? [];
         const hasNext = index + 1 < pages.length;
@@ -59,7 +63,7 @@ function stubGmail(pages: string[][]): void {
           { status: 200 },
         );
       }
-      const id = u.split("/messages/")[1]?.split("?")[0] ?? "x";
+      const id = parsed.pathname.split("/messages/")[1] ?? "x";
       return new Response(JSON.stringify(dsnMessage(id)), { status: 200 });
     }),
   );

--- a/packages/core/__tests__/gmail-bounce.test.ts
+++ b/packages/core/__tests__/gmail-bounce.test.ts
@@ -1,0 +1,250 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyBounce,
+  parseBounce,
+  type GmailMessageMeta,
+  type GmailPayloadPart,
+} from "../src/gmail.ts";
+
+const b64 = (s: string): string => Buffer.from(s, "utf8").toString("base64url");
+
+/** Wrap parts in the multipart/report envelope Gmail returns for a DSN. */
+function dsn(opts: {
+  from?: string;
+  subject?: string;
+  humanText?: string;
+  report?: string;
+}): GmailMessageMeta {
+  const parts: GmailPayloadPart[] = [];
+  if (opts.humanText) parts.push({ mimeType: "text/plain", body: { data: b64(opts.humanText) } });
+  if (opts.report) {
+    parts.push({ mimeType: "message/delivery-status", body: { data: b64(opts.report) } });
+  }
+  return {
+    id: "msg-1",
+    threadId: "thread-1",
+    internalDate: "1755000000000",
+    payload: {
+      mimeType: "multipart/report",
+      headers: [
+        {
+          name: "From",
+          value: opts.from ?? "Mail Delivery Subsystem <mailer-daemon@googlemail.com>",
+        },
+        { name: "Subject", value: opts.subject ?? "Delivery Status Notification (Failure)" },
+      ],
+      parts,
+    },
+  };
+}
+
+describe("classifyBounce", () => {
+  it.each([
+    ["5.1.1", "smtp; 550 user unknown", "hard"],
+    ["5.0.0", null, "hard"],
+    ["4.2.2", "smtp; 452 mailbox full", "soft"],
+    ["4.4.1", null, "soft"],
+    // 5.7.x is the policy class — a verdict on the message, not the mailbox.
+    ["5.7.1", "smtp; 550 5.7.1 message rejected", "block"],
+    ["5.7.26", "smtp; 550 unauthenticated", "block"],
+    // Servers that reject on policy with a plain 5.x.x and say so only in prose.
+    ["5.2.0", "smtp; 550 message identified as spam", "block"],
+    ["5.4.1", "smtp; 550 listed on Spamhaus", "block"],
+  ] as const)("%s → %s", (code, diagnostic, expected) => {
+    expect(classifyBounce(code, diagnostic)).toBe(expected);
+  });
+
+  it("falls back to the bare SMTP reply class when no enhanced code exists", () => {
+    expect(classifyBounce(null, "smtp; 550 No such user here")).toBe("hard");
+    expect(classifyBounce(null, "smtp; 452 try again later")).toBe("soft");
+    expect(classifyBounce(null, "smtp; 554 blocked by policy")).toBe("block");
+  });
+
+  it("reads an enhanced code embedded in the diagnostic when the Status field is absent", () => {
+    expect(classifyBounce(null, "smtp; 550 5.1.1 user unknown")).toBe("hard");
+  });
+
+  it("treats unparseable severity as soft rather than guessing hard", () => {
+    // `hard` suppresses the address permanently. Guessing it from a message we
+    // couldn't actually read would silently drop a live prospect.
+    expect(classifyBounce(null, null)).toBe("soft");
+    expect(classifyBounce(null, "something went wrong")).toBe("soft");
+  });
+});
+
+describe("parseBounce — structured delivery-status report", () => {
+  it("extracts recipient, status and diagnostic from a hard bounce", () => {
+    const msg = dsn({
+      report: [
+        "Reporting-MTA: dns; googlemail.com",
+        "",
+        "Final-Recipient: rfc822; jane@dead.example",
+        "Action: failed",
+        "Status: 5.1.1",
+        "Diagnostic-Code: smtp; 550-5.1.1 The email account that you tried to reach",
+        " does not exist.",
+      ].join("\r\n"),
+    });
+    expect(parseBounce(msg)).toEqual([
+      {
+        recipient: "jane@dead.example",
+        kind: "hard",
+        statusCode: "5.1.1",
+        // Folded continuation line is joined, not truncated mid-sentence.
+        diagnostic: "smtp; 550-5.1.1 The email account that you tried to reach does not exist.",
+      },
+    ]);
+  });
+
+  it("classifies a 5.7.1 policy rejection as a block, not a dead address", () => {
+    const msg = dsn({
+      report: [
+        "Final-Recipient: rfc822; bob@corp.example",
+        "Action: failed",
+        "Status: 5.7.1",
+        "Diagnostic-Code: smtp; 550 5.7.1 Message rejected as spam",
+      ].join("\r\n"),
+    });
+    expect(parseBounce(msg)[0]).toMatchObject({ recipient: "bob@corp.example", kind: "block" });
+  });
+
+  it("classifies a 4.x.x as soft", () => {
+    const msg = dsn({
+      report: [
+        "Final-Recipient: rfc822; full@corp.example",
+        "Action: delayed",
+        "Status: 4.2.2",
+        "Diagnostic-Code: smtp; 452 4.2.2 Mailbox full",
+      ].join("\r\n"),
+    });
+    expect(parseBounce(msg)[0]).toMatchObject({ kind: "soft" });
+  });
+
+  it("returns one entry per failed recipient and skips delivered ones", () => {
+    const msg = dsn({
+      report: [
+        "Reporting-MTA: dns; mx.example",
+        "",
+        "Final-Recipient: rfc822; ok@corp.example",
+        "Action: delivered",
+        "Status: 2.0.0",
+        "",
+        "Final-Recipient: rfc822; gone@corp.example",
+        "Action: failed",
+        "Status: 5.1.1",
+      ].join("\r\n"),
+    });
+    const out = parseBounce(msg);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ recipient: "gone@corp.example", kind: "hard" });
+  });
+
+  it("lowercases the recipient and strips the address-type prefix", () => {
+    const msg = dsn({
+      report: ["Final-Recipient: rfc822; <Jane.Doe@Dead.Example>", "Status: 5.1.1"].join("\r\n"),
+    });
+    expect(parseBounce(msg)[0]?.recipient).toBe("jane.doe@dead.example");
+  });
+});
+
+describe("parseBounce — prose fallback", () => {
+  it("scrapes a DSN with no conforming report part", () => {
+    const msg = dsn({
+      humanText: [
+        "** Address not found **",
+        "",
+        "Your message wasn't delivered to bob@nowhere.example because the address",
+        "couldn't be found, or is unable to receive mail.",
+        "",
+        "The response from the remote server was:",
+        "550 5.1.1 <bob@nowhere.example>: Recipient address rejected: User unknown",
+      ].join("\n"),
+    });
+    expect(parseBounce(msg)[0]).toMatchObject({
+      recipient: "bob@nowhere.example",
+      kind: "hard",
+      statusCode: "5.1.1",
+    });
+  });
+
+  it("prefers the address on the SMTP response line over the quoted original sender", () => {
+    const msg = dsn({
+      humanText: [
+        "Delivery to the following recipient failed permanently:",
+        "",
+        "From: founder@ourdomain.example",
+        "",
+        "550 5.1.1 <target@dead.example>: User unknown",
+      ].join("\n"),
+    });
+    expect(parseBounce(msg)[0]?.recipient).toBe("target@dead.example");
+  });
+
+  it("never treats the daemon's own address as the failed recipient", () => {
+    const msg = dsn({
+      humanText: "mailer-daemon@googlemail.com reports: 550 5.1.1 delivery failed",
+    });
+    expect(parseBounce(msg)).toEqual([]);
+  });
+});
+
+describe("parseBounce — non-bounces", () => {
+  it("ignores an ordinary reply", () => {
+    const msg: GmailMessageMeta = {
+      id: "m",
+      threadId: "t",
+      internalDate: "1755000000000",
+      payload: {
+        mimeType: "text/plain",
+        headers: [
+          { name: "From", value: "Jane <jane@corp.example>" },
+          { name: "Subject", value: "Re: quick question" },
+        ],
+        body: { data: b64("Thanks — let's talk next week.") },
+      },
+    };
+    expect(parseBounce(msg)).toEqual([]);
+  });
+
+  it("ignores ordinary mail that merely contains a 5xx-looking number and an address", () => {
+    // The Gmail query is a coarse net; without the DSN-shape gate this would
+    // parse as a hard bounce and suppress a live prospect.
+    const msg: GmailMessageMeta = {
+      id: "m",
+      threadId: "t",
+      internalDate: "1755000000000",
+      payload: {
+        mimeType: "text/plain",
+        headers: [
+          { name: "From", value: "Sam <sam@corp.example>" },
+          { name: "Subject", value: "we hit 550 users" },
+        ],
+        body: { data: b64("We just passed 550 users — reach me at sam@corp.example.") },
+      },
+    };
+    expect(parseBounce(msg)).toEqual([]);
+  });
+
+  it("returns nothing when a report part exists but names no recipient", () => {
+    const msg = dsn({ report: "Reporting-MTA: dns; mx.example\r\nX-Postfix-Queue-ID: ABC" });
+    expect(parseBounce(msg)).toEqual([]);
+  });
+});
+
+describe("parseBounce — success reports", () => {
+  it("ignores a 2.x.x status block with no Action field", () => {
+    // Some MTAs emit a success report without an Action. Recording it would
+    // inflate the failure counts doctor reports off an actual delivery.
+    const msg = dsn({
+      report: ["Final-Recipient: rfc822; ok@corp.example", "Status: 2.0.0"].join("\r\n"),
+    });
+    expect(parseBounce(msg)).toEqual([]);
+  });
+
+  it("still records a failure that carries no Action field", () => {
+    const msg = dsn({
+      report: ["Final-Recipient: rfc822; gone@corp.example", "Status: 5.1.1"].join("\r\n"),
+    });
+    expect(parseBounce(msg)[0]).toMatchObject({ kind: "hard" });
+  });
+});

--- a/packages/core/__tests__/gmail-bounce.test.ts
+++ b/packages/core/__tests__/gmail-bounce.test.ts
@@ -248,3 +248,117 @@ describe("parseBounce — success reports", () => {
     expect(parseBounce(msg)[0]).toMatchObject({ kind: "hard" });
   });
 });
+
+describe("parseBounce — prose fallback, review hardening", () => {
+  it("records a failed recipient at a no-reply address", () => {
+    // A blanket daemon-pattern filter would discard this and the hard bounce
+    // would never be recorded or suppressed.
+    const msg = dsn({
+      humanText: "550 5.1.1 <no-reply@customer.example>: User unknown",
+    });
+    expect(parseBounce(msg)[0]).toMatchObject({
+      recipient: "no-reply@customer.example",
+      kind: "hard",
+    });
+  });
+
+  it("never returns the DSN's own sender as the failed recipient", () => {
+    const msg = dsn({
+      from: "Mail Delivery Subsystem <mailer-daemon@googlemail.com>",
+      humanText: "mailer-daemon@googlemail.com: 550 5.1.1 delivery failed",
+    });
+    expect(parseBounce(msg)).toEqual([]);
+  });
+
+  it("excludes the actual sender address even when it isn't daemon-shaped", () => {
+    const msg = dsn({
+      from: "Bounce Handler <bounces@relay.example>",
+      subject: "Undelivered Mail Returned to Sender",
+      humanText: "bounces@relay.example reports: 550 5.1.1 failure",
+    });
+    expect(parseBounce(msg)).toEqual([]);
+  });
+
+  it("does not lock in a quoted sender when a later coded line has no address", () => {
+    // Breaking on any coded line would return founder@ourdomain.example and a
+    // hard bounce would suppress the founder's own address.
+    const msg = dsn({
+      humanText: [
+        "Delivery failed for one recipient.",
+        "",
+        "From: founder@ourdomain.example",
+        "To: target@dead.example",
+        "",
+        "The remote server returned:",
+        "550 5.1.1 User unknown",
+      ].join("\n"),
+    });
+    expect(parseBounce(msg)[0]?.recipient).toBe("target@dead.example");
+  });
+
+  it("classifies on the full prose, not the truncated diagnostic", () => {
+    // A bare SMTP code past the 300-char truncation point would otherwise be
+    // invisible to classifyBounce, defaulting to soft and never suppressing.
+    const padding = "This message could not be delivered. ".repeat(12);
+    const msg = dsn({
+      humanText: `Delivery failed for target@dead.example\n${padding}\nRemote said: 550 No such user`,
+    });
+    const out = parseBounce(msg)[0];
+    expect(out?.kind).toBe("hard");
+    // …while the STORED diagnostic stays truncated.
+    expect(out?.diagnostic?.length).toBe(300);
+  });
+
+  it("still parses when the body is enormous", () => {
+    // Scanning is capped; the verdict must come from the leading prose.
+    const msg = dsn({
+      humanText: `550 5.1.1 <target@dead.example>: User unknown\n${"!".repeat(50_000)}`,
+    });
+    expect(parseBounce(msg)[0]).toMatchObject({ recipient: "target@dead.example", kind: "hard" });
+  });
+
+  it("returns quickly on a hostile body with no address", () => {
+    // Bounded quantifiers + scan cap: a long run of local-part characters with
+    // no '@' must not blow up backtracking.
+    const msg = dsn({ humanText: `550 failure\n${"!".repeat(60_000)}` });
+    const started = Date.now();
+    expect(parseBounce(msg)).toEqual([]);
+    expect(Date.now() - started).toBeLessThan(1000);
+  });
+});
+
+describe("parseBounce — recipient scoring", () => {
+  it("never picks an address off a From:/Return-Path: header", () => {
+    const msg = dsn({
+      humanText:
+        [
+          "Your message could not be delivered.",
+          "From: founder@ourdomain.example",
+          "Return-Path: bounce@ourdomain.example",
+          "To: target@dead.example",
+        ].join("\n") + "\n550 failure",
+    });
+    expect(parseBounce(msg)[0]?.recipient).toBe("target@dead.example");
+  });
+
+  it("prefers the SMTP response line over an earlier To: header", () => {
+    const msg = dsn({
+      humanText: [
+        "To: listed-first@corp.example",
+        "550 5.1.1 <actually-failed@corp.example>: User unknown",
+      ].join("\n"),
+    });
+    expect(parseBounce(msg)[0]?.recipient).toBe("actually-failed@corp.example");
+  });
+
+  it("prefers a recipient-cue line over an incidental mention", () => {
+    const msg = dsn({
+      humanText: [
+        "Contact support@ourdomain.example if this persists.",
+        "Your message wasn't delivered to target@dead.example.",
+        "The response was: 550 no such user",
+      ].join("\n"),
+    });
+    expect(parseBounce(msg)[0]?.recipient).toBe("target@dead.example");
+  });
+});

--- a/packages/core/__tests__/oneshot-gmail-dispatch.test.ts
+++ b/packages/core/__tests__/oneshot-gmail-dispatch.test.ts
@@ -31,6 +31,8 @@ vi.mock("../src/ledger.ts", async () => {
   return {
     ...actual,
     getLedger: () => ({
+      // No prior hard bounce: these tests exercise the normal send path.
+      suppressionFor: () => null,
       recordReceipt,
       // Rotation routing dependencies: fresh prospect, no pins, no history.
       getSenderAssignment: () => null,

--- a/packages/core/__tests__/oneshot-reply.test.ts
+++ b/packages/core/__tests__/oneshot-reply.test.ts
@@ -44,6 +44,8 @@ vi.mock("../src/ledger.ts", async () => {
   return {
     ...actual,
     getLedger: () => ({
+      // No prior hard bounce: these tests exercise the normal send path.
+      suppressionFor: () => null,
       recordReceipt,
       // Rotation dependencies for the sendEmail() path: fresh prospect, no pins.
       getSenderAssignment: () => null,

--- a/packages/core/__tests__/placement.test.ts
+++ b/packages/core/__tests__/placement.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { classifyPlacement, parseAuthResults, rfc822MsgIdQuery } from "../src/gmail.ts";
+
+describe("classifyPlacement", () => {
+  it("reads a clean inbox delivery", () => {
+    expect(classifyPlacement(["UNREAD", "INBOX", "CATEGORY_PERSONAL"])).toBe("inbox");
+  });
+
+  it("reports Promotions even though the message also carries INBOX", () => {
+    // The whole point of the test: a tab-binned message looks delivered by
+    // every other measure. Checking INBOX first would call this a clean hit.
+    expect(classifyPlacement(["INBOX", "CATEGORY_PROMOTIONS", "UNREAD"])).toBe("promotions");
+  });
+
+  it.each([["CATEGORY_SOCIAL"], ["CATEGORY_UPDATES"], ["CATEGORY_FORUMS"]])(
+    "reports %s as a tab, not an inbox hit",
+    (tab) => {
+      expect(classifyPlacement(["INBOX", tab])).toBe("tab");
+    },
+  );
+
+  it("reports spam", () => {
+    expect(classifyPlacement(["SPAM", "UNREAD"])).toBe("spam");
+  });
+
+  it("prefers SPAM over any other label", () => {
+    expect(classifyPlacement(["SPAM", "INBOX", "CATEGORY_PROMOTIONS"])).toBe("spam");
+  });
+
+  it("treats CATEGORY_PERSONAL as the primary tab, not a demotion", () => {
+    expect(classifyPlacement(["INBOX", "CATEGORY_PERSONAL"])).toBe("inbox");
+  });
+
+  it("reports a message with no inbox label as archived", () => {
+    expect(classifyPlacement(["UNREAD"])).toBe("archived");
+    expect(classifyPlacement([])).toBe("archived");
+    expect(classifyPlacement(["TRASH"])).toBe("archived");
+  });
+});
+
+describe("parseAuthResults", () => {
+  it("reads spf/dkim/dmarc off a real Gmail header", () => {
+    const header =
+      "mx.google.com; dkim=pass header.i=@corp.example header.s=google header.b=Ab1; " +
+      "spf=pass (google.com: domain of me@corp.example designates 209.85.0.1 as permitted sender) " +
+      "smtp.mailfrom=me@corp.example; dmarc=pass (p=REJECT sp=REJECT dis=NONE) header.from=corp.example";
+    expect(parseAuthResults([header])).toEqual({ spf: "pass", dkim: "pass", dmarc: "pass" });
+  });
+
+  it("reads failures and softfails", () => {
+    expect(
+      parseAuthResults(["mx.google.com; spf=softfail; dkim=fail; dmarc=fail (p=NONE)"]),
+    ).toEqual({ spf: "softfail", dkim: "fail", dmarc: "fail" });
+  });
+
+  it("reports unknown for mechanisms the header doesn't mention", () => {
+    // Absence is not a pass — an internal relay may evaluate nothing at all.
+    expect(parseAuthResults(["mx.google.com; spf=pass"])).toEqual({
+      spf: "pass",
+      dkim: "unknown",
+      dmarc: "unknown",
+    });
+  });
+
+  it("returns all-unknown when there is no header", () => {
+    expect(parseAuthResults([])).toEqual({ spf: "unknown", dkim: "unknown", dmarc: "unknown" });
+  });
+
+  it("takes the first header that states a verdict, ignoring later ARC copies", () => {
+    expect(
+      parseAuthResults(["mx.google.com; dmarc=pass", "i=1; mx.relay.example; dmarc=fail"]),
+    ).toMatchObject({ dmarc: "pass" });
+  });
+
+  it("does not mistake an arc- prefixed mechanism for the real one", () => {
+    expect(parseAuthResults(["mx.google.com; arc=pass; spf=fail"])).toMatchObject({
+      spf: "fail",
+    });
+  });
+
+  it("ignores values that aren't real verdicts", () => {
+    expect(parseAuthResults(["mx.google.com; spf=weird"])).toMatchObject({ spf: "unknown" });
+  });
+});
+
+describe("rfc822MsgIdQuery", () => {
+  it("strips the angle brackets Gmail's operator won't match", () => {
+    expect(rfc822MsgIdQuery("<CAB123@mail.gmail.com>")).toBe("rfc822msgid:CAB123@mail.gmail.com");
+  });
+
+  it("passes a bare id through", () => {
+    expect(rfc822MsgIdQuery(" CAB123@mail.gmail.com ")).toBe("rfc822msgid:CAB123@mail.gmail.com");
+  });
+});
+
+describe("parseAuthResults — token boundaries", () => {
+  it("does not read a hyphen-prefixed mechanism as the real one", () => {
+    // `\b` matches after a hyphen, so a naive boundary would report
+    // "arc-dkim=pass" as a dkim pass.
+    expect(parseAuthResults(["mx.google.com; arc-dkim=pass; dkim=fail"])).toMatchObject({
+      dkim: "fail",
+    });
+  });
+
+  it("reads a mechanism at the very start of the header", () => {
+    expect(parseAuthResults(["spf=pass; dkim=pass"])).toMatchObject({ spf: "pass" });
+  });
+
+  it("does not match a mechanism embedded in a longer word", () => {
+    expect(parseAuthResults(["mx.google.com; xspf=pass"])).toMatchObject({ spf: "unknown" });
+  });
+});

--- a/packages/core/__tests__/send-suppression.test.ts
+++ b/packages/core/__tests__/send-suppression.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The suppression backstop in sendEmail. A OneShot send is BILLED BEFORE
+// dispatch, so a send to a known-dead address costs money and sending
+// reputation for a message that cannot possibly arrive. This asserts the gate
+// fires before any routing, billing or network work happens.
+
+const getSenderAssignment = vi.fn(() => null);
+const assignSender = vi.fn((_email: string, id: string) => id);
+const recordReceipt = vi.fn().mockReturnValue(1);
+/** Set per test: what suppressionFor returns for the recipient. */
+let suppression: { status_code: string | null; bounced_at: string } | null = null;
+
+vi.mock("../src/config.ts", async () => {
+  const actual = await vi.importActual<typeof import("../src/config.ts")>("../src/config.ts");
+  return {
+    ...actual,
+    loadConfig: () => ({
+      ...actual.loadConfig(),
+      emailProvider: "oneshot",
+      emailIdentities: null,
+      sendingDomain: "corp.example",
+      founderName: "Jane Doe",
+    }),
+  };
+});
+
+vi.mock("../src/ledger.ts", async () => {
+  const actual = await vi.importActual<typeof import("../src/ledger.ts")>("../src/ledger.ts");
+  return {
+    ...actual,
+    getLedger: () => ({
+      suppressionFor: () => suppression,
+      getSenderAssignment,
+      assignSender,
+      recordReceipt,
+      hasPriorEmailSend: () => false,
+      countEmailSendsSince: () => 0,
+      firstEmailSendAt: () => null,
+    }),
+  };
+});
+
+const { sendEmail } = await import("../src/oneshot.ts");
+const { isSuppressedRecipient } = await import("../src/send-routing.ts");
+
+const CTX = { playName: "post-funding", memo: "test" };
+const INPUT = { to: "jane@dead.example", subject: "s", body: "b" };
+
+beforeEach(() => {
+  suppression = null;
+  getSenderAssignment.mockClear();
+  assignSender.mockClear();
+  recordReceipt.mockClear();
+});
+
+describe("sendEmail suppression backstop", () => {
+  it("refuses a recipient that previously hard-bounced", async () => {
+    suppression = { status_code: "5.1.1", bounced_at: "2026-08-01T10:00:00.000Z" };
+    await expect(sendEmail(INPUT, CTX)).rejects.toThrow(/hard-bounced/);
+  });
+
+  it("throws a SuppressedRecipientError, not a deferral", async () => {
+    // Callers distinguish the two: a deferral leaves work queued for tomorrow,
+    // a suppression is permanent and must not be retried.
+    suppression = { status_code: "5.1.1", bounced_at: "2026-08-01T10:00:00.000Z" };
+    const err = await sendEmail(INPUT, CTX).catch((e: unknown) => e);
+    expect(isSuppressedRecipient(err)).toBe(true);
+  });
+
+  it("names the address, the code and the date so the refusal is diagnosable", async () => {
+    suppression = { status_code: "5.1.1", bounced_at: "2026-08-01T10:00:00.000Z" };
+    const err = (await sendEmail(INPUT, CTX).catch((e: unknown) => e)) as Error;
+    expect(err.message).toContain("jane@dead.example");
+    expect(err.message).toContain("5.1.1");
+    expect(err.message).toContain("2026-08-01");
+  });
+
+  it("gates BEFORE sender routing, so no identity is pinned and nothing is billed", async () => {
+    suppression = { status_code: "5.1.1", bounced_at: "2026-08-01T10:00:00.000Z" };
+    await sendEmail(INPUT, CTX).catch(() => undefined);
+    expect(getSenderAssignment).not.toHaveBeenCalled();
+    expect(assignSender).not.toHaveBeenCalled();
+    expect(recordReceipt).not.toHaveBeenCalled();
+  });
+
+  it("still tolerates a missing status code", async () => {
+    suppression = { status_code: null, bounced_at: "2026-08-01T10:00:00.000Z" };
+    await expect(sendEmail(INPUT, CTX)).rejects.toThrow(/not sending/);
+  });
+
+  it("lets an address with no bounce history through to routing", async () => {
+    suppression = null;
+    // Routing runs (and then the real SDK call fails, which is fine) — the
+    // point is that the pre-flight didn't short-circuit it.
+    await sendEmail(INPUT, CTX).catch(() => undefined);
+    expect(getSenderAssignment).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/canary.ts
+++ b/packages/core/src/canary.ts
@@ -1,0 +1,220 @@
+import { loadConfig } from "./config.ts";
+import { logEvent } from "./events.ts";
+import {
+  findPlacedMessage,
+  getGmailProfile,
+  getSentMessageId,
+  rfc822MsgIdQuery,
+  sendGmailMessage,
+  type AuthResults,
+} from "./gmail.ts";
+import { gmailAccountFor, resolveIdentities } from "./identities.ts";
+import { getLedger } from "./ledger.ts";
+import type { EmailIdentity, GmailPlacement } from "./types.ts";
+
+/**
+ * Inbox-placement canary: send a real message from one authorized mailbox to
+ * another, then look up where the receiving account actually filed it.
+ *
+ * Bounce harvesting answers "was it refused?". This answers the question that
+ * silently kills cold outreach: accepted, but into spam or a tab. There is no
+ * API that reports this — the only source of truth is a mailbox you control on
+ * the receiving side, which is why this needs TWO connected accounts. A message
+ * sent to itself is never filtered, so a self-send would always read "inbox"
+ * and mean nothing.
+ *
+ * Deliberately NOT wired into doctor or any sweep: it sends real mail. Repeated
+ * canaries to the same address also train that mailbox's filter in your favour,
+ * so the result drifts optimistic the more often you run it. Manual only.
+ */
+
+/** Give up waiting for the canary to show up in the receiving mailbox. */
+const DEFAULT_DEADLINE_MS = 120_000;
+const FIRST_POLL_DELAY_MS = 3_000;
+const POLL_INTERVAL_MS = 5_000;
+
+export interface CanaryOptions {
+  /** Identity id to send from. Default: first Gmail identity in the pool. */
+  fromIdentityId?: string;
+  /** Identity id to receive. Default: first Gmail identity that isn't the sender. */
+  toIdentityId?: string;
+  /** Play whose most recent real email is replayed as the canary body. Default: newest of any play. */
+  playName?: string;
+  deadlineMs?: number;
+  /** Test seam — polling clock. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export interface CanaryResult {
+  fromIdentity: string;
+  fromAddress: string;
+  toIdentity: string;
+  toAddress: string;
+  placement: GmailPlacement;
+  labelIds: string[];
+  auth: AuthResults;
+  subject: string;
+  /** Play whose copy was replayed, or null when no real send existed to borrow. */
+  sourcePlay: string | null;
+  /** True when both mailboxes share a domain — see `sameDomainWarning`. */
+  sameDomain: boolean;
+  latencyMs: number | null;
+}
+
+const sleepDefault = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Generic stand-in used only when the ledger holds no real sent email to
+ * replay. Flagged as such in the result: spam filters judge CONTENT, so a
+ * placement verdict on filler text says very little about the copy that
+ * actually ships.
+ */
+function sampleCopy(): { subject: string; body: string } {
+  const cfg = loadConfig();
+  const product = cfg.productOneLiner ?? "what we're building";
+  const name = cfg.founderName ?? "";
+  return {
+    subject: "quick question",
+    body: [
+      "Hey —",
+      "",
+      `Saw what you're working on and wanted to reach out. We're building ${product}.`,
+      "",
+      "Worth a short conversation?",
+      "",
+      name,
+    ].join("\n"),
+  };
+}
+
+/** Pick the two mailboxes, failing loudly rather than degrading to a meaningless self-send. */
+export function resolveCanaryPair(opts: CanaryOptions = {}): {
+  from: EmailIdentity;
+  to: EmailIdentity;
+} {
+  const gmail = resolveIdentities(loadConfig()).filter((i) => i.provider === "gmail");
+  if (gmail.length < 2) {
+    throw new Error(
+      `inbox-placement testing needs two authorized Gmail accounts (found ${gmail.length}) — ` +
+        `a message sent to itself is never filtered, so a single account can't measure placement. ` +
+        `Add a second with: bun run cli -- gmail auth`,
+    );
+  }
+  const from = opts.fromIdentityId
+    ? gmail.find((i) => i.id === opts.fromIdentityId)
+    : (gmail[0] as EmailIdentity);
+  if (!from) throw new Error(`no Gmail identity '${opts.fromIdentityId}' in the pool`);
+  const to = opts.toIdentityId
+    ? gmail.find((i) => i.id === opts.toIdentityId)
+    : gmail.find((i) => i.id !== from.id);
+  if (!to) throw new Error(`no Gmail identity '${opts.toIdentityId}' in the pool`);
+  if (to.id === from.id) {
+    throw new Error(
+      "sender and recipient must be different identities — a self-send isn't filtered",
+    );
+  }
+  return { from, to };
+}
+
+function domainOf(address: string): string {
+  return address.split("@")[1]?.toLowerCase() ?? "";
+}
+
+/**
+ * Why a same-domain result can't be trusted: mail between two mailboxes on one
+ * Workspace domain is routed internally. It skips the spam filtering and the
+ * SPF/DKIM/DMARC evaluation that a stranger's server would apply, so it reads
+ * clean regardless of how the domain would actually be treated by a recipient.
+ */
+export const SAME_DOMAIN_WARNING =
+  "both mailboxes are on the same domain — internal routing skips most filtering and authentication, " +
+  "so this result does NOT predict how a stranger's mail server will treat you";
+
+/** Placement measured against ONE mailbox is an anecdote, not a rate. */
+export const SINGLE_SEED_CAVEAT =
+  "one seed mailbox is a single data point, not an inbox-placement rate; " +
+  "re-testing the same address repeatedly also trains its filter in your favour";
+
+export async function runPlacementCanary(opts: CanaryOptions = {}): Promise<CanaryResult> {
+  const ledger = getLedger();
+  const { from, to } = resolveCanaryPair(opts);
+  const fromAccount = gmailAccountFor(from);
+  const toAccount = gmailAccountFor(to);
+  if (!fromAccount) throw new Error(`no stored Gmail token for '${from.id}' — re-run: gmail auth`);
+  if (!toAccount) throw new Error(`no stored Gmail token for '${to.id}' — re-run: gmail auth`);
+
+  const fromAddress = from.address ?? (await getGmailProfile(fromAccount)).emailAddress;
+  const toAddress = to.address ?? (await getGmailProfile(toAccount)).emailAddress;
+  const sameDomain = domainOf(fromAddress) === domainOf(toAddress);
+
+  // Replay real shipping copy where possible: filters judge content, so a
+  // verdict on invented filler wouldn't transfer to the mail that matters.
+  const real = ledger.latestSentEmailCopy(opts.playName ? { playName: opts.playName } : {});
+  const copy = real ?? sampleCopy();
+  const sourcePlay = real?.playName ?? null;
+
+  // Sent directly, NOT through sendEmail: a diagnostic must not consume warm-up
+  // capacity, pin a sender assignment, or leave a receipt that reads as outreach.
+  const sentAt = Date.now();
+  const sent = await sendGmailMessage(
+    {
+      to: toAddress,
+      fromEmail: fromAddress,
+      fromName: loadConfig().founderName,
+      subject: copy.subject,
+      htmlBody: copy.body.replace(/\n/g, "<br>"),
+    },
+    fromAccount,
+  );
+
+  // Gmail rewrites any Message-ID we supply, so read back the one it assigned.
+  // Without this the receiving-side lookup has nothing exact to match on.
+  const messageId = await getSentMessageId(sent.id, fromAccount).catch(() => null);
+  // Subject+sender is the fallback query. Deliberately no marker token in the
+  // subject: anything we added to make it findable would also be judged by the
+  // filter we're trying to measure. `after:` is bounded to this run because the
+  // subject is REPLAYED copy — an earlier canary of the same play would
+  // otherwise be a valid match, and a stale hit would report the previous run's
+  // placement as if it were this one's.
+  const afterEpoch = Math.floor(sentAt / 1000) - 60;
+  const query = messageId
+    ? rfc822MsgIdQuery(messageId)
+    : `from:${fromAddress} subject:"${copy.subject.replace(/"/g, "")}" after:${afterEpoch}`;
+
+  const sleep = opts.sleep ?? sleepDefault;
+  const deadline = sentAt + (opts.deadlineMs ?? DEFAULT_DEADLINE_MS);
+  await sleep(FIRST_POLL_DELAY_MS);
+  let found = await findPlacedMessage(query, toAccount);
+  while (!found && Date.now() < deadline) {
+    await sleep(POLL_INTERVAL_MS);
+    found = await findPlacedMessage(query, toAccount);
+  }
+
+  const result: CanaryResult = {
+    fromIdentity: from.id,
+    fromAddress,
+    toIdentity: to.id,
+    toAddress,
+    // Never seen inside the deadline. Reported as its own outcome rather than
+    // folded into "spam" — it may still be in transit, and guessing either way
+    // would be a fabricated verdict.
+    placement: found?.placement ?? "not_delivered",
+    labelIds: found?.labelIds ?? [],
+    auth: found?.auth ?? { spf: "unknown", dkim: "unknown", dmarc: "unknown" },
+    subject: copy.subject,
+    sourcePlay,
+    sameDomain,
+    latencyMs: found ? Date.now() - sentAt : null,
+  };
+
+  ledger.recordCanaryResult(result);
+  logEvent("canary.placement", {
+    placement: result.placement,
+    same_domain: sameDomain,
+    spf: result.auth.spf,
+    dkim: result.auth.dkim,
+    dmarc: result.auth.dmarc,
+  });
+  return result;
+}

--- a/packages/core/src/canary.ts
+++ b/packages/core/src/canary.ts
@@ -10,6 +10,7 @@ import {
 } from "./gmail.ts";
 import { gmailAccountFor, resolveIdentities } from "./identities.ts";
 import { getLedger } from "./ledger.ts";
+import { toHtmlBody } from "./oneshot.ts";
 import type { EmailIdentity, GmailPlacement } from "./types.ts";
 
 /**
@@ -163,7 +164,11 @@ export async function runPlacementCanary(opts: CanaryOptions = {}): Promise<Cana
       fromEmail: fromAddress,
       fromName: loadConfig().founderName,
       subject: copy.subject,
-      htmlBody: copy.body.replace(/\n/g, "<br>"),
+      // The real send path's exact encoder. Escaping matters beyond
+      // correctness here: copy containing & < > would otherwise reach the
+      // filter as different content from what ships, and the whole point is
+      // to measure a verdict on the real thing.
+      htmlBody: toHtmlBody(copy.body),
     },
     fromAccount,
   );

--- a/packages/core/src/gmail.ts
+++ b/packages/core/src/gmail.ts
@@ -1,5 +1,6 @@
 import type { InboxEmail, InboxListResult } from "@oneshot-agent/sdk";
 import { parallelMap } from "./parallel.ts";
+import type { AuthVerdict, BounceKind, GmailPlacement } from "./types.ts";
 
 /**
  * Gmail / Google Workspace send + reply path. Plain-fetch OAuth2 + Gmail REST
@@ -247,14 +248,14 @@ export async function getGmailProfile(account?: GmailAccount): Promise<{ emailAd
   return profile;
 }
 
-interface GmailMessageMeta {
+export interface GmailMessageMeta {
   id: string;
   threadId: string;
   internalDate: string;
   payload?: GmailPayloadPart;
 }
 
-interface GmailPayloadPart {
+export interface GmailPayloadPart {
   mimeType?: string;
   headers?: Array<{ name: string; value: string }>;
   body?: { data?: string };
@@ -327,4 +328,376 @@ export async function listGmailReplies(
     },
   );
   return { emails, count: emails.length, has_more: false, agent_id: "gmail" };
+}
+
+/* ── Bounce (DSN) harvesting ─────────────────────────────────────────────────
+ * Delivery Status Notifications are the only first-party deliverability signal
+ * available without a second mailbox: the receiving server tells us, in the
+ * sender's own inbox, that a message was refused and why. Parsed here rather
+ * than in the reply path because (a) DSNs would otherwise compete with genuine
+ * replies for the 50-message poll window, and (b) fetching them deliberately
+ * lets us read the structured RFC 3464 report instead of regexing localized
+ * human-readable prose.
+ */
+
+/** Matches an RFC 3463 enhanced status code ("5.1.1"). */
+const ENHANCED_STATUS_RE = /\b([45]\.\d{1,3}\.\d{1,3})\b/;
+/** Matches a bare 3-digit SMTP reply code, for servers that omit the enhanced one. */
+const SMTP_CODE_RE = /\b([45]\d\d)\b/;
+/**
+ * Diagnostics that mean "we refused this message" rather than "this address
+ * doesn't exist". Catches servers that reject on policy with a plain 550 and
+ * no 5.7.x enhanced code, which would otherwise be miscounted as a dead
+ * address (and wrongly suppress a perfectly valid prospect).
+ */
+const POLICY_DIAGNOSTIC_RE =
+  /\b(spam|blocked|blocklist|blacklist|policy|reputation|unsolicited|bulk|rejected due to|spamhaus|barracuda|greylist)/i;
+/** DSN envelope senders — never the failed recipient, so excluded when scraping prose. */
+const DAEMON_ADDRESS_RE = /(mailer-daemon|postmaster|no-?reply|do-?not-?reply)@/i;
+const EMAIL_RE = /[\w.!#$%&'*+/=?^`{|}~-]+@[\w-]+(?:\.[\w-]+)+/g;
+
+/**
+ * Severity for a delivery failure. `statusCode` is the enhanced RFC 3463 code
+ * when the DSN provided one; `diagnostic` is the remote server's text. Policy
+ * rejections are separated from address failures because only the latter
+ * justifies suppressing the address — see BounceKind.
+ */
+export function classifyBounce(statusCode: string | null, diagnostic: string | null): BounceKind {
+  const code = statusCode ?? diagnostic?.match(ENHANCED_STATUS_RE)?.[1] ?? null;
+  const policy = diagnostic != null && POLICY_DIAGNOSTIC_RE.test(diagnostic);
+  if (code) {
+    if (code.startsWith("4.")) return "soft";
+    if (code.startsWith("5.7.")) return "block";
+    if (code.startsWith("5.")) return policy ? "block" : "hard";
+  }
+  // No enhanced code — fall back to the bare SMTP reply class.
+  const smtp = diagnostic?.match(SMTP_CODE_RE)?.[1];
+  if (smtp?.startsWith("4")) return "soft";
+  if (smtp?.startsWith("5")) return policy ? "block" : "hard";
+  // Unparseable severity: treat as transient. Guessing `hard` here would
+  // suppress a live address on the strength of an unrecognized message.
+  return "soft";
+}
+
+/** Depth-first search for the first part of a given MIME type. */
+function findPart(
+  part: GmailPayloadPart | undefined,
+  mimeType: string,
+): GmailPayloadPart | undefined {
+  if (!part) return undefined;
+  if (part.mimeType === mimeType) return part;
+  for (const child of part.parts ?? []) {
+    const hit = findPart(child, mimeType);
+    if (hit) return hit;
+  }
+  return undefined;
+}
+
+/**
+ * Unfold RFC 5322 continuation lines (a line beginning with whitespace belongs
+ * to the previous one). Diagnostic-Code routinely wraps across several lines,
+ * and reading only the first would truncate the SMTP response mid-sentence.
+ */
+function unfold(text: string): string[] {
+  const out: string[] = [];
+  for (const raw of text.split(/\r?\n/)) {
+    if (/^[ \t]/.test(raw) && out.length > 0) out[out.length - 1] += ` ${raw.trim()}`;
+    else out.push(raw);
+  }
+  return out;
+}
+
+function fieldValue(lines: string[], name: string): string | null {
+  const prefix = `${name.toLowerCase()}:`;
+  for (const line of lines) {
+    if (line.toLowerCase().startsWith(prefix)) return line.slice(prefix.length).trim();
+  }
+  return null;
+}
+
+/** "rfc822; jane@x.com" / "<jane@x.com>" → "jane@x.com". */
+function stripAddressType(value: string): string {
+  const afterType = value.includes(";") ? value.slice(value.indexOf(";") + 1) : value;
+  return afterType.trim().replace(/^<|>$/g, "").trim().toLowerCase();
+}
+
+export interface ParsedBounce {
+  /** The address that failed (Final-Recipient), lowercased. */
+  recipient: string;
+  kind: BounceKind;
+  statusCode: string | null;
+  diagnostic: string | null;
+}
+
+/**
+ * Pull every failed recipient out of a DSN. Returns [] for ordinary mail, which
+ * is what makes a deliberately broad Gmail query safe — the parser, not the
+ * query, decides what counts as a bounce.
+ *
+ * Prefers the structured `message/delivery-status` report (locale-independent,
+ * one block per recipient). Falls back to scraping the human-readable part for
+ * senders that don't emit a conforming report.
+ */
+export function parseBounce(msg: GmailMessageMeta): ParsedBounce[] {
+  const report = findPart(msg.payload, "message/delivery-status");
+  if (report?.body?.data) {
+    const text = Buffer.from(report.body.data, "base64url").toString("utf8");
+    const out: ParsedBounce[] = [];
+    // Per-message fields come first, then one block per recipient, blank-line
+    // separated. Only blocks naming a recipient describe a delivery failure.
+    for (const block of text.split(/\r?\n\s*\r?\n/)) {
+      const lines = unfold(block);
+      const finalRecipient =
+        fieldValue(lines, "Final-Recipient") ?? fieldValue(lines, "Original-Recipient");
+      if (!finalRecipient) continue;
+      const recipient = stripAddressType(finalRecipient);
+      if (!recipient.includes("@")) continue;
+      const status = fieldValue(lines, "Status");
+      const statusCode = status?.match(ENHANCED_STATUS_RE)?.[1] ?? null;
+      const diagnostic = fieldValue(lines, "Diagnostic-Code");
+      // `action: delivered/relayed/expanded` blocks are successes riding along
+      // in a multi-recipient report — not failures.
+      const action = fieldValue(lines, "Action")?.toLowerCase() ?? "";
+      if (action && !action.startsWith("failed") && !action.startsWith("delayed")) continue;
+      // A 2.x.x status is a SUCCESS report. MTAs that emit these without an
+      // Action field would otherwise be recorded as bounces — harmless in
+      // effect (they classify soft) but they'd inflate the failure counts the
+      // doctor check reports.
+      if (status?.trim().startsWith("2.")) continue;
+      out.push({
+        recipient,
+        kind: classifyBounce(statusCode, diagnostic),
+        statusCode,
+        diagnostic: diagnostic?.slice(0, 300) ?? null,
+      });
+    }
+    if (out.length > 0) return out;
+  }
+
+  // Fallback: no conforming report. Gate it on the message actually being a
+  // delivery report first — prose-scraping is loose enough that an ordinary
+  // email mentioning "550 users" next to an address would otherwise parse as a
+  // hard bounce and suppress a live prospect. A structured report needs no such
+  // guard; its presence is proof on its own.
+  const from = msg.payload?.headers?.find((h) => h.name.toLowerCase() === "from")?.value ?? "";
+  const subject =
+    msg.payload?.headers?.find((h) => h.name.toLowerCase() === "subject")?.value ?? "";
+  const looksLikeDsn =
+    DAEMON_ADDRESS_RE.test(from) ||
+    /(delivery (status notification|failure|has failed)|undelivered mail|returned to sender|address not found)/i.test(
+      subject,
+    );
+  if (!looksLikeDsn) return [];
+
+  // Scrape the prose for an address plus a status code. Prefer an address on a
+  // line that also carries a code (that's the SMTP response line naming the
+  // failed recipient) over a bare first match, which could be the quoted
+  // original sender.
+  const body = extractPlainText(msg.payload);
+  if (!body) return [];
+  const statusCode = body.match(ENHANCED_STATUS_RE)?.[1] ?? null;
+  if (!statusCode && !SMTP_CODE_RE.test(body)) return [];
+  let recipient: string | null = null;
+  for (const line of body.split(/\r?\n/)) {
+    const hasCode = ENHANCED_STATUS_RE.test(line) || SMTP_CODE_RE.test(line);
+    for (const addr of line.match(EMAIL_RE) ?? []) {
+      if (DAEMON_ADDRESS_RE.test(addr)) continue;
+      recipient ??= addr.toLowerCase();
+      if (hasCode) {
+        recipient = addr.toLowerCase();
+        break;
+      }
+    }
+    if (recipient && hasCode) break;
+  }
+  if (!recipient) return [];
+  const diagnostic = body.replace(/\s+/g, " ").trim().slice(0, 300);
+  return [{ recipient, kind: classifyBounce(statusCode, diagnostic), statusCode, diagnostic }];
+}
+
+export interface GmailBounce extends ParsedBounce {
+  /** Gmail id of the DSN message. With `recipient`, the idempotency key for re-sweeps. */
+  messageId: string;
+  bouncedAt: string;
+}
+
+/**
+ * Delivery failures reported to this mailbox. The query is a coarse net (DSN
+ * senders and subjects vary by MTA); `parseBounce` discards anything that isn't
+ * actually a delivery report, so over-matching costs a wasted fetch, not a
+ * false bounce. No `in:inbox` — a DSN the founder archived still counts — and
+ * no `-from:me`, which would drop self-relayed reports.
+ */
+export async function listGmailBounces(
+  opts?: { since?: string; limit?: number },
+  account?: GmailAccount,
+): Promise<GmailBounce[]> {
+  const sinceClause = opts?.since
+    ? `after:${Math.floor(new Date(opts.since).getTime() / 1000)}`
+    : "newer_than:30d";
+  const params = new URLSearchParams({
+    q:
+      `(from:mailer-daemon OR from:postmaster OR subject:"Delivery Status Notification" ` +
+      `OR subject:"Undelivered Mail Returned to Sender" OR subject:"Delivery Failure") ${sinceClause}`,
+    maxResults: String(opts?.limit ?? 100),
+  });
+  const list = await gmailJson<{ messages?: Array<{ id: string }> }>(
+    `/messages?${params}`,
+    undefined,
+    account,
+  );
+  const ids = (list.messages ?? []).map((m) => m.id);
+  const perMessage = await parallelMap(ids, 4, async (id): Promise<GmailBounce[]> => {
+    const msg = await gmailJson<GmailMessageMeta>(
+      `/messages/${id}?format=full`,
+      undefined,
+      account,
+    );
+    const bouncedAt = new Date(Number(msg.internalDate)).toISOString();
+    // Object.assign, not a spread: parseBounce just built these objects and
+    // nothing else holds a reference, so mutating in place is safe and avoids
+    // a fresh allocation per recipient.
+    return parseBounce(msg).map((b) => Object.assign(b, { messageId: msg.id, bouncedAt }));
+  });
+  return perMessage.flat();
+}
+
+/* ── Inbox placement ─────────────────────────────────────────────────────────
+ * What DSN harvesting structurally cannot tell you: a message can be accepted
+ * without complaint and still be filtered into spam or buried in a tab. The
+ * only way to know is to look in a real receiving mailbox — which requires a
+ * SECOND authorized account, since a message you send to yourself is never
+ * filtered.
+ */
+
+/** All values for a header that may legitimately appear more than once. */
+function headerValues(msg: GmailMessageMeta, name: string): string[] {
+  const lower = name.toLowerCase();
+  return (msg.payload?.headers ?? [])
+    .filter((h) => h.name.toLowerCase() === lower)
+    .map((h) => h.value);
+}
+
+/**
+ * Where Gmail filed the message, from its labelIds. Order matters: a message
+ * in Promotions carries BOTH `INBOX` and `CATEGORY_PROMOTIONS`, so checking
+ * `INBOX` first would report a tab-binned message as a clean inbox hit — the
+ * exact failure this test exists to catch. SPAM is checked first because a
+ * spammed message carries neither INBOX nor a category.
+ */
+export function classifyPlacement(labelIds: string[]): GmailPlacement {
+  const labels = new Set(labelIds);
+  if (labels.has("SPAM")) return "spam";
+  if (labels.has("TRASH")) return "archived";
+  if (labels.has("CATEGORY_PROMOTIONS")) return "promotions";
+  for (const tab of ["CATEGORY_SOCIAL", "CATEGORY_UPDATES", "CATEGORY_FORUMS"]) {
+    if (labels.has(tab)) return "tab";
+  }
+  // CATEGORY_PERSONAL is the primary tab, not a demotion — INBOX decides.
+  if (labels.has("INBOX")) return "inbox";
+  return "archived";
+}
+
+export interface AuthResults {
+  spf: AuthVerdict;
+  dkim: AuthVerdict;
+  dmarc: AuthVerdict;
+}
+
+const VERDICTS: AuthVerdict[] = ["pass", "fail", "softfail", "neutral", "none"];
+
+/**
+ * SPF/DKIM/DMARC as judged by the RECEIVING server, read off the delivered
+ * message's `Authentication-Results` header. This is a verdict on the actual
+ * message path — strictly better evidence than resolving DNS records ourselves,
+ * and it needs no DNS tooling at all.
+ *
+ * Returns `unknown` per mechanism when the header is absent or silent on it,
+ * which is normal for internal (same-Workspace) delivery that never crosses an
+ * authenticating boundary.
+ */
+export function parseAuthResults(headers: string[]): AuthResults {
+  const out: AuthResults = { spf: "unknown", dkim: "unknown", dmarc: "unknown" };
+  for (const raw of headers) {
+    const text = raw.toLowerCase();
+    for (const mech of ["spf", "dkim", "dmarc"] as const) {
+      if (out[mech] !== "unknown") continue;
+      // The mechanism must start the token. `\b` alone is not enough: it
+      // matches after a hyphen too, so "arc-dkim=pass" would be read as a
+      // dkim verdict. Require the preceding char to be absent or neither a
+      // word char nor a hyphen.
+      const m = text.match(new RegExp(`(?:^|[^a-z0-9_-])${mech}=([a-z]+)`));
+      const value = m?.[1];
+      if (value && (VERDICTS as string[]).includes(value)) out[mech] = value as AuthVerdict;
+    }
+  }
+  return out;
+}
+
+/** Both auth-results header spellings a receiving Gmail may use, newest evaluation first. */
+export function authResultsFor(msg: GmailMessageMeta): AuthResults {
+  return parseAuthResults([
+    ...headerValues(msg, "Authentication-Results"),
+    ...headerValues(msg, "ARC-Authentication-Results"),
+  ]);
+}
+
+/** RFC 2822 Message-ID Gmail actually assigned to a message we sent (it rewrites any we supply). */
+export async function getSentMessageId(
+  gmailMessageId: string,
+  account?: GmailAccount,
+): Promise<string | null> {
+  const msg = await gmailJson<GmailMessageMeta>(
+    `/messages/${gmailMessageId}?format=metadata&metadataHeaders=Message-ID`,
+    undefined,
+    account,
+  );
+  return headerValues(msg, "Message-ID")[0] ?? null;
+}
+
+export interface PlacedMessage {
+  id: string;
+  labelIds: string[];
+  placement: GmailPlacement;
+  auth: AuthResults;
+  receivedAt: string;
+}
+
+/**
+ * Find a message in this mailbox by Gmail search and report where it landed.
+ *
+ * `in:anywhere` is load-bearing: Gmail's default search EXCLUDES spam and
+ * trash, so without it the one outcome this test exists to detect — the
+ * message was filtered as spam — would read identically to "never arrived".
+ */
+export async function findPlacedMessage(
+  query: string,
+  account?: GmailAccount,
+): Promise<PlacedMessage | null> {
+  const params = new URLSearchParams({ q: `in:anywhere ${query}`, maxResults: "5" });
+  const list = await gmailJson<{ messages?: Array<{ id: string }> }>(
+    `/messages?${params}`,
+    undefined,
+    account,
+  );
+  const id = list.messages?.[0]?.id;
+  if (!id) return null;
+  const msg = await gmailJson<GmailMessageMeta & { labelIds?: string[] }>(
+    `/messages/${id}?format=metadata&metadataHeaders=Authentication-Results&metadataHeaders=ARC-Authentication-Results&metadataHeaders=Subject`,
+    undefined,
+    account,
+  );
+  const labelIds = msg.labelIds ?? [];
+  return {
+    id: msg.id,
+    labelIds,
+    placement: classifyPlacement(labelIds),
+    auth: authResultsFor(msg),
+    receivedAt: new Date(Number(msg.internalDate)).toISOString(),
+  };
+}
+
+/** Gmail's `rfc822msgid:` operator wants the id bare — angle brackets make it match nothing. */
+export function rfc822MsgIdQuery(messageId: string): string {
+  return `rfc822msgid:${messageId.trim().replace(/^<|>$/g, "")}`;
 }

--- a/packages/core/src/gmail.ts
+++ b/packages/core/src/gmail.ts
@@ -352,9 +352,27 @@ const SMTP_CODE_RE = /\b([45]\d\d)\b/;
  */
 const POLICY_DIAGNOSTIC_RE =
   /\b(spam|blocked|blocklist|blacklist|policy|reputation|unsolicited|bulk|rejected due to|spamhaus|barracuda|greylist)/i;
-/** DSN envelope senders — never the failed recipient, so excluded when scraping prose. */
-const DAEMON_ADDRESS_RE = /(mailer-daemon|postmaster|no-?reply|do-?not-?reply)@/i;
-const EMAIL_RE = /[\w.!#$%&'*+/=?^`{|}~-]+@[\w-]+(?:\.[\w-]+)+/g;
+/**
+ * Canonical DSN envelope senders. Used only as a fallback to the message's
+ * actual From address — kept narrow deliberately: a broad pattern (no-reply@,
+ * donotreply@…) would also discard a genuine failed recipient at one of those
+ * addresses, and then the hard bounce would never be recorded or suppressed.
+ */
+const DAEMON_ADDRESS_RE = /^(mailer-daemon|postmaster)@/i;
+/**
+ * Quantifiers are bounded to RFC 5321's limits (local-part 64, labels 63)
+ * rather than left open. An unbounded `[...]+@` over a body that never contains
+ * `@` backtracks from every start position — and DSN bodies are attacker-
+ * influenced, since anyone can send mail with a mailer-daemon From. See also
+ * PROSE_SCAN_LIMIT.
+ */
+const EMAIL_RE = /[\w.!#$%&'*+/=?^`{|}~-]{1,64}@[\w-]{1,63}(?:\.[\w-]{1,63}){1,8}/g;
+/**
+ * Prose scanned by the fallback parser, in characters. A real DSN states the
+ * failure in its first few lines; the rest is the quoted original message.
+ * Capping bounds the regex work on hostile input.
+ */
+const PROSE_SCAN_LIMIT = 8_000;
 
 /**
  * Severity for a delivery failure. `statusCode` is the enhanced RFC 3463 code
@@ -482,37 +500,77 @@ export function parseBounce(msg: GmailMessageMeta): ParsedBounce[] {
   const from = msg.payload?.headers?.find((h) => h.name.toLowerCase() === "from")?.value ?? "";
   const subject =
     msg.payload?.headers?.find((h) => h.name.toLowerCase() === "subject")?.value ?? "";
+  const senderAddress = from.match(EMAIL_RE)?.[0]?.toLowerCase() ?? null;
   const looksLikeDsn =
-    DAEMON_ADDRESS_RE.test(from) ||
+    (senderAddress != null && DAEMON_ADDRESS_RE.test(senderAddress)) ||
     /(delivery (status notification|failure|has failed)|undelivered mail|returned to sender|address not found)/i.test(
       subject,
     );
   if (!looksLikeDsn) return [];
 
-  // Scrape the prose for an address plus a status code. Prefer an address on a
-  // line that also carries a code (that's the SMTP response line naming the
-  // failed recipient) over a bare first match, which could be the quoted
-  // original sender.
-  const body = extractPlainText(msg.payload);
+  /**
+   * The DSN's own sender is never the address that failed. Matched by exact
+   * address first, falling back to the canonical daemon pattern — a broader
+   * pattern would discard a real failed recipient at, say,
+   * `no-reply@customer.example` and the bounce would go unrecorded.
+   */
+  const isSender = (addr: string): boolean =>
+    addr === senderAddress || DAEMON_ADDRESS_RE.test(addr);
+
+  const body = extractPlainText(msg.payload).slice(0, PROSE_SCAN_LIMIT);
   if (!body) return [];
   const statusCode = body.match(ENHANCED_STATUS_RE)?.[1] ?? null;
   if (!statusCode && !SMTP_CODE_RE.test(body)) return [];
+
+  /*
+   * A DSN's prose contains several addresses and only one of them failed.
+   * Picking the first non-sender match is wrong: a quoted `From:` header
+   * usually appears above the SMTP response, so a hard bounce would suppress
+   * the FOUNDER'S address rather than the target's. Score candidates by how
+   * strongly their line implies "this is the address that failed" and take the
+   * best, rather than the earliest.
+   */
+  // Header lines naming the originator — never the failed recipient.
+  const ORIGINATOR_LINE = /^\s*(from|sender|reply-to|return-path|x-original-from)\s*:/i;
+  // Phrasing that introduces the failed recipient across common MTAs.
+  const RECIPIENT_CUE =
+    /^\s*(to|final-recipient|original-recipient)\s*:|(recipient|delivered to|deliver to|failed for|wasn't delivered to|was not delivered to)/i;
+  const CODED_LINE = 3;
   let recipient: string | null = null;
-  for (const line of body.split(/\r?\n/)) {
-    const hasCode = ENHANCED_STATUS_RE.test(line) || SMTP_CODE_RE.test(line);
+  let bestScore = 0;
+  outer: for (const line of body.split(/\r?\n/)) {
+    if (ORIGINATOR_LINE.test(line)) continue;
+    const score =
+      ENHANCED_STATUS_RE.test(line) || SMTP_CODE_RE.test(line)
+        ? CODED_LINE
+        : RECIPIENT_CUE.test(line)
+          ? 2
+          : 1;
+    if (score <= bestScore) continue;
     for (const addr of line.match(EMAIL_RE) ?? []) {
-      if (DAEMON_ADDRESS_RE.test(addr)) continue;
-      recipient ??= addr.toLowerCase();
-      if (hasCode) {
-        recipient = addr.toLowerCase();
-        break;
-      }
+      const lower = addr.toLowerCase();
+      if (isSender(lower)) continue;
+      recipient = lower;
+      bestScore = score;
+      // Nothing outranks the SMTP response line — stop looking.
+      if (score === CODED_LINE) break outer;
+      break;
     }
-    if (recipient && hasCode) break;
   }
   if (!recipient) return [];
-  const diagnostic = body.replace(/\s+/g, " ").trim().slice(0, 300);
-  return [{ recipient, kind: classifyBounce(statusCode, diagnostic), statusCode, diagnostic }];
+  const normalized = body.replace(/\s+/g, " ").trim();
+  // Classify against the FULL prose but store only a truncated diagnostic: a
+  // bare SMTP code past the truncation point would otherwise be invisible to
+  // classifyBounce, which then defaults to `soft` and never suppresses a
+  // genuinely dead address.
+  return [
+    {
+      recipient,
+      kind: classifyBounce(statusCode, normalized),
+      statusCode,
+      diagnostic: normalized.slice(0, 300),
+    },
+  ];
 }
 
 export interface GmailBounce extends ParsedBounce {
@@ -527,6 +585,11 @@ export interface GmailBounce extends ParsedBounce {
  * actually a delivery report, so over-matching costs a wasted fetch, not a
  * false bounce. No `in:inbox` — a DSN the founder archived still counts — and
  * no `-from:me`, which would drop self-relayed reports.
+ *
+ * Paginated: a heavy sender can exceed one page of DSNs inside the window, and
+ * stopping at the first page would leave those recipients unsuppressed while
+ * reporting a falsely low bounce rate — a silent undercount, the worst failure
+ * mode for a check whose whole job is to notice trouble.
  */
 export async function listGmailBounces(
   opts?: { since?: string; limit?: number },
@@ -535,18 +598,28 @@ export async function listGmailBounces(
   const sinceClause = opts?.since
     ? `after:${Math.floor(new Date(opts.since).getTime() / 1000)}`
     : "newer_than:30d";
-  const params = new URLSearchParams({
-    q:
-      `(from:mailer-daemon OR from:postmaster OR subject:"Delivery Status Notification" ` +
-      `OR subject:"Undelivered Mail Returned to Sender" OR subject:"Delivery Failure") ${sinceClause}`,
-    maxResults: String(opts?.limit ?? 100),
-  });
-  const list = await gmailJson<{ messages?: Array<{ id: string }> }>(
-    `/messages?${params}`,
-    undefined,
-    account,
-  );
-  const ids = (list.messages ?? []).map((m) => m.id);
+  const query =
+    `(from:mailer-daemon OR from:postmaster OR subject:"Delivery Status Notification" ` +
+    `OR subject:"Undelivered Mail Returned to Sender" OR subject:"Delivery Failure") ${sinceClause}`;
+  // Ceiling on total DSNs pulled per sweep. Bounds both the page walk and the
+  // per-message fetches that follow, so a mailbox full of delivery reports
+  // can't turn one sweep into thousands of API calls.
+  const limit = opts?.limit ?? 500;
+  const ids: string[] = [];
+  let pageToken: string | undefined;
+  do {
+    const params = new URLSearchParams({
+      q: query,
+      maxResults: String(Math.min(100, limit - ids.length)),
+      ...(pageToken ? { pageToken } : {}),
+    });
+    const list = await gmailJson<{
+      messages?: Array<{ id: string }>;
+      nextPageToken?: string;
+    }>(`/messages?${params}`, undefined, account);
+    for (const m of list.messages ?? []) ids.push(m.id);
+    pageToken = list.nextPageToken;
+  } while (pageToken && ids.length < limit);
   const perMessage = await parallelMap(ids, 4, async (id): Promise<GmailBounce[]> => {
     const msg = await gmailJson<GmailMessageMeta>(
       `/messages/${id}?format=full`,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -7,6 +7,7 @@ export * from "./telemetry.ts";
 export * from "./version.ts";
 export * from "./json.ts";
 export * from "./gmail.ts";
+export * from "./canary.ts";
 export * from "./identities.ts";
 export * from "./send-routing.ts";
 export * from "./parallel.ts";

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -1292,9 +1292,18 @@ export class Ledger {
         // (same convention as eventsByPlay). Matching only 'sent' would skip the
         // copy of every prospect who answered — precisely the best-performing
         // copy, and the canary would silently replay something older or nothing.
+        // Usability is filtered in SQL, not by scanning a fixed slice in JS.
+        // A slice can be exhausted by a run of pre-v8 / bodyless rows and then
+        // report "no copy" while perfectly good copy sits just past the cut —
+        // but dropping the bound entirely would load every send ever made to
+        // find one body. Letting SQLite discard the unusable rows means the
+        // small bound below only ever trims genuinely valid candidates.
         `SELECT play_name, metadata_json FROM sequence_events
          WHERE status IN ('sent', 'delivered', 'replied')
            AND channel = 'email' AND metadata_json IS NOT NULL
+           AND json_valid(metadata_json)
+           AND json_extract(metadata_json, '$.subject') IS NOT NULL
+           AND trim(coalesce(json_extract(metadata_json, '$.body'), '')) != ''
            ${opts.playName ? "AND play_name = ?" : ""}
          -- id DESC breaks ties: created_at is second-precision, and a cadence
          -- batch writes several rows within one second, leaving their relative
@@ -1305,8 +1314,8 @@ export class Ledger {
       play_name: string;
       metadata_json: string;
     }>;
-    // Scan a few: pre-v8 rows and non-email payloads have no subject/body, and
-    // taking only the newest row would return null whenever one of those is on top.
+    // Backstop for shapes SQL can't reject — a numeric subject, say, which
+    // json_extract happily returns but which isn't usable copy.
     for (const row of rows) {
       let meta: { subject?: unknown; body?: unknown };
       try {

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -3,6 +3,11 @@ import { existsSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { configDir } from "./config.ts";
 import type {
+  AuthVerdict,
+  BounceKind,
+  BounceRecord,
+  CanaryResultRecord,
+  GmailPlacement,
   InterviewRecord,
   ProspectRecord,
   QueueRow,
@@ -391,6 +396,55 @@ export class Ledger {
       CREATE INDEX IF NOT EXISTS idx_receipts_goal
         ON receipts(goal_id) WHERE goal_id IS NOT NULL;
     `);
+    // v18 (2026-08): delivery failures parsed from DSNs. Until now nothing ever
+    // wrote sequence_events.status='bounced' — the tool kept emailing addresses
+    // the receiving server had already refused, paying for each send and burning
+    // sending reputation, while the evidence sat unread in the mailbox.
+    // PK is (message_id, recipient): the DSN's own provider id makes a re-sweep
+    // idempotent (the sweep runs on every scheduler tick and re-sees the same
+    // 30-day window), and the recipient column keeps a multi-recipient report
+    // from collapsing into one row.
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS bounces (
+        message_id  TEXT NOT NULL,
+        recipient   TEXT NOT NULL,
+        identity_id TEXT,
+        kind        TEXT NOT NULL,
+        status_code TEXT,
+        diagnostic  TEXT,
+        prospect_id INTEGER,
+        bounced_at  TEXT NOT NULL,
+        created_at  TEXT NOT NULL DEFAULT (datetime('now')),
+        PRIMARY KEY (message_id, recipient)
+      );
+      -- doctor's per-identity rate over a trailing window.
+      CREATE INDEX IF NOT EXISTS idx_bounces_identity ON bounces(identity_id, bounced_at);
+      -- suppressionFor, on the send pre-flight path — must be an index seek.
+      CREATE INDEX IF NOT EXISTS idx_bounces_recipient ON bounces(recipient, kind);
+    `);
+    // v19 (2026-08): inbox-placement canary results. Bounces tell you a message
+    // was refused; nothing told you it was ACCEPTED and then filtered into spam
+    // or a tab, which for cold outreach is the same as never arriving. Each row
+    // is one manual A→B test. Append-only history so a reputation trend is
+    // visible rather than just the latest verdict.
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS canary_results (
+        id            INTEGER PRIMARY KEY AUTOINCREMENT,
+        from_identity TEXT NOT NULL,
+        to_identity   TEXT NOT NULL,
+        placement     TEXT NOT NULL,
+        labels_json   TEXT,
+        spf           TEXT NOT NULL,
+        dkim          TEXT NOT NULL,
+        dmarc         TEXT NOT NULL,
+        subject       TEXT,
+        source_play   TEXT,
+        same_domain   INTEGER NOT NULL DEFAULT 0,
+        latency_ms    INTEGER,
+        created_at    TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      CREATE INDEX IF NOT EXISTS idx_canary_created ON canary_results(created_at DESC);
+    `);
   }
 
   /**
@@ -580,12 +634,14 @@ export class Ledger {
   setCadenceStatus(input: {
     prospectId: number;
     playName: string;
-    status: "active" | "replied" | "breakup" | "completed";
+    status: "active" | "replied" | "breakup" | "completed" | "bounced";
   }): void {
     // Non-active terminal states clear the persisted draft AND any send
-    // marker — a replied / breakup / completed cadence shouldn't have a
-    // sendable preview hanging around or a stuck "sending" flag. A reply /
-    // breakup / completion also clears any stale send-failure marker.
+    // marker — a replied / breakup / completed / bounced cadence shouldn't have
+    // a sendable preview hanging around or a stuck "sending" flag. A reply /
+    // breakup / completion / bounce also clears any stale send-failure marker
+    // (for a bounce that marker is actively misleading: it reads as
+    // "retrying", but a dead address will never accept a retry).
     this.db
       .prepare(
         `UPDATE cadence_state
@@ -1089,6 +1145,171 @@ export class Ledger {
       )
       .get(identityId) as { first: string | null };
     return row.first;
+  }
+
+  /**
+   * Record one delivery failure. INSERT OR IGNORE against the (message_id,
+   * recipient) PK: the sweep re-reads a 30-day window on every tick, so the
+   * same DSN is re-seen dozens of times and must only ever count once.
+   * Returns true when this was a NEW bounce — callers use that to decide
+   * whether to act on the cadence (stopping it repeatedly is harmless, but
+   * re-tagging receipts and logging on every tick is not).
+   */
+  recordBounce(input: {
+    messageId: string;
+    recipient: string;
+    identityId: string | null;
+    kind: BounceKind;
+    statusCode: string | null;
+    diagnostic: string | null;
+    prospectId: number | null;
+    bouncedAt: string;
+  }): boolean {
+    const result = this.db
+      .prepare(
+        `INSERT OR IGNORE INTO bounces
+           (message_id, recipient, identity_id, kind, status_code, diagnostic, prospect_id, bounced_at)
+         VALUES(?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        input.messageId,
+        canonEmail(input.recipient),
+        input.identityId,
+        input.kind,
+        input.statusCode,
+        input.diagnostic?.slice(0, 300) ?? null,
+        input.prospectId,
+        input.bouncedAt,
+      );
+    return result.changes > 0;
+  }
+
+  /**
+   * The hard bounce that suppresses this address, or null if it's still
+   * sendable. HARD ONLY — a `block` is the receiving server refusing a message
+   * on policy, not a statement that the mailbox is dead, so suppressing on it
+   * would permanently burn valid prospects over one spam-filter verdict.
+   * Soft bounces are transient by definition.
+   */
+  suppressionFor(email: string): BounceRecord | null {
+    return (
+      (this.db
+        .query(
+          `SELECT * FROM bounces WHERE recipient = ? AND kind = 'hard'
+           ORDER BY bounced_at DESC LIMIT 1`,
+        )
+        .get(canonEmail(email)) as BounceRecord) ?? null
+    );
+  }
+
+  /** Bounce counts per sending identity since `sinceIso` — the doctor check's numerator. */
+  bounceStatsByIdentity(opts: {
+    sinceIso: string;
+  }): Map<string, { hard: number; block: number; soft: number }> {
+    const rows = this.db
+      .query(
+        `SELECT identity_id, kind, COUNT(*) AS n FROM bounces
+         WHERE bounced_at >= ? AND identity_id IS NOT NULL
+         GROUP BY identity_id, kind`,
+      )
+      .all(opts.sinceIso) as Array<{ identity_id: string; kind: BounceKind; n: number }>;
+    const out = new Map<string, { hard: number; block: number; soft: number }>();
+    for (const r of rows) {
+      let entry = out.get(r.identity_id);
+      if (!entry) {
+        entry = { hard: 0, block: 0, soft: 0 };
+        out.set(r.identity_id, entry);
+      }
+      entry[r.kind] = r.n;
+    }
+    return out;
+  }
+
+  /** Most recent bounces for display (doctor detail lines, debugging). */
+  listRecentBounces(opts: { limit?: number } = {}): BounceRecord[] {
+    return this.db
+      .query(`SELECT * FROM bounces ORDER BY bounced_at DESC LIMIT ?`)
+      .all(opts.limit ?? 20) as BounceRecord[];
+  }
+
+  recordCanaryResult(input: {
+    fromIdentity: string;
+    toIdentity: string;
+    placement: GmailPlacement;
+    labelIds: string[];
+    auth: { spf: AuthVerdict; dkim: AuthVerdict; dmarc: AuthVerdict };
+    subject: string | null;
+    sourcePlay: string | null;
+    sameDomain: boolean;
+    latencyMs: number | null;
+  }): number {
+    const result = this.db
+      .prepare(
+        `INSERT INTO canary_results
+           (from_identity, to_identity, placement, labels_json, spf, dkim, dmarc,
+            subject, source_play, same_domain, latency_ms)
+         VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        input.fromIdentity,
+        input.toIdentity,
+        input.placement,
+        JSON.stringify(input.labelIds),
+        input.auth.spf,
+        input.auth.dkim,
+        input.auth.dmarc,
+        input.subject,
+        input.sourcePlay,
+        input.sameDomain ? 1 : 0,
+        input.latencyMs,
+      );
+    return Number(result.lastInsertRowid);
+  }
+
+  /** Newest placement test, or null if one has never been run. */
+  latestCanaryResult(): CanaryResultRecord | null {
+    return (
+      (this.db
+        .query(`SELECT * FROM canary_results ORDER BY created_at DESC, id DESC LIMIT 1`)
+        .get() as CanaryResultRecord) ?? null
+    );
+  }
+
+  /**
+   * Subject + body of the most recent email this tool actually SENT, for the
+   * placement canary to replay. Spam filters judge content, so testing with
+   * invented copy would measure nothing that transfers to real outreach.
+   * Reads the persisted draft off the sequence_events row (metadata_json
+   * carries {subject, body} for sent email steps).
+   */
+  latestSentEmailCopy(
+    opts: { playName?: string } = {},
+  ): { subject: string; body: string; playName: string } | null {
+    const rows = this.db
+      .query(
+        `SELECT play_name, metadata_json FROM sequence_events
+         WHERE status = 'sent' AND channel = 'email' AND metadata_json IS NOT NULL
+           ${opts.playName ? "AND play_name = ?" : ""}
+         ORDER BY created_at DESC LIMIT 25`,
+      )
+      .all(...(opts.playName ? [opts.playName] : [])) as Array<{
+      play_name: string;
+      metadata_json: string;
+    }>;
+    // Scan a few: pre-v8 rows and non-email payloads have no subject/body, and
+    // taking only the newest row would return null whenever one of those is on top.
+    for (const row of rows) {
+      let meta: { subject?: unknown; body?: unknown };
+      try {
+        meta = JSON.parse(row.metadata_json) as { subject?: unknown; body?: unknown };
+      } catch {
+        continue;
+      }
+      if (typeof meta.subject === "string" && typeof meta.body === "string" && meta.body.trim()) {
+        return { subject: meta.subject, body: meta.body, playName: row.play_name };
+      }
+    }
+    return null;
   }
 
   getReceipt(id: number): ReceiptRecord | null {

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -1287,8 +1287,14 @@ export class Ledger {
   ): { subject: string; body: string; playName: string } | null {
     const rows = this.db
       .query(
+        // All three statuses mean "this email was sent": a step is written as
+        // 'sent' and later UPDATEd in place to 'replied' by markLatestStepReplied
+        // (same convention as eventsByPlay). Matching only 'sent' would skip the
+        // copy of every prospect who answered — precisely the best-performing
+        // copy, and the canary would silently replay something older or nothing.
         `SELECT play_name, metadata_json FROM sequence_events
-         WHERE status = 'sent' AND channel = 'email' AND metadata_json IS NOT NULL
+         WHERE status IN ('sent', 'delivered', 'replied')
+           AND channel = 'email' AND metadata_json IS NOT NULL
            ${opts.playName ? "AND play_name = ?" : ""}
          ORDER BY created_at DESC LIMIT 25`,
       )

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -1296,7 +1296,10 @@ export class Ledger {
          WHERE status IN ('sent', 'delivered', 'replied')
            AND channel = 'email' AND metadata_json IS NOT NULL
            ${opts.playName ? "AND play_name = ?" : ""}
-         ORDER BY created_at DESC LIMIT 25`,
+         -- id DESC breaks ties: created_at is second-precision, and a cadence
+         -- batch writes several rows within one second, leaving their relative
+         -- order otherwise unspecified.
+         ORDER BY created_at DESC, id DESC LIMIT 25`,
       )
       .all(...(opts.playName ? [opts.playName] : [])) as Array<{
       play_name: string;

--- a/packages/core/src/oneshot.ts
+++ b/packages/core/src/oneshot.ts
@@ -20,10 +20,20 @@ import { createHash } from "node:crypto";
 import { getLedger } from "./ledger.ts";
 import { loadConfig, oneshotEnvReady } from "./config.ts";
 import { logEvent } from "./events.ts";
-import { getGmailProfile, listGmailReplies, sendGmailMessage } from "./gmail.ts";
+import {
+  type GmailBounce,
+  getGmailProfile,
+  listGmailBounces,
+  listGmailReplies,
+  sendGmailMessage,
+} from "./gmail.ts";
 import { gmailAccountFor, resolveIdentities } from "./identities.ts";
 import { parallelMap, withDeadline } from "./parallel.ts";
-import { isTransientToolError, resolveSenderIdentity } from "./send-routing.ts";
+import {
+  isTransientToolError,
+  resolveSenderIdentity,
+  SuppressedRecipientError,
+} from "./send-routing.ts";
 import type { EmailIdentity } from "./types.ts";
 
 /** Re-exported so callers don't reach into the SDK for the domain-pool shape. */
@@ -287,6 +297,17 @@ async function sendEmailViaGmail(input: SendEmailInput, ctx: CallContext, identi
 }
 
 export async function sendEmail(input: SendEmailInput, ctx: CallContext) {
+  // Suppression backstop, ahead of everything else: a previously hard-bounced
+  // address can only fail again, and the send is billed before dispatch. Every
+  // caller funnels through here (plays, cadence, queue), so this is the one
+  // place that guarantees it. `replyEmail` is deliberately NOT gated — a manual
+  // inbox reply goes to someone who just emailed us, so they demonstrably exist.
+  const suppression = getLedger().suppressionFor(input.to);
+  if (suppression) {
+    throw new SuppressedRecipientError(
+      `${input.to} hard-bounced${suppression.status_code ? ` (${suppression.status_code})` : ""} on ${suppression.bounced_at.slice(0, 10)} — not sending`,
+    );
+  }
   // Sender rotation: resolve the sticky per-prospect identity BEFORE any
   // network call. Throws SendDeferredError when every identity is at its
   // daily cap — callers leave the work queued for tomorrow.
@@ -730,6 +751,56 @@ export async function listInbox(opts?: {
     has_more: ok.some((r) => r.has_more),
     agent_id: ok.map((r) => r.agent_id).join("+"),
   };
+}
+
+export interface IdentityBounce extends GmailBounce {
+  /** Identity whose mailbox received the DSN — which is the identity that sent the message. */
+  identityId: string;
+}
+
+/**
+ * Delivery failures across the whole sender pool. Gmail identities only: a DSN
+ * comes back to the envelope sender, and for OneShot sends that return path
+ * belongs to the platform, not to us — nothing surfaces in its inbox API.
+ *
+ * Attribution is free and exact: the mailbox that RECEIVED the bounce is the
+ * mailbox that sent the message, so no join back through sender_assignments is
+ * needed to know whose reputation this counts against.
+ *
+ * Per-source try/catch like listInbox — one revoked Gmail token must not blind
+ * bounce detection for every other identity. Unlike listInbox this NEVER throws
+ * on total failure: it runs on a background sweep where the only sane response
+ * to "no sources answered" is to report nothing and retry next tick.
+ */
+export async function listBounces(opts?: {
+  since?: string;
+  limit?: number;
+}): Promise<IdentityBounce[]> {
+  const identities = resolveIdentities(loadConfig()).filter((i) => i.provider === "gmail");
+  const results = await parallelMap(identities, 3, async (identity) => {
+    const account = gmailAccountFor(identity);
+    if (!account) {
+      logEvent("bounce.source_skipped", { source: identity.id, reason: "no_token" }, "warn");
+      return [];
+    }
+    try {
+      const bounces = await withDeadline(
+        listGmailBounces(opts, account),
+        INBOX_SOURCE_TIMEOUT_MS,
+        `bounce source '${identity.id}'`,
+      );
+      // Freshly parsed objects with no other holder — assign in place.
+      return bounces.map((b) => Object.assign(b, { identityId: identity.id }));
+    } catch (err) {
+      logEvent(
+        "bounce.source_failed",
+        { source: identity.id, message_120: ((err as Error).message ?? "").slice(0, 120) },
+        "warn",
+      );
+      return [];
+    }
+  });
+  return results.flat();
 }
 
 export interface BuildSiteInput {

--- a/packages/core/src/send-routing.ts
+++ b/packages/core/src/send-routing.ts
@@ -23,6 +23,23 @@ export function isSendDeferred(err: unknown): boolean {
 }
 
 /**
+ * Thrown by sendEmail (pre-flight, before any network or LLM spend) when the
+ * recipient has previously HARD bounced. Unlike SendDeferredError this is
+ * permanent — callers must not leave the work queued for a retry, because no
+ * retry can ever succeed. Name-based for the same cross-module reason.
+ */
+export class SuppressedRecipientError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "SuppressedRecipientError";
+  }
+}
+
+export function isSuppressedRecipient(err: unknown): boolean {
+  return err instanceof Error && err.name === "SuppressedRecipientError";
+}
+
+/**
  * True when an error is a TRANSIENT platform/transport failure (the OneShot
  * backend or the network briefly broke) rather than a genuine negative result
  * (email not found, undeliverable, no enrichment data). Callers must NOT treat
@@ -72,6 +89,11 @@ export function todayStartSqliteUtc(now = new Date()): string {
   const localMidnight = new Date(now);
   localMidnight.setHours(0, 0, 0, 0);
   return toSqliteUtc(localMidnight);
+}
+
+/** `days` ago in the SQLite UTC format receipts.created_at stores — trailing-window queries (doctor's bounce rate). */
+export function daysAgoSqliteUtc(days: number, now = new Date()): string {
+  return toSqliteUtc(new Date(now.getTime() - days * 24 * 3600 * 1000));
 }
 
 const MS_PER_WEEK = 7 * 24 * 3600 * 1000;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -67,6 +67,78 @@ export interface SequenceEventRecord {
   created_at: string;
 }
 
+/**
+ * Severity of a delivery failure, derived from the DSN's RFC 3463 status code.
+ *  - `hard`  — permanent, address-level (5.1.1 no such user). Suppresses the
+ *              address: re-sending can only ever fail again and costs money.
+ *  - `block` — permanent, POLICY-level (5.7.x, spam/reputation rejection). The
+ *              reputation signal. Kept distinct from `hard` because it's about
+ *              the message or the sending domain, not the recipient — the same
+ *              address may well accept mail tomorrow, so it never suppresses.
+ *  - `soft`  — transient (4.x.x mailbox full, greylisted). Recorded for context
+ *              only; no cadence or suppression effect.
+ */
+export type BounceKind = "hard" | "block" | "soft";
+
+export interface BounceRecord {
+  /** Provider message id of the DSN itself — PK, so re-sweeping is idempotent. */
+  message_id: string;
+  /** Identity whose mailbox received the DSN (= the identity that sent). Null pre-rotation. */
+  identity_id: string | null;
+  /** Canonical Final-Recipient — the address that failed, not the DSN sender. */
+  recipient: string;
+  kind: BounceKind;
+  /** RFC 3463 status, e.g. "5.1.1". Null when only prose was parseable. */
+  status_code: string | null;
+  /** Truncated Diagnostic-Code / remote SMTP response. */
+  diagnostic: string | null;
+  /** Matched prospect, or null when the address isn't one of ours. */
+  prospect_id: number | null;
+  /** When the DSN arrived (provider timestamp). */
+  bounced_at: string;
+  created_at: string;
+}
+
+/**
+ * Where a message actually landed in the receiving mailbox. This is the
+ * question DSN harvesting cannot answer: a message can be accepted (no bounce)
+ * and still be filtered into spam or buried in a tab, which for cold outreach
+ * is indistinguishable from never arriving.
+ */
+export type GmailPlacement =
+  | "inbox"
+  /** Delivered but tab-binned (Promotions/Social/Updates/Forums) — effectively invisible for cold outreach. */
+  | "promotions"
+  | "tab"
+  | "spam"
+  /** Accepted but not in the inbox or any tab — filtered straight to a label/archive. */
+  | "archived"
+  /** Never showed up within the deadline. Inconclusive: silently dropped, or just slow. */
+  | "not_delivered";
+
+/** SPF/DKIM/DMARC verdict as reported by the RECEIVING server, not by a DNS lookup. */
+export type AuthVerdict = "pass" | "fail" | "softfail" | "neutral" | "none" | "unknown";
+
+export interface CanaryResultRecord {
+  id: number;
+  from_identity: string;
+  to_identity: string;
+  placement: GmailPlacement;
+  /** Raw Gmail labelIds, JSON — kept so a placement call can be re-litigated later. */
+  labels_json: string | null;
+  spf: AuthVerdict;
+  dkim: AuthVerdict;
+  dmarc: AuthVerdict;
+  subject: string | null;
+  /** Which play's real copy was replayed, or null when a generic sample was used. */
+  source_play: string | null;
+  /** True when both identities share a domain — internal routing skips most filtering. */
+  same_domain: number;
+  /** Send → observed, in ms. Null when never observed. */
+  latency_ms: number | null;
+  created_at: string;
+}
+
 export interface InterviewRecord {
   id: number;
   person: string;

--- a/packages/doctor/src/check.ts
+++ b/packages/doctor/src/check.ts
@@ -97,13 +97,28 @@ function deliverabilityChecks(): CheckResult[] {
       return results;
     }
     for (const identity of identities) {
+      if (identity.provider === "oneshot") continue; // reported once above, as uncovered
       const s = stats.get(identity.id);
-      if (!s) continue;
       const sent = ledger.countEmailSendsSince(
         identity.id,
         daysAgoSqliteUtc(BOUNCE_WINDOW_DAYS + SEND_WINDOW_GRACE_DAYS),
       );
       const label = identity.address ?? identity.sendingDomain ?? identity.id;
+      // A monitored identity with no bounces gets its own line rather than
+      // being skipped. Silently omitting it is indistinguishable from "not
+      // evaluated" — and once ANOTHER identity is reporting numbers, the
+      // absence of a line reads as an oversight rather than as good news.
+      if (!s) {
+        results.push({
+          name: "deliverability",
+          severity: "ok",
+          message:
+            sent === 0
+              ? `${label} no sends in the last ${BOUNCE_WINDOW_DAYS}d`
+              : `${label} 0 bounced of ${sent} sent (${BOUNCE_WINDOW_DAYS}d)`,
+        });
+        continue;
+      }
       const blockNote =
         s.block > 0
           ? ` — ${s.block} spam-block${s.block === 1 ? "" : "s"}, check content/volume`

--- a/packages/doctor/src/check.ts
+++ b/packages/doctor/src/check.ts
@@ -39,6 +39,18 @@ const MIN_SENDS_TO_JUDGE = 20;
 /** Industry rule of thumb: sustained hard bounces above ~2% start costing reputation, ~5% is where providers act. */
 const HARD_WARN_RATE = 0.02;
 const HARD_FAIL_RATE = 0.05;
+/**
+ * Extra days of SENDS included in the denominator beyond the bounce window.
+ *
+ * The two sides are timestamped by different events: a bounce is dated when the
+ * DSN arrived, a send when it went out. Using an identical window would count a
+ * DSN that landed just inside it while excluding the send that caused it —
+ * inflating the rate, on a check that can report `fail`. A DSN almost always
+ * arrives within minutes and effectively always within two days, so widening
+ * only the denominator makes the ratio honest. It biases the rate very slightly
+ * LOW, which is the right direction for an error that would otherwise cry wolf.
+ */
+const SEND_WINDOW_GRACE_DAYS = 2;
 
 /**
  * Per-identity delivery health from harvested DSNs. Two numbers, deliberately
@@ -87,7 +99,10 @@ function deliverabilityChecks(): CheckResult[] {
     for (const identity of identities) {
       const s = stats.get(identity.id);
       if (!s) continue;
-      const sent = ledger.countEmailSendsSince(identity.id, daysAgoSqliteUtc(BOUNCE_WINDOW_DAYS));
+      const sent = ledger.countEmailSendsSince(
+        identity.id,
+        daysAgoSqliteUtc(BOUNCE_WINDOW_DAYS + SEND_WINDOW_GRACE_DAYS),
+      );
       const label = identity.address ?? identity.sendingDomain ?? identity.id;
       const blockNote =
         s.block > 0

--- a/packages/doctor/src/check.ts
+++ b/packages/doctor/src/check.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import {
   capGroupKey,
   configDir,
+  daysAgoSqliteUtc,
   getBalance,
   getGmailProfile,
   getLedger,
@@ -25,6 +26,164 @@ interface CheckResult {
   severity: CheckSeverity;
   message: string;
   hint?: string;
+}
+
+/** Trailing window for the bounce rate — long enough to accumulate signal at founder-scale volume. */
+const BOUNCE_WINDOW_DAYS = 30;
+/**
+ * Sends required before a rate is reported at all. At low volume the rate is
+ * mostly noise: one bad address out of three sends is 33%, which would scream
+ * about a perfectly healthy mailbox.
+ */
+const MIN_SENDS_TO_JUDGE = 20;
+/** Industry rule of thumb: sustained hard bounces above ~2% start costing reputation, ~5% is where providers act. */
+const HARD_WARN_RATE = 0.02;
+const HARD_FAIL_RATE = 0.05;
+
+/**
+ * Per-identity delivery health from harvested DSNs. Two numbers, deliberately
+ * not averaged together:
+ *  - hard-bounce RATE — list quality. Noisy at low volume, hence the sample gate.
+ *  - policy-block COUNT — reputation. Reported from the first occurrence, because
+ *    a single "blocked as spam" is a real signal about the sending domain and
+ *    would vanish if divided into a percentage.
+ */
+function deliverabilityChecks(): CheckResult[] {
+  const results: CheckResult[] = [];
+  try {
+    const ledger = getLedger();
+    const identities = resolveIdentities(loadConfig());
+    const since = new Date(Date.now() - BOUNCE_WINDOW_DAYS * 24 * 3600 * 1000);
+    const stats = ledger.bounceStatsByIdentity({ sinceIso: since.toISOString() });
+
+    // Bounce detection reads DSNs out of a mailbox we can authenticate to, so
+    // it only covers Gmail identities. A OneShot send's return path belongs to
+    // the platform and surfaces nothing in its inbox API — those identities are
+    // structurally invisible here. Saying so matters: silence about an
+    // unmonitored sender reads as "no bounces" when it means "we can't tell".
+    const blind = identities.filter((i) => i.provider === "oneshot");
+    if (blind.length > 0) {
+      results.push({
+        name: "deliverability",
+        severity: "warn",
+        message: `${blind.length} OneShot identit${blind.length === 1 ? "y" : "ies"} not covered — bounce detection reads DSNs from Gmail mailboxes only`,
+      });
+    }
+
+    // Nothing has ever bounced anywhere — say so once instead of emitting a
+    // reassuring "0.0%" per identity that only means the sweep hasn't run.
+    if (stats.size === 0) {
+      const gmailCount = identities.length - blind.length;
+      results.push({
+        name: "deliverability",
+        severity: "ok",
+        message:
+          gmailCount === 0
+            ? `no Gmail identity to monitor — no bounce data available`
+            : `no delivery failures recorded in the last ${BOUNCE_WINDOW_DAYS}d`,
+      });
+      return results;
+    }
+    for (const identity of identities) {
+      const s = stats.get(identity.id);
+      if (!s) continue;
+      const sent = ledger.countEmailSendsSince(identity.id, daysAgoSqliteUtc(BOUNCE_WINDOW_DAYS));
+      const label = identity.address ?? identity.sendingDomain ?? identity.id;
+      const blockNote =
+        s.block > 0
+          ? ` — ${s.block} spam-block${s.block === 1 ? "" : "s"}, check content/volume`
+          : "";
+
+      if (sent < MIN_SENDS_TO_JUDGE) {
+        results.push({
+          name: "deliverability",
+          severity: s.block > 0 ? "warn" : "ok",
+          message: `${label} ${s.hard} hard / ${s.block} blocked of ${sent} sent (${BOUNCE_WINDOW_DAYS}d) — too few sends to rate${blockNote}`,
+        });
+        continue;
+      }
+
+      const rate = s.hard / sent;
+      const pct = `${(rate * 100).toFixed(1)}%`;
+      const severity: CheckSeverity =
+        rate > HARD_FAIL_RATE ? "fail" : rate > HARD_WARN_RATE || s.block > 0 ? "warn" : "ok";
+      results.push({
+        name: "deliverability",
+        severity,
+        message: `${label} ${pct} bounced (${s.hard}/${sent}, ${BOUNCE_WINDOW_DAYS}d)${blockNote}`,
+        ...(severity === "ok"
+          ? {}
+          : {
+              hint:
+                rate > HARD_WARN_RATE
+                  ? "verify emails before sending — hard bounces are dead addresses"
+                  : "spam-blocks are a reputation signal, not a bad address",
+            }),
+      });
+    }
+  } catch (err) {
+    results.push({
+      name: "deliverability",
+      severity: "warn",
+      message: `could not evaluate: ${(err as Error).message}`,
+    });
+  }
+  return results;
+}
+
+/** A placement result older than this is reported as stale — reputation moves. */
+const CANARY_STALE_DAYS = 14;
+
+/**
+ * REPORTS the last inbox-placement canary; never runs one. doctor is expected
+ * to be safe to run at any time, and a canary sends real mail — firing one per
+ * doctor invocation would both spend sending reputation and, by repeatedly
+ * mailing the same seed address, train its filter until the test always passed.
+ */
+function placementCheck(): CheckResult {
+  try {
+    const last = getLedger().latestCanaryResult();
+    if (!last) {
+      return {
+        name: "inbox placement",
+        severity: "ok",
+        message: "never tested",
+        hint: "run: bun run cli -- gmail placement (needs a second authorized Gmail account)",
+      };
+    }
+    const ageDays = Math.floor(
+      (Date.now() - new Date(`${last.created_at.replace(" ", "T")}Z`).getTime()) / 86_400_000,
+    );
+    const age = Number.isFinite(ageDays) ? `${ageDays}d ago` : "unknown age";
+    const auth = `spf=${last.spf} dkim=${last.dkim} dmarc=${last.dmarc}`;
+    const caveat = last.same_domain ? " · same-domain, not a real-world verdict" : "";
+    // A tab-binned message is delivered but unread in practice, so it is not an
+    // "ok" outcome for cold outreach even though nothing rejected it.
+    const severity: CheckSeverity =
+      last.placement === "spam"
+        ? "fail"
+        : last.placement === "promotions" ||
+            last.placement === "tab" ||
+            last.placement === "not_delivered" ||
+            last.same_domain === 1 ||
+            ageDays > CANARY_STALE_DAYS
+          ? "warn"
+          : "ok";
+    return {
+      name: "inbox placement",
+      severity,
+      message: `${last.placement} (${age}) · ${auth}${caveat}`,
+      ...(ageDays > CANARY_STALE_DAYS
+        ? { hint: `last tested ${age} — re-run: bun run cli -- gmail placement` }
+        : {}),
+    };
+  } catch (err) {
+    return {
+      name: "inbox placement",
+      severity: "warn",
+      message: `could not evaluate: ${(err as Error).message}`,
+    };
+  }
 }
 
 export async function runDoctor(): Promise<CheckResult[]> {
@@ -209,6 +368,13 @@ export async function runDoctor(): Promise<CheckResult[]> {
       message: `could not evaluate: ${(err as Error).message}`,
     });
   }
+
+  // Pushed separately, NOT from inside deliverabilityChecks: that function
+  // returns early when nothing has ever bounced, which would have silently
+  // dropped the placement line on exactly the fresh installs that most need
+  // the "never tested" prompt.
+  results.push(...deliverabilityChecks());
+  results.push(placementCheck());
 
   if (oneshotEnvReady()) {
     try {

--- a/packages/plays/__tests__/cadence-batch.test.ts
+++ b/packages/plays/__tests__/cadence-batch.test.ts
@@ -50,6 +50,8 @@ vi.mock("@oneshot-gtm/core", async () => {
     },
     listInbox: async () => ({ emails: [], has_more: false }),
     getLedger: () => ({
+      // No prior hard bounce: these tests exercise the normal send path.
+      suppressionFor: () => null,
       listAllCadences: () => cadenceRows,
       listActiveCadences: () => cadenceRows.filter((c) => c.status === "active"),
       listCadencesForProspect: (prospectId: number) =>

--- a/packages/plays/__tests__/cadence-bounce.test.ts
+++ b/packages/plays/__tests__/cadence-bounce.test.ts
@@ -1,0 +1,192 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Drives pollInboxBounces: DSN → recorded bounce → (hard only) cadence stopped.
+// The behaviour that decides whether the tool keeps paying to email an address
+// the receiving server has already refused.
+
+type Bounce = {
+  messageId: string;
+  recipient: string;
+  identityId: string;
+  kind: "hard" | "block" | "soft";
+  statusCode: string | null;
+  diagnostic: string | null;
+  bouncedAt: string;
+};
+
+let bounces: Bounce[] = [];
+/** message ids the stub ledger has already stored — mirrors the real PK dedupe. */
+let seen: Set<string>;
+let recorded: Array<{ recipient: string; kind: string; prospectId: number | null }> = [];
+let sequenceEvents: Array<{ playName: string; stepIndex: number; status: string }> = [];
+let statusWrites: Array<{ prospectId: number; playName: string; status: string }> = [];
+
+const PROSPECT_EMAIL = "jane@dead.example";
+type Row = { prospect_id: number; play_name: string; status: string; current_step: number };
+let rows: Row[] = [];
+
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    listBounces: async () => bounces,
+    getLedger: () => ({
+      findProspectByEmail: (email: string) =>
+        email.trim().toLowerCase() === PROSPECT_EMAIL ? { id: 1 } : null,
+      recordBounce: (input: {
+        messageId: string;
+        recipient: string;
+        kind: string;
+        prospectId: number | null;
+      }) => {
+        const key = `${input.messageId}|${input.recipient}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        recorded.push({
+          recipient: input.recipient,
+          kind: input.kind,
+          prospectId: input.prospectId,
+        });
+        return true;
+      },
+      listCadencesForProspect: (prospectId: number) =>
+        rows.filter((r) => r.prospect_id === prospectId),
+      recordSequenceEvent: (input: { playName: string; stepIndex: number; status: string }) => {
+        sequenceEvents.push({
+          playName: input.playName,
+          stepIndex: input.stepIndex,
+          status: input.status,
+        });
+        return 1;
+      },
+      setCadenceStatus: (input: { prospectId: number; playName: string; status: string }) => {
+        statusWrites.push(input);
+        const row = rows.find(
+          (r) => r.prospect_id === input.prospectId && r.play_name === input.playName,
+        );
+        if (row) row.status = input.status;
+      },
+    }),
+  };
+});
+
+const { pollInboxBounces } = await import("../src/_cadence.ts");
+
+function bounce(over: Partial<Bounce> = {}): Bounce {
+  return {
+    messageId: "dsn-1",
+    recipient: PROSPECT_EMAIL,
+    identityId: "gmail:me@corp.example",
+    kind: "hard",
+    statusCode: "5.1.1",
+    diagnostic: "smtp; 550 user unknown",
+    bouncedAt: "2026-08-01T10:00:00.000Z",
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  bounces = [];
+  seen = new Set();
+  recorded = [];
+  sequenceEvents = [];
+  statusWrites = [];
+  rows = [{ prospect_id: 1, play_name: "post-funding", status: "active", current_step: 2 }];
+});
+
+describe("pollInboxBounces", () => {
+  it("stops the cadence on a hard bounce and logs the step that failed", async () => {
+    bounces = [bounce()];
+    const out = await pollInboxBounces();
+
+    expect(out).toMatchObject({ polled: 1, recorded: 1, cadencesStopped: 1 });
+    // current_step is the most recently SENT touch — that's what bounced.
+    expect(sequenceEvents).toEqual([{ playName: "post-funding", stepIndex: 2, status: "bounced" }]);
+    expect(statusWrites).toEqual([{ prospectId: 1, playName: "post-funding", status: "bounced" }]);
+  });
+
+  it("records a policy block WITHOUT stopping the cadence", async () => {
+    // 5.7.x is a verdict on the message or our sending domain, not the mailbox.
+    // Killing the sequence would discard a live prospect over a spam filter.
+    bounces = [bounce({ kind: "block", statusCode: "5.7.1" })];
+    const out = await pollInboxBounces();
+
+    expect(out.recorded).toBe(1);
+    expect(out.cadencesStopped).toBe(0);
+    expect(sequenceEvents).toHaveLength(1);
+    expect(statusWrites).toEqual([]);
+    expect(rows[0]?.status).toBe("active");
+  });
+
+  it("records a soft bounce and takes no further action", async () => {
+    bounces = [bounce({ kind: "soft", statusCode: "4.2.2" })];
+    const out = await pollInboxBounces();
+
+    expect(recorded).toHaveLength(1);
+    expect(out.cadencesStopped).toBe(0);
+    expect(sequenceEvents).toEqual([]);
+    expect(statusWrites).toEqual([]);
+  });
+
+  it("acts only on the first sighting of a DSN", async () => {
+    // The 30-day window is re-read every tick; re-acting would re-write the
+    // cadence and re-log the event forever.
+    bounces = [bounce()];
+    await pollInboxBounces();
+    sequenceEvents = [];
+    statusWrites = [];
+    rows[0]!.status = "active";
+
+    const second = await pollInboxBounces();
+    expect(second).toMatchObject({ polled: 1, recorded: 0, cadencesStopped: 0 });
+    expect(sequenceEvents).toEqual([]);
+    expect(statusWrites).toEqual([]);
+  });
+
+  it("records a bounce for an unknown address without touching any cadence", async () => {
+    // Still counts toward the identity's rate — reputation damage is the same
+    // whether or not we happen to track the recipient.
+    bounces = [bounce({ recipient: "stranger@elsewhere.example" })];
+    const out = await pollInboxBounces();
+
+    expect(recorded).toEqual([
+      { recipient: "stranger@elsewhere.example", kind: "hard", prospectId: null },
+    ]);
+    expect(out.cadencesStopped).toBe(0);
+    expect(sequenceEvents).toEqual([]);
+    expect(out.details[0]).toMatchObject({ playName: null });
+  });
+
+  it("leaves a replied cadence alone", async () => {
+    // They answered — the mailbox demonstrably works, whatever this DSN is.
+    rows = [{ prospect_id: 1, play_name: "post-funding", status: "replied", current_step: 1 }];
+    bounces = [bounce()];
+    const out = await pollInboxBounces();
+
+    expect(out.cadencesStopped).toBe(0);
+    expect(statusWrites).toEqual([]);
+    expect(rows[0]?.status).toBe("replied");
+  });
+
+  it("stops every cadence the bounced prospect is enrolled in", async () => {
+    rows = [
+      { prospect_id: 1, play_name: "post-funding", status: "active", current_step: 0 },
+      { prospect_id: 1, play_name: "hiring-signal", status: "active", current_step: 3 },
+    ];
+    bounces = [bounce()];
+    const out = await pollInboxBounces();
+
+    expect(out.cadencesStopped).toBe(2);
+    expect(sequenceEvents).toEqual([
+      { playName: "post-funding", stepIndex: 0, status: "bounced" },
+      { playName: "hiring-signal", stepIndex: 3, status: "bounced" },
+    ]);
+  });
+
+  it("attributes the bounce to the identity whose mailbox received the DSN", async () => {
+    bounces = [bounce({ identityId: "gmail:second@corp.example" })];
+    await pollInboxBounces();
+    expect(sequenceEvents).toHaveLength(1);
+    expect(recorded).toHaveLength(1);
+  });
+});

--- a/packages/plays/__tests__/cadence-deferral.test.ts
+++ b/packages/plays/__tests__/cadence-deferral.test.ts
@@ -59,6 +59,8 @@ vi.mock("@oneshot-gtm/core", async () => {
     },
     listInbox: async () => ({ emails: [], has_more: false }),
     getLedger: () => ({
+      // No prior hard bounce: these tests exercise the normal send path.
+      suppressionFor: () => null,
       listAllCadences: () => cadenceRows,
       listActiveCadences: () => cadenceRows.filter((c) => c.status === "active"),
       listCadencesForProspect: (prospectId: number) =>

--- a/packages/plays/__tests__/cadence-step-runner.test.ts
+++ b/packages/plays/__tests__/cadence-step-runner.test.ts
@@ -45,6 +45,8 @@ let deferOnSend = false;
 // Simulates a sequence_events row already existing at the step about to be sent
 // (nextIndex) — the crash-mid-send state the re-send guard must catch.
 let alreadySentNextStep = false;
+// Simulates a prior hard bounce for this cadence's prospect.
+let suppression: { status_code: string | null; bounced_at: string } | null = null;
 
 vi.mock("@oneshot-gtm/core", async () => {
   const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
@@ -89,6 +91,8 @@ vi.mock("@oneshot-gtm/core", async () => {
     },
     listInbox: async () => ({ emails: [], has_more: false }),
     getLedger: () => ({
+      // Null by default: most tests exercise the normal send path.
+      suppressionFor: () => suppression,
       listAllCadences: () => cadenceRows,
       listActiveCadences: () => cadenceRows.filter((c) => c.status === "active"),
       listCadencesForProspect: (prospectId: number) =>
@@ -231,6 +235,7 @@ beforeEach(() => {
   throwOnSend = false;
   deferOnSend = false;
   alreadySentNextStep = false;
+  suppression = null;
   seedActiveCadence();
 });
 
@@ -472,5 +477,51 @@ describe("runCadenceStepForProspect", () => {
     });
     expect(result.action).toBe("skipped");
     expect(result.note).toMatch(/no registered sequence/i);
+  });
+
+  describe("hard-bounce suppression", () => {
+    it("skips a suppressed prospect without drafting or sending", async () => {
+      // sendEmail would refuse this anyway, but only after an LLM draft has
+      // been paid for — the whole point of checking here is to not spend.
+      suppression = { status_code: "5.1.1", bounced_at: "2026-08-01T10:00:00.000Z" };
+      const result = await runCadenceStepForProspect({
+        prospectId: 1,
+        playName: "stack-consolidation",
+        dryRun: false,
+      });
+
+      expect(result.action).toBe("skipped");
+      expect(result.note).toMatch(/suppressed/i);
+      expect(calls.llm).toBe(0);
+      expect(calls.sendEmail).toBe(0);
+    });
+
+    it("marks the cadence bounced rather than leaving it due forever", async () => {
+      suppression = { status_code: "5.1.1", bounced_at: "2026-08-01T10:00:00.000Z" };
+      await runCadenceStepForProspect({
+        prospectId: 1,
+        playName: "stack-consolidation",
+        dryRun: false,
+      });
+
+      expect(statusCalls).toEqual([
+        { prospectId: 1, playName: "stack-consolidation", status: "bounced" },
+      ]);
+      // NOT recorded as a send failure: that renders as "retrying", and a dead
+      // address will never accept a retry.
+      expect(sendErrorCalls).toEqual([]);
+      expect(advanceCalls).toEqual([]);
+    });
+
+    it("leaves an unsuppressed prospect on the normal path", async () => {
+      suppression = null;
+      const result = await runCadenceStepForProspect({
+        prospectId: 1,
+        playName: "stack-consolidation",
+        dryRun: false,
+      });
+      expect(result.action).not.toBe("skipped");
+      expect(calls.sendEmail).toBe(1);
+    });
   });
 });

--- a/packages/plays/__tests__/target-error-logging.test.ts
+++ b/packages/plays/__tests__/target-error-logging.test.ts
@@ -110,3 +110,52 @@ describe("logTargetError redaction", () => {
     expect(logged[0]?.ctx).not.toHaveProperty("to_domain");
   });
 });
+
+describe("logTargetError never throws", () => {
+  // It runs inside the per-target catch. A TypeError raised while logging
+  // would escape that catch and abort the whole drain — the exact failure the
+  // catch exists to prevent. A thrown value is `unknown`, so nothing about its
+  // shape can be assumed.
+  const nasty: Array<[string, unknown]> = [
+    ["non-string message", { message: 500, stack: 42 }],
+    ["thrown string", "just a string"],
+    ["thrown number", 500],
+    ["null", null],
+    ["undefined", undefined],
+    [
+      "object with throwing getter",
+      {
+        get message() {
+          throw new Error("boom");
+        },
+      },
+    ],
+    ["non-Error cause", new Error("outer", { cause: { code: 7 } })],
+  ];
+
+  for (const [label, err] of nasty) {
+    it(`survives ${label}`, () => {
+      logged.length = 0;
+      expect(() => logTargetError({ playName: "show-hn", err })).not.toThrow();
+      // A hostile getter costs us the log entry, never the run.
+      if (label !== "object with throwing getter") {
+        expect(logged).toHaveLength(1);
+        expect(typeof logged[0]?.ctx["message_200"]).toBe("string");
+        expect(typeof logged[0]?.ctx["stack_300"]).toBe("string");
+      }
+    });
+  }
+
+  it("coerces a non-string message instead of crashing", () => {
+    logged.length = 0;
+    logTargetError({ playName: "show-hn", err: { message: 500, stack: 42 } });
+    expect(logged[0]?.ctx["message_200"]).toBe("500");
+    expect(logged[0]?.ctx["stack_300"]).toBe("42");
+  });
+
+  it("tolerates a non-string recipient", () => {
+    logged.length = 0;
+    logTargetError({ playName: "show-hn", to: 42 as unknown as string, err: new Error("x") });
+    expect(logged[0]?.ctx).not.toHaveProperty("to_domain");
+  });
+});

--- a/packages/plays/__tests__/target-error-logging.test.ts
+++ b/packages/plays/__tests__/target-error-logging.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+
+// A per-target failure surfaces on the queue row as errorDraft's 80-char slice
+// of err.message — for an SDK ToolError that's the generic "Tool request
+// failed". The 2026-08-13 luma-events drain failed all 8 of its sends that way
+// and left NOTHING in events.jsonl to diagnose from. logTargetError is what
+// keeps the status code + response body, which is where the real reason lives.
+
+const logged: Array<{ kind: string; ctx: Record<string, unknown>; level?: string }> = [];
+
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    logEvent: (kind: string, ctx: Record<string, unknown>, level?: string) => {
+      logged.push({ kind, ctx, ...(level ? { level } : {}) });
+    },
+  };
+});
+
+const { logTargetError, errorDraft } = await import("../src/_lib.ts");
+
+/** Shape of the OneShot SDK's ToolError: generic message, real detail alongside. */
+function toolError(): Error {
+  const e = new Error("Tool request failed") as Error & {
+    statusCode: number;
+    responseBody: string;
+  };
+  e.statusCode = 403;
+  e.responseBody = JSON.stringify({
+    error: "domain_not_owned",
+    message: "Domain is owned by a different agent.",
+    domain: "oneshotagent.com",
+  });
+  return e;
+}
+
+describe("logTargetError", () => {
+  it("keeps the status code and response body the row throws away", () => {
+    logged.length = 0;
+    logTargetError({ playName: "luma-events", to: "a@b.dev", err: toolError() });
+
+    expect(logged).toHaveLength(1);
+    const [entry] = logged;
+    expect(entry?.kind).toBe("play.target_error");
+    expect(entry?.level).toBe("error");
+    expect(entry?.ctx).toMatchObject({
+      play: "luma-events",
+      to: "a@b.dev",
+      message_200: "Tool request failed",
+      status_code: 403,
+    });
+    // The reason the founder actually needs — absent from the queue row.
+    expect(String(entry?.ctx["response_body_400"])).toContain("domain_not_owned");
+
+    // Contrast: this is all the row itself carries.
+    expect(errorDraft(toolError().message).flags).toEqual(["error: Tool request failed"]);
+  });
+
+  it("records a plain Error without inventing SDK fields", () => {
+    logged.length = 0;
+    logTargetError({ playName: "show-hn", to: "c@d.dev", err: new Error("boom") });
+    expect(logged[0]?.ctx).toMatchObject({
+      play: "show-hn",
+      message_200: "boom",
+      status_code: null,
+      response_body_400: null,
+      cause_200: null,
+    });
+  });
+
+  it("unwraps a nested cause", () => {
+    logged.length = 0;
+    const err = new Error("outer", { cause: new Error("the real reason") });
+    logTargetError({ playName: "show-hn", err });
+    expect(logged[0]?.ctx["cause_200"]).toBe("the real reason");
+    // No recipient supplied → the key is omitted rather than logged as null.
+    expect(logged[0]?.ctx).not.toHaveProperty("to");
+  });
+
+  it("truncates a huge response body instead of dumping it into the log", () => {
+    logged.length = 0;
+    const e = new Error("Tool request failed") as Error & { responseBody: string };
+    e.responseBody = "x".repeat(5000);
+    logTargetError({ playName: "luma-events", err: e });
+    expect(String(logged[0]?.ctx["response_body_400"])).toHaveLength(400);
+  });
+});

--- a/packages/plays/__tests__/target-error-logging.test.ts
+++ b/packages/plays/__tests__/target-error-logging.test.ts
@@ -46,10 +46,12 @@ describe("logTargetError", () => {
     expect(entry?.level).toBe("error");
     expect(entry?.ctx).toMatchObject({
       play: "luma-events",
-      to: "a@b.dev",
+      // Domain only — events.jsonl is a PII-free sink.
+      to_domain: "b.dev",
       message_200: "Tool request failed",
       status_code: 403,
     });
+    expect(JSON.stringify(entry?.ctx)).not.toContain("a@b.dev");
     // The reason the founder actually needs — absent from the queue row.
     expect(String(entry?.ctx["response_body_400"])).toContain("domain_not_owned");
 
@@ -75,7 +77,7 @@ describe("logTargetError", () => {
     logTargetError({ playName: "show-hn", err });
     expect(logged[0]?.ctx["cause_200"]).toBe("the real reason");
     // No recipient supplied → the key is omitted rather than logged as null.
-    expect(logged[0]?.ctx).not.toHaveProperty("to");
+    expect(logged[0]?.ctx).not.toHaveProperty("to_domain");
   });
 
   it("truncates a huge response body instead of dumping it into the log", () => {
@@ -84,5 +86,27 @@ describe("logTargetError", () => {
     e.responseBody = "x".repeat(5000);
     logTargetError({ playName: "luma-events", err: e });
     expect(String(logged[0]?.ctx["response_body_400"])).toHaveLength(400);
+  });
+});
+
+describe("logTargetError redaction", () => {
+  // Asserts on the address itself, not on "@" — stack_300 legitimately carries
+  // node_modules paths like `@vitest+runner@4.1.5`.
+  it("keeps the domain and drops the local part, whatever the caller passes", () => {
+    for (const [to, domain] of [
+      ["pat@acme.io", "acme.io"],
+      ["ODD@Example.CO", "Example.CO"],
+    ] as const) {
+      logged.length = 0;
+      logTargetError({ playName: "show-hn", to, err: new Error("x") });
+      expect(logged[0]?.ctx["to_domain"], to).toBe(domain);
+      expect(String(logged[0]?.ctx["to_domain"]), to).not.toContain(to.split("@")[0]);
+    }
+  });
+
+  it("omits the key entirely for a value that isn't an address", () => {
+    logged.length = 0;
+    logTargetError({ playName: "show-hn", to: "not-an-email", err: new Error("x") });
+    expect(logged[0]?.ctx).not.toHaveProperty("to_domain");
   });
 });

--- a/packages/plays/src/_cadence.ts
+++ b/packages/plays/src/_cadence.ts
@@ -2,6 +2,7 @@ import {
   getLedger,
   hasAnySendCapacity,
   isSendDeferred,
+  listBounces,
   listInbox,
   loadConfig,
   logEvent,
@@ -13,6 +14,7 @@ import {
   tagOutcomeValue,
   trackSend,
   voiceCall,
+  type BounceKind,
   type ProspectRecord,
 } from "@oneshot-gtm/core";
 import { complete, loadPrompt, tryParseJsonObject } from "@oneshot-gtm/intel";
@@ -239,6 +241,120 @@ export async function pollInboxReplies(): Promise<ReplyPollResult> {
   return out;
 }
 
+export interface BouncePollResult {
+  /** Delivery failures parsed from the mailbox this poll (including already-known ones). */
+  polled: number;
+  /** Failures seen for the FIRST time — the ones that were acted on. */
+  recorded: number;
+  /** Cadences stopped by a hard bounce this poll. */
+  cadencesStopped: number;
+  details: Array<{
+    recipient: string;
+    kind: BounceKind;
+    statusCode: string | null;
+    playName: string | null;
+  }>;
+}
+
+/**
+ * Poll the mailbox for DSNs and act on them. Sibling to pollInboxReplies:
+ * read-only except for the bounce row and the resulting cadence stop, so it's
+ * safe on a background timer as well as inside advanceCadence.
+ *
+ * Without a background caller the tool learns an address is dead only by
+ * failing to get a reply — meanwhile the sequence keeps emailing it, paying
+ * per send, and each refusal costs sending reputation.
+ */
+export async function pollInboxBounces(): Promise<BouncePollResult> {
+  const ledger = getLedger();
+  const out: BouncePollResult = { polled: 0, recorded: 0, cadencesStopped: 0, details: [] };
+  const bounces = await listBounces();
+  out.polled = bounces.length;
+
+  for (const b of bounces) {
+    const prospect = ledger.findProspectByEmail(b.recipient);
+    const isNew = ledger.recordBounce({
+      messageId: b.messageId,
+      recipient: b.recipient,
+      identityId: b.identityId,
+      kind: b.kind,
+      statusCode: b.statusCode,
+      diagnostic: b.diagnostic,
+      prospectId: prospect?.id ?? null,
+      bouncedAt: b.bouncedAt,
+    });
+    // The sweep re-reads a 30-day window every tick, so most of what comes back
+    // was handled days ago. Acting only on first sight keeps the cadence writes
+    // and event log from repeating forever.
+    if (!isNew) continue;
+    out.recorded++;
+
+    // Soft = transient (mailbox full, greylisted). Stored for context, but it
+    // says nothing durable about the address or our reputation.
+    if (b.kind === "soft") continue;
+
+    if (!prospect) {
+      // A bounce for an address we don't track — still counts toward the
+      // identity's rate, which is the number that matters for reputation.
+      out.details.push({
+        recipient: b.recipient,
+        kind: b.kind,
+        statusCode: b.statusCode,
+        playName: null,
+      });
+      continue;
+    }
+
+    for (const cad of ledger.listCadencesForProspect(prospect.id)) {
+      // current_step is the most recently SENT step (intro = 0; each follow-up
+      // is recorded at current_step + 1 as it fires) — that's the touch that
+      // came back undelivered.
+      ledger.recordSequenceEvent({
+        prospectId: prospect.id,
+        playName: cad.play_name,
+        stepIndex: cad.current_step,
+        channel: "email",
+        status: "bounced",
+        metadata: {
+          kind: b.kind,
+          statusCode: b.statusCode,
+          diagnostic: b.diagnostic,
+          identityId: b.identityId,
+        },
+      });
+      // Only a HARD bounce stops the sequence. A 5.7.x block is a verdict on
+      // this message or our sending domain, not on the mailbox — the address
+      // may well accept mail tomorrow, so killing the cadence would throw away
+      // a live prospect over one spam-filter decision. Blocks surface through
+      // the doctor check instead. Only `active` rows flip: a `replied` cadence
+      // has already proved the human is there.
+      if (b.kind === "hard" && cad.status === "active") {
+        ledger.setCadenceStatus({
+          prospectId: prospect.id,
+          playName: cad.play_name,
+          status: "bounced",
+        });
+        out.cadencesStopped++;
+      }
+      out.details.push({
+        recipient: b.recipient,
+        kind: b.kind,
+        statusCode: b.statusCode,
+        playName: cad.play_name,
+      });
+    }
+  }
+
+  if (out.recorded > 0) {
+    logEvent("bounce.poll.done", {
+      polled: out.polled,
+      recorded: out.recorded,
+      cadences_stopped: out.cadencesStopped,
+    });
+  }
+  return out;
+}
+
 export async function advanceCadence(
   opts: { dryRun: boolean } = { dryRun: false },
 ): Promise<AdvanceResult> {
@@ -273,6 +389,30 @@ export async function advanceCadence(
         playName: "(poll)",
         action: "skipped",
         note: `inbox poll failed: ${(err as Error).message}`,
+        receiptIds: [],
+      });
+    }
+
+    // 1b. Poll for delivery failures. Runs BEFORE the due-step loop below so a
+    // bounce detected this pass stops today's follow-up rather than next
+    // pass's — otherwise we'd send one more email to a known-dead address.
+    try {
+      const bouncePoll = await pollInboxBounces();
+      for (const d of bouncePoll.details) {
+        result.details.push({
+          prospectEmail: d.recipient,
+          playName: d.playName ?? "(bounce)",
+          action: "skipped",
+          note: `bounced${d.statusCode ? ` ${d.statusCode}` : ""} (${d.kind})`,
+          receiptIds: [],
+        });
+      }
+    } catch (err) {
+      result.details.push({
+        prospectEmail: null,
+        playName: "(bounce-poll)",
+        action: "skipped",
+        note: `bounce poll failed: ${(err as Error).message}`,
         receiptIds: [],
       });
     }
@@ -382,6 +522,27 @@ export async function runCadenceStepForProspect(
       receiptIds: [],
       note: `cadence is ${cadence.status}`,
     };
+  }
+  // Suppression check ahead of drafting. sendEmail would refuse this anyway,
+  // but only after an LLM draft has been paid for, and the resulting throw
+  // would land in recordCadenceSendError as "send failed · retrying" — which
+  // misrepresents a permanent failure as a transient one. Both the batch pass
+  // and the /cadences UI route through here, so this covers both.
+  if (cadence.prospect_email) {
+    const suppression = ledger.suppressionFor(cadence.prospect_email);
+    if (suppression) {
+      ledger.setCadenceStatus({
+        prospectId: opts.prospectId,
+        playName: opts.playName,
+        status: "bounced",
+      });
+      return {
+        action: "skipped",
+        payload: null,
+        receiptIds: [],
+        note: `suppressed: hard-bounced${suppression.status_code ? ` ${suppression.status_code}` : ""}`,
+      };
+    }
   }
   const seq = effectiveSequence(opts.playName);
   if (!seq) {

--- a/packages/plays/src/_lib.ts
+++ b/packages/plays/src/_lib.ts
@@ -239,6 +239,47 @@ export function errorDraft(message: string | null | undefined): ErrorDraft {
 }
 
 /**
+ * Record WHY a single target failed, next to every `errorDraft` call site.
+ *
+ * What reaches the queue row (and the founder's screen) is errorDraft's 80-char
+ * slice of `err.message` — for an SDK ToolError that's the generic "Tool
+ * request failed", true and useless. The status code and response body carry
+ * the actual reason (`403 domain_not_owned`, the last time one was captured).
+ * Without this, a drain could fail every send and leave nothing in
+ * events.jsonl to diagnose from.
+ *
+ * Mirrors the whole-run handler in apps/server/src/api/run.ts, which already
+ * logs these fields; per-target failures were the gap.
+ */
+export function logTargetError(input: {
+  playName: string;
+  to?: string | null;
+  err: unknown;
+}): void {
+  const e = input.err as Error & {
+    cause?: unknown;
+    statusCode?: number;
+    responseBody?: string;
+  };
+  const causeMsg = e?.cause instanceof Error ? e.cause.message : e?.cause ? String(e.cause) : null;
+  logEvent(
+    "play.target_error",
+    {
+      play: input.playName,
+      ...(input.to ? { to: input.to } : {}),
+      message_200: (e?.message ?? "").slice(0, 200),
+      // OneShot SDK ToolError carries the failing call's HTTP status + server
+      // response body — the real reason, vs the generic message.
+      status_code: typeof e?.statusCode === "number" ? e.statusCode : null,
+      response_body_400: typeof e?.responseBody === "string" ? e.responseBody.slice(0, 400) : null,
+      cause_200: causeMsg ? causeMsg.slice(0, 200) : null,
+      stack_300: (e?.stack ?? "").slice(0, 300),
+    },
+    "error",
+  );
+}
+
+/**
  * Deterministic, semantics-preserving cleanups that the LLM occasionally
  * slips through despite the humanizer rules being in its system prompt.
  * Applied silently inside `draftEmailFromPrompt` so these four flags never

--- a/packages/plays/src/_lib.ts
+++ b/packages/plays/src/_lib.ts
@@ -253,6 +253,13 @@ export function errorDraft(message: string | null | undefined): ErrorDraft {
  */
 export function logTargetError(input: {
   playName: string;
+  /**
+   * Recipient address. Only its DOMAIN is logged — events.jsonl is a
+   * PII-free sink (see the `email_domain` precedent in core/send-routing.ts),
+   * and the domain is the diagnostic half anyway: it tells you whether one
+   * receiving domain is rejecting. Redaction lives here, not at the call
+   * sites, so no caller can leak the address by accident.
+   */
   to?: string | null;
   err: unknown;
 }): void {
@@ -266,7 +273,7 @@ export function logTargetError(input: {
     "play.target_error",
     {
       play: input.playName,
-      ...(input.to ? { to: input.to } : {}),
+      ...(input.to?.includes("@") ? { to_domain: input.to.split("@")[1] } : {}),
       message_200: (e?.message ?? "").slice(0, 200),
       // OneShot SDK ToolError carries the failing call's HTTP status + server
       // response body — the real reason, vs the generic message.

--- a/packages/plays/src/_lib.ts
+++ b/packages/plays/src/_lib.ts
@@ -268,19 +268,45 @@ export function logTargetError(input: {
     statusCode?: number;
     responseBody?: string;
   };
-  const causeMsg = e?.cause instanceof Error ? e.cause.message : e?.cause ? String(e.cause) : null;
+  // Nothing here may throw. This runs INSIDE the per-target catch whose whole
+  // job is to stop one bad target from killing the batch — a TypeError raised
+  // while logging would escape that catch and abort the entire drain. A thrown
+  // value is `unknown`: `{ message: 500 }` is legal, so is a rejected string,
+  // and `.slice()` on either blows up. Coerce, don't assume.
+  try {
+    logTargetErrorUnsafe(e, input);
+  } catch {
+    // Belt and braces: a hostile shape (a throwing `message` getter, a
+    // String()-hostile object) must not turn a logged failure into a dead
+    // batch. Losing the diagnosis is bad; losing the run is worse.
+  }
+}
+
+/** Coerce an unknown thrown field to a string — never assume `.slice()` exists. */
+function text(v: unknown): string {
+  return typeof v === "string" ? v : v == null ? "" : String(v);
+}
+
+function logTargetErrorUnsafe(
+  e: Error & { cause?: unknown; statusCode?: number; responseBody?: string },
+  input: { playName: string; to?: string | null },
+): void {
+  const causeMsg =
+    e?.cause instanceof Error ? text(e.cause.message) : e?.cause ? text(e.cause) : null;
   logEvent(
     "play.target_error",
     {
       play: input.playName,
-      ...(input.to?.includes("@") ? { to_domain: input.to.split("@")[1] } : {}),
-      message_200: (e?.message ?? "").slice(0, 200),
+      ...(typeof input.to === "string" && input.to.includes("@")
+        ? { to_domain: input.to.split("@")[1] }
+        : {}),
+      message_200: text(e?.message).slice(0, 200),
       // OneShot SDK ToolError carries the failing call's HTTP status + server
       // response body — the real reason, vs the generic message.
       status_code: typeof e?.statusCode === "number" ? e.statusCode : null,
       response_body_400: typeof e?.responseBody === "string" ? e.responseBody.slice(0, 400) : null,
       cause_200: causeMsg ? causeMsg.slice(0, 200) : null,
-      stack_300: (e?.stack ?? "").slice(0, 300),
+      stack_300: text(e?.stack).slice(0, 300),
     },
     "error",
   );

--- a/packages/plays/src/_run-play.ts
+++ b/packages/plays/src/_run-play.ts
@@ -10,6 +10,7 @@ import {
   errorDraft,
   firstNameFrom,
   lintEmail,
+  logTargetError,
   safeEnrich,
   sendDraftedEmail,
   socialProofBlock,
@@ -189,6 +190,7 @@ export async function runEmailPlay<T, X = Record<string, never>>(
         // Daily-cap deferral is not a per-target failure — propagate so the
         // caller (drain / SSE run) leaves remaining targets queued.
         if (isSendDeferred(err)) throw err;
+        logTargetError({ playName: def.playName, to: def.toEmail(target), err });
         return {
           target,
           ...errorDraft((err as Error)?.message),

--- a/packages/plays/src/breakup-revive.ts
+++ b/packages/plays/src/breakup-revive.ts
@@ -1,5 +1,11 @@
 import { getLedger, isSendDeferred, loadConfig } from "@oneshot-gtm/core";
-import { draftEmailFromPrompt, errorDraft, lintEmail, sendDraftedEmail } from "./_lib.ts";
+import {
+  draftEmailFromPrompt,
+  errorDraft,
+  lintEmail,
+  logTargetError,
+  sendDraftedEmail,
+} from "./_lib.ts";
 
 const PLAY_NAME = "breakup-revive";
 
@@ -103,6 +109,7 @@ export async function runBreakupRevive(
       // Daily-cap deferral is not a per-target failure — abort the run so the
       // caller leaves remaining targets queued instead of stamping error drafts.
       if (isSendDeferred(err)) throw err;
+      logTargetError({ playName: PLAY_NAME, to: t.email, err });
       const stub = errorDraft((err as Error)?.message);
       drafted.push({
         prospectEmail: t.email,

--- a/packages/plays/src/demo-no-show.ts
+++ b/packages/plays/src/demo-no-show.ts
@@ -1,6 +1,12 @@
 import { getLedger, isSendDeferred, loadConfig, sendSms } from "@oneshot-gtm/core";
 import { complete, loadPrompt, tryParseJsonObject } from "@oneshot-gtm/intel";
-import { draftEmailFromPrompt, errorDraft, lintEmail, sendDraftedEmail } from "./_lib.ts";
+import {
+  draftEmailFromPrompt,
+  errorDraft,
+  lintEmail,
+  logTargetError,
+  sendDraftedEmail,
+} from "./_lib.ts";
 import { buildFollowUpEmail, enrollInCadence, registerSequence } from "./_cadence.ts";
 
 const PLAY_NAME = "demo-no-show";
@@ -111,6 +117,7 @@ export async function runDemoNoShow(opts: DemoNoShowRunOptions): Promise<DemoNoS
       // Daily-cap deferral is not a per-target failure — abort so remaining
       // targets stay queued instead of getting error drafts.
       if (isSendDeferred(err)) throw err;
+      logTargetError({ playName: PLAY_NAME, to: t.email, err });
       const stub = errorDraft((err as Error)?.message);
       outcomes.push({
         target: t,

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -3,7 +3,14 @@
  * These are the API contracts for /api/* endpoints. Keep stable.
  */
 
-export type CadenceStatus = "active" | "replied" | "breakup" | "completed" | "paused";
+export type CadenceStatus =
+  | "active"
+  | "replied"
+  | "breakup"
+  | "completed"
+  | "paused"
+  /** Stopped by a hard bounce — the address is dead and is suppressed from further sends. */
+  | "bounced";
 
 export interface CadenceNextStepDraft {
   subject: string;
@@ -76,6 +83,7 @@ export interface CadenceCounts {
   breakup: number;
   completed: number;
   paused: number;
+  bounced: number;
   overdue: number;
 }
 


### PR DESCRIPTION
Two things the tool could not previously see: whether a message was **refused**, and whether an accepted message actually **reached the inbox**.

## 1. Bounce harvesting

Gmail DSNs were already arriving in the mailbox the reply poll reads, matching no prospect, and getting discarded — `apps/web/src/lib/replyFilter.ts` literally categorised bounces alongside newsletters. Meanwhile `sequence_events.status` has carried a `'bounced'` value since forever that **nothing ever wrote**.

Net effect: the tool kept emailing addresses the receiving server had already refused, paying for each send and spending sending reputation, while the evidence sat unread in the mailbox.

- **`listGmailBounces`** — its own Gmail query, so DSNs don't compete with genuine replies for the 50-message poll window, and a deliberate fetch can parse the structured RFC 3464 `message/delivery-status` part (with header unfolding, so a wrapped `Diagnostic-Code` isn't truncated) rather than regexing localised prose.
- **`classifyBounce`** splits `hard` / `block` / `soft`. A `5.7.x` policy block is kept distinct from a dead address deliberately — it's a verdict on the message or the sending domain, so it must **never** suppress the recipient.
- **`bounces` table** (ledger v18), PK `(message_id, recipient)` — the sweep re-reads a 30-day window, so each DSN must count exactly once, and a multi-recipient report mustn't collapse into one row.
- **`pollInboxBounces`** runs in `advanceCadence` ahead of the due-step loop, and on the scheduler tick throttled to 30 min. Hard bounce → cadence stopped + address suppressed.
- **Suppression** gates `sendEmail` before sender routing, plus a proactive check in `runCadenceStepForProspect` so a suppressed row doesn't burn an LLM draft and then surface as "send failed · retrying" — a framing no retry can fix.

```
! deliverability   good@corp.example 0.5% bounced (1/205, 30d) — 2 spam-blocks, check content/volume
✗ deliverability   bad@corp.example 8.0% bounced (8/100, 30d)
✓ deliverability   tiny@corp.example 1 hard / 0 blocked of 3 sent (30d) — too few sends to rate
```

Warn >2%, fail >5%, with a 20-send minimum so 1-of-3 doesn't read as 33%. Spam-blocks are reported by **count**, not averaged into the rate — a single one matters and would vanish as a percentage.

## 2. Inbox placement canary

Bounces structurally cannot tell you a message was accepted and then filed into spam, which for cold outreach is the same as never arriving. `gmail placement` sends one real message between two authorized mailboxes and reads where the receiving account filed it — plus the SPF/DKIM/DMARC verdicts the receiving server recorded on the delivered copy, which is a verdict on the real message path and needs no DNS tooling.

```
✓ inbox placement  inbox (1d ago) · spf=pass dkim=pass dmarc=pass
! inbox placement  promotions (2d ago) · spf=pass dkim=pass dmarc=pass
✗ inbox placement  spam (1d ago) · spf=fail dkim=none dmarc=fail
```

## Decisions worth reviewing

- **`in:anywhere` on the lookup is load-bearing.** Gmail's default search excludes spam, so without it the one outcome this test exists to detect reads identically to "never arrived".
- **Message-ID is read back off the sent copy.** Gmail rewrites any we supply, so searching for one we generated would match nothing.
- **No marker token in the subject.** The obvious way to make a canary findable would itself be judged by the spam filter being measured.
- **Classification order.** A Promotions message carries *both* `INBOX` and `CATEGORY_PROMOTIONS` — checking `INBOX` first would report the tab-binned case as a clean hit.
- **The prose-fallback DSN gate.** Without it, ordinary mail reading *"we passed 550 users … sam@corp.example"* parses as a hard bounce and suppresses a live prospect. There's a test pinning this.
- **doctor reports, never runs.** A canary sends real mail, and repeatedly mailing one seed trains its filter until the test always passes.
- **Same-domain pairs are flagged.** Internal Workspace routing skips most filtering and authentication, so that result predicts nothing about a stranger's server.
- **`not_delivered` is its own outcome**, not folded into spam — silence is ambiguous.
- **Gmail-only coverage is stated plainly.** A OneShot send's return path belongs to the platform, so those identities are invisible here; silence about an unmonitored sender would otherwise read as "no bounces" when it means "we can't tell".

## Testing

1404 tests pass (72 new); typecheck, lint and format clean. Every doctor branch was exercised against a seeded ledger — inbox / promotions / spam / stale / same-domain / never-tested / OneShot-blindspot.

**Not verified here:** the live paths — a real DSN, and a real canary between two accounts on different domains. Both fail loudly (subject-fallback query, `not_delivered`, unparsed DSNs simply dropped) rather than silently, but the first real run is what proves them. Real DSN formats vary more than fixtures do.

https://claude.ai/code/session_01HuWi3EgNCRicFoCKHytmJZ


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add bounce harvesting, send suppression, and inbox placement canary testing
> - Polls Gmail inboxes for DSN bounce messages every 30 minutes via `pollInboxBounces`, records them in the ledger, and marks affected cadences as `bounced` on hard bounces.
> - Adds a `suppressionFor` ledger lookup that gates `sendEmail` and `runCadenceStepForProspect`: hard-bounced recipients are rejected with `SuppressedRecipientError` before any drafting or billing occurs.
> - Adds `runPlacementCanary` in [canary.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/22/files#diff-a378dc3f2a5a0e4fa08610533496378bc92ad3a6a956de1b2b8be3f74cce86e8) to send a real email between two Gmail identities and record placement (inbox/promotions/spam/archived), SPF/DKIM/DMARC verdicts, and latency in the ledger.
> - Exposes a `gmail placement` CLI command in [gmail.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/22/files#diff-b620eaf1631ff75800da8e81dac68f438e25873d52b0c3bea8397915ac0ca87a) to trigger a canary run interactively and print a formatted placement report.
> - Adds deliverability and placement checks to the `runDoctor` output, reporting per-identity hard-bounce rates over 30 days and warning when canary results are stale, tabbed, or indicate spam.
> - Surfaces a `Bounced` summary tile in the cadences UI and includes `bounced` counts in server-side tally responses.
> - Risk: suppression is permanent until manually cleared — a mistaken hard-bounce record will silently drop all future sends to that address.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a837ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->