### PR TITLE
fix(demo): address the five review findings on #27

### DIFF
--- a/apps/cli/__tests__/demo-seed.test.ts
+++ b/apps/cli/__tests__/demo-seed.test.ts
@@ -4,15 +4,23 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   rmSync,
   statSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { scrubInheritedSecrets } from "../src/commands/demo.ts";
-import { DEMO_MARKER, DemoSeedError, resetDemoHome, seedDemoHome } from "../src/demo/seed.ts";
+import {
+  canonicalize,
+  DEMO_MARKER,
+  DemoSeedError,
+  resetDemoHome,
+  seedDemoHome,
+} from "../src/demo/seed.ts";
 
 const ANCHOR = new Date("2026-08-17T09:00:00.000Z");
 
@@ -32,6 +40,10 @@ function open(dir: string): Database {
 
 function rows(db: Database, sql: string): Array<Record<string, unknown>> {
   return db.query(sql).all() as Array<Record<string, unknown>>;
+}
+
+function totalSpend(entries: Array<{ spend: number }>): number {
+  return entries.reduce((a, r) => a + r.spend, 0);
 }
 
 describe("seedDemoHome", () => {
@@ -171,6 +183,83 @@ describe("seedDemoHome", () => {
     const real = join(homedir(), ".oneshot-gtm");
     expect(() => seedDemoHome({ home: real, anchor: ANCHOR })).toThrow(DemoSeedError);
     expect(() => seedDemoHome({ home: real, anchor: ANCHOR })).toThrow(/real install/i);
+  });
+
+  it("refuses a SYMLINK to a protected install — lexical path comparison is not enough", () => {
+    // ONESHOT_GTM_HOME (the vitest temp home) stands in for a protected
+    // install that definitely exists. A symlink to it must be caught by the
+    // canonicalized comparison, not slip past a string match.
+    const protectedHome = process.env["ONESHOT_GTM_HOME"] as string;
+    mkdirSync(home, { recursive: true });
+    const link = join(home, "sneaky-link");
+    symlinkSync(protectedHome, link);
+    expect(() => seedDemoHome({ home: link, anchor: ANCHOR })).toThrow(DemoSeedError);
+    expect(() => seedDemoHome({ home: link, anchor: ANCHOR })).toThrow(/ONESHOT_GTM_HOME/);
+  });
+
+  it("canonicalize follows symlinked parents of a not-yet-existing path", () => {
+    mkdirSync(home, { recursive: true });
+    const link = join(home, "parent-link");
+    symlinkSync(home, link);
+    expect(canonicalize(join(link, "new-dir"))).toBe(join(realpathSync(home), "new-dir"));
+  });
+
+  it("keys the RoCS fixture by period so the Measure range chips vary", () => {
+    seedDemoHome({ home, anchor: ANCHOR });
+    const rocs = JSON.parse(readFileSync(join(home, "demo", "rocs-by-goal.json"), "utf8")) as {
+      "7": Array<{ spend: number }>;
+      "30": Array<{ spend: number }>;
+      all: Array<{ spend: number }>;
+    };
+    expect(rocs["all"].length).toBeGreaterThan(0);
+    // The seeded history spans 30 days, so each narrower window must aggregate
+    // strictly less spend — equal totals would mean the filter isn't filtering.
+    expect(totalSpend(rocs["7"])).toBeLessThan(totalSpend(rocs["30"]));
+    expect(totalSpend(rocs["30"])).toBeLessThanOrEqual(totalSpend(rocs["all"]));
+  });
+
+  it("attaches inbox drafts and sent history to the correct prospect's thread", () => {
+    seedDemoHome({ home, anchor: ANCHOR });
+    const inbox = JSON.parse(readFileSync(join(home, "demo", "inbox.json"), "utf8")) as {
+      emails: Array<{ id: string; from: string; thread_id: string }>;
+    };
+    const threadOwner = new Map(inbox.emails.map((e) => [e.thread_id, e.from]));
+
+    const db = open(home);
+    const drafts = rows(db, "SELECT thread_key, to_email FROM inbox_drafts");
+    const sent = rows(db, "SELECT thread_key, to_email FROM inbox_sent");
+    db.close();
+
+    // Every draft/sent row must live inside the thread of the prospect it
+    // addresses — a mismatch shows one person's reply inside another's thread.
+    for (const r of [...drafts, ...sent]) {
+      const owner = threadOwner.get(String(r["thread_key"]));
+      expect(
+        owner,
+        `thread ${String(r["thread_key"])} should exist in the inbox fixture`,
+      ).toBeTruthy();
+      expect(owner).toContain(String(r["to_email"]));
+    }
+  });
+
+  it("links run send events to the recipients' actual email.send receipts", () => {
+    seedDemoHome({ home, anchor: ANCHOR });
+    const db = open(home);
+    const [run] = rows(db, "SELECT events_json, prospect_emails_json FROM runs");
+    const events = JSON.parse(String(run?.["events_json"])) as Array<{
+      kind: string;
+      receiptIds?: number[];
+    }>;
+    const sendIds = events.filter((e) => e.kind === "send").flatMap((e) => e.receiptIds ?? []);
+    expect(sendIds.length).toBeGreaterThan(0);
+    const emails = JSON.parse(String(run?.["prospect_emails_json"])) as string[];
+    for (const id of sendIds) {
+      const [receipt] = rows(db, `SELECT call_type, signed_receipt FROM receipts WHERE id = ${id}`);
+      expect(receipt?.["call_type"]).toBe("email.send");
+      const to = (JSON.parse(String(receipt?.["signed_receipt"])) as { to?: string }).to;
+      expect(emails).toContain(to);
+    }
+    db.close();
   });
 
   it("refuses a non-empty directory it did not create, unless forced", () => {

--- a/apps/cli/src/commands/demo.ts
+++ b/apps/cli/src/commands/demo.ts
@@ -1,8 +1,15 @@
 import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { join } from "node:path";
 import { SECRET_KEYS } from "@oneshot-gtm/core";
 import { bail, c, header, note, ok, warn } from "../output.ts";
-import { DEFAULT_DEMO_HOME, DemoSeedError, resetDemoHome, seedDemoHome } from "../demo/seed.ts";
+import {
+  canonicalize,
+  DEFAULT_DEMO_HOME,
+  DEMO_MARKER,
+  DemoSeedError,
+  resetDemoHome,
+  seedDemoHome,
+} from "../demo/seed.ts";
 import { commandUi } from "./ui.ts";
 
 /**
@@ -75,9 +82,19 @@ interface DemoUiOpts {
 }
 
 export async function commandDemoUi(opts: DemoUiOpts): Promise<void> {
-  const home = resolve(opts.home);
+  // Canonicalized (symlinks followed), and required to carry the seed marker.
+  // Without the marker check, `demo ui --home ~/.oneshot-gtm` — or a symlink
+  // pointing there — would launch the REAL install under the demo flag: real
+  // credentials behind a UI the operator believes is fake.
+  const home = canonicalize(opts.home);
   if (!existsSync(home)) {
     bail(`no demo home at ${home}. Run ${c.cyan("bun run cli -- demo seed")} first.`);
+  }
+  if (!existsSync(join(home, DEMO_MARKER))) {
+    bail(
+      `${home} has no ${DEMO_MARKER} marker — not a seeded demo install. ` +
+        `demo ui refuses to run a real install under the demo flag.`,
+    );
   }
 
   // `commandUi` spawns the server with `...process.env`, so mutating it here
@@ -96,7 +113,7 @@ export async function commandDemoUi(opts: DemoUiOpts): Promise<void> {
 
 export async function commandDemoReset(opts: { home: string }): Promise<void> {
   header("oneshot-gtm demo reset");
-  const home = resolve(opts.home);
+  const home = canonicalize(opts.home);
   try {
     resetDemoHome(home);
   } catch (err) {

--- a/apps/cli/src/demo/dataset.ts
+++ b/apps/cli/src/demo/dataset.ts
@@ -921,7 +921,7 @@ export function buildDemoDataset(anchor: Date): DemoDataset {
     outcomes,
     queue: buildQueue(anchor),
     triggers: buildTriggers(anchor),
-    runs: buildRuns(anchor),
+    runs: buildRuns(anchor, receipts),
     bounces: buildBounces(anchor, prospects),
     canaries: buildCanaries(anchor),
     senderAssignments,
@@ -930,7 +930,7 @@ export function buildDemoDataset(anchor: Date): DemoDataset {
     interviews: buildInterviews(anchor),
     fixtures: {
       "inbox.json": buildInboxFixture(anchor),
-      "rocs-by-goal.json": buildRocsFixture(receipts),
+      "rocs-by-goal.json": buildRocsFixture(receipts, anchor),
       "domains.json": buildDomainsFixture(anchor),
       "balance.json": { balance: "41.86 USDC", raw: "41.86 USDC" },
     },
@@ -1430,7 +1430,19 @@ function buildTriggers(anchor: Date): DemoDataset["triggers"] {
 // Runs
 // ---------------------------------------------------------------------------
 
-function buildRuns(anchor: Date): DemoDataset["runs"] {
+function buildRuns(anchor: Date, receipts: DemoReceipt[]): DemoDataset["runs"] {
+  // Receipt ids are assigned globally while iterating PEOPLE, so a run's send
+  // events must look up the actual email.send receipt per recipient — a
+  // hardcoded [1]/[2] would link this run's sends to whoever's prep calls
+  // happened to be recorded first.
+  const sendReceiptIdFor = (email: string): number => {
+    const r = receipts.find(
+      (x) => x.callType === "email.send" && (x.signedReceipt as { to?: string }).to === email,
+    );
+    if (!r) throw new Error(`demo dataset: no email.send receipt for ${email}`);
+    return r.id;
+  };
+
   const targets = [
     { name: "Elin Dahl", email: "elin@northport.works", company: "Northport" },
     { name: "Ravi Menon", email: "ravi@stanchion.dev", company: "Stanchion" },
@@ -1446,7 +1458,7 @@ function buildRuns(anchor: Date): DemoDataset["runs"] {
       body: "Hey Elin,\n\nThe top comment on your Show HN asks how you debug a stuck run, and your answer was basically 'carefully'. That is the gap Tracepoint fills.\n\nWorth fifteen minutes?\n\nMira",
       flags: [],
     },
-    { kind: "send", index: 0, receiptIds: [1] },
+    { kind: "send", index: 0, receiptIds: [sendReceiptIdFor("elin@northport.works")] },
     {
       kind: "draft",
       index: 1,
@@ -1454,7 +1466,7 @@ function buildRuns(anchor: Date): DemoDataset["runs"] {
       body: "Hey Ravi,\n\nGoing from three to eleven engineers is exactly when the async parts of the system stop fitting in one person's head.\n\nTracepoint drops into a worker with one import.\n\nMira",
       flags: [],
     },
-    { kind: "send", index: 1, receiptIds: [2] },
+    { kind: "send", index: 1, receiptIds: [sendReceiptIdFor("ravi@stanchion.dev")] },
     { kind: "done", total: 2, sent: 2 },
   ];
 
@@ -1541,15 +1553,36 @@ function repliers(): DemoPerson[] {
   );
 }
 
+/**
+ * Thread/email ids are positional in the repliers() ordering, so any row that
+ * references one (inbox_drafts, inbox_sent) must derive it from the SAME
+ * ordering by email — a hardcoded "thread_demo_0001" silently attaches to
+ * whichever reply happens to sort first, putting one prospect's history inside
+ * another prospect's thread.
+ */
+function replierIndex(email: string): number {
+  const i = repliers().findIndex((p) => p.email === email);
+  if (i < 0) throw new Error(`demo dataset: ${email} has no reply — cannot build a thread id`);
+  return i;
+}
+
+function threadIdFor(email: string): string {
+  return `thread_demo_${String(replierIndex(email) + 1).padStart(4, "0")}`;
+}
+
+function inboundEmailIdFor(email: string): string {
+  return `email_demo_${String(replierIndex(email) + 1).padStart(4, "0")}`;
+}
+
 function buildInboxFixture(anchor: Date): unknown {
   const emails = repliers().map((p, i) => {
     const r = p.reply as NonNullable<DemoPerson["reply"]>;
     return {
-      id: `email_demo_${String(i + 1).padStart(4, "0")}`,
+      id: inboundEmailIdFor(p.email),
       from: `${p.name} <${p.email}>`,
       subject: r.subject,
       received_at: isoAt(anchor, r.daysAgo, r.hour, jitter(i)),
-      thread_id: `thread_demo_${String(i + 1).padStart(4, "0")}`,
+      thread_id: threadIdFor(p.email),
       body: r.body,
       source_identity_id: p.identity,
       message_id: `<reply-${i + 1}@${p.email.split("@")[1] ?? "example.dev"}>`,
@@ -1578,8 +1611,8 @@ function buildInboxDrafts(anchor: Date): DemoDataset["inboxDrafts"] {
   // blank box.
   return [
     {
-      threadKey: "thread_demo_0002",
-      inboundEmailId: "email_demo_0002",
+      threadKey: threadIdFor("dmitri@cascade.systems"),
+      inboundEmailId: inboundEmailIdFor("dmitri@cascade.systems"),
       toEmail: "dmitri@cascade.systems",
       subject: "Re: reliability as the year's focus",
       identityId: IDENTITY_PRIMARY,
@@ -1592,7 +1625,7 @@ function buildInboxDrafts(anchor: Date): DemoDataset["inboxDrafts"] {
 function buildInboxSent(anchor: Date): DemoDataset["inboxSent"] {
   return [
     {
-      threadKey: "thread_demo_0001",
+      threadKey: threadIdFor("aisha@tidewater.build"),
       toEmail: "aisha@tidewater.build",
       subject: "Re: 'find out on Monday what broke on Saturday'",
       body: "Hey Aisha,\n\nPricing is per job, not per host — attached. For a Saturday batch run of your size it lands around $600/mo, and you can point it at that one pipeline before touching anything else.\n\nMira",
@@ -1635,7 +1668,21 @@ function buildInterviews(anchor: Date): DemoDataset["interviews"] {
 // Platform RoCS rollup
 // ---------------------------------------------------------------------------
 
-function buildRocsFixture(receipts: DemoReceipt[]): unknown {
+/**
+ * Keyed by period ("7" / "30" / "all") because the Measure page's range chips
+ * pass `periodDays` through to `cadenceRocs` — a single all-time rollup would
+ * show identical numbers on every chip, which reads as a broken filter on
+ * camera. The demo seam in `cadenceRocs` picks the matching key.
+ */
+function buildRocsFixture(receipts: DemoReceipt[], anchor: Date): unknown {
+  return {
+    "7": rocsForWindow(receipts.filter((r) => r.createdAt >= sqlAt(anchor, 7, 0, 0))),
+    "30": rocsForWindow(receipts.filter((r) => r.createdAt >= sqlAt(anchor, 30, 0, 0))),
+    all: rocsForWindow(receipts),
+  };
+}
+
+function rocsForWindow(receipts: DemoReceipt[]): unknown {
   // Derived from the receipts we just wrote, so the platform rollup and the
   // local ledger agree — the goalIds match, and so does the spend.
   const byGoal = new Map<

--- a/apps/cli/src/demo/seed.ts
+++ b/apps/cli/src/demo/seed.ts
@@ -1,7 +1,15 @@
 import { Database } from "bun:sqlite";
-import { chmodSync, existsSync, mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { Ledger } from "@oneshot-gtm/core";
 import { buildDemoDataset, type DemoDataset } from "./dataset.ts";
 
@@ -13,6 +21,27 @@ export const DEFAULT_DEMO_HOME = join(homedir(), ".oneshot-gtm-demo");
 /** The real install. Seeding into it would overwrite a working config and ledger. */
 function realHome(): string {
   return join(homedir(), ".oneshot-gtm");
+}
+
+/**
+ * Resolve a path with symlinks followed, not just lexically. `resolve()` alone
+ * would let `--home some-symlink-to-the-real-install` slip past the guards
+ * below and write through the link into `~/.oneshot-gtm`. A path that doesn't
+ * exist yet can't be realpath'd directly, so canonicalize the nearest existing
+ * ancestor and re-append the rest — that also catches a symlinked PARENT
+ * directory pointing into the real install's parent.
+ */
+export function canonicalize(p: string): string {
+  let base = resolve(p);
+  const tail: string[] = [];
+  while (!existsSync(base)) {
+    const parent = dirname(base);
+    if (parent === base) break;
+    tail.unshift(basename(base));
+    base = parent;
+  }
+  const real = existsSync(base) ? realpathSync(base) : base;
+  return tail.length > 0 ? join(real, ...tail) : real;
 }
 
 export class DemoSeedError extends Error {}
@@ -57,15 +86,17 @@ export interface SeedResult {
  * never touches that. Everything here is written through explicit paths.
  */
 export function seedDemoHome(opts: { home?: string; anchor?: Date; force?: boolean }): SeedResult {
-  const home = resolve(opts.home ?? DEFAULT_DEMO_HOME);
+  // Canonical (symlink-followed) on BOTH sides of every comparison, and used
+  // for all writes below, so the guard and the writes refer to the same target.
+  const home = canonicalize(opts.home ?? DEFAULT_DEMO_HOME);
   const anchor = opts.anchor ?? new Date();
 
-  if (home === resolve(realHome())) {
+  if (home === canonicalize(realHome())) {
     throw new DemoSeedError(
       `refusing to seed into your real install (${home}). Pass --home with a different directory.`,
     );
   }
-  if (process.env["ONESHOT_GTM_HOME"] && home === resolve(process.env["ONESHOT_GTM_HOME"])) {
+  if (process.env["ONESHOT_GTM_HOME"] && home === canonicalize(process.env["ONESHOT_GTM_HOME"])) {
     throw new DemoSeedError(
       `refusing to seed into the active ONESHOT_GTM_HOME (${home}). Pass --home with a different directory.`,
     );
@@ -390,7 +421,7 @@ function writeLedger(dbPath: string, data: DemoDataset): Record<string, number> 
 
 /** Remove a seeded demo home. Refuses anything without the marker file. */
 export function resetDemoHome(home: string): void {
-  const dir = resolve(home);
+  const dir = canonicalize(home);
   if (!existsSync(dir)) return;
   if (!existsSync(join(dir, DEMO_MARKER))) {
     throw new DemoSeedError(

--- a/packages/core/__tests__/demo-fixtures.test.ts
+++ b/packages/core/__tests__/demo-fixtures.test.ts
@@ -14,6 +14,11 @@ function writeFixture(name: string, value: unknown): void {
   writeFileSync(join(dir(), name), JSON.stringify(value));
 }
 
+/** One RoCS goal row with the given spend — for the period-keyed fixture tests. */
+function g(spend: number): Array<Record<string, unknown>> {
+  return [{ goalId: "goal_x", spend, value: 4800, pendingValue: 0, rocs: 1, receiptCount: 8 }];
+}
+
 beforeEach(() => {
   rmSync(dir(), { recursive: true, force: true });
   delete process.env["ONESHOT_GTM_DEMO"];
@@ -73,13 +78,24 @@ describe("the four network reads under demo mode", () => {
     await expect(listInbox({ limit: 200 })).resolves.toEqual(fixture);
   });
 
-  it("cadenceRocs serves rocs-by-goal.json", async () => {
+  it("cadenceRocs picks the period key from rocs-by-goal.json", async () => {
+    writeFixture("rocs-by-goal.json", { "7": g(0.1), "30": g(0.5), all: g(0.9) });
+    process.env["ONESHOT_GTM_DEMO"] = "1";
+    await expect(cadenceRocs({ periodDays: 7 })).resolves.toEqual(g(0.1));
+    await expect(cadenceRocs({ periodDays: 30 })).resolves.toEqual(g(0.5));
+    await expect(cadenceRocs()).resolves.toEqual(g(0.9));
+    // Unknown period falls back to all-time rather than an empty table.
+    await expect(cadenceRocs({ periodDays: 90 })).resolves.toEqual(g(0.9));
+  });
+
+  it("cadenceRocs still serves a legacy plain-array fixture for every period", async () => {
     const fixture = [
       { goalId: "goal_x", spend: 0.2, value: 4800, pendingValue: 0, rocs: 24000, receiptCount: 8 },
     ];
     writeFixture("rocs-by-goal.json", fixture);
     process.env["ONESHOT_GTM_DEMO"] = "1";
     await expect(cadenceRocs()).resolves.toEqual(fixture);
+    await expect(cadenceRocs({ periodDays: 7 })).resolves.toEqual(fixture);
   });
 
   it("listSendingDomains serves domains.json", async () => {

--- a/packages/core/src/oneshot.ts
+++ b/packages/core/src/oneshot.ts
@@ -1073,8 +1073,14 @@ export interface CadenceRocsGoal {
  */
 export async function cadenceRocs(opts: { periodDays?: number } = {}): Promise<CadenceRocsGoal[]> {
   if (demoMode()) {
-    const fixture = demoFixture<CadenceRocsGoal[]>("rocs-by-goal.json");
-    if (fixture) return fixture;
+    // Keyed by period ("7"/"30"/"all") so the Measure range chips actually
+    // change the numbers in a demo. A plain array (a fixture from an older
+    // `demo seed`) is served as-is for every period.
+    const fixture = demoFixture<CadenceRocsGoal[] | Record<string, CadenceRocsGoal[]>>(
+      "rocs-by-goal.json",
+    );
+    if (Array.isArray(fixture)) return fixture;
+    if (fixture) return fixture[String(opts.periodDays ?? "all")] ?? fixture["all"] ?? [];
   }
   try {
     const agent = await getAgent();


### PR DESCRIPTION
Follow-up to #27, fixing all five Macroscope review findings — each verified against the code before fixing.

## High — guard bypass

1. **Symlink-proof the real-install guards** (`seed.ts`). `resolve()` is lexical; a symlinked `--home` (or symlinked parent) could slip past the refusal checks and write through into `~/.oneshot-gtm`. New `canonicalize()` follows symlinks via the nearest existing ancestor; every comparison **and every write** now uses the canonical path.
2. **`demo ui` now requires the `.demo-home` marker** (`commands/demo.ts`). The gap was wider than the symlink case: `demo ui --home ~/.oneshot-gtm` launched the real install under the demo flag — real credentials behind a UI the operator believes is fake.

## Medium — dataset consistency

3. **Inbox thread/email ids derived from the `repliers()` ordering.** `thread_demo_0001` belongs to whoever's reply sorts first (Nils), not Aisha — the seeded draft/sent history attached to the wrong prospects' threads. Now `threadIdFor(email)` / `inboundEmailIdFor(email)`, with a match asserted in tests against the inbox fixture.
4. **Run send events link the recipients' actual `email.send` receipts.** Hardcoded `[1]`/`[2]` pointed at Jane's `web.search`/`email.find` prep calls, not Elin's and Ravi's sends.
5. **RoCS fixture keyed by period** (`"7"`/`"30"`/`"all"`), picked in the `cadenceRocs` demo seam — the Measure range chips now change the numbers (7d: 1 goal / \$0.004 · 30d: 7 goals / \$1.17) instead of one all-time rollup on every chip. Legacy plain-array fixtures still serve as-is.

## Verification

All five confirmed live against a reseeded home: rocs totals differ per period, draft/sent rows match their thread owners, run receipts resolve to `email.send` for the right recipients. 1524 tests / 117 files (6 new: symlink refusal, canonicalize-through-parent, period-keyed + legacy fixture, thread ownership, run receipt linkage). typecheck + oxlint + oxfmt clean.

https://claude.ai/code/session_01WfjkhiBKFjEbkkL5TzmRLZ

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix demo seed symlink guards and link run send events to receipt IDs
> - Adds `canonicalize` in [seed.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/28/files#diff-2c058086790c3da501d50336e4624a05072469a2ccbc9069ff8359973ef3ad3d) to resolve symlinked paths by walking up to the nearest existing ancestor, ensuring `seedDemoHome` and `resetDemoHome` compare and write against canonical paths rather than symlinks.
> - `commandDemoUi` and `commandDemoReset` in [demo.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/28/files#diff-4e3a5057d934ddaffed8c2e51a4a20e6609b24d3c99e03999e93ad9f1451b52e) now canonicalize the provided home path and refuse to run if the demo marker file is absent.
> - Run send events in [dataset.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/28/files#diff-6f006f5ebb3282e9ecbcd025785a83c2d861d0077c235dea57fdf3178b6f09cf) now reference the actual `email.send` receipt ID for each recipient instead of hardcoded IDs; inbox thread and email IDs are keyed by prospect email rather than positional index.
> - `buildRocsFixture` now produces a period-keyed object (`7`, `30`, `all`) with per-window spend rollups, and `cadenceRocs` in [oneshot.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/28/files#diff-a75653098eb1094047ae1458ce831158ed4abd7e08122279a6827b46c0c2e9db) selects the matching period or falls back to `all`.
> - Risk: the RoCS fixture format change is a breaking schema change for any consumer expecting a plain array; legacy plain-array fixtures are still served as-is for backward compatibility.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 723f9ce. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->