### PR TITLE
docs: embed the launch video in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ bunx oneshot-gtm-server     # dashboard only — published, no clone
 
 [![Built with oneshot-sdk](https://img.shields.io/badge/built%20with-oneshot--sdk-0a0a0a?style=flat&labelColor=18181b&color=22c55e)](https://www.npmjs.com/package/@oneshot-agent/sdk) [![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE) [![Bun](https://img.shields.io/badge/runtime-Bun%201.3+-fbf0df?logo=bun&logoColor=black)](https://bun.sh) [![TypeScript](https://img.shields.io/badge/typed-TypeScript%206-3178c6?logo=typescript&logoColor=white)](https://www.typescriptlang.org)
 
+https://github.com/user-attachments/assets/bba2fb2d-35c3-4171-a358-fd3a987c24bc
+
 ---
 
 ## What this is
@@ -299,3 +301,8 @@ One summary event per invocation: command, flags, outcome, duration, version, OS
 MIT. See [LICENSE](./LICENSE).
 
 Read every prompt. Fork every play. We expect you to.
+
+---
+
+Built by [free.butter](https://freebutter.com) — the lead infrastructure behind this
+is the same pipeline that runs there.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -42,6 +42,7 @@ The ICP filter currently judges each candidate cold.
 
 Not code — these need capture, not commits. `demo seed` + `demo ui` now stand up a populated, fictional install to record against, so neither is blocked on having something to point a camera at.
 
+- [x] Launch video (55s, voiced) — embedded at the top of the README.
 - [ ] vhs terminal recording (60s), to embed in the README.
 - [ ] Dashboard demo gif (30s).
 - [ ] Launch posts — drafts are in `launch/`, unpublished.

--- a/STATUS.md
+++ b/STATUS.md
@@ -48,7 +48,7 @@ Five of those also stay **not ready** until you give them required config, and r
 - **`oneshot-gtm-server` requires Bun.** `bun:sqlite`, `Bun.serve`, and `Bun.stdin` are Bun-native; a runtime check in `dist/bin.mjs` fails loudly under plain `node`. A self-contained `bun build --compile` binary is a future option.
 - **The CLI is not on npm.** Only `oneshot-gtm-server` is published (0.7.0). The CLI needs a repo clone plus `bun link`.
 - **No public benchmarks page.** The telemetry endpoint is live and verified; the surface that renders aggregates from it is still roadmap.
-- **Launch assets not captured.** The terminal recording and dashboard gif the roadmap calls for don't exist yet, so no doc embeds one. The data to record against does: `demo seed` builds a populated fictional install.
+- **Launch assets partially captured.** The 55-second voiced launch video is embedded at the top of the README. The vhs terminal recording and dashboard gif the roadmap calls for are still open; `demo seed` builds the populated fictional install to record them against.
 - **Demo mode fixtures four network reads.** `listInbox`, `cadenceRocs`, `listSendingDomains` and `getBalance` read JSON from the demo home when `ONESHOT_GTM_DEMO=1`, and the scheduler idles. All four are reads; nothing that sends, drafts or spends is stubbed, and the flag is only ever set by `demo ui`. Under the flag the demo home's `.env` is also the **sole** source of secrets — inherited env vars and Bun's auto-loaded repo-root `.env` are overwritten or deleted, so a demo can never act with real credentials.
 
 ## GitHub stargazer discovery is degraded by upstream


### PR DESCRIPTION
Embeds the 55s voiced launch video at the top of the README as an inline player, right under the badges:

https://github.com/user-attachments/assets/bba2fb2d-35c3-4171-a358-fd3a987c24bc

Also:
- carries the free.butter credit footer
- checks the launch-video item off the roadmap's Launch assets list
- updates the STATUS bullet: terminal recording + dashboard gif still open

https://claude.ai/code/session_01WfjkhiBKFjEbkkL5TzmRLZ

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Embed launch video in `README.md`
> - Inserts the 55-second voiced launch video beneath the badges in [README.md](https://github.com/oneshot-agent/oneshot-gtm/pull/31/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)
> - Adds a closing attribution section noting the project author and pipeline relationship
> - Updates [ROADMAP.md](https://github.com/oneshot-agent/oneshot-gtm/pull/31/files#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51) and [STATUS.md](https://github.com/oneshot-agent/oneshot-gtm/pull/31/files#diff-6c33a39439907887e8de50ebb50d264136cb2a7c916dc8d4c184ee24fb5cec9e) to reflect the embedded video while noting the terminal recording and dashboard gif remain pending
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6675a62.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->