### PR TITLE
fix(gmail): read the DSN when Gmail nests it in a child part

### DIFF
--- a/packages/core/__tests__/gmail-bounce.test.ts
+++ b/packages/core/__tests__/gmail-bounce.test.ts
@@ -362,3 +362,83 @@ describe("parseBounce — recipient scoring", () => {
     expect(parseBounce(msg)[0]?.recipient).toBe("target@dead.example");
   });
 });
+
+/**
+ * Gmail's own NDR shape, taken from a real 5.1.3 bounce: the
+ * `message/delivery-status` part is a container with an empty body and the
+ * RFC 3464 fields sit in a nested `text/plain` child. Every other fixture in
+ * this file uses the Exchange shape (fields on the part itself), which is why
+ * this went unnoticed until a hard bounce failed to suppress its address.
+ */
+describe("parseBounce — Gmail nests the report in a child part", () => {
+  const nested = (report: string): GmailMessageMeta => ({
+    id: "msg-nested",
+    threadId: "thread-nested",
+    internalDate: "1755000000000",
+    payload: {
+      mimeType: "multipart/report",
+      headers: [
+        { name: "From", value: "Mail Delivery Subsystem <mailer-daemon@googlemail.com>" },
+        { name: "Subject", value: "Delivery Status Notification (Failure)" },
+      ],
+      parts: [
+        {
+          mimeType: "multipart/related",
+          parts: [{ mimeType: "text/plain", body: { data: b64("Address not found") } }],
+        },
+        // container: no body of its own
+        {
+          mimeType: "message/delivery-status",
+          parts: [{ mimeType: "text/plain", body: { data: b64(report) } }],
+        },
+        { mimeType: "message/global-headers", body: { data: b64("To: s.zhu@pnptc.com") } },
+      ],
+    },
+  });
+
+  it("reads a hard bounce out of the nested text/plain child", () => {
+    const out = parseBounce(
+      nested(
+        "Final-Recipient: rfc822; s.zhu@pnptc.com\n" +
+          "Action: failed\n" +
+          "Status: 5.1.3\n" +
+          "Diagnostic-Code: smtp; The email account that you tried to reach does not exist.\n" +
+          "Last-Attempt-Date: Wed, 19 Aug 2026 13:04:20 -0700 (PDT)\n",
+      ),
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0]?.recipient).toBe("s.zhu@pnptc.com");
+    expect(out[0]?.kind).toBe("hard");
+    expect(out[0]?.statusCode).toBe("5.1.3");
+  });
+
+  it("still classifies a nested soft bounce as soft", () => {
+    const out = parseBounce(
+      nested("Final-Recipient: rfc822; aurelien@getcargoapp.com\nAction: failed\nStatus: 4.4.1\n"),
+    );
+    expect(out[0]?.kind).toBe("soft");
+  });
+
+  it("does not descend past the direct children into the returned original", () => {
+    // A message/rfc822 copy of our own outbound mail carries To:/Final-Recipient-
+    // looking headers. Parsing it would invent a bounce for a live address.
+    const msg = nested(
+      "Final-Recipient: rfc822; real@bounced.com\nAction: failed\nStatus: 5.1.1\n",
+    );
+    msg.payload?.parts?.push({
+      mimeType: "message/rfc822",
+      parts: [
+        {
+          mimeType: "text/plain",
+          body: {
+            data: b64(
+              "Final-Recipient: rfc822; live@prospect.com\nAction: failed\nStatus: 5.1.1\n",
+            ),
+          },
+        },
+      ],
+    });
+    const out = parseBounce(msg);
+    expect(out.map((b) => b.recipient)).toEqual(["real@bounced.com"]);
+  });
+});

--- a/packages/core/src/gmail.ts
+++ b/packages/core/src/gmail.ts
@@ -412,6 +412,35 @@ function findPart(
 }
 
 /**
+ * The RFC 3464 field block of a `message/delivery-status` part.
+ *
+ * Two shapes occur in the wild. Exchange and most MTAs put the fields directly
+ * on the part. Gmail's own NDRs make the part a container with an empty body
+ * and nest the fields in a `text/plain` child. Reading only the direct body
+ * therefore skipped every Gmail-generated DSN — the most common shape when the
+ * sending identity is itself Gmail — so the structured branch never ran, the
+ * prose fallback declined too, and a hard bounce recorded nothing and
+ * suppressed nobody.
+ *
+ * Only the part's own body and its direct children are considered. Descending
+ * further would reach the `message/rfc822` copy of the original outbound mail,
+ * whose headers name the recipient we sent to and would parse as a failure
+ * report for an address that never bounced.
+ */
+function decodeB64Url(data: string): string {
+  return Buffer.from(data, "base64url").toString("utf8");
+}
+
+function dsnReportText(part: GmailPayloadPart | undefined): string | null {
+  if (!part) return null;
+  if (part.body?.data) return decodeB64Url(part.body.data);
+  const child =
+    (part.parts ?? []).find((c) => c.mimeType === "text/plain" && c.body?.data) ??
+    (part.parts ?? []).find((c) => c.body?.data);
+  return child?.body?.data ? decodeB64Url(child.body.data) : null;
+}
+
+/**
  * Unfold RFC 5322 continuation lines (a line beginning with whitespace belongs
  * to the previous one). Diagnostic-Code routinely wraps across several lines,
  * and reading only the first would truncate the SMTP response mid-sentence.
@@ -457,9 +486,8 @@ export interface ParsedBounce {
  * senders that don't emit a conforming report.
  */
 export function parseBounce(msg: GmailMessageMeta): ParsedBounce[] {
-  const report = findPart(msg.payload, "message/delivery-status");
-  if (report?.body?.data) {
-    const text = Buffer.from(report.body.data, "base64url").toString("utf8");
+  const text = dsnReportText(findPart(msg.payload, "message/delivery-status"));
+  if (text) {
     const out: ParsedBounce[] = [];
     // Per-message fields come first, then one block per recipient, blank-line
     // separated. Only blocks naming a recipient describe a delivery failure.


### PR DESCRIPTION
A hard bounce arrived on 19 Aug for `s.zhu@pnptc.com` — "the email account that you tried to reach does not exist." Four days later the address was still unsuppressed, still in the ledger, and still eligible to be mailed. This is why.

## The bug

`parseBounce` read the RFC 3464 fields directly off the `message/delivery-status` part:

```js
const report = findPart(msg.payload, "message/delivery-status");
if (report?.body?.data) {
```

Exchange puts them there. **Gmail does not** — it makes that part a container with `body.size = 0` and nests the fields in a `text/plain` child:

```
multipart/report
├── multipart/related
├── message/delivery-status   ← body.size = 0
│   └── text/plain            ← Final-Recipient / Action / Status live here
└── message/global-headers
```

So the structured branch never ran. The prose fallback then declined as designed — it is deliberately gated so an ordinary email mentioning an address cannot be scraped into a bounce. `parseBounce` returned `[]`, and a 5.1.3 was recorded as nothing at all.

Because outbound already sends from Gmail identities, **Gmail-to-Gmail is the common case**, so the most frequent bounce shape was precisely the invisible one. The only bounces ever recorded were `5.7.520`s from Exchange, which happen to put the report where we looked.

## Measured impact

Across the three connected mailboxes, 30-day window:

| | |
|---|---|
| DSN messages present | 8 |
| Parsed before this change | 2 |
| **Missed** | **5** |

The misses: `s.zhu@pnptc.com` (5.1.3, hard), `alexanne.hilll@lostrprob.com` (5.1.2, hard — NXDOMAIN), and three 4.4.1 soft retries. Both hard-bounced addresses were live and enrolled.

## The fix

`dsnReportText` takes the part's own body when present, otherwise its direct `text/plain` child.

It **does not recurse further**, and that is load-bearing: a DSN also carries a `message/rfc822` copy of the original outbound mail, whose headers name the address we sent to. Descending into it would parse a failure report for a mailbox that never bounced and suppress a live prospect. A test pins that boundary.

Everything downstream — `classifyBounce`, suppression, cadence stop, the doctor rate — was already correct and needed no change.

## Tests

Three added, all built from the real message. Verified they fail without the fix and pass with it:

```
× reads a hard bounce out of the nested text/plain child
× still classifies a nested soft bounce as soft
× does not descend past the direct children into the returned original
```

Every pre-existing fixture in `gmail-bounce.test.ts` used the Exchange shape, which is why this stayed green from the day the feature shipped.

Full suite **1527 passing / 117 files** (+3, no new files) · oxlint 0 warnings · typecheck clean · `fmt:check` clean.

## Backfill

The sweep was run against the live mailboxes after the fix: 7 polled, 5 recorded. Both hard bounces now return a suppression record, so neither address can be mailed again. The soft 4.4.1 correctly does not suppress. Ledger backed up first.

`STATUS.md` lists bounce harvesting as "not verified against live OneShot" — it is now verified, and it was broken.

https://claude.ai/code/session_01HuWi3EgNCRicFoCKHytmJZ

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `parseBounce` to read DSN text from nested child parts in Gmail NDRs
> - Gmail sometimes places the RFC 3464 delivery-status fields in a `text/plain` child of the `message/delivery-status` container instead of in the container's own body. `parseBounce` previously read `report.body.data` directly, which returned empty for these messages.
> - Adds `dsnReportText` in [gmail.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/30/files#diff-ef867799f446a23ce68039253fb0c9747bdc62d1d0db4350608ad4d6cf9293fb) which checks the delivery-status part's own body first, then falls back to its direct children. It intentionally does not descend past direct children, avoiding reading DSN-like headers from nested `message/rfc822` parts.
> - Adds `decodeB64Url` helper for base64url-to-UTF-8 decoding.
> - Behavioral Change: `parseBounce` now returns recipients from Gmail-style nested delivery-status reports that previously produced empty results, and ignores deeper nested `message/rfc822` content.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac2f366.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->