### PR TITLE
feat(demo): seed a filmable demo install, isolated from real credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ bun run cli -- find drain podcast-guest --dry-run  # preview approved /queue row
 bun run cli -- cadence advance                     # daily tick: poll inbox, fire follow-ups
 ```
 
-38 commands — ten groups, plus `init`, `doctor` and `ui` at the top level. `bun run cli -- --help` (or `oneshot-gtm --help` once linked) is the reference:
+41 commands — eleven groups, plus `init`, `doctor` and `ui` at the top level. `bun run cli -- --help` (or `oneshot-gtm --help` once linked) is the reference:
 
 | Group                    | Commands                                                                                                                                                        |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -86,6 +86,7 @@ bun run cli -- cadence advance                     # daily tick: poll inbox, fir
 | `discover`               | `icp interview-prep` · `icp synthesize` · `pmf classify` · `pmf survey` · `pmf survey-collect`                                                                  |
 | `intel`                  | `advise` · `personalize` · `triage-replies` · `weekly-review`                                                                                                   |
 | `handoff`                | `readiness` · `templatize` · `first-ae`                                                                                                                         |
+| `demo`                   | `seed` · `ui` · `reset` — a fictional install for screenshots and video                                                                                         |
 
 Spend, CAC, RoCS and outcome logging deliberately have no CLI group — they live on the dashboard's Measure and Cadences pages so there's one source of truth. The `/api/measure/*` routes are there if you'd rather script them.
 
@@ -111,6 +112,25 @@ Nine pages plus a run form:
 A floating strategist dock sits on every page: it reads your ICP and product one-liner and proposes trigger configs as confirmation chips (`POST /api/strategist/stream`, SSE).
 
 Next to it is a **privacy toggle**. Flip it on and names, emails, companies and phone numbers render partially masked everywhere — enough to screenshot a receipt or a cadence without exposing a real contact. Costs, receipt IDs and every other figure stay untouched, since the numbers are the reason to show a receipt in the first place. Off by default, remembered per browser. It's readable obfuscation for screenshots, not secure redaction.
+
+### Demo mode
+
+A fresh install is nine empty states, which makes it hard to show anyone what this looks like in use. `demo` builds a fictional, fully-populated install in its own home and opens the dashboard against it.
+
+```bash
+bun run cli -- demo seed      # → ~/.oneshot-gtm-demo
+bun run cli -- demo ui        # dashboard, pointed at the demo install
+bun run cli -- demo reset     # delete it
+```
+
+The cast is invented (it extends the one in `examples/`) and the numbers are internally consistent: ~24 prospects across eight plays and 30 days, 147 signed receipts totalling $2.94, cadences in all five states, replies matched to their prospects, two closed deals. Everything is anchored to a timestamp, so `--now` reproduces a ledger exactly and a re-shoot matches the first take.
+
+What demo mode changes, and nothing else:
+
+- Four **read-only** calls that fetch at request time rather than reading the ledger — the reply list, the platform RoCS rollup, the domain pool, the wallet balance — are served from JSON fixtures in the demo home. Without that, Replies is blank no matter what's in SQLite.
+- The in-process **scheduler idles**, so enabled triggers don't fire against the demo install and overwrite its state mid-screenshot.
+
+Nothing that sends, drafts or spends is faked. Under the flag, the demo home's `.env` is the **sole** source of secrets — real credentials inherited from your shell, your install, or a repo-root `.env` are overwritten or deleted — so a stray click on Run or Send fails at auth rather than doing something real. `demo seed` refuses to touch `~/.oneshot-gtm`, and `demo reset` only removes a directory it marked as its own.
 
 ---
 
@@ -196,7 +216,7 @@ Add a OneShot domain and mailbox from `/setup` or `identities add` — pick a pr
 
 ```
 apps/
-  cli/        38-command CLI (commander)
+  cli/        41-command CLI (commander); src/demo/ seeds the demo install
   server/     Bun.serve + SSE; tsdown bundle published as `oneshot-gtm-server`
   web/        Vite + React 19 + TanStack + Base UI — 9 pages, run form, strategist dock, privacy mode
 packages/
@@ -227,7 +247,7 @@ bun install
 bun run typecheck                  # tsc --noEmit across cli + server + packages
 bun run lint                       # oxlint
 bun run fmt                        # oxfmt --write   (fmt:check in CI)
-bun run test                       # vitest — 1487 cases across 115 files
+bun run test                       # vitest — 1518 cases across 117 files
 bun run cli -- doctor              # smoke check
 ```
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,7 +40,7 @@ The ICP filter currently judges each candidate cold.
 
 ## Launch assets
 
-Not code — these need capture, not commits.
+Not code — these need capture, not commits. `demo seed` + `demo ui` now stand up a populated, fictional install to record against, so neither is blocked on having something to point a camera at.
 
 - [ ] vhs terminal recording (60s), to embed in the README.
 - [ ] Dashboard demo gif (30s).

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,8 @@
 # Status
 
-**Assume green unless it's listed below.** The 38 CLI commands, 14 plays, 10 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and, with the seven exceptions on this page, verified end to end against the live OneShot API.
+**Assume green unless it's listed below.** The 41 CLI commands, 14 plays, 10 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and, with the seven exceptions on this page, verified end to end against the live OneShot API.
 
-Last verified **2026-08-17** · Bun 1.3.13 · OneShot SDK 0.22.0 · 1487 tests / 115 files · typecheck + oxlint clean (295 files).
+Last verified **2026-08-17** · Bun 1.3.13 · OneShot SDK 0.22.0 · 1518 tests / 117 files · typecheck + oxlint clean (301 files).
 
 Updated by hand after each dogfood run. CI auto-update is on the roadmap.
 
@@ -48,7 +48,8 @@ Five of those also stay **not ready** until you give them required config, and r
 - **`oneshot-gtm-server` requires Bun.** `bun:sqlite`, `Bun.serve`, and `Bun.stdin` are Bun-native; a runtime check in `dist/bin.mjs` fails loudly under plain `node`. A self-contained `bun build --compile` binary is a future option.
 - **The CLI is not on npm.** Only `oneshot-gtm-server` is published (0.7.0). The CLI needs a repo clone plus `bun link`.
 - **No public benchmarks page.** The telemetry endpoint is live and verified; the surface that renders aggregates from it is still roadmap.
-- **Launch assets not captured.** The terminal recording and dashboard gif the roadmap calls for don't exist yet, so no doc embeds one.
+- **Launch assets not captured.** The terminal recording and dashboard gif the roadmap calls for don't exist yet, so no doc embeds one. The data to record against does: `demo seed` builds a populated fictional install.
+- **Demo mode fixtures four network reads.** `listInbox`, `cadenceRocs`, `listSendingDomains` and `getBalance` read JSON from the demo home when `ONESHOT_GTM_DEMO=1`, and the scheduler idles. All four are reads; nothing that sends, drafts or spends is stubbed, and the flag is only ever set by `demo ui`. Under the flag the demo home's `.env` is also the **sole** source of secrets — inherited env vars and Bun's auto-loaded repo-root `.env` are overwritten or deleted, so a demo can never act with real credentials.
 
 ## GitHub stargazer discovery is degraded by upstream
 

--- a/apps/cli/__tests__/demo-seed.test.ts
+++ b/apps/cli/__tests__/demo-seed.test.ts
@@ -1,0 +1,247 @@
+import { Database } from "bun:sqlite";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { scrubInheritedSecrets } from "../src/commands/demo.ts";
+import { DEMO_MARKER, DemoSeedError, resetDemoHome, seedDemoHome } from "../src/demo/seed.ts";
+
+const ANCHOR = new Date("2026-08-17T09:00:00.000Z");
+
+let home: string;
+
+beforeEach(() => {
+  home = join(mkdtempSync(join(tmpdir(), "oneshot-gtm-demo-test-")), "demo");
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+function open(dir: string): Database {
+  return new Database(join(dir, "ledger.sqlite"), { readonly: true });
+}
+
+function rows(db: Database, sql: string): Array<Record<string, unknown>> {
+  return db.query(sql).all() as Array<Record<string, unknown>>;
+}
+
+describe("seedDemoHome", () => {
+  it("writes config, secrets, fixtures and a marker", () => {
+    seedDemoHome({ home, anchor: ANCHOR });
+
+    expect(existsSync(join(home, DEMO_MARKER))).toBe(true);
+    const cfg = JSON.parse(readFileSync(join(home, "config.json"), "utf8")) as Record<
+      string,
+      unknown
+    >;
+    expect(cfg["founderName"]).toBe("Mira Vance");
+    expect(cfg["icpOneLiner"]).toBeTruthy();
+    expect((cfg["emailIdentities"] as unknown[]).length).toBe(3);
+    // Telemetry must be off: a demo install is not a real one and must not
+    // report itself as such.
+    expect(cfg["telemetryEnabled"]).toBe(false);
+
+    for (const f of ["inbox.json", "rocs-by-goal.json", "domains.json", "balance.json"]) {
+      expect(existsSync(join(home, "demo", f))).toBe(true);
+    }
+  });
+
+  it("chmods the secrets file to 600 and keeps the keys non-functional", () => {
+    seedDemoHome({ home, anchor: ANCHOR });
+    const env = join(home, ".env");
+    expect(statSync(env).mode & 0o777).toBe(0o600);
+    const body = readFileSync(env, "utf8");
+    expect(body).toMatch(/OPENROUTER_API_KEY=/);
+    expect(body).toMatch(/AGENT_PRIVATE_KEY=/);
+    expect(body).toMatch(/demo/i);
+  });
+
+  it("populates every table the dashboard reads", () => {
+    const { counts } = seedDemoHome({ home, anchor: ANCHOR });
+    for (const table of [
+      "prospects",
+      "receipts",
+      "sequence_events",
+      "cadence_state",
+      "deal_outcomes",
+      "target_queue",
+      "triggers",
+      "runs",
+      "bounces",
+      "canary_results",
+    ]) {
+      expect(counts[table], `${table} should be seeded`).toBeGreaterThan(0);
+    }
+  });
+
+  it("covers every cadence status, so each summary tile has a number behind it", () => {
+    seedDemoHome({ home, anchor: ANCHOR });
+    const db = open(home);
+    const statuses = rows(db, "SELECT DISTINCT status FROM cadence_state").map((r) => r["status"]);
+    db.close();
+    expect(new Set(statuses)).toEqual(
+      new Set(["active", "replied", "breakup", "completed", "bounced"]),
+    );
+  });
+
+  it("covers every queue status the filter chips offer", () => {
+    seedDemoHome({ home, anchor: ANCHOR });
+    const db = open(home);
+    const statuses = rows(db, "SELECT DISTINCT status FROM target_queue").map((r) => r["status"]);
+    db.close();
+    expect(new Set(statuses)).toEqual(new Set(["pending", "approved", "rejected", "sent"]));
+  });
+
+  it("backdates receipts across a 30-day window so the range filters have data", () => {
+    seedDemoHome({ home, anchor: ANCHOR });
+    const db = open(home);
+    const [span] = rows(db, "SELECT MIN(created_at) lo, MAX(created_at) hi FROM receipts");
+    const within7d = rows(
+      db,
+      "SELECT COUNT(*) n FROM receipts WHERE created_at >= '2026-08-10 00:00:00'",
+    );
+    db.close();
+    // Same shape production writes via the datetime('now') column DEFAULT.
+    expect(String(span?.["lo"])).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+    expect(String(span?.["hi"])).toMatch(/^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/);
+    expect(Number(within7d[0]?.["n"])).toBeGreaterThan(0);
+  });
+
+  it("writes ISO timestamps to the columns the app writes with toISOString()", () => {
+    seedDemoHome({ home, anchor: ANCHOR });
+    const db = open(home);
+    const due = rows(db, "SELECT next_due_at FROM cadence_state WHERE next_due_at IS NOT NULL");
+    const polled = rows(db, "SELECT last_polled_at FROM triggers WHERE last_polled_at IS NOT NULL");
+    db.close();
+    expect(due.length).toBeGreaterThan(0);
+    for (const r of [...due, ...polled]) {
+      expect(String(Object.values(r)[0])).toMatch(/^\d{4}-\d{2}-\d{2}T.*Z$/);
+    }
+  });
+
+  it("value-tags only the receipts belonging to a goal with an outcome", () => {
+    seedDemoHome({ home, anchor: ANCHOR });
+    const db = open(home);
+    const tagged = rows(db, "SELECT COUNT(*) n FROM receipts WHERE value_tag IS NOT NULL");
+    const orphan = rows(
+      db,
+      "SELECT COUNT(*) n FROM receipts WHERE value_tag IS NOT NULL AND goal_id IS NULL",
+    );
+    db.close();
+    expect(Number(tagged[0]?.["n"])).toBeGreaterThan(0);
+    expect(Number(orphan[0]?.["n"])).toBe(0);
+  });
+
+  it("is deterministic — the same anchor reproduces the same ledger", () => {
+    const a = seedDemoHome({ home, anchor: ANCHOR });
+    const db1 = open(home);
+    const before = JSON.stringify(rows(db1, "SELECT * FROM receipts ORDER BY id"));
+    db1.close();
+
+    const b = seedDemoHome({ home, anchor: ANCHOR });
+    const db2 = open(home);
+    const after = JSON.stringify(rows(db2, "SELECT * FROM receipts ORDER BY id"));
+    db2.close();
+
+    expect(after).toBe(before);
+    expect(b.counts).toEqual(a.counts);
+  });
+
+  it("re-seeds in place without stacking duplicate rows", () => {
+    const first = seedDemoHome({ home, anchor: ANCHOR });
+    const second = seedDemoHome({ home, anchor: new Date("2026-09-01T09:00:00.000Z") });
+    expect(second.counts["prospects"]).toBe(first.counts["prospects"]);
+
+    const db = open(home);
+    const n = rows(db, "SELECT COUNT(*) n FROM prospects");
+    db.close();
+    expect(Number(n[0]?.["n"])).toBe(first.counts["prospects"]);
+  });
+
+  it("refuses to seed into the real install", () => {
+    const real = join(homedir(), ".oneshot-gtm");
+    expect(() => seedDemoHome({ home: real, anchor: ANCHOR })).toThrow(DemoSeedError);
+    expect(() => seedDemoHome({ home: real, anchor: ANCHOR })).toThrow(/real install/i);
+  });
+
+  it("refuses a non-empty directory it did not create, unless forced", () => {
+    mkdirSync(home, { recursive: true });
+    writeFileSync(join(home, "something-important.txt"), "do not delete me");
+
+    expect(() => seedDemoHome({ home, anchor: ANCHOR })).toThrow(/--force/);
+    expect(() => seedDemoHome({ home, anchor: ANCHOR, force: true })).not.toThrow();
+    // --force overwrites the install, it doesn't wipe unrelated files.
+    expect(existsSync(join(home, "something-important.txt"))).toBe(true);
+  });
+});
+
+describe("scrubInheritedSecrets", () => {
+  // The CLI parent has already run core's applySecretsToEnv() by the time
+  // `demo ui` executes, so process.env carries the REAL install's credentials.
+  // The child server only fills BLANK vars from the demo .env — an unscrubbed
+  // inherited key would shadow the placeholder and hand the "demo" a live
+  // wallet. This is the regression test for that leak.
+  it("removes every stored secret plus the env-only tokens", () => {
+    const env: NodeJS.ProcessEnv = {
+      OPENROUTER_API_KEY: "sk-or-real",
+      OPENAI_API_KEY: "sk-real",
+      ANTHROPIC_API_KEY: "sk-ant-real",
+      CDP_API_KEY_ID: "real",
+      CDP_API_KEY_SECRET: "real",
+      CDP_WALLET_SECRET: "real",
+      AGENT_PRIVATE_KEY: "0xreal",
+      GMAIL_CLIENT_ID: "real",
+      GMAIL_CLIENT_SECRET: "real",
+      GMAIL_REFRESH_TOKEN: "real",
+      GITHUB_TOKEN: "ghp_real",
+      LUMA_SESSION_COOKIE: "real",
+    };
+    scrubInheritedSecrets(env);
+    expect(Object.keys(env)).toEqual([]);
+  });
+
+  it("leaves non-secret vars alone", () => {
+    const env: NodeJS.ProcessEnv = {
+      PATH: "/usr/bin",
+      HOME: "/Users/someone",
+      PORT: "3030",
+      ONESHOT_GTM_HOME: "/tmp/x",
+      AGENT_PRIVATE_KEY: "0xreal",
+    };
+    scrubInheritedSecrets(env);
+    expect(env).toEqual({
+      PATH: "/usr/bin",
+      HOME: "/Users/someone",
+      PORT: "3030",
+      ONESHOT_GTM_HOME: "/tmp/x",
+    });
+  });
+});
+
+describe("resetDemoHome", () => {
+  it("removes a seeded home", () => {
+    seedDemoHome({ home, anchor: ANCHOR });
+    resetDemoHome(home);
+    expect(existsSync(home)).toBe(false);
+  });
+
+  it("refuses a directory without the marker", () => {
+    mkdirSync(home, { recursive: true });
+    writeFileSync(join(home, "ledger.sqlite"), "not really a ledger");
+    expect(() => resetDemoHome(home)).toThrow(DemoSeedError);
+    expect(existsSync(home)).toBe(true);
+  });
+
+  it("is a no-op on a path that doesn't exist", () => {
+    expect(() => resetDemoHome(join(home, "nope"))).not.toThrow();
+  });
+});

--- a/apps/cli/src/commands/demo.ts
+++ b/apps/cli/src/commands/demo.ts
@@ -1,0 +1,109 @@
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { SECRET_KEYS } from "@oneshot-gtm/core";
+import { bail, c, header, note, ok, warn } from "../output.ts";
+import { DEFAULT_DEMO_HOME, DemoSeedError, resetDemoHome, seedDemoHome } from "../demo/seed.ts";
+import { commandUi } from "./ui.ts";
+
+/**
+ * Strip every real credential from an env before it reaches the demo server.
+ *
+ * The CLI process imports core, and core's `applySecretsToEnv()` fills blank
+ * `process.env` vars from the REAL home's `.env` at import time — before this
+ * command ever runs. `commandUi` spawns the server with `...process.env`, and
+ * the child's own secrets-loader only fills vars that are still blank, so
+ * without this scrub the inherited real wallet/LLM/Gmail keys would SHADOW the
+ * demo home's placeholders. That is the exact failure the demo exists to
+ * prevent: a stray Run or Send click spending real money from a "demo".
+ * Deleting them here lets the child re-load from the demo `.env`, whose
+ * placeholder values cannot authenticate.
+ *
+ * GITHUB_TOKEN / LUMA_SESSION_COOKIE aren't in SECRET_KEYS (they're read
+ * straight from env, never stored), but a demo "Run now" shouldn't act with the
+ * founder's real tokens either.
+ */
+export function scrubInheritedSecrets(env: NodeJS.ProcessEnv): void {
+  for (const key of [...SECRET_KEYS, "GITHUB_TOKEN", "LUMA_SESSION_COOKIE"]) {
+    delete env[key];
+  }
+}
+
+interface SeedOpts {
+  home: string;
+  now?: string;
+  force: boolean;
+}
+
+export async function commandDemoSeed(opts: SeedOpts): Promise<void> {
+  header("oneshot-gtm demo seed");
+
+  let anchor: Date | undefined;
+  if (opts.now) {
+    const parsed = new Date(opts.now);
+    if (Number.isNaN(parsed.getTime())) {
+      bail(`--now must be a parseable date (got "${opts.now}")`);
+    }
+    anchor = parsed;
+  }
+
+  let result;
+  try {
+    result = seedDemoHome({ home: opts.home, force: opts.force, ...(anchor ? { anchor } : {}) });
+  } catch (err) {
+    if (err instanceof DemoSeedError) bail(err.message);
+    throw err;
+  }
+
+  const total = Object.values(result.counts).reduce((a, b) => a + b, 0);
+  ok(`seeded ${total} rows into ${c.cyan(result.home)}`);
+  for (const [table, n] of Object.entries(result.counts)) {
+    note(`  ${table.padEnd(20)} ${n}`);
+  }
+  note("");
+  note(`Anchored at ${result.anchor.toISOString()} — re-seed with the same ${c.cyan("--now")} to`);
+  note("reproduce this ledger exactly, so a re-shoot matches an earlier take.");
+  note("");
+  ok(`Launch it:  ${c.cyan("bun run cli -- demo ui")}`);
+  warn("Placeholder credentials — clicking Run or Send in the demo fails at auth by design.");
+}
+
+interface DemoUiOpts {
+  home: string;
+  port: number;
+  noBrowser: boolean;
+  dev: boolean;
+}
+
+export async function commandDemoUi(opts: DemoUiOpts): Promise<void> {
+  const home = resolve(opts.home);
+  if (!existsSync(home)) {
+    bail(`no demo home at ${home}. Run ${c.cyan("bun run cli -- demo seed")} first.`);
+  }
+
+  // `commandUi` spawns the server with `...process.env`, so mutating it here
+  // redirects the whole child process at the demo install. The scrub comes
+  // first — see its doc comment: without it, real credentials inherited at
+  // core-import time shadow the demo home's placeholders in the child.
+  scrubInheritedSecrets(process.env);
+  process.env["ONESHOT_GTM_HOME"] = home;
+  process.env["ONESHOT_GTM_DEMO"] = "1";
+  // A demo run is not a real install and must not report itself as one.
+  process.env["ONESHOT_GTM_TELEMETRY"] = "0";
+
+  note(`demo home: ${c.cyan(home)}  ·  scheduler idle, network reads served from fixtures`);
+  await commandUi({ port: opts.port, noBrowser: opts.noBrowser, dev: opts.dev });
+}
+
+export async function commandDemoReset(opts: { home: string }): Promise<void> {
+  header("oneshot-gtm demo reset");
+  const home = resolve(opts.home);
+  try {
+    resetDemoHome(home);
+  } catch (err) {
+    if (err instanceof DemoSeedError) bail(err.message);
+    throw err;
+  }
+  ok(`removed ${c.cyan(home)}`);
+}
+
+export { DEFAULT_DEMO_HOME };

--- a/apps/cli/src/demo/dataset.ts
+++ b/apps/cli/src/demo/dataset.ts
@@ -1,0 +1,1707 @@
+import { cadenceGoalId } from "@oneshot-gtm/core";
+
+/**
+ * The demo install, as pure data. No I/O — `seed.ts` writes it.
+ *
+ * Two rules hold this file together:
+ *
+ * 1. **Deterministic.** Every timestamp is an offset from the anchor the caller
+ *    passes, and there is no `Math.random` anywhere. Seeding twice with the same
+ *    anchor produces the same ledger, so a re-shoot matches the first take and
+ *    the tests can assert on exact rows.
+ *
+ * 2. **Two timestamp formats, matched to what production writes.** Columns whose
+ *    value comes from the `datetime('now')` DEFAULT (`created_at`, `found_at`,
+ *    `enrolled_at`, `recorded_at`, …) get SQLite's `YYYY-MM-DD HH:MM:SS`; columns
+ *    the app writes with `toISOString()` (`next_due_at`, `reviewed_at`,
+ *    `triggers.last_polled_at`, `runs.started_at`, `bounced_at`, …) get ISO.
+ *    Mixing them silently breaks the string comparisons those columns are read
+ *    with — `next_due_at <= ?` and friends.
+ *
+ * The cast extends the one already in `examples/*.json` (Jane Founder / Acme,
+ * Sam Builder / Beacon, Rae Kim / Stellar, Jordan Lee / Acme Data, Priya Shah /
+ * Northstar AI) so the sample target files and the demo tell one story.
+ */
+
+const DAY_MS = 86_400_000;
+
+/** ISO — for columns the app writes with `new Date().toISOString()`. */
+function isoAt(anchor: Date, daysAgo: number, hour: number, minute: number): string {
+  const d = new Date(anchor.getTime() - daysAgo * DAY_MS);
+  d.setUTCHours(hour, minute, 0, 0);
+  return d.toISOString();
+}
+
+/** SQLite `datetime('now')` format — for columns filled by the column DEFAULT. */
+function sqlAt(anchor: Date, daysAgo: number, hour: number, minute: number): string {
+  return isoAt(anchor, daysAgo, hour, minute).slice(0, 19).replace("T", " ");
+}
+
+/** ISO, minutes before the anchor — for trigger poll times, see buildTriggers. */
+function isoMinutesAgo(anchor: Date, minutesAgo: number): string {
+  return new Date(anchor.getTime() - minutesAgo * 60_000).toISOString();
+}
+
+/** Deterministic minute-of-hour so rows don't all share a timestamp. */
+function jitter(i: number): number {
+  return (i * 37) % 60;
+}
+
+// ---------------------------------------------------------------------------
+// Founder
+// ---------------------------------------------------------------------------
+
+// A fictional dev-tools founder, deliberately selling something OTHER than
+// OneShot so a viewer never confuses the demo product with the tool being demoed.
+export const DEMO_FOUNDER = {
+  name: "Mira Vance",
+  email: "mira@tracepoint.dev",
+  product: "Tracepoint",
+  oneLiner: "Drop-in distributed tracing for background jobs — no sampling, no agent.",
+  productDomain: "tracepoint.dev",
+  sendingDomain: "tracepoint.email",
+  icp: "Seed to Series A dev-tool and AI-infra startups running background job queues in production, where a founding or staff engineer owns reliability.",
+} as const;
+
+const IDENTITY_PRIMARY = "oneshot:mira@tracepoint.email";
+const IDENTITY_SECOND = "oneshot:hey@tracepoint.email";
+const IDENTITY_WARMING = "oneshot:mira@trace-mail.dev";
+
+// OneShot identities only. A Gmail identity would need a stored refresh token
+// and a live profile call for `doctor` to read green, and faking OAuth is well
+// past what a screenshot is worth.
+const IDENTITIES = [
+  {
+    id: IDENTITY_PRIMARY,
+    provider: "oneshot",
+    label: "Mira · tracepoint.email",
+    sendingDomain: "tracepoint.email",
+    mailbox: "mira",
+    maxPerDay: 50,
+    warmup: { startPerDay: 10, incrementPerWeek: 10 },
+  },
+  {
+    id: IDENTITY_SECOND,
+    provider: "oneshot",
+    label: "Hey · tracepoint.email",
+    sendingDomain: "tracepoint.email",
+    mailbox: "hey",
+    maxPerDay: 50,
+    warmup: { startPerDay: 10, incrementPerWeek: 10 },
+  },
+  {
+    id: IDENTITY_WARMING,
+    provider: "oneshot",
+    label: "Mira · trace-mail.dev (warming)",
+    sendingDomain: "trace-mail.dev",
+    mailbox: "mira",
+    maxPerDay: 30,
+    warmup: { startPerDay: 10, incrementPerWeek: 10 },
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Cast
+// ---------------------------------------------------------------------------
+
+type CadenceStatus = "active" | "replied" | "breakup" | "completed" | "bounced";
+
+interface DemoPerson {
+  name: string;
+  email: string;
+  company: string;
+  title: string;
+  play: string;
+  source: string;
+  linkedin: string | null;
+  /** Why this person surfaced — becomes the receipt memo and the dossier hook. */
+  hook: string;
+  /** Days before the anchor that the first touch went out. */
+  daysAgo: number;
+  /** Emails actually sent (intro + follow-ups). current_step is steps - 1. */
+  steps: number;
+  status: CadenceStatus;
+  identity: string;
+  outcome?: {
+    kind: "meeting_booked" | "sql_qualified" | "deal_won" | "ghosted";
+    amountUsd?: number;
+    daysAgo: number;
+    notes: string;
+  };
+  /** Drives the inbox fixture. Only set on `replied` rows. */
+  reply?: { daysAgo: number; hour: number; subject: string; body: string };
+}
+
+const PEOPLE: DemoPerson[] = [
+  {
+    name: "Jane Founder",
+    email: "jane@acme.dev",
+    company: "Acme",
+    title: "Co-founder / CTO",
+    play: "show-hn",
+    source: "show-hn",
+    linkedin: "https://linkedin.com/in/jane-founder-fake",
+    hook: "Show HN for open-source durable workflows for AI agents; defended the Postgres queue choice at 1k concurrent jobs.",
+    daysAgo: 26,
+    steps: 2,
+    status: "replied",
+    identity: IDENTITY_PRIMARY,
+    outcome: {
+      kind: "meeting_booked",
+      daysAgo: 21,
+      notes: "30 min Thursday, wants to see span capture on their worker pool.",
+    },
+    reply: {
+      daysAgo: 23,
+      hour: 14,
+      subject: "Re: your Postgres queue answer in the HN thread",
+      body: "Ha, that thread ate my whole afternoon. We are at about 1k concurrent jobs and the thing I actually cannot see is which step in a chain is slow. If Tracepoint does that without a sidecar I want a look. Thursday works.",
+    },
+  },
+  {
+    name: "Sam Builder",
+    email: "sam@beacon.run",
+    company: "Beacon",
+    title: "Founder",
+    play: "show-hn",
+    source: "show-hn",
+    linkedin: "https://linkedin.com/in/sam-builder-fake",
+    hook: "Show HN: distributed cron with at-least-once semantics; shipped v1 with no dashboard on purpose.",
+    daysAgo: 5,
+    steps: 1,
+    status: "active",
+    identity: IDENTITY_PRIMARY,
+  },
+  {
+    name: "Rae Kim",
+    email: "rae@stellar.dev",
+    company: "Stellar",
+    title: "Co-founder",
+    play: "podcast-guest",
+    source: "podcast-guest",
+    linkedin: "https://linkedin.com/in/rae-kim-fake",
+    hook: "Latent Space, 'The economics of agent infra' — argued the eval suite is the moat, not the model.",
+    daysAgo: 19,
+    steps: 2,
+    status: "replied",
+    identity: IDENTITY_SECOND,
+    outcome: {
+      kind: "sql_qualified",
+      daysAgo: 15,
+      notes: "Budget confirmed, wants a security review before a pilot.",
+    },
+    reply: {
+      daysAgo: 17,
+      hour: 11,
+      subject: "Re: the eval-cost argument from 38:20",
+      body: "Nice catch on the timestamp, most people who mail me about that episode have clearly not listened to it. Deterministic per-call cost is exactly the problem. Send me whatever you have on the security posture and I will route it internally.",
+    },
+  },
+  {
+    name: "Jordan Lee",
+    email: "jordan@acmedata.io",
+    company: "Acme Data",
+    title: "Head of Platform",
+    play: "job-change",
+    source: "job-change",
+    linkedin: "https://linkedin.com/in/jordan-lee-fake",
+    hook: "Moved from Staff Engineer, Infra at Stripe to Head of Platform — first 90 days, owns reliability.",
+    daysAgo: 4,
+    steps: 1,
+    status: "active",
+    identity: IDENTITY_PRIMARY,
+  },
+  {
+    name: "Priya Shah",
+    email: "priya@northstar.ai",
+    company: "Northstar AI",
+    title: "VP Engineering",
+    play: "competitor-switch",
+    source: "competitor-switch",
+    linkedin: "https://linkedin.com/in/priya-shah-fake",
+    hook: "Public G2 review complaining that their current tracing vendor samples away the failures they care about.",
+    daysAgo: 24,
+    steps: 3,
+    status: "replied",
+    identity: IDENTITY_PRIMARY,
+    outcome: {
+      kind: "deal_won",
+      amountUsd: 4800,
+      daysAgo: 9,
+      notes: "Annual, 12 months up front. Started on the worker fleet only.",
+    },
+    reply: {
+      daysAgo: 20,
+      hour: 9,
+      subject: "Re: the sampling complaint in your G2 review",
+      body: "You are the first person to email me about that review instead of about a renewal. Sampling is the whole problem — the traces we lose are the ones from the runs that failed. What does pricing look like for about forty workers?",
+    },
+  },
+  {
+    name: "Marco Ruiz",
+    email: "marco@quaydb.com",
+    company: "QuayDB",
+    title: "Co-founder / CEO",
+    play: "post-funding",
+    source: "post-funding-auto",
+    linkedin: "https://linkedin.com/in/marco-ruiz-fake",
+    hook: "Raised a $6M seed to build a managed Postgres branching service; hiring infra now.",
+    daysAgo: 22,
+    steps: 3,
+    status: "breakup",
+    identity: IDENTITY_SECOND,
+  },
+  {
+    name: "Lena Fischer",
+    email: "lena@sift.works",
+    company: "Sift",
+    title: "Founding Engineer",
+    play: "hiring-signal",
+    source: "hiring-signal",
+    linkedin: "https://linkedin.com/in/lena-fischer-fake",
+    hook: "Open Ashby role for a Founding Reliability Engineer — the job description names background-job visibility as the first project.",
+    daysAgo: 6,
+    steps: 2,
+    status: "active",
+    identity: IDENTITY_PRIMARY,
+  },
+  {
+    name: "Tobi Adeyemi",
+    email: "tobi@relaykit.dev",
+    company: "RelayKit",
+    title: "Founder",
+    play: "repo-interest",
+    source: "github-stars",
+    linkedin: "https://linkedin.com/in/tobi-adeyemi-fake",
+    hook: "Starred an adjacent OpenTelemetry worker-instrumentation repo three days after publishing their own queue library.",
+    daysAgo: 27,
+    steps: 3,
+    status: "completed",
+    identity: IDENTITY_SECOND,
+  },
+  {
+    name: "Hana Sato",
+    email: "hana@obsidianflow.io",
+    company: "Obsidian Flow",
+    title: "CTO",
+    play: "luma-events",
+    source: "luma-events",
+    linkedin: "https://linkedin.com/in/hana-sato-fake",
+    hook: "Hosting an AI-infra meetup in SF next week; the listing describes their pipeline as 'mostly cron and hope'.",
+    daysAgo: 3,
+    steps: 1,
+    status: "active",
+    identity: IDENTITY_PRIMARY,
+  },
+  {
+    name: "Dmitri Volkov",
+    email: "dmitri@cascade.systems",
+    company: "Cascade Systems",
+    title: "Co-founder / CTO",
+    play: "post-funding",
+    source: "post-funding-auto",
+    linkedin: "https://linkedin.com/in/dmitri-volkov-fake",
+    hook: "Series A for an agent-orchestration platform; the announcement calls out reliability as the year's focus.",
+    daysAgo: 12,
+    steps: 2,
+    status: "replied",
+    identity: IDENTITY_PRIMARY,
+    outcome: {
+      kind: "meeting_booked",
+      daysAgo: 8,
+      notes: "Intro call booked with them plus their staff SRE.",
+    },
+    reply: {
+      daysAgo: 10,
+      hour: 16,
+      subject: "Re: reliability as the year's focus",
+      body: "Timing is uncomfortable, we spent Tuesday arguing about exactly this. Can you do next week with our SRE on the call? He will have harder questions than me.",
+    },
+  },
+  {
+    name: "Ana Lopes",
+    email: "ana@driftline.ai",
+    company: "Driftline",
+    title: "Founder",
+    play: "show-hn",
+    source: "show-hn",
+    linkedin: null,
+    hook: "Show HN for a serverless inference router; the thread is all about tail latency.",
+    daysAgo: 15,
+    steps: 1,
+    status: "bounced",
+    identity: IDENTITY_SECOND,
+  },
+  {
+    name: "Owen Byrne",
+    email: "owen@pinch.dev",
+    company: "Pinch",
+    title: "Director of Engineering",
+    play: "job-change",
+    source: "job-change",
+    linkedin: "https://linkedin.com/in/owen-byrne-fake",
+    hook: "Joined as Director of Engineering from Datadog — knows what good tracing feels like and does not have it here.",
+    daysAgo: 8,
+    steps: 2,
+    status: "active",
+    identity: IDENTITY_SECOND,
+  },
+  {
+    name: "Yara Haddad",
+    email: "yara@kelp.systems",
+    company: "Kelp",
+    title: "Co-founder",
+    play: "hiring-signal",
+    source: "hiring-signal",
+    linkedin: "https://linkedin.com/in/yara-haddad-fake",
+    hook: "Two Greenhouse listings for platform engineers, both mentioning 'observability for async workloads'.",
+    daysAgo: 25,
+    steps: 3,
+    status: "breakup",
+    identity: IDENTITY_PRIMARY,
+  },
+  {
+    name: "Nils Berg",
+    email: "nils@fenwick.sh",
+    company: "Fenwick",
+    title: "Founder",
+    play: "podcast-guest",
+    source: "podcast-guest",
+    linkedin: "https://linkedin.com/in/nils-berg-fake",
+    hook: "On 20VC describing a three-day outage they could not reconstruct after the fact.",
+    daysAgo: 7,
+    steps: 2,
+    status: "replied",
+    identity: IDENTITY_PRIMARY,
+    reply: {
+      daysAgo: 3,
+      hour: 15,
+      subject: "Re: the outage you described on 20VC",
+      body: "Three days, and we still do not really know what happened on day one. I am not in a hurry to relive it, but I am in a hurry to not repeat it. What does setup actually look like on a Celery fleet?",
+    },
+  },
+  {
+    name: "Ines Moreau",
+    email: "ines@baseplate.dev",
+    company: "Baseplate",
+    title: "VP Platform",
+    play: "competitor-switch",
+    source: "competitor-switch",
+    linkedin: "https://linkedin.com/in/ines-moreau-fake",
+    hook: "Wrote a public postmortem blaming per-host pricing for turning off tracing on the worker fleet.",
+    daysAgo: 10,
+    steps: 2,
+    status: "replied",
+    identity: IDENTITY_SECOND,
+    outcome: {
+      kind: "meeting_booked",
+      daysAgo: 2,
+      notes: "Tuesday, wants the per-job pricing model in writing first.",
+    },
+    reply: {
+      daysAgo: 4,
+      hour: 12,
+      subject: "Re: the line in your postmortem about per-host pricing",
+      body: "You read the whole postmortem, which puts you ahead of our own board. Per-job pricing is the thing that would let me turn tracing back on for the workers. Send me the model and let us book something.",
+    },
+  },
+  {
+    name: "Kwame Mensah",
+    email: "kwame@triacore.io",
+    company: "Triacore",
+    title: "Staff Engineer",
+    play: "repo-interest",
+    source: "github-stars",
+    linkedin: "https://linkedin.com/in/kwame-mensah-fake",
+    hook: "Starred the job-queue instrumentation repo and opened an issue about missing span context across retries.",
+    daysAgo: 17,
+    steps: 2,
+    status: "replied",
+    identity: IDENTITY_PRIMARY,
+    outcome: {
+      kind: "meeting_booked",
+      daysAgo: 13,
+      notes: "Technical deep dive; he wants to see retry span linking specifically.",
+    },
+    reply: {
+      daysAgo: 14,
+      hour: 10,
+      subject: "Re: your retry-context issue",
+      body: "That issue has been open for four months with no answer, so this is already better support than upstream. Retry span linking is the entire reason I filed it. Show me.",
+    },
+  },
+  {
+    name: "Sofia Rossi",
+    email: "sofia@quarry.build",
+    company: "Quarry",
+    title: "Head of Infrastructure",
+    play: "luma-events",
+    source: "luma-events",
+    linkedin: "https://linkedin.com/in/sofia-rossi-fake",
+    hook: "Featured speaker at a Berlin platform-engineering event; talk abstract is about async debugging.",
+    daysAgo: 28,
+    steps: 3,
+    status: "completed",
+    identity: IDENTITY_SECOND,
+  },
+  {
+    name: "Ravi Menon",
+    email: "ravi@stanchion.dev",
+    company: "Stanchion",
+    title: "Co-founder / CTO",
+    play: "post-funding",
+    source: "post-funding-auto",
+    linkedin: "https://linkedin.com/in/ravi-menon-fake",
+    hook: "Seed round for a data-contract enforcement tool; scaling from three to eleven engineers.",
+    daysAgo: 2,
+    steps: 1,
+    status: "active",
+    identity: IDENTITY_PRIMARY,
+  },
+  {
+    name: "Elin Dahl",
+    email: "elin@northport.works",
+    company: "Northport",
+    title: "Founder",
+    play: "show-hn",
+    source: "show-hn",
+    linkedin: "https://linkedin.com/in/elin-dahl-fake",
+    hook: "Show HN for an open-source workflow engine; top comment asks how they debug a stuck run.",
+    daysAgo: 1,
+    steps: 1,
+    status: "active",
+    identity: IDENTITY_PRIMARY,
+  },
+  {
+    name: "Bruno Castro",
+    email: "bruno@aperture-labs.dev",
+    company: "Aperture Labs",
+    title: "Head of Engineering",
+    play: "job-change",
+    source: "job-change",
+    linkedin: "https://linkedin.com/in/bruno-castro-fake",
+    hook: "Stepped into Head of Engineering after the previous lead left mid-migration.",
+    daysAgo: 21,
+    steps: 3,
+    status: "breakup",
+    identity: IDENTITY_SECOND,
+  },
+  {
+    name: "Mei Tanaka",
+    email: "mei@keelson.io",
+    company: "Keelson",
+    title: "Founding Engineer",
+    play: "hiring-signal",
+    source: "hiring-signal",
+    linkedin: "https://linkedin.com/in/mei-tanaka-fake",
+    hook: "Lever posting for an SRE whose first listed responsibility is 'make the nightly pipeline explainable'.",
+    daysAgo: 9,
+    steps: 2,
+    status: "active",
+    identity: IDENTITY_WARMING,
+  },
+  {
+    name: "Felix Braun",
+    email: "felix@waypost.dev",
+    company: "Waypost",
+    title: "Co-founder",
+    play: "repo-interest",
+    source: "github-stars",
+    linkedin: "https://linkedin.com/in/felix-braun-fake",
+    hook: "Starred two OpenTelemetry worker repos in one week while shipping a queue rewrite.",
+    daysAgo: 6,
+    steps: 1,
+    status: "active",
+    identity: IDENTITY_WARMING,
+  },
+  {
+    name: "Aisha Rahman",
+    email: "aisha@tidewater.build",
+    company: "Tidewater",
+    title: "CTO",
+    play: "podcast-guest",
+    source: "podcast-guest",
+    linkedin: "https://linkedin.com/in/aisha-rahman-fake",
+    hook: "On Lenny's Podcast: 'we ship fast and find out on Monday what broke on Saturday'.",
+    daysAgo: 20,
+    steps: 2,
+    status: "replied",
+    identity: IDENTITY_PRIMARY,
+    outcome: {
+      kind: "deal_won",
+      amountUsd: 7200,
+      daysAgo: 5,
+      notes: "Two-year, paid annually. Rolled out fleet-wide in week one.",
+    },
+    reply: {
+      daysAgo: 18,
+      hour: 8,
+      subject: "Re: 'find out on Monday what broke on Saturday'",
+      body: "I regret saying that line on a podcast and I stand by it completely. Yes — send pricing. If this works on our Saturday batch run we will buy it this quarter.",
+    },
+  },
+  {
+    name: "Piotr Nowak",
+    email: "piotr@grainline.dev",
+    company: "Grainline",
+    title: "Founder",
+    play: "luma-events",
+    source: "luma-events",
+    linkedin: "https://linkedin.com/in/piotr-nowak-fake",
+    hook: "Listed as a guest at a Warsaw AI-infra dinner; builds ETL for model training runs.",
+    daysAgo: 13,
+    steps: 1,
+    status: "bounced",
+    identity: IDENTITY_SECOND,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Cost model
+// ---------------------------------------------------------------------------
+
+// Plausible per-call USD, in the same order of magnitude as real OneShot calls.
+// The whole 30-day install lands around $6 of spend, which is the point of the
+// Measure page: CAC in single-digit dollars, attested per call.
+const COST: Record<string, number> = {
+  "web.search": 0.012,
+  "email.find": 0.02,
+  "email.verify": 0.008,
+  "enrich.profile": 0.05,
+  "research.person": 0.12,
+  "email.send": 0.004,
+};
+
+/** Follow-up spacing, in days after the intro. */
+const STEP_OFFSETS = [0, 3, 7];
+
+// ---------------------------------------------------------------------------
+// Row shapes
+// ---------------------------------------------------------------------------
+
+export interface DemoReceipt {
+  id: number;
+  playName: string;
+  callType: string;
+  costUsd: number;
+  signedReceipt: unknown;
+  oneshotRequestId: string;
+  senderIdentity: string | null;
+  memo: string;
+  decisionContext: unknown;
+  valueTag: unknown | null;
+  valueTaggedAt: string | null;
+  goalId: string;
+  createdAt: string;
+}
+
+export interface DemoProspectRow {
+  id: number;
+  name: string;
+  email: string;
+  company: string;
+  linkedinUrl: string | null;
+  dossierJson: string;
+  source: string;
+  sourceProfileUrl: string | null;
+  createdAt: string;
+}
+
+export interface DemoSequenceEvent {
+  prospectId: number;
+  playName: string;
+  stepIndex: number;
+  channel: string;
+  status: string;
+  metadataJson: string;
+  receiptId: number;
+  createdAt: string;
+}
+
+export interface DemoCadence {
+  prospectId: number;
+  playName: string;
+  currentStep: number;
+  status: string;
+  enrolledAt: string;
+  nextDueAt: string | null;
+  nextStepDraftJson: string | null;
+  nextStepDraftedAt: string | null;
+}
+
+export interface DemoDataset {
+  config: Record<string, unknown>;
+  secrets: Record<string, string>;
+  prospects: DemoProspectRow[];
+  receipts: DemoReceipt[];
+  sequenceEvents: DemoSequenceEvent[];
+  cadences: DemoCadence[];
+  outcomes: Array<{
+    prospectId: number;
+    playName: string;
+    outcome: string;
+    amountUsd: number | null;
+    notes: string;
+    recordedAt: string;
+  }>;
+  queue: Array<{
+    playName: string;
+    payloadJson: string;
+    dedupeKey: string;
+    source: string;
+    status: string;
+    foundAt: string;
+    reviewedAt: string | null;
+    sentAt: string | null;
+    notes: string | null;
+    prospectId: number | null;
+    lastDraftJson: string | null;
+    lastDraftedAt: string | null;
+  }>;
+  triggers: Array<{
+    name: string;
+    lastPolledAt: string | null;
+    lastRunSummary: string | null;
+    enabled: number;
+    configJson: string;
+  }>;
+  runs: Array<{
+    playName: string;
+    dryRun: number;
+    status: string;
+    startedAt: string;
+    completedAt: string;
+    targetCount: number;
+    draftedCount: number;
+    sentCount: number;
+    errorCount: number;
+    targetsJson: string;
+    eventsJson: string;
+    prospectEmailsJson: string;
+  }>;
+  bounces: Array<{
+    messageId: string;
+    recipient: string;
+    identityId: string;
+    kind: string;
+    statusCode: string;
+    diagnostic: string;
+    prospectId: number;
+    bouncedAt: string;
+    createdAt: string;
+  }>;
+  canaries: Array<{
+    fromIdentity: string;
+    toIdentity: string;
+    placement: string;
+    labelsJson: string;
+    spf: string;
+    dkim: string;
+    dmarc: string;
+    subject: string;
+    sourcePlay: string;
+    sameDomain: number;
+    latencyMs: number;
+    createdAt: string;
+  }>;
+  senderAssignments: Array<{ email: string; identityId: string; assignedAt: string }>;
+  inboxDrafts: Array<{
+    threadKey: string;
+    inboundEmailId: string;
+    toEmail: string;
+    subject: string;
+    identityId: string;
+    body: string;
+    updatedAt: string;
+  }>;
+  inboxSent: Array<{
+    threadKey: string;
+    toEmail: string;
+    subject: string;
+    body: string;
+    identityId: string;
+    requestId: string;
+    sentAt: string;
+  }>;
+  interviews: Array<{
+    person: string;
+    transcriptPath: string | null;
+    jtbd: string;
+    painQuotesJson: string;
+    createdAt: string;
+  }>;
+  fixtures: {
+    "inbox.json": unknown;
+    "rocs-by-goal.json": unknown;
+    "domains.json": unknown;
+    "balance.json": unknown;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Builder
+// ---------------------------------------------------------------------------
+
+export function buildDemoDataset(anchor: Date): DemoDataset {
+  const prospects: DemoProspectRow[] = [];
+  const receipts: DemoReceipt[] = [];
+  const sequenceEvents: DemoSequenceEvent[] = [];
+  const cadences: DemoCadence[] = [];
+  const outcomes: DemoDataset["outcomes"] = [];
+  const senderAssignments: DemoDataset["senderAssignments"] = [];
+
+  let receiptId = 0;
+
+  PEOPLE.forEach((p, i) => {
+    const prospectId = i + 1;
+    const goalId = cadenceGoalId(p.play, p.email);
+    const valueTag = p.outcome ? outcomeValueTag(p.outcome) : null;
+    const valueTaggedAt = p.outcome ? sqlAt(anchor, p.outcome.daysAgo, 17, jitter(i)) : null;
+
+    prospects.push({
+      id: prospectId,
+      name: p.name,
+      email: p.email,
+      company: p.company,
+      linkedinUrl: p.linkedin,
+      dossierJson: JSON.stringify({
+        title: p.title,
+        company: p.company,
+        hook: p.hook,
+        source: p.source,
+      }),
+      source: p.source,
+      sourceProfileUrl: p.linkedin,
+      createdAt: sqlAt(anchor, p.daysAgo, 8, jitter(i)),
+    });
+
+    senderAssignments.push({
+      email: p.email,
+      identityId: p.identity,
+      assignedAt: sqlAt(anchor, p.daysAgo, 8, jitter(i)),
+    });
+
+    // Discovery + contact resolution, all on the day the finder surfaced them.
+    const prep: Array<{ callType: string; memo: string }> = [
+      { callType: "web.search", memo: `${p.play} — surface ${p.company} from ${p.source}` },
+      { callType: "email.find", memo: `${p.play} — resolve contact for ${p.name}` },
+      { callType: "email.verify", memo: `${p.play} — verify ${p.email} before sending` },
+      { callType: "enrich.profile", memo: `${p.play} — enrich ${p.name} for the draft` },
+    ];
+    // A deep person-research call on the higher-intent plays only, which is how
+    // the spend actually distributes: you don't pay $0.12 to research a Show HN
+    // poster whose whole pitch is in the thread.
+    if (p.play === "competitor-switch" || p.play === "podcast-guest") {
+      prep.push({ callType: "research.person", memo: `${p.play} — dossier for ${p.name}` });
+    }
+
+    prep.forEach((call, k) => {
+      receiptId += 1;
+      receipts.push({
+        id: receiptId,
+        playName: p.play,
+        callType: call.callType,
+        costUsd: COST[call.callType] ?? 0.01,
+        signedReceipt: signedReceiptFor(call.callType, p, receiptId),
+        oneshotRequestId: `req_demo_${String(receiptId).padStart(5, "0")}`,
+        senderIdentity: null,
+        memo: call.memo,
+        decisionContext: {
+          playName: p.play,
+          callType: call.callType,
+          goalId,
+          source: p.source,
+          company: p.company,
+        },
+        valueTag,
+        valueTaggedAt,
+        goalId,
+        createdAt: sqlAt(anchor, p.daysAgo, 8, jitter(i * 4 + k)),
+      });
+    });
+
+    // One send receipt + one sequence_event per step actually delivered.
+    for (let step = 0; step < p.steps; step++) {
+      const stepDaysAgo = p.daysAgo - (STEP_OFFSETS[step] ?? 0);
+      const bounced = p.status === "bounced" && step === p.steps - 1;
+      receiptId += 1;
+      const sendReceiptId = receiptId;
+      receipts.push({
+        id: sendReceiptId,
+        playName: p.play,
+        callType: "email.send",
+        costUsd: COST["email.send"] ?? 0.004,
+        signedReceipt: signedReceiptFor("email.send", p, sendReceiptId),
+        oneshotRequestId: `req_demo_${String(sendReceiptId).padStart(5, "0")}`,
+        senderIdentity: p.identity,
+        memo:
+          step === 0
+            ? `${p.play} intro to ${p.name} — ${p.hook.slice(0, 60)}`
+            : `${p.play} follow-up ${step} to ${p.name}`,
+        decisionContext: {
+          playName: p.play,
+          callType: "email.send",
+          goalId,
+          stepIndex: step,
+          senderIdentity: p.identity,
+        },
+        valueTag,
+        valueTaggedAt,
+        goalId,
+        createdAt: sqlAt(anchor, stepDaysAgo, 9, jitter(i * 3 + step)),
+      });
+
+      sequenceEvents.push({
+        prospectId,
+        playName: p.play,
+        stepIndex: step,
+        channel: "email",
+        status: bounced
+          ? "bounced"
+          : p.status === "replied" && step === p.steps - 1
+            ? "replied"
+            : "sent",
+        metadataJson: JSON.stringify({
+          subject: subjectFor(p, step),
+          body: bodyFor(p, step),
+          evidence: p.hook,
+          senderIdentity: p.identity,
+        }),
+        receiptId: sendReceiptId,
+        createdAt: sqlAt(anchor, stepDaysAgo, 9, jitter(i * 3 + step)),
+      });
+    }
+
+    cadences.push({
+      prospectId,
+      playName: p.play,
+      currentStep: p.steps - 1,
+      status: p.status,
+      enrolledAt: sqlAt(anchor, p.daysAgo, 9, jitter(i)),
+      // Only a live cadence has a next step pending; everything else is settled.
+      // Due dates fan out from two days overdue to four days out rather than
+      // deriving from the last send, which would put nearly every active row in
+      // the overdue column and make the founder look like they'd abandoned the
+      // thing. A couple of overdue rows is the honest picture: that's the
+      // founder's to-do list, and the demo scheduler won't clear it.
+      nextDueAt: p.status === "active" ? isoAt(anchor, 2 - (i % 7), 9, jitter(i)) : null,
+      nextStepDraftJson:
+        p.status === "active" && p.steps > 1
+          ? JSON.stringify({
+              subject: subjectFor(p, p.steps),
+              body: bodyFor(p, p.steps),
+              flags: [],
+              payload: { name: p.name, company: p.company, hook: p.hook },
+              draftedAt: isoAt(anchor, 1, 7, jitter(i)),
+            })
+          : null,
+      nextStepDraftedAt:
+        p.status === "active" && p.steps > 1 ? isoAt(anchor, 1, 7, jitter(i)) : null,
+    });
+
+    if (p.outcome) {
+      outcomes.push({
+        prospectId,
+        playName: p.play,
+        outcome: p.outcome.kind,
+        amountUsd: p.outcome.amountUsd ?? null,
+        notes: p.outcome.notes,
+        recordedAt: sqlAt(anchor, p.outcome.daysAgo, 17, jitter(i)),
+      });
+    }
+  });
+
+  return {
+    config: buildConfig(),
+    secrets: DEMO_SECRETS,
+    prospects,
+    receipts,
+    sequenceEvents,
+    cadences,
+    outcomes,
+    queue: buildQueue(anchor),
+    triggers: buildTriggers(anchor),
+    runs: buildRuns(anchor),
+    bounces: buildBounces(anchor, prospects),
+    canaries: buildCanaries(anchor),
+    senderAssignments,
+    inboxDrafts: buildInboxDrafts(anchor),
+    inboxSent: buildInboxSent(anchor),
+    interviews: buildInterviews(anchor),
+    fixtures: {
+      "inbox.json": buildInboxFixture(anchor),
+      "rocs-by-goal.json": buildRocsFixture(receipts),
+      "domains.json": buildDomainsFixture(anchor),
+      "balance.json": { balance: "41.86 USDC", raw: "41.86 USDC" },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Config + secrets
+// ---------------------------------------------------------------------------
+
+// Deliberately non-functional. They exist so `doctor`'s pure-env checks
+// (llmApiKey, oneshotEnvReady) read green without a network call, and so an
+// accidental Run click fails at auth instead of spending real money.
+const DEMO_SECRETS: Record<string, string> = {
+  OPENROUTER_API_KEY: "sk-or-v1-demo-not-a-real-key-do-not-use",
+  AGENT_PRIVATE_KEY: "0xdemo0000000000000000000000000000000000000000000000000000000000",
+};
+
+function buildConfig(): Record<string, unknown> {
+  return {
+    walletMode: "private-key",
+    llmProvider: "openrouter",
+    llmModel: "anthropic/claude-sonnet-4.6",
+    telemetryEnabled: false,
+    founderName: DEMO_FOUNDER.name,
+    founderEmail: DEMO_FOUNDER.email,
+    productOneLiner: DEMO_FOUNDER.oneLiner,
+    productDomain: DEMO_FOUNDER.productDomain,
+    sendingDomain: DEMO_FOUNDER.sendingDomain,
+    emailProvider: "oneshot",
+    emailIdentities: IDENTITIES,
+    icpOneLiner: DEMO_FOUNDER.icp,
+    cadenceOverrides: { "show-hn": [3, 7] },
+    founderCredentials: "Ran platform reliability at a 400-engineer infra company before this.",
+    productPortfolio: "Tracepoint — used by 60+ teams to trace background jobs end to end.",
+    partners: "Built on OpenTelemetry; ships adapters for Sidekiq, Celery, BullMQ and Temporal.",
+    mobileSignature: false,
+    clientId: "demo-00000000-0000-4000-8000-000000000000",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Copy
+// ---------------------------------------------------------------------------
+
+function subjectFor(p: DemoPerson, step: number): string {
+  if (step === 0) return `${p.company} + background job traces`;
+  if (step === 1) return `Re: ${p.company} + background job traces`;
+  return `Closing the loop, ${p.name.split(" ")[0] ?? p.name}`;
+}
+
+function bodyFor(p: DemoPerson, step: number): string {
+  const first = p.name.split(" ")[0] ?? p.name;
+  if (step === 0) {
+    return [
+      `Hey ${first},`,
+      "",
+      `${p.hook}`,
+      "",
+      "I built Tracepoint because I kept hitting the same wall: the job failed, the logs are fine, and there is no trace to follow. It drops into a worker with one import and no sidecar.",
+      "",
+      "Worth fifteen minutes?",
+      "",
+      "Mira",
+    ].join("\n");
+  }
+  if (step === 1) {
+    return [
+      `Hey ${first},`,
+      "",
+      `One concrete thing since last week: retries now inherit the parent span, so a job that succeeds on attempt four still shows you what attempts one through three did.`,
+      "",
+      `That is the part ${p.company} would feel first.`,
+      "",
+      "Mira",
+    ].join("\n");
+  }
+  return [
+    `Hey ${first},`,
+    "",
+    "I will stop here so I am not clogging your inbox. If background job visibility becomes a problem worth solving this quarter, reply to this and I will pick it back up.",
+    "",
+    "Mira",
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Signed receipts
+// ---------------------------------------------------------------------------
+
+function signedReceiptFor(callType: string, p: DemoPerson, id: number): unknown {
+  const base = {
+    receipt_id: `rcpt_demo_${String(id).padStart(5, "0")}`,
+    request_id: `req_demo_${String(id).padStart(5, "0")}`,
+    status: "completed",
+    settlement: {
+      network: "base",
+      asset: "USDC",
+      amount: String(COST[callType] ?? 0.01),
+      tx_hash: `0xdemo${String(id).padStart(6, "0")}`,
+    },
+  };
+  if (callType === "email.send") {
+    return {
+      ...base,
+      email: {
+        id: `msg_demo_${String(id).padStart(5, "0")}`,
+        provider_message_id: `<demo-${id}@tracepoint.email>`,
+        status: "sent",
+      },
+      to: p.email,
+    };
+  }
+  return { ...base, subject_ref: p.email };
+}
+
+function outcomeValueTag(outcome: NonNullable<DemoPerson["outcome"]>): unknown {
+  switch (outcome.kind) {
+    case "meeting_booked":
+      return { type: "meeting", label: "meeting booked" };
+    case "sql_qualified":
+      return { type: "qualified", label: "SQL qualified" };
+    case "deal_won":
+      return { type: "revenue", amount: outcome.amountUsd, label: "deal won" };
+    default:
+      return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Queue
+// ---------------------------------------------------------------------------
+
+function buildQueue(anchor: Date): DemoDataset["queue"] {
+  // Rows the finders surfaced but that haven't shipped yet — the founder's
+  // actual inbox of work. A mix of statuses so every filter chip has something
+  // behind it, and drafts on the approved rows so the preview expands.
+  const pending = [
+    {
+      play: "show-hn",
+      source: "show-hn",
+      payload: {
+        postTitle: "Show HN: Halyard — deterministic replay for distributed workers",
+        postUrl: "https://news.ycombinator.com/item?id=41200011",
+        founderName: "Tom Whitfield",
+        founderEmail: "tom@halyard.dev",
+        hookSummary:
+          "Thread argues replay is only useful if you captured the span in the first place; Tom concedes the point.",
+      },
+      daysAgo: 0,
+    },
+    {
+      play: "show-hn",
+      source: "show-hn",
+      payload: {
+        postTitle: "Show HN: Cutter — a job queue that refuses to lose work",
+        postUrl: "https://news.ycombinator.com/item?id=41200042",
+        founderName: "Ida Sorensen",
+        founderEmail: "ida@cutter.works",
+        hookSummary:
+          "Front page in 40 minutes; the top comment asks how you debug a stuck consumer.",
+      },
+      daysAgo: 0,
+    },
+    {
+      play: "post-funding",
+      source: "post-funding-auto",
+      payload: {
+        name: "Gabriel Okafor",
+        email: "gabriel@ridgeline.systems",
+        company: "Ridgeline",
+        round: "Seed",
+        amount: "$4.2M",
+        announcementUrl: "https://example.com/ridgeline-seed",
+      },
+      daysAgo: 1,
+    },
+    {
+      play: "hiring-signal",
+      source: "hiring-signal",
+      payload: {
+        name: "Clara Bianchi",
+        email: "clara@spindrift.dev",
+        company: "Spindrift",
+        role: "Founding Reliability Engineer",
+        jobUrl: "https://jobs.ashbyhq.com/spindrift/example",
+        yourClaim: "Tracepoint gives a new reliability hire a map of the async system in week one.",
+      },
+      daysAgo: 2,
+    },
+    {
+      play: "podcast-guest",
+      source: "podcast-guest",
+      payload: {
+        name: "Victor Aalto",
+        email: "victor@lodestar.build",
+        company: "Lodestar",
+        podcast: "Latent Space",
+        episodeTitle: "Shipping agents that recover",
+        hookQuote:
+          "At 22:10 you said the hard part is not the failure, it is reconstructing what the agent did before it failed.",
+        bridge: "That reconstruction is literally the product.",
+      },
+      daysAgo: 2,
+    },
+  ];
+
+  const approved = [
+    {
+      play: "job-change",
+      source: "job-change",
+      payload: {
+        name: "Noor Farouk",
+        email: "noor@brightkiln.io",
+        newRole: "VP Engineering",
+        newCompany: "Brightkiln",
+        previousRole: "Director of Platform",
+        previousCompany: "Datadog",
+        linkedinUrl: "https://linkedin.com/in/noor-farouk-fake",
+      },
+      daysAgo: 1,
+      draft: {
+        subject: "Brightkiln + background job traces",
+        body: "Hey Noor,\n\nYou came from a place where tracing was a given. Brightkiln's queue workers almost certainly are not instrumented yet, and the first eight weeks is when you get to decide that.\n\nTracepoint drops into a worker with one import, no sidecar, no sampling.\n\nWorth fifteen minutes?\n\nMira",
+      },
+    },
+    {
+      play: "competitor-switch",
+      source: "competitor-switch",
+      payload: {
+        name: "Grace Odum",
+        email: "grace@fathomline.ai",
+        company: "Fathomline",
+        competitor: "per-host APM",
+        evidenceUrl: "https://example.com/fathomline-postmortem",
+        yourEdge: "Per-job pricing, so nobody turns off tracing on the worker fleet to save money.",
+      },
+      daysAgo: 3,
+      draft: {
+        subject: "The line in your postmortem about turning off tracing",
+        body: "Hey Grace,\n\nYour postmortem says you disabled tracing on the worker fleet because per-host pricing made it untenable, and then the next incident took six hours to reconstruct. Those two sentences are the whole pitch.\n\nTracepoint prices per job, not per host.\n\nWorth a look?\n\nMira",
+      },
+    },
+  ];
+
+  const rows: DemoDataset["queue"] = [];
+
+  pending.forEach((r, i) => {
+    rows.push({
+      playName: r.play,
+      payloadJson: JSON.stringify(r.payload),
+      dedupeKey: `demo-pending-${i}`,
+      source: r.source,
+      status: "pending",
+      foundAt: sqlAt(anchor, r.daysAgo, 6, jitter(i)),
+      reviewedAt: null,
+      sentAt: null,
+      notes: null,
+      prospectId: null,
+      lastDraftJson: null,
+      lastDraftedAt: null,
+    });
+  });
+
+  approved.forEach((r, i) => {
+    rows.push({
+      playName: r.play,
+      payloadJson: JSON.stringify(r.payload),
+      dedupeKey: `demo-approved-${i}`,
+      source: r.source,
+      status: "approved",
+      foundAt: sqlAt(anchor, r.daysAgo, 6, jitter(i)),
+      reviewedAt: isoAt(anchor, r.daysAgo, 18, jitter(i)),
+      sentAt: null,
+      notes: null,
+      prospectId: null,
+      lastDraftJson: JSON.stringify({
+        subject: r.draft.subject,
+        body: r.draft.body,
+        flags: [],
+        sent: false,
+        receiptIds: [],
+        dryRun: false,
+        draftedAt: isoAt(anchor, r.daysAgo, 18, jitter(i)),
+      }),
+      lastDraftedAt: isoAt(anchor, r.daysAgo, 18, jitter(i)),
+    });
+  });
+
+  // A rejected row, so the reject filter isn't a dead chip and the ICP filter
+  // visibly has teeth.
+  rows.push({
+    playName: "show-hn",
+    payloadJson: JSON.stringify({
+      postTitle: "Show HN: a Chrome extension that summarises your tabs",
+      postUrl: "https://news.ycombinator.com/item?id=41200099",
+      founderName: "Rick Alvarez",
+      founderEmail: "rick@tabsummary.app",
+      hookSummary: "Consumer browser extension, no backend workers, no queue.",
+    }),
+    dedupeKey: "demo-rejected-0",
+    source: "show-hn",
+    status: "rejected",
+    foundAt: sqlAt(anchor, 2, 6, 11),
+    reviewedAt: isoAt(anchor, 2, 7, 3),
+    sentAt: null,
+    notes: "Out of ICP — consumer extension, no background job surface.",
+    prospectId: null,
+    lastDraftJson: null,
+    lastDraftedAt: null,
+  });
+
+  // Two already shipped, matching prospects that exist above.
+  const sentRows: Array<{
+    play: string;
+    source: string;
+    email: string;
+    name: string;
+    prospectId: number;
+    daysAgo: number;
+  }> = [
+    {
+      play: "show-hn",
+      source: "show-hn",
+      email: "elin@northport.works",
+      name: "Elin Dahl",
+      prospectId: 19,
+      daysAgo: 1,
+    },
+    {
+      play: "post-funding",
+      source: "post-funding-auto",
+      email: "ravi@stanchion.dev",
+      name: "Ravi Menon",
+      prospectId: 18,
+      daysAgo: 2,
+    },
+  ];
+  sentRows.forEach((r, i) => {
+    rows.push({
+      playName: r.play,
+      payloadJson: JSON.stringify({ name: r.name, email: r.email }),
+      dedupeKey: `demo-sent-${i}`,
+      source: r.source,
+      status: "sent",
+      foundAt: sqlAt(anchor, r.daysAgo, 6, jitter(i)),
+      reviewedAt: isoAt(anchor, r.daysAgo, 8, jitter(i)),
+      sentAt: isoAt(anchor, r.daysAgo, 9, jitter(i)),
+      notes: null,
+      prospectId: r.prospectId,
+      lastDraftJson: null,
+      lastDraftedAt: null,
+    });
+  });
+
+  return rows;
+}
+
+// ---------------------------------------------------------------------------
+// Triggers
+// ---------------------------------------------------------------------------
+
+function buildTriggers(anchor: Date): DemoDataset["triggers"] {
+  // Config values mirror each finder's defaultConfig shape in
+  // packages/find/src/registry.ts, tuned to this founder's ICP.
+  //
+  // Enabled triggers are polled MINUTES before the anchor, not at a fixed hour.
+  // The dashboard derives "next due" as last_polled_at + interval and flags
+  // anything past due as overdue — and the demo scheduler is idle, so nothing
+  // will ever clear that flag. Recent polls (against 6h–24h intervals) keep the
+  // strip reading "due in 5h" instead of a wall of red. This is why `--now`
+  // defaults to seed time: film soon after seeding.
+  return [
+    {
+      name: "show-hn",
+      lastPolledAt: isoMinutesAgo(anchor, 18),
+      lastRunSummary: JSON.stringify({ scanned: 31, enqueued: 3, rejected: 12, costUsd: 0.41 }),
+      enabled: 1,
+      configJson: JSON.stringify({ sinceDays: 1, limit: 25, maxCostUsd: 5 }),
+    },
+    {
+      name: "post-funding-auto",
+      lastPolledAt: isoMinutesAgo(anchor, 46),
+      lastRunSummary: JSON.stringify({ scanned: 18, enqueued: 1, rejected: 9, costUsd: 0.27 }),
+      enabled: 1,
+      configJson: JSON.stringify({
+        autoRounds: ["Seed", "Series A"],
+        autoIndustry: "developer tools and AI infrastructure",
+        autoSinceDays: 7,
+        limit: 25,
+        maxCostUsd: 5,
+      }),
+    },
+    {
+      name: "hiring-signal",
+      lastPolledAt: isoMinutesAgo(anchor, 190),
+      lastRunSummary: JSON.stringify({ scanned: 44, enqueued: 1, rejected: 21, costUsd: 0.33 }),
+      enabled: 1,
+      configJson: JSON.stringify({
+        roles: ["Founding Reliability Engineer", "Staff SRE", "Platform Engineer"],
+        yourClaim:
+          "Tracepoint gives a new reliability hire a map of the async system in week one instead of month three.",
+        sinceDays: 14,
+        limit: 25,
+        maxCostUsd: 5,
+      }),
+    },
+    {
+      name: "podcast-guest",
+      lastPolledAt: isoMinutesAgo(anchor, 320),
+      lastRunSummary: JSON.stringify({ scanned: 12, enqueued: 1, rejected: 6, costUsd: 0.19 }),
+      enabled: 1,
+      configJson: JSON.stringify({
+        podcasts: ["Latent Space", "Lenny's Podcast", "20VC"],
+        sinceDays: 21,
+        skipRead: false,
+        limit: 25,
+        maxCostUsd: 5,
+      }),
+    },
+    {
+      name: "github-stars",
+      lastPolledAt: isoMinutesAgo(anchor, 125),
+      lastRunSummary: JSON.stringify({ scanned: 96, enqueued: 0, rejected: 38, costUsd: 0.12 }),
+      enabled: 1,
+      configJson: JSON.stringify({
+        repos: [
+          { repo: "open-telemetry/opentelemetry-js", rel: "adjacent", label: "OTel JS" },
+          {
+            repo: "example/job-queue-instrumentation",
+            rel: "adjacent",
+            label: "queue instrumentation",
+          },
+        ],
+        yourEdge:
+          "Span context that survives retries, which OTel worker instrumentation still drops.",
+        sinceDays: 30,
+        limit: 25,
+        maxCostUsd: 5,
+      }),
+    },
+    {
+      name: "job-change",
+      lastPolledAt: isoAt(anchor, 3, 6, 30),
+      lastRunSummary: JSON.stringify({ scanned: 27, enqueued: 1, rejected: 14, costUsd: 0.22 }),
+      enabled: 0,
+      configJson: JSON.stringify({
+        personas: ["VP Engineering", "Head of Platform", "Director of Engineering"],
+        sinceDays: 14,
+        limit: 25,
+        maxCostUsd: 5,
+      }),
+    },
+    {
+      name: "luma-events",
+      lastPolledAt: isoAt(anchor, 4, 6, 15),
+      lastRunSummary: JSON.stringify({ scanned: 9, enqueued: 2, rejected: 4, costUsd: 0.16 }),
+      enabled: 0,
+      configJson: JSON.stringify({
+        topics: ["AI infrastructure", "platform engineering"],
+        cities: ["San Francisco", "Berlin"],
+        sinceDays: 14,
+        yourEdge: "Tracing that works on background jobs, not just web requests.",
+        limit: 25,
+        maxCostUsd: 5,
+      }),
+    },
+    // Deliberately left unconfigured, so the dashboard shows a real
+    // "not ready" trigger with its toggle disabled and the reason attached.
+    {
+      name: "github-topics",
+      lastPolledAt: null,
+      lastRunSummary: null,
+      enabled: 0,
+      configJson: JSON.stringify({
+        topics: [],
+        vendors: [],
+        directCompetitors: [],
+        yourEdge: "",
+        minStars: 5,
+        maxAgeDays: 90,
+        minVendors: 1,
+        concurrency: 3,
+      }),
+    },
+    {
+      name: "breakup-revive",
+      lastPolledAt: isoAt(anchor, 6, 6, 0),
+      lastRunSummary: JSON.stringify({ scanned: 24, enqueued: 0, rejected: 0, costUsd: 0 }),
+      enabled: 0,
+      configJson: JSON.stringify({ minDays: 60, maxDays: 90, limit: 25 }),
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Runs
+// ---------------------------------------------------------------------------
+
+function buildRuns(anchor: Date): DemoDataset["runs"] {
+  const targets = [
+    { name: "Elin Dahl", email: "elin@northport.works", company: "Northport" },
+    { name: "Ravi Menon", email: "ravi@stanchion.dev", company: "Stanchion" },
+  ];
+  const events = [
+    { kind: "runStarted", runId: 1, startedAt: isoAt(anchor, 1, 9, 0) },
+    { kind: "verify", total: 2, verified: 2, dropped: [] },
+    { kind: "stage", stage: "drafting" },
+    {
+      kind: "draft",
+      index: 0,
+      subject: "Northport + background job traces",
+      body: "Hey Elin,\n\nThe top comment on your Show HN asks how you debug a stuck run, and your answer was basically 'carefully'. That is the gap Tracepoint fills.\n\nWorth fifteen minutes?\n\nMira",
+      flags: [],
+    },
+    { kind: "send", index: 0, receiptIds: [1] },
+    {
+      kind: "draft",
+      index: 1,
+      subject: "Stanchion + background job traces",
+      body: "Hey Ravi,\n\nGoing from three to eleven engineers is exactly when the async parts of the system stop fitting in one person's head.\n\nTracepoint drops into a worker with one import.\n\nMira",
+      flags: [],
+    },
+    { kind: "send", index: 1, receiptIds: [2] },
+    { kind: "done", total: 2, sent: 2 },
+  ];
+
+  return [
+    {
+      playName: "show-hn",
+      dryRun: 0,
+      status: "done",
+      startedAt: isoAt(anchor, 1, 9, 0),
+      completedAt: isoAt(anchor, 1, 9, 4),
+      targetCount: 2,
+      draftedCount: 2,
+      sentCount: 2,
+      errorCount: 0,
+      targetsJson: JSON.stringify(targets),
+      eventsJson: JSON.stringify(events),
+      prospectEmailsJson: JSON.stringify(targets.map((t) => t.email)),
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Deliverability
+// ---------------------------------------------------------------------------
+
+function buildBounces(anchor: Date, prospects: DemoProspectRow[]): DemoDataset["bounces"] {
+  const byEmail = (email: string): number => prospects.find((p) => p.email === email)?.id ?? 0;
+  return [
+    {
+      messageId: "<demo-bounce-1@tracepoint.email>",
+      recipient: "ana@driftline.ai",
+      identityId: IDENTITY_SECOND,
+      kind: "hard",
+      statusCode: "5.1.1",
+      diagnostic: "550 5.1.1 The email account that you tried to reach does not exist.",
+      prospectId: byEmail("ana@driftline.ai"),
+      bouncedAt: isoAt(anchor, 15, 9, 12),
+      createdAt: sqlAt(anchor, 15, 9, 20),
+    },
+    {
+      messageId: "<demo-bounce-2@tracepoint.email>",
+      recipient: "piotr@grainline.dev",
+      identityId: IDENTITY_SECOND,
+      kind: "soft",
+      statusCode: "4.2.2",
+      diagnostic: "452 4.2.2 The recipient's mailbox is over its storage limit.",
+      prospectId: byEmail("piotr@grainline.dev"),
+      bouncedAt: isoAt(anchor, 13, 9, 30),
+      createdAt: sqlAt(anchor, 13, 9, 38),
+    },
+  ];
+}
+
+function buildCanaries(anchor: Date): DemoDataset["canaries"] {
+  return [
+    {
+      fromIdentity: IDENTITY_PRIMARY,
+      toIdentity: IDENTITY_WARMING,
+      placement: "inbox",
+      labelsJson: JSON.stringify(["INBOX", "CATEGORY_PERSONAL"]),
+      spf: "pass",
+      dkim: "pass",
+      dmarc: "pass",
+      subject: "placement canary — tracepoint.email → trace-mail.dev",
+      sourcePlay: "show-hn",
+      // Cross-domain, which is the only configuration that yields a verdict
+      // worth reporting — a same-domain canary tells you nothing about how a
+      // stranger's mail server files your mail.
+      sameDomain: 0,
+      latencyMs: 3120,
+      createdAt: sqlAt(anchor, 4, 11, 5),
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Inbox
+// ---------------------------------------------------------------------------
+
+/** Everyone in the cast who replied, in the order the fixture should list them. */
+function repliers(): DemoPerson[] {
+  return PEOPLE.filter((p) => p.reply != null).toSorted(
+    (a, b) => (a.reply?.daysAgo ?? 0) - (b.reply?.daysAgo ?? 0),
+  );
+}
+
+function buildInboxFixture(anchor: Date): unknown {
+  const emails = repliers().map((p, i) => {
+    const r = p.reply as NonNullable<DemoPerson["reply"]>;
+    return {
+      id: `email_demo_${String(i + 1).padStart(4, "0")}`,
+      from: `${p.name} <${p.email}>`,
+      subject: r.subject,
+      received_at: isoAt(anchor, r.daysAgo, r.hour, jitter(i)),
+      thread_id: `thread_demo_${String(i + 1).padStart(4, "0")}`,
+      body: r.body,
+      source_identity_id: p.identity,
+      message_id: `<reply-${i + 1}@${p.email.split("@")[1] ?? "example.dev"}>`,
+    };
+  });
+
+  // One unmatched message so the match filter on /inbox has both sides. It maps
+  // to no prospect, which is what the "no-match" chip is for.
+  emails.push({
+    id: "email_demo_0099",
+    from: "The Pragmatic Engineer <newsletter@example-news.dev>",
+    subject: "Issue 214: what on-call actually costs",
+    received_at: isoAt(anchor, 2, 7, 15),
+    thread_id: "thread_demo_0099",
+    body: "This week: the hidden cost of on-call rotations, and why incident review meetings keep getting cancelled.",
+    source_identity_id: IDENTITY_PRIMARY,
+    message_id: "<issue-214@example-news.dev>",
+  });
+
+  emails.sort((a, b) => (a.received_at < b.received_at ? 1 : -1));
+  return { emails, count: emails.length, has_more: false, agent_id: "agent_demo" };
+}
+
+function buildInboxDrafts(anchor: Date): DemoDataset["inboxDrafts"] {
+  // One reply half-written, so the composer opens with content rather than a
+  // blank box.
+  return [
+    {
+      threadKey: "thread_demo_0002",
+      inboundEmailId: "email_demo_0002",
+      toEmail: "dmitri@cascade.systems",
+      subject: "Re: reliability as the year's focus",
+      identityId: IDENTITY_PRIMARY,
+      body: "Hey Dmitri,\n\nNext week works. Send me two slots and I will make either one. Happy to have your SRE dig in — the retry span linking is the part that usually gets the hard questions, so I will lead with it.\n\nMira",
+      updatedAt: sqlAt(anchor, 9, 10, 12),
+    },
+  ];
+}
+
+function buildInboxSent(anchor: Date): DemoDataset["inboxSent"] {
+  return [
+    {
+      threadKey: "thread_demo_0001",
+      toEmail: "aisha@tidewater.build",
+      subject: "Re: 'find out on Monday what broke on Saturday'",
+      body: "Hey Aisha,\n\nPricing is per job, not per host — attached. For a Saturday batch run of your size it lands around $600/mo, and you can point it at that one pipeline before touching anything else.\n\nMira",
+      identityId: IDENTITY_PRIMARY,
+      requestId: "req_demo_reply_0001",
+      sentAt: sqlAt(anchor, 17, 12, 30),
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Interviews
+// ---------------------------------------------------------------------------
+
+function buildInterviews(anchor: Date): DemoDataset["interviews"] {
+  return [
+    {
+      person: "Priya Shah (Northstar AI)",
+      transcriptPath: null,
+      jtbd: "When a nightly job fails, reconstruct what it did without re-running it.",
+      painQuotesJson: JSON.stringify([
+        "The traces we lose are the ones from the runs that failed.",
+        "We turned sampling up after the incident and turned it back down when the bill came.",
+      ]),
+      createdAt: sqlAt(anchor, 19, 15, 0),
+    },
+    {
+      person: "Kwame Mensah (Triacore)",
+      transcriptPath: null,
+      jtbd: "See which retry attempt actually did the damage.",
+      painQuotesJson: JSON.stringify([
+        "Attempt four succeeded, so as far as the dashboard is concerned nothing happened.",
+      ]),
+      createdAt: sqlAt(anchor, 12, 16, 30),
+    },
+  ];
+}
+
+// ---------------------------------------------------------------------------
+// Platform RoCS rollup
+// ---------------------------------------------------------------------------
+
+function buildRocsFixture(receipts: DemoReceipt[]): unknown {
+  // Derived from the receipts we just wrote, so the platform rollup and the
+  // local ledger agree — the goalIds match, and so does the spend.
+  const byGoal = new Map<
+    string,
+    { spend: number; count: number; value: number; tagged: boolean }
+  >();
+  for (const r of receipts) {
+    const entry = byGoal.get(r.goalId) ?? { spend: 0, count: 0, value: 0, tagged: false };
+    entry.spend += r.costUsd;
+    entry.count += 1;
+    const tag = r.valueTag as { type?: string; amount?: number } | null;
+    if (tag) {
+      entry.tagged = true;
+      // Only closed revenue carries a dollar value. A booked meeting is real
+      // progress but it is not money, and inventing a number for it would
+      // inflate every RoCS figure on the Measure page — exactly the estimated,
+      // dashboard-shaped accounting this tool exists to avoid. One value per
+      // goal, not per receipt: the platform records the outcome once and fans
+      // it across the goal's receipts.
+      if (tag.type === "revenue" && typeof tag.amount === "number") entry.value = tag.amount;
+    }
+    byGoal.set(r.goalId, entry);
+  }
+
+  // Every goal with an outcome, valued or not. The zero-value rows are the
+  // honest half of the picture: spend that has produced a meeting and nothing
+  // banked yet.
+  return Array.from(byGoal.entries())
+    .filter(([, v]) => v.tagged)
+    .map(([goalId, v]) => ({
+      goalId,
+      spend: Number(v.spend.toFixed(4)),
+      value: v.value,
+      pendingValue: 0,
+      rocs: v.value > 0 ? Number((v.value / v.spend).toFixed(1)) : 0,
+      receiptCount: v.count,
+    }));
+}
+
+// ---------------------------------------------------------------------------
+// Domain pool
+// ---------------------------------------------------------------------------
+
+function buildDomainsFixture(anchor: Date): unknown {
+  return [
+    {
+      domain: "tracepoint.email",
+      pool_status: "active",
+      provisioning_status: "provisioned",
+      warmup_score: 87,
+      warmup_started_at: isoAt(anchor, 54, 12, 0),
+      daily_send_limit: 50,
+      daily_sent_count: 6,
+      daily_sent_date: isoAt(anchor, 0, 0, 0).slice(0, 10),
+      last_used_at: isoAt(anchor, 0, 9, 12),
+    },
+    {
+      domain: "trace-mail.dev",
+      pool_status: "warming",
+      provisioning_status: "provisioned",
+      warmup_score: 34,
+      warmup_started_at: isoAt(anchor, 11, 12, 0),
+      daily_send_limit: 20,
+      daily_sent_count: 2,
+      daily_sent_date: isoAt(anchor, 0, 0, 0).slice(0, 10),
+      last_used_at: isoAt(anchor, 6, 9, 30),
+    },
+  ];
+}

--- a/apps/cli/src/demo/seed.ts
+++ b/apps/cli/src/demo/seed.ts
@@ -1,0 +1,401 @@
+import { Database } from "bun:sqlite";
+import { chmodSync, existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+import { Ledger } from "@oneshot-gtm/core";
+import { buildDemoDataset, type DemoDataset } from "./dataset.ts";
+
+/** Written into every demo home. `demo reset` refuses to delete a dir without it. */
+export const DEMO_MARKER = ".demo-home";
+
+export const DEFAULT_DEMO_HOME = join(homedir(), ".oneshot-gtm-demo");
+
+/** The real install. Seeding into it would overwrite a working config and ledger. */
+function realHome(): string {
+  return join(homedir(), ".oneshot-gtm");
+}
+
+export class DemoSeedError extends Error {}
+
+/**
+ * Every table a seed touches, cleared before it writes. Includes the caches and
+ * retry queues the demo never populates — leftovers there would let a stale
+ * enrichment or a pending candidate from an earlier run surface on screen.
+ */
+const SEEDED_TABLES = [
+  "receipts",
+  "prospects",
+  "sequence_events",
+  "interviews",
+  "cadence_state",
+  "deal_outcomes",
+  "target_queue",
+  "triggers",
+  "enrichment_cache",
+  "linkedin_lookup_cache",
+  "runs",
+  "sender_assignments",
+  "inbox_drafts",
+  "inbox_sent",
+  "pending_resolution",
+  "bounces",
+  "canary_results",
+] as const;
+
+export interface SeedResult {
+  home: string;
+  anchor: Date;
+  counts: Record<string, number>;
+}
+
+/**
+ * Build a complete, self-contained demo install at `home`.
+ *
+ * Deliberately does NOT use `saveConfig()` or `getLedger()`. `CONFIG_DIR` is
+ * captured at module load (packages/core/src/config.ts), so in this process both
+ * point at the founder's REAL home — the whole point of the demo is that it
+ * never touches that. Everything here is written through explicit paths.
+ */
+export function seedDemoHome(opts: { home?: string; anchor?: Date; force?: boolean }): SeedResult {
+  const home = resolve(opts.home ?? DEFAULT_DEMO_HOME);
+  const anchor = opts.anchor ?? new Date();
+
+  if (home === resolve(realHome())) {
+    throw new DemoSeedError(
+      `refusing to seed into your real install (${home}). Pass --home with a different directory.`,
+    );
+  }
+  if (process.env["ONESHOT_GTM_HOME"] && home === resolve(process.env["ONESHOT_GTM_HOME"])) {
+    throw new DemoSeedError(
+      `refusing to seed into the active ONESHOT_GTM_HOME (${home}). Pass --home with a different directory.`,
+    );
+  }
+
+  const alreadySeeded = existsSync(join(home, DEMO_MARKER));
+  if (existsSync(home) && readdirSync(home).length > 0 && !alreadySeeded && !opts.force) {
+    throw new DemoSeedError(
+      `${home} is not empty and has no ${DEMO_MARKER} marker. Re-run with --force to overwrite it.`,
+    );
+  }
+
+  const data = buildDemoDataset(anchor);
+
+  mkdirSync(home, { recursive: true });
+  mkdirSync(join(home, "demo"), { recursive: true });
+
+  const dbPath = join(home, "ledger.sqlite");
+
+  writeFileSync(join(home, "config.json"), `${JSON.stringify(data.config, null, 2)}\n`);
+
+  const env = Object.entries(data.secrets)
+    .map(([k, v]) => `${k}=${v}`)
+    .join("\n");
+  writeFileSync(
+    join(home, ".env"),
+    `# Demo install — these are placeholders and cannot authenticate.\n${env}\n`,
+  );
+  chmodSync(join(home, ".env"), 0o600);
+
+  for (const [name, value] of Object.entries(data.fixtures)) {
+    writeFileSync(join(home, "demo", name), `${JSON.stringify(value, null, 2)}\n`);
+  }
+
+  writeFileSync(
+    join(home, DEMO_MARKER),
+    `seeded by oneshot-gtm demo seed\nanchor=${anchor.toISOString()}\n`,
+  );
+
+  const counts = writeLedger(dbPath, data);
+
+  return { home, anchor, counts };
+}
+
+/**
+ * Open the ledger once through `Ledger` so `migrate()` builds the real schema,
+ * then write rows with raw SQL.
+ *
+ * Raw SQL is not a shortcut here. `created_at` and its siblings are filled by a
+ * `datetime('now')` column DEFAULT and no public method accepts a value for
+ * them, so backdated history — which is what makes the Home KPIs, the Measure
+ * ranges and the Receipts day-groups render at all — can only be written
+ * directly. Tests use the same escape hatch (packages/core/__tests__/send-routing.test.ts).
+ *
+ * A re-seed clears the tables rather than deleting the file. Deleting it would
+ * strand the open handle of a dashboard already running against this home —
+ * every page would go blank and doctor would read `ledger fail` until the server
+ * restarted. Truncating in place means you can re-seed mid-session and just
+ * refresh the browser.
+ */
+function writeLedger(dbPath: string, data: DemoDataset): Record<string, number> {
+  const migrator = new Ledger(dbPath);
+  migrator.close();
+
+  const db = new Database(dbPath);
+  const counts: Record<string, number> = {};
+
+  try {
+    db.exec("BEGIN");
+
+    for (const table of SEEDED_TABLES) {
+      db.prepare(`DELETE FROM ${table}`).run();
+    }
+    // Reset AUTOINCREMENT counters so a re-seed reproduces the same row ids —
+    // receipt #5 has to stay receipt #5 across takes.
+    db.prepare(
+      `DELETE FROM sqlite_sequence WHERE name IN (${SEEDED_TABLES.map(() => "?").join(", ")})`,
+    ).run(...SEEDED_TABLES);
+
+    const insertProspect = db.prepare(
+      `INSERT INTO prospects (id, name, email, company, linkedin_url, dossier_json, source, source_profile_url, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (const p of data.prospects) {
+      insertProspect.run(
+        p.id,
+        p.name,
+        p.email,
+        p.company,
+        p.linkedinUrl,
+        p.dossierJson,
+        p.source,
+        p.sourceProfileUrl,
+        p.createdAt,
+      );
+    }
+    counts["prospects"] = data.prospects.length;
+
+    const insertReceipt = db.prepare(
+      `INSERT INTO receipts (id, play_name, call_type, cost_usd, signed_receipt, oneshot_request_id, sender_identity, memo, decision_context, value_tag, value_tagged_at, goal_id, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (const r of data.receipts) {
+      insertReceipt.run(
+        r.id,
+        r.playName,
+        r.callType,
+        r.costUsd,
+        JSON.stringify(r.signedReceipt),
+        r.oneshotRequestId,
+        r.senderIdentity,
+        r.memo,
+        JSON.stringify(r.decisionContext),
+        r.valueTag ? JSON.stringify(r.valueTag) : null,
+        r.valueTag ? r.valueTaggedAt : null,
+        r.goalId,
+        r.createdAt,
+      );
+    }
+    counts["receipts"] = data.receipts.length;
+
+    const insertEvent = db.prepare(
+      `INSERT INTO sequence_events (prospect_id, play_name, step_index, channel, status, metadata_json, receipt_id, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (const e of data.sequenceEvents) {
+      insertEvent.run(
+        e.prospectId,
+        e.playName,
+        e.stepIndex,
+        e.channel,
+        e.status,
+        e.metadataJson,
+        e.receiptId,
+        e.createdAt,
+      );
+    }
+    counts["sequence_events"] = data.sequenceEvents.length;
+
+    const insertCadence = db.prepare(
+      `INSERT INTO cadence_state (prospect_id, play_name, current_step, status, enrolled_at, next_due_at, next_step_draft_json, next_step_drafted_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (const c of data.cadences) {
+      insertCadence.run(
+        c.prospectId,
+        c.playName,
+        c.currentStep,
+        c.status,
+        c.enrolledAt,
+        c.nextDueAt,
+        c.nextStepDraftJson,
+        c.nextStepDraftedAt,
+      );
+    }
+    counts["cadence_state"] = data.cadences.length;
+
+    const insertOutcome = db.prepare(
+      `INSERT INTO deal_outcomes (prospect_id, play_name, outcome, amount_usd, notes, recorded_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+    );
+    for (const o of data.outcomes) {
+      insertOutcome.run(o.prospectId, o.playName, o.outcome, o.amountUsd, o.notes, o.recordedAt);
+    }
+    counts["deal_outcomes"] = data.outcomes.length;
+
+    const insertQueue = db.prepare(
+      `INSERT INTO target_queue (play_name, payload_json, dedupe_key, source, status, found_at, reviewed_at, sent_at, notes, prospect_id, last_draft_json, last_drafted_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (const q of data.queue) {
+      insertQueue.run(
+        q.playName,
+        q.payloadJson,
+        q.dedupeKey,
+        q.source,
+        q.status,
+        q.foundAt,
+        q.reviewedAt,
+        q.sentAt,
+        q.notes,
+        q.prospectId,
+        q.lastDraftJson,
+        q.lastDraftedAt,
+      );
+    }
+    counts["target_queue"] = data.queue.length;
+
+    const insertTrigger = db.prepare(
+      `INSERT INTO triggers (name, last_polled_at, last_run_summary, enabled, config_json, running_started_at)
+       VALUES (?, ?, ?, ?, ?, NULL)`,
+    );
+    for (const t of data.triggers) {
+      insertTrigger.run(t.name, t.lastPolledAt, t.lastRunSummary, t.enabled, t.configJson);
+    }
+    counts["triggers"] = data.triggers.length;
+
+    const insertRun = db.prepare(
+      `INSERT INTO runs (play_name, dry_run, status, started_at, completed_at, target_count, drafted_count, sent_count, error_count, targets_json, events_json, prospect_emails_json)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (const r of data.runs) {
+      insertRun.run(
+        r.playName,
+        r.dryRun,
+        r.status,
+        r.startedAt,
+        r.completedAt,
+        r.targetCount,
+        r.draftedCount,
+        r.sentCount,
+        r.errorCount,
+        r.targetsJson,
+        r.eventsJson,
+        r.prospectEmailsJson,
+      );
+    }
+    counts["runs"] = data.runs.length;
+
+    const insertBounce = db.prepare(
+      `INSERT INTO bounces (message_id, recipient, identity_id, kind, status_code, diagnostic, prospect_id, bounced_at, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (const b of data.bounces) {
+      insertBounce.run(
+        b.messageId,
+        b.recipient,
+        b.identityId,
+        b.kind,
+        b.statusCode,
+        b.diagnostic,
+        b.prospectId,
+        b.bouncedAt,
+        b.createdAt,
+      );
+    }
+    counts["bounces"] = data.bounces.length;
+
+    const insertCanary = db.prepare(
+      `INSERT INTO canary_results (from_identity, to_identity, placement, labels_json, spf, dkim, dmarc, subject, source_play, same_domain, latency_ms, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (const c of data.canaries) {
+      insertCanary.run(
+        c.fromIdentity,
+        c.toIdentity,
+        c.placement,
+        c.labelsJson,
+        c.spf,
+        c.dkim,
+        c.dmarc,
+        c.subject,
+        c.sourcePlay,
+        c.sameDomain,
+        c.latencyMs,
+        c.createdAt,
+      );
+    }
+    counts["canary_results"] = data.canaries.length;
+
+    const insertAssignment = db.prepare(
+      `INSERT INTO sender_assignments (email, identity_id, assigned_at) VALUES (?, ?, ?)`,
+    );
+    for (const a of data.senderAssignments) {
+      insertAssignment.run(a.email, a.identityId, a.assignedAt);
+    }
+    counts["sender_assignments"] = data.senderAssignments.length;
+
+    const insertDraft = db.prepare(
+      `INSERT INTO inbox_drafts (thread_key, inbound_email_id, to_email, subject, identity_id, body, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (const d of data.inboxDrafts) {
+      insertDraft.run(
+        d.threadKey,
+        d.inboundEmailId,
+        d.toEmail,
+        d.subject,
+        d.identityId,
+        d.body,
+        d.updatedAt,
+      );
+    }
+    counts["inbox_drafts"] = data.inboxDrafts.length;
+
+    const insertSent = db.prepare(
+      `INSERT INTO inbox_sent (thread_key, to_email, subject, body, identity_id, request_id, sent_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (const s of data.inboxSent) {
+      insertSent.run(
+        s.threadKey,
+        s.toEmail,
+        s.subject,
+        s.body,
+        s.identityId,
+        s.requestId,
+        s.sentAt,
+      );
+    }
+    counts["inbox_sent"] = data.inboxSent.length;
+
+    const insertInterview = db.prepare(
+      `INSERT INTO interviews (person, transcript_path, jtbd, pain_quotes_json, created_at)
+       VALUES (?, ?, ?, ?, ?)`,
+    );
+    for (const iv of data.interviews) {
+      insertInterview.run(iv.person, iv.transcriptPath, iv.jtbd, iv.painQuotesJson, iv.createdAt);
+    }
+    counts["interviews"] = data.interviews.length;
+
+    db.exec("COMMIT");
+  } catch (err) {
+    db.exec("ROLLBACK");
+    throw err;
+  } finally {
+    db.close();
+  }
+
+  return counts;
+}
+
+/** Remove a seeded demo home. Refuses anything without the marker file. */
+export function resetDemoHome(home: string): void {
+  const dir = resolve(home);
+  if (!existsSync(dir)) return;
+  if (!existsSync(join(dir, DEMO_MARKER))) {
+    throw new DemoSeedError(
+      `${dir} has no ${DEMO_MARKER} marker — refusing to delete a directory this command didn't create.`,
+    );
+  }
+  rmSync(dir, { recursive: true, force: true });
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -40,6 +40,12 @@ import {
   commandIdentitiesRemove,
 } from "./commands/identities.ts";
 import { commandUi } from "./commands/ui.ts";
+import {
+  commandDemoReset,
+  commandDemoSeed,
+  commandDemoUi,
+  DEFAULT_DEMO_HOME,
+} from "./commands/demo.ts";
 import { commandEnrichLinkedIn } from "./commands/enrich-linkedin.ts";
 import { commandFindDrain, commandFindWatch } from "./commands/find.ts";
 import {
@@ -84,6 +90,58 @@ program
   .action(
     runOrFail(async (opts: { port: number; browser: boolean; dev: boolean }) => {
       await commandUi({ port: opts.port, noBrowser: !opts.browser, dev: opts.dev });
+    }),
+  );
+
+// Demo: a fictional, deterministic install in its own home, for screenshots and
+// video. Never reads or writes the real ledger.
+const demo = program
+  .command("demo")
+  .description("Seed and run a self-contained demo install (for screenshots and video)");
+demo
+  .command("seed")
+  .option("--home <dir>", "where to build the demo install", DEFAULT_DEMO_HOME)
+  .option("--now <iso>", "anchor every timestamp to this instant (default: now)")
+  .option("--force", "overwrite a non-empty directory", false)
+  .description("Build a populated demo ledger, config and fixtures")
+  .action(
+    runOrFail(async (opts: { home: string; now?: string; force: boolean }) => {
+      await commandDemoSeed({
+        home: opts.home,
+        force: opts.force,
+        ...(opts.now ? { now: opts.now } : {}),
+      });
+    }),
+  );
+demo
+  .command("ui")
+  .option("--home <dir>", "the demo install to open", DEFAULT_DEMO_HOME)
+  .option(
+    "--port <n>",
+    "port for the API server (default 3030)",
+    (v) => Number.parseInt(v, 10),
+    3030,
+  )
+  .option("--no-browser", "do not auto-open the browser")
+  .option("--dev", "use vite dev server (5173) + API server", false)
+  .description("Open the dashboard against the demo install")
+  .action(
+    runOrFail(async (opts: { home: string; port: number; browser: boolean; dev: boolean }) => {
+      await commandDemoUi({
+        home: opts.home,
+        port: opts.port,
+        noBrowser: !opts.browser,
+        dev: opts.dev,
+      });
+    }),
+  );
+demo
+  .command("reset")
+  .option("--home <dir>", "the demo install to remove", DEFAULT_DEMO_HOME)
+  .description("Delete a seeded demo install")
+  .action(
+    runOrFail(async (opts: { home: string }) => {
+      await commandDemoReset({ home: opts.home });
     }),
   );
 

--- a/apps/server/__tests__/scheduler.test.ts
+++ b/apps/server/__tests__/scheduler.test.ts
@@ -27,7 +27,12 @@ vi.mock("@oneshot-gtm/core", () => ({
   logEvent: (kind: string) => {
     calls.eventKinds.push(kind);
   },
+  // These cases exercise the real scheduler loop. Demo mode short-circuits it
+  // to a no-op handle — covered separately below.
+  demoMode: () => demoModeValue,
 }));
+
+let demoModeValue = false;
 
 const { startScheduler } = await import("../src/scheduler.ts");
 
@@ -39,6 +44,7 @@ beforeEach(() => {
   nextOutcomes = [];
   nextSleepValue = 60_000;
   throwOnNextRun = null;
+  demoModeValue = false;
 });
 
 afterEach(() => {
@@ -181,5 +187,18 @@ describe("startScheduler", () => {
     expect(calls.runDueTriggers).toBe(2); // both fired
     a.stop();
     b.stop();
+  });
+
+  // A seeded demo home is a still life. If the scheduler ran, it would fire the
+  // enabled triggers against placeholder credentials and overwrite the
+  // last_run_summary / last_polled_at values that make the dashboard look alive
+  // — mid-screenshot.
+  it("never ticks in demo mode, no matter how far time advances", async () => {
+    demoModeValue = true;
+    const handle = startScheduler();
+    await vi.advanceTimersByTimeAsync(60 * 60_000);
+    expect(calls.runDueTriggers).toBe(0);
+    expect(calls.eventKinds).toContain("demo.scheduler_idle");
+    expect(() => handle.stop()).not.toThrow();
   });
 });

--- a/apps/server/src/scheduler.ts
+++ b/apps/server/src/scheduler.ts
@@ -1,4 +1,4 @@
-import { logEvent, type TelemetryOutcome } from "@oneshot-gtm/core";
+import { demoMode, logEvent, type TelemetryOutcome } from "@oneshot-gtm/core";
 import {
   nextSleepMs,
   runDueTriggers,
@@ -59,6 +59,16 @@ const REPLY_POLL_MAX_MS = 5 * 60_000;
 const BOUNCE_POLL_INTERVAL_MS = 30 * 60_000;
 
 export function startScheduler(): SchedulerHandle {
+  // A seeded demo home is a still life: the scheduler would fire its enabled
+  // triggers against placeholder credentials and overwrite the very
+  // last_run_summary / last_polled_at values that make the dashboard look alive,
+  // mid-take. Idle instead — demo mode is for capture, and nothing in it is
+  // waiting on new signal.
+  if (demoMode()) {
+    logEvent("demo.scheduler_idle");
+    return { stop: () => {} };
+  }
+
   let cancelled = false;
   let timer: ReturnType<typeof setTimeout> | null = null;
   // 0 = never polled, so the first tick always sweeps.

--- a/packages/core/__tests__/demo-fixtures.test.ts
+++ b/packages/core/__tests__/demo-fixtures.test.ts
@@ -1,0 +1,168 @@
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { _applySecretsToEnvForTests, configDir, secretsPath } from "../src/config.ts";
+import { demoFixture, demoFixtureDir, demoMode } from "../src/demo.ts";
+import { cadenceRocs, getBalance, listInbox, listSendingDomains } from "../src/oneshot.ts";
+
+// ONESHOT_GTM_HOME is a fresh temp dir per test file (vitest.setup.ts), so
+// configDir() — and therefore the fixture dir — is already isolated.
+const dir = (): string => demoFixtureDir();
+
+function writeFixture(name: string, value: unknown): void {
+  mkdirSync(dir(), { recursive: true });
+  writeFileSync(join(dir(), name), JSON.stringify(value));
+}
+
+beforeEach(() => {
+  rmSync(dir(), { recursive: true, force: true });
+  delete process.env["ONESHOT_GTM_DEMO"];
+});
+
+afterEach(() => {
+  delete process.env["ONESHOT_GTM_DEMO"];
+});
+
+describe("demoMode", () => {
+  it("is off unless ONESHOT_GTM_DEMO is exactly 1", () => {
+    expect(demoMode()).toBe(false);
+    process.env["ONESHOT_GTM_DEMO"] = "0";
+    expect(demoMode()).toBe(false);
+    process.env["ONESHOT_GTM_DEMO"] = "true";
+    expect(demoMode()).toBe(false);
+    process.env["ONESHOT_GTM_DEMO"] = "1";
+    expect(demoMode()).toBe(true);
+  });
+});
+
+describe("demoFixture", () => {
+  it("reads and parses a fixture from the demo home", () => {
+    writeFixture("thing.json", { hello: "world" });
+    expect(demoFixture<{ hello: string }>("thing.json")).toEqual({ hello: "world" });
+  });
+
+  it("returns null when the fixture is missing", () => {
+    expect(demoFixture("nope.json")).toBeNull();
+  });
+
+  it("returns null on unparseable JSON rather than throwing mid-render", () => {
+    mkdirSync(dir(), { recursive: true });
+    writeFileSync(join(dir(), "broken.json"), "{ not json");
+    expect(demoFixture("broken.json")).toBeNull();
+  });
+
+  it("resolves under configDir(), so a relocated home relocates the fixtures", () => {
+    expect(dir()).toBe(join(configDir(), "demo"));
+  });
+});
+
+// No wallet credentials are set in the test env, so `getAgent()` throws. A
+// resolved promise is therefore proof that the demo seam short-circuited BEFORE
+// any agent construction — which is the property that lets the demo run with
+// placeholder keys.
+describe("the four network reads under demo mode", () => {
+  it("listInbox serves inbox.json", async () => {
+    const fixture = {
+      emails: [{ id: "e1", from: "a@b.dev", subject: "hi", received_at: "2026-08-01T00:00:00Z" }],
+      count: 1,
+      has_more: false,
+      agent_id: "agent_demo",
+    };
+    writeFixture("inbox.json", fixture);
+    process.env["ONESHOT_GTM_DEMO"] = "1";
+    await expect(listInbox({ limit: 200 })).resolves.toEqual(fixture);
+  });
+
+  it("cadenceRocs serves rocs-by-goal.json", async () => {
+    const fixture = [
+      { goalId: "goal_x", spend: 0.2, value: 4800, pendingValue: 0, rocs: 24000, receiptCount: 8 },
+    ];
+    writeFixture("rocs-by-goal.json", fixture);
+    process.env["ONESHOT_GTM_DEMO"] = "1";
+    await expect(cadenceRocs()).resolves.toEqual(fixture);
+  });
+
+  it("listSendingDomains serves domains.json", async () => {
+    const fixture = [{ domain: "demo.email", pool_status: "active", warmup_score: 87 }];
+    writeFixture("domains.json", fixture);
+    process.env["ONESHOT_GTM_DEMO"] = "1";
+    await expect(listSendingDomains()).resolves.toEqual(fixture);
+  });
+
+  it("getBalance serves balance.json", async () => {
+    writeFixture("balance.json", { balance: "41.86 USDC", raw: "41.86 USDC" });
+    process.env["ONESHOT_GTM_DEMO"] = "1";
+    await expect(getBalance()).resolves.toEqual({ balance: "41.86 USDC", raw: "41.86 USDC" });
+  });
+
+  it("falls through to the real path when the fixture is absent", async () => {
+    process.env["ONESHOT_GTM_DEMO"] = "1";
+    // No balance.json written — the seam must not swallow the call, so this
+    // reaches getAgent() and fails on the missing wallet credentials.
+    await expect(getBalance()).rejects.toThrow(/wallet credentials/i);
+  });
+
+  it("ignores fixtures entirely when demo mode is off", async () => {
+    writeFixture("balance.json", { balance: "999 USDC", raw: "999 USDC" });
+    await expect(getBalance()).rejects.toThrow(/wallet credentials/i);
+  });
+});
+
+// In demo mode the home's .env must be the SOLE source of secrets. Fill-the-
+// blanks is not enough: the CLI parent inherits the real install's secrets
+// before spawning the demo server, and Bun auto-loads a repo-root .env into
+// every `bun run` child — either would shadow the demo placeholders and hand a
+// "demo" dashboard a live wallet. This is the regression test for both paths.
+describe("applySecretsToEnv under demo mode", () => {
+  const TOUCHED = [
+    "OPENROUTER_API_KEY",
+    "AGENT_PRIVATE_KEY",
+    "CDP_API_KEY_ID",
+    "GITHUB_TOKEN",
+  ] as const;
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of TOUCHED) saved[k] = process.env[k];
+  });
+
+  afterEach(() => {
+    delete process.env["ONESHOT_GTM_DEMO"];
+    rmSync(secretsPath(), { force: true });
+    for (const k of TOUCHED) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it("overwrites inherited values with the file's, and deletes secrets the file lacks", () => {
+    writeFileSync(
+      secretsPath(),
+      "OPENROUTER_API_KEY=sk-or-demo-placeholder\nAGENT_PRIVATE_KEY=0xdemo\n",
+    );
+    // Simulate both leak paths: an inherited real key and a Bun-injected one.
+    process.env["OPENROUTER_API_KEY"] = "sk-or-REAL";
+    process.env["AGENT_PRIVATE_KEY"] = "0xREAL";
+    process.env["CDP_API_KEY_ID"] = "real-cdp";
+    process.env["GITHUB_TOKEN"] = "ghp_real";
+
+    process.env["ONESHOT_GTM_DEMO"] = "1";
+    _applySecretsToEnvForTests();
+
+    expect(process.env["OPENROUTER_API_KEY"]).toBe("sk-or-demo-placeholder");
+    expect(process.env["AGENT_PRIVATE_KEY"]).toBe("0xdemo");
+    expect(process.env["CDP_API_KEY_ID"]).toBeUndefined();
+    expect(process.env["GITHUB_TOKEN"]).toBeUndefined();
+  });
+
+  it("keeps fill-the-blanks semantics when demo mode is off", () => {
+    writeFileSync(secretsPath(), "OPENROUTER_API_KEY=sk-or-from-file\n");
+    process.env["OPENROUTER_API_KEY"] = "sk-or-from-shell";
+    delete process.env["AGENT_PRIVATE_KEY"];
+
+    _applySecretsToEnvForTests();
+
+    // Shell value wins; nothing is deleted.
+    expect(process.env["OPENROUTER_API_KEY"]).toBe("sk-or-from-shell");
+  });
+});

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -149,13 +149,43 @@ function loadSecretsFile(): Record<string, string> {
   return out;
 }
 
+/**
+ * Env-only credentials that are never stored in `.env` via saveSecrets but are
+ * read directly from the environment by finders. Demo mode must neutralize
+ * these too — a demo "Run now" acting with the founder's real GitHub token is
+ * the same category of leak as a real wallet key.
+ */
+const ENV_ONLY_SECRET_KEYS = ["GITHUB_TOKEN", "LUMA_SESSION_COOKIE"] as const;
+
 function applySecretsToEnv(): void {
   const stored = loadSecretsFile();
+
+  // Demo mode (`ONESHOT_GTM_DEMO=1`, checked inline — importing demo.ts here
+  // would be circular): this home's .env is the SOLE source of secrets, not a
+  // fallback for blanks. Two real-credential leak paths make fill-the-blanks
+  // insufficient: the CLI parent inherits the real install's secrets into
+  // process.env before spawning the demo server, and Bun auto-loads a repo-root
+  // .env into every `bun run` child — both would shadow the demo placeholders
+  // and hand a "demo" a live wallet. Overwrite-or-delete closes both.
+  if (process.env["ONESHOT_GTM_DEMO"] === "1") {
+    for (const k of [...SECRET_KEYS, ...ENV_ONLY_SECRET_KEYS]) {
+      const v = stored[k];
+      if (v) process.env[k] = v;
+      else delete process.env[k];
+    }
+    return;
+  }
+
   for (const [k, v] of Object.entries(stored)) {
     if (process.env[k] === undefined || process.env[k] === "") {
       process.env[k] = v;
     }
   }
+}
+
+/** Test-only re-run hook — applySecretsToEnv normally fires once at import. */
+export function _applySecretsToEnvForTests(): void {
+  applySecretsToEnv();
 }
 
 export function saveSecrets(updates: Partial<Record<SecretKey, string>>): void {

--- a/packages/core/src/demo.ts
+++ b/packages/core/src/demo.ts
@@ -1,0 +1,40 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { configDir } from "./config.ts";
+
+// Demo mode exists for one reason: capturing a screenshot or a video of a
+// populated dashboard without a real ledger full of real prospects. It is a
+// READ-ONLY seam. Four calls the dashboard makes at request time can't be
+// populated by seeding SQLite, because they fetch from the network rather than
+// the ledger — the reply list, the platform RoCS rollup, the provisioned-domain
+// pool, and the wallet balance. In demo mode those four read a JSON fixture
+// written by `demo seed` instead.
+//
+// Nothing that sends, drafts, spends or writes is faked. The demo home carries
+// placeholder credentials, so a stray click on Run or Send fails at auth — which
+// is the intended behavior, not a limitation to paper over.
+
+/** True when the process was launched against a seeded demo home (`demo ui`). */
+export function demoMode(): boolean {
+  return process.env["ONESHOT_GTM_DEMO"] === "1";
+}
+
+/** Directory `demo seed` writes its network-read fixtures into. */
+export function demoFixtureDir(): string {
+  return join(configDir(), "demo");
+}
+
+/**
+ * Read one fixture from the demo home. Returns null when it's missing or
+ * unparseable, so callers fall through to their normal path — a half-seeded
+ * demo home degrades to real behavior rather than throwing mid-render.
+ */
+export function demoFixture<T>(name: string): T | null {
+  const path = join(demoFixtureDir(), name);
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as T;
+  } catch {
+    return null;
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,6 +2,7 @@ export * from "./oneshot.ts";
 export * from "./inflight.ts";
 export * from "./ledger.ts";
 export * from "./config.ts";
+export * from "./demo.ts";
 export * from "./events.ts";
 export * from "./telemetry.ts";
 export * from "./version.ts";

--- a/packages/core/src/oneshot.ts
+++ b/packages/core/src/oneshot.ts
@@ -19,6 +19,7 @@ import {
 import { createHash } from "node:crypto";
 import { getLedger } from "./ledger.ts";
 import { loadConfig, oneshotEnvReady } from "./config.ts";
+import { demoFixture, demoMode } from "./demo.ts";
 import { logEvent } from "./events.ts";
 import {
   type GmailBounce,
@@ -162,6 +163,11 @@ async function getAgent(): Promise<OneShot> {
  * a real config error the founder needs to see.
  */
 export async function listSendingDomains(): Promise<DomainPoolEntry[]> {
+  // Demo mode: read-only fixture, before any agent construction (see demo.ts).
+  if (demoMode()) {
+    const fixture = demoFixture<DomainPoolEntry[]>("domains.json");
+    if (fixture) return fixture;
+  }
   try {
     const agent = await getAgent();
     const result = await agent.listDomains();
@@ -613,6 +619,10 @@ export async function verifyEmail(input: VerifyEmailInput, ctx: CallContext) {
 export async function getBalance(
   tokenAddress?: string,
 ): Promise<{ balance: string; raw: unknown }> {
+  if (demoMode()) {
+    const fixture = demoFixture<{ balance: string; raw: unknown }>("balance.json");
+    if (fixture) return fixture;
+  }
   const agent = await getAgent();
   const raw = await agent.getBalance(tokenAddress);
   return { balance: raw, raw };
@@ -671,6 +681,10 @@ export async function listInbox(opts?: {
   since?: string;
   limit?: number;
 }): Promise<AnnotatedInboxListResult> {
+  if (demoMode()) {
+    const fixture = demoFixture<AnnotatedInboxListResult>("inbox.json");
+    if (fixture) return fixture;
+  }
   const identities = resolveIdentities(loadConfig());
   const sources: Array<{
     label: string;
@@ -1058,6 +1072,10 @@ export interface CadenceRocsGoal {
  * Measure page; genuine auth errors propagate so misconfig is visible.
  */
 export async function cadenceRocs(opts: { periodDays?: number } = {}): Promise<CadenceRocsGoal[]> {
+  if (demoMode()) {
+    const fixture = demoFixture<CadenceRocsGoal[]>("rocs-by-goal.json");
+    if (fixture) return fixture;
+  }
   try {
     const agent = await getAgent();
     const res = await agent.rocsByGoal(opts.periodDays != null ? { period: opts.periodDays } : {});


### PR DESCRIPTION
## What

A `demo` command group that stands up a fictional, fully-populated install for screenshots and video — closing the "nothing to record" blocker on the roadmap's launch assets.

```bash
bun run cli -- demo seed      # → ~/.oneshot-gtm-demo
bun run cli -- demo ui        # dashboard against it
bun run cli -- demo reset     # delete it
```

**The dataset** (`apps/cli/src/demo/dataset.ts`): 24 prospects across eight plays and 30 days, 147 signed receipts totalling $2.94, cadences in all five states, 8 replies matched to their prospects plus one deliberate no-match, all four queue statuses, triggers in enabled/disabled/not-ready states, one completed run, bounces, a placement canary, two closed deals. The cast extends `examples/`. No `Math.random`; every timestamp offsets an anchor, so the same `--now` reproduces the ledger byte-for-byte.

## What demo mode changes (`ONESHOT_GTM_DEMO=1`, set only by `demo ui`)

1. **Four read-only fixture reads.** `listInbox`, `cadenceRocs`, `listSendingDomains`, `getBalance` fetch from the network at request time rather than the ledger — Replies would be blank no matter what's in SQLite. In demo mode they read JSON from the demo home, before any agent construction.
2. **Scheduler idles**, so enabled triggers can't fire against placeholder keys and overwrite the seeded `last_run_summary` mid-take.
3. **The demo home's `.env` is the sole source of secrets.** Fill-the-blanks leaks real credentials two ways: the CLI parent inherits the real install's keys into `process.env` before spawning, and **Bun auto-loads the repo-root `.env` into every `bun run` child** (ours holds a real `OPENROUTER_API_KEY` + `GITHUB_TOKEN`). Under the flag, `applySecretsToEnv()` overwrites every secret key from the demo file or deletes it. Verified end-to-end with a poisoned-env probe: doctor reports every key as `set (file)`.

Nothing that sends, drafts or spends is faked — a stray Run/Send click fails at auth on placeholder keys.

## Safety rails

- `demo seed` refuses `~/.oneshot-gtm` and the active `ONESHOT_GTM_HOME`; non-empty unmarked dirs need `--force`
- Re-seeds truncate tables in place (a dashboard already running against the home survives; refresh shows the new data)
- `demo reset` only deletes a directory carrying the `.demo-home` marker
- Demo telemetry is off — a demo install must not report itself as real

## Verification

Walked all nine dashboard pages + receipt detail + privacy mode in the browser against a seeded home — every surface populated, doctor green except the honest Gmail-only bounce warn. Real `~/.oneshot-gtm` mtimes byte-identical across a seed.

1518 tests / 117 files (30 new: seeder determinism + refusal paths, fixture seam, scheduler idle, both secret-leak regressions). typecheck + oxlint + oxfmt clean.

https://claude.ai/code/session_01WfjkhiBKFjEbkkL5TzmRLZ

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `demo seed`, `demo ui`, and `demo reset` CLI commands for a filmable demo install
> - Adds a `demo` command group with three subcommands: `seed` builds a fully-populated SQLite ledger, config, `.env`, and fixture files under `~/.oneshot-gtm-demo`; `ui` launches the dashboard pointed at that home with `ONESHOT_GTM_DEMO=1` and telemetry disabled; `reset` safely deletes the demo home only when the demo marker file is present.
> - [`dataset.ts`](https://github.com/oneshot-agent/oneshot-gtm/pull/27/files#diff-6f006f5ebb3282e9ecbcd025785a83c2d861d0077c235dea57fdf3178b6f09cf) generates a deterministic, anchor-dated dataset covering prospects, receipts, sequence events, cadences, queue items, triggers, runs, bounces, canaries, inbox, interviews, and RoCS rollups — all with stable IDs and backdated timestamps.
> - In demo mode, four network-read functions (`listInbox`, `cadenceRocs`, `listSendingDomains`, `getBalance`) short-circuit to return JSON fixture files instead of making live calls.
> - `startScheduler` returns a no-op handle when `demoMode()` is true, logging `demo.scheduler_idle` and skipping all trigger ticks.
> - Real credentials inherited from the parent environment are scrubbed before the demo server starts; the `.env` written to the demo home contains only placeholder values.
> - Risk: `applySecretsToEnv` behavior changes in demo mode — stored secrets overwrite (rather than fill) existing env vars, and missing secrets are explicitly deleted.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized fa6907f. 12 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->