### PR TITLE
fix(demo): a run only claims sends from its own play

### DIFF
--- a/apps/cli/__tests__/demo-seed.test.ts
+++ b/apps/cli/__tests__/demo-seed.test.ts
@@ -242,10 +242,10 @@ describe("seedDemoHome", () => {
     }
   });
 
-  it("links run send events to the recipients' actual email.send receipts", () => {
+  it("links run send events to email.send receipts from the run's own play", () => {
     seedDemoHome({ home, anchor: ANCHOR });
     const db = open(home);
-    const [run] = rows(db, "SELECT events_json, prospect_emails_json FROM runs");
+    const [run] = rows(db, "SELECT play_name, events_json, prospect_emails_json FROM runs");
     const events = JSON.parse(String(run?.["events_json"])) as Array<{
       kind: string;
       receiptIds?: number[];
@@ -254,8 +254,14 @@ describe("seedDemoHome", () => {
     expect(sendIds.length).toBeGreaterThan(0);
     const emails = JSON.parse(String(run?.["prospect_emails_json"])) as string[];
     for (const id of sendIds) {
-      const [receipt] = rows(db, `SELECT call_type, signed_receipt FROM receipts WHERE id = ${id}`);
+      const [receipt] = rows(
+        db,
+        `SELECT play_name, call_type, signed_receipt FROM receipts WHERE id = ${id}`,
+      );
       expect(receipt?.["call_type"]).toBe("email.send");
+      // The receipt must belong to THIS run's play — a recipient-only lookup
+      // once linked a show-hn run to a post-funding send from another day.
+      expect(receipt?.["play_name"]).toBe(run?.["play_name"]);
       const to = (JSON.parse(String(receipt?.["signed_receipt"])) as { to?: string }).to;
       expect(emails).toContain(to);
     }

--- a/apps/cli/src/demo/dataset.ts
+++ b/apps/cli/src/demo/dataset.ts
@@ -1434,22 +1434,29 @@ function buildRuns(anchor: Date, receipts: DemoReceipt[]): DemoDataset["runs"] {
   // Receipt ids are assigned globally while iterating PEOPLE, so a run's send
   // events must look up the actual email.send receipt per recipient — a
   // hardcoded [1]/[2] would link this run's sends to whoever's prep calls
-  // happened to be recorded first.
-  const sendReceiptIdFor = (email: string): number => {
+  // happened to be recorded first. Matching is by (play, recipient), not
+  // recipient alone: a prospect who was ALSO emailed by another play would
+  // otherwise satisfy the lookup with the wrong play's receipt and timestamp,
+  // and a run must only ever claim sends that belong to it.
+  const sendReceiptIdFor = (playName: string, email: string): number => {
     const r = receipts.find(
-      (x) => x.callType === "email.send" && (x.signedReceipt as { to?: string }).to === email,
+      (x) =>
+        x.callType === "email.send" &&
+        x.playName === playName &&
+        (x.signedReceipt as { to?: string }).to === email,
     );
-    if (!r) throw new Error(`demo dataset: no email.send receipt for ${email}`);
+    if (!r) throw new Error(`demo dataset: no ${playName} email.send receipt for ${email}`);
     return r.id;
   };
 
-  const targets = [
-    { name: "Elin Dahl", email: "elin@northport.works", company: "Northport" },
-    { name: "Ravi Menon", email: "ravi@stanchion.dev", company: "Stanchion" },
-  ];
+  // Single target on purpose: Elin is the only show-hn send from the day this
+  // run ran. Padding the run with a prospect from another play (as an earlier
+  // draft did with Ravi) makes the run claim a send with the wrong play and
+  // timestamp — the play-aware lookup above now throws on that.
+  const targets = [{ name: "Elin Dahl", email: "elin@northport.works", company: "Northport" }];
   const events = [
     { kind: "runStarted", runId: 1, startedAt: isoAt(anchor, 1, 9, 0) },
-    { kind: "verify", total: 2, verified: 2, dropped: [] },
+    { kind: "verify", total: 1, verified: 1, dropped: [] },
     { kind: "stage", stage: "drafting" },
     {
       kind: "draft",
@@ -1458,16 +1465,8 @@ function buildRuns(anchor: Date, receipts: DemoReceipt[]): DemoDataset["runs"] {
       body: "Hey Elin,\n\nThe top comment on your Show HN asks how you debug a stuck run, and your answer was basically 'carefully'. That is the gap Tracepoint fills.\n\nWorth fifteen minutes?\n\nMira",
       flags: [],
     },
-    { kind: "send", index: 0, receiptIds: [sendReceiptIdFor("elin@northport.works")] },
-    {
-      kind: "draft",
-      index: 1,
-      subject: "Stanchion + background job traces",
-      body: "Hey Ravi,\n\nGoing from three to eleven engineers is exactly when the async parts of the system stop fitting in one person's head.\n\nTracepoint drops into a worker with one import.\n\nMira",
-      flags: [],
-    },
-    { kind: "send", index: 1, receiptIds: [sendReceiptIdFor("ravi@stanchion.dev")] },
-    { kind: "done", total: 2, sent: 2 },
+    { kind: "send", index: 0, receiptIds: [sendReceiptIdFor("show-hn", "elin@northport.works")] },
+    { kind: "done", total: 1, sent: 1 },
   ];
 
   return [
@@ -1477,9 +1476,9 @@ function buildRuns(anchor: Date, receipts: DemoReceipt[]): DemoDataset["runs"] {
       status: "done",
       startedAt: isoAt(anchor, 1, 9, 0),
       completedAt: isoAt(anchor, 1, 9, 4),
-      targetCount: 2,
-      draftedCount: 2,
-      sentCount: 2,
+      targetCount: 1,
+      draftedCount: 1,
+      sentCount: 1,
       errorCount: 0,
       targetsJson: JSON.stringify(targets),
       eventsJson: JSON.stringify(events),


### PR DESCRIPTION
Follow-up to #28's remaining Macroscope finding: the seeded `show-hn` run included Ravi, a `post-funding` prospect, so its send event linked a receipt from the wrong play and day.

- Run is now single-target — Elin, the only show-hn send from the day the run ran
- `sendReceiptIdFor` matches `(play, recipient)` instead of recipient alone, and throws at dataset-build time on any future mismatch
- Regression test asserts each linked receipt's `play_name` equals the run's

Verified live: run receipt resolves to `show-hn email.send to elin@northport.works`. 1524 tests, typecheck + oxlint + oxfmt clean.

https://claude.ai/code/session_01WfjkhiBKFjEbkkL5TzmRLZ

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix demo runs to only claim email sends from their own play
> - `sendReceiptIdFor` in [dataset.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/29/files#diff-6f006f5ebb3282e9ecbcd025785a83c2d861d0077c235dea57fdf3178b6f09cf) now matches receipts by both `play_name` and recipient address, preventing a run from claiming send receipts belonging to a different play.
> - The demo run is simplified to a single target (Elin, `show-hn` play), with all event counts and summaries updated from 2 to 1.
> - The test in [demo-seed.test.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/29/files#diff-4f841be391572f55dc056fb8b0a5e247df0246142a8bd5b9168e5b4dfc3a0a4a) asserts that each receipt's `play_name` matches the run's `play_name`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5235e37.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->