### PR TITLE
chore(release): v0.7.0

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oneshot-gtm",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Open-source GTM agent for technical founders. Pay-per-result, signed receipts.",
   "license": "MIT",
   "bin": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "oneshot-gtm-server",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Local dashboard server for oneshot-gtm. Boots Bun.serve, opens the browser to your GTM operating state.",
   "homepage": "https://github.com/oneshot-agent/oneshot-gtm",
   "license": "MIT",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneshot-gtm/web",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneshot-gtm/core",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/doctor/package.json
+++ b/packages/doctor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneshot-gtm/doctor",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/find/package.json
+++ b/packages/find/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneshot-gtm/find",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/intel/package.json
+++ b/packages/intel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneshot-gtm/intel",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/plays/package.json
+++ b/packages/plays/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneshot-gtm/plays",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {

--- a/packages/prompts/package.json
+++ b/packages/prompts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneshot-gtm/prompts",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "files": [
     "*.md"

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oneshot-gtm/shared-types",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "type": "module",
   "main": "./src/index.ts",
   "exports": {


### PR DESCRIPTION
Version bump only — 0.6.0 → 0.7.0 across all workspace packages.

**Merging this does not publish anything.** The npm publish is triggered separately by pushing the `v0.7.0` tag (`bun run release:server`), which runs `.github/workflows/release.yml`: build → `npm publish --access public --provenance` → GitHub Release with auto-generated notes.

## What's in 0.7.0

17 commits since v0.6.0, two months ago:

- **github-stars survives GitHub's July-2026 stargazers restriction** — falls back to the public events feed (#18)
- **/queue drains from one button instead of nine**, and can drain an explicit row selection (#19)
- **Bounce harvesting + inbox placement testing** (#22)
- **Add Prospect from a LinkedIn/X/GitHub URL** + cadence quick-select (#15)
- **Resume/pause OneShot sending domains** (#14)
- **Per-target send failures log the SDK's status code + response body** instead of a bare "Tool request failed" (#21)
- Anonymous distribution telemetry (#2, #4, #11, #12)
- `fmt:check` gated in CI, oxfmt debt cleared (#20)

## Verification

- typecheck clean, `oxlint` 0/0, `fmt:check` clean, **1424/1424** tests
- The actual publish artifact builds: `apps/web` vite build + `apps/server` tsdown → `npm pack --dry-run` gives a 1.6 MB tarball, 115 files, bundled web UI included

## Note

`version` in the root `package.json` stays `0.0.0` (private workspace root, deliberate). Only `oneshot-gtm-server` is published to npm; the other packages are versioned in lockstep but not published.

https://claude.ai/code/session_01WfjkhiBKFjEbkkL5TzmRLZ

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Bump all packages from v0.6.0 to v0.7.0
> Updates the version field to `0.7.0` across all apps and packages in the monorepo, including `cli`, `server`, `web`, `core`, `doctor`, `find`, `intel`, `plays`, `prompts`, and `shared-types`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 07d6f00.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->