### PR TITLE
feat(prompts): allow the anti-pitch open, sparingly

### DIFF
--- a/packages/prompts/_humanizer.md
+++ b/packages/prompts/_humanizer.md
@@ -15,6 +15,30 @@ Every first-touch outbound email follows this order. Per-play prompts may add pl
 
 When the input block contains a `PROSPECT_FIRST_NAME: <name>` line, you MAY occasionally open with `Hey <name>,` followed by a blank line and then the Hook. Don't do this on every email — vary so it feels human, not templated. Roughly 1 in 3 is right; the rest should dive straight into the Hook. When the field is ABSENT, never invent a greeting and never guess a name from EMAIL or COMPANY — open with the Hook as usual. Use exactly `Hey` (not `Hi`, `Hello`, `Dear`, `Hey there`); this is the chosen register.
 
+## Optional anti-pitch open (sparing)
+
+A cold reader is braced for a pitch. Naming that expectation and declining it disarms faster than
+any value proposition — but it works because it is unexpected, so a template kills it. Use it at
+most 1 in 4, less if the play already has strong evidence to open on.
+
+Shape: acknowledge → name the move they expect → decline it → give the real reason you wrote →
+then continue into the normal Offer and CTA.
+
+Allowed:
+
+- "This is the part where I'd ask about your agent stack. Skipping that."
+- "I'll skip the bit where I explain what we do."
+
+Constraints:
+
+- **Never promise more than the email delivers.** "No pitch coming" becomes a lie the moment a
+  follow-up pitches. "Skipping that" is true when written and stays true.
+- **It replaces the Hook's framing, not the Offer or the CTA.** An email that declines to pitch and
+  then asks nothing leaves the reader with nothing to answer. On LinkedIn the connection request
+  already earned the reply; a cold email has no such handshake and still has to carry a topic.
+- **Never stack it on strong specific evidence.** If the play opens on a repo they starred or an
+  event they signed up for, that evidence IS the disarming move. Doing both reads as a bit.
+
 ## Subject-line patterns (allowed)
 
 - 2-5 lowercase words. Always all-lowercase including brand names + acronyms.

--- a/packages/prompts/_humanizer.md
+++ b/packages/prompts/_humanizer.md
@@ -22,7 +22,7 @@ any value proposition — but it works because it is unexpected, so a template k
 most 1 in 4, less if the play already has strong evidence to open on.
 
 Shape: acknowledge → name the move they expect → decline it → give the real reason you wrote →
-then continue into the normal Offer and CTA.
+then continue into the normal Identity, Offer and CTA.
 
 Allowed:
 
@@ -33,7 +33,7 @@ Constraints:
 
 - **Never promise more than the email delivers.** "No pitch coming" becomes a lie the moment a
   follow-up pitches. "Skipping that" is true when written and stays true.
-- **It replaces the Hook's framing, not the Offer or the CTA.** An email that declines to pitch and
+- **It replaces the Hook's framing, not the Identity, Offer or CTA.** An email that declines to pitch and
   then asks nothing leaves the reader with nothing to answer. On LinkedIn the connection request
   already earned the reply; a cold email has no such handshake and still has to carry a topic.
 - **Never stack it on strong specific evidence.** If the play opens on a repo they starred or an


### PR DESCRIPTION
## Why

A LinkedIn message that named the pitch the reader was braced for and then refused to deliver it landed better than the pitch it replaced. The device is worth having in email — but not by copying the LinkedIn copy wholesale, which is why this is deliberately small.

## What

One new section in `_humanizer.md`: an **optional** Hook framing, capped at ~1 in 4. It works because it's unexpected, so a template kills it.

The 4-step shape (Hook → Identity → Offer → CTA) is unchanged. Nothing existing was removed or softened.

## Three constraints, and why each is load-bearing

**Never promise more than the email delivers.** "No pitch coming" becomes a lie the moment a follow-up pitches. "Skipping that" is true when written and stays true.

**It replaces the Hook's framing, not the Offer or the CTA.** This is the part that does *not* transfer from LinkedIn. There, message one can drop both the identity beat and the offer, because the connection request already did the recognition work and the reader **accepted** it — that's an opt-in. A cold email has no handshake. An email that declines to pitch and then asks for nothing leaves the reader with nothing to answer, and the "skipping the pitch" move reads as a trick when there was no expectation to subvert.

**Never stack it on strong specific evidence.** If the play opens on a repo they starred or an event they signed up for, that evidence *is* the disarming move. Doing both reads as a bit.

## Scope note

`_humanizer.md` is prepended to every LLM call via `injectHumanizer()` (`packages/intel/src/client.ts:44`), so this is genuinely universal — hence adding an allowed option rather than a mandate.

Worth recording that email was already most of the way there: step 3 already says the Offer is "a shared topic, NEVER a deal — no cold discounts, credits, free trials", and the banned-CTA list already excludes "I'd love to chat" and "worth a 15-min". The gap this closes is one of register, not discipline.

## Verification

1524 tests / 117 files passing · oxlint 0 warnings · typecheck clean · `fmt:check` clean. Prompt-only diff.

https://claude.ai/code/session_01HuWi3EgNCRicFoCKHytmJZ

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add optional anti-pitch open technique to `_humanizer.md` prompt
> Introduces a new "Optional anti-pitch open (sparing)" section in [packages/prompts/_humanizer.md](https://github.com/oneshot-agent/oneshot-gtm/pull/32/files#diff-1af3dfa9b12552c5af223cc2772c713a4a6090ae38ea654a37bb61fa22fa5d30) that defines an alternative cold-email opening. It is capped at 1-in-4 frequency and follows a five-step structure: acknowledge, name the expected move, decline it, give the real reason, then proceed into Identity/Offer/CTA.
> - Provides two allowed example lines and constraints: never overpromise (e.g., do not claim "no pitch coming"), replace only the Hook's framing while keeping Identity/Offer/CTA, and avoid combining with strong specific-evidence opens.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0180b70.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->