### PR TITLE
fix(inbox): extract HTML-only reply bodies, and stop the counts lying

### DIFF
--- a/apps/server/__tests__/inbox-route.test.ts
+++ b/apps/server/__tests__/inbox-route.test.ts
@@ -35,7 +35,8 @@ vi.mock("@oneshot-gtm/core", async () => {
 // draftInboxReply isn't exercised here but the module imports it.
 vi.mock("@oneshot-gtm/plays", () => ({ draftInboxReply: vi.fn() }));
 
-const { listInboxRoute, saveDraftRoute, sendReplyRoute } = await import("../src/api/inbox.ts");
+const { draftReplyRoute, listInboxRoute, saveDraftRoute, sendReplyRoute } =
+  await import("../src/api/inbox.ts");
 
 function post(path: string, body: unknown): Request {
   return new Request(`http://localhost${path}`, {
@@ -156,5 +157,40 @@ describe("inbox route — persisted drafts & sent replies", () => {
       }),
     );
     expect(res.status).toBe(400);
+  });
+});
+
+describe("inbox route — window honesty & empty-body drafting", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getInboxThreadsMock.mockReturnValue(new Map());
+  });
+
+  it("passes listInbox's has_more through instead of hardcoding false", async () => {
+    listInboxMock.mockResolvedValue({ emails: [], has_more: true });
+    const res = await listInboxRoute(new Request("http://localhost/api/inbox"));
+    const out = (await res.json()) as { hasMore: boolean };
+    // The UI renders this as a "+" on its counts — a clamped window must never
+    // be presented as the whole mailbox.
+    expect(out.hasMore).toBe(true);
+  });
+
+  it("reports hasMore false when the window really is everything", async () => {
+    listInboxMock.mockResolvedValue({ emails: [], has_more: false });
+    const res = await listInboxRoute(new Request("http://localhost/api/inbox"));
+    expect(((await res.json()) as { hasMore: boolean }).hasMore).toBe(false);
+  });
+
+  it("draft-reply 400s legibly on a bodyless email", async () => {
+    const res = await draftReplyRoute(
+      post("/api/inbox/draft-reply", {
+        fromEmail: "founder@acme.com",
+        subject: "Re: hi",
+        body: "",
+      }),
+    );
+    expect(res.status).toBe(400);
+    const out = (await res.json()) as { error: string };
+    expect(out.error).toMatch(/no body/i);
   });
 });

--- a/apps/server/src/api/inbox.ts
+++ b/apps/server/src/api/inbox.ts
@@ -52,6 +52,7 @@ export async function listInboxRoute(req: Request): Promise<Response> {
   const ledger = getLedger();
 
   let emails: Awaited<ReturnType<typeof listInbox>>["emails"];
+  let hasMore = false;
   try {
     // Fetch a wide window (not just the newest handful): mailboxes fill with
     // newsletters/bounces/DMARC noise, and matching only runs over what's
@@ -60,6 +61,10 @@ export async function listInboxRoute(req: Request): Promise<Response> {
     // those; this gives it enough history to find them.
     const result = await listInbox({ limit: 200 });
     emails = result.emails;
+    // Truthful truncation signal: listInbox says whether this window is the
+    // whole story. The UI turns it into a "+" on its counts — the page must
+    // never present a clamped window as the entire mailbox.
+    hasMore = result.has_more;
   } catch (err) {
     logEvent(
       "inbox.list_failed",
@@ -162,7 +167,7 @@ export async function listInboxRoute(req: Request): Promise<Response> {
     .filter((r) => !selfAddresses.has(r.fromEmail))
     .toSorted((a, b) => (a.receivedAt < b.receivedAt ? 1 : a.receivedAt > b.receivedAt ? -1 : 0));
 
-  const out: InboxResult = { replies: visible, hasMore: false };
+  const out: InboxResult = { replies: visible, hasMore };
   return jsonResponse(out, 200, req);
 }
 
@@ -182,8 +187,14 @@ export async function draftReplyRoute(req: Request): Promise<Response> {
   const fromEmail = (body.fromEmail ?? "").trim().toLowerCase();
   const subject = (body.subject ?? "").trim();
   const inboundBody = (body.body ?? "").trim();
-  if (!fromEmail || !inboundBody) {
-    return jsonResponse({ error: "fromEmail and body are required" }, 400, req);
+  if (!fromEmail) {
+    return jsonResponse({ error: "fromEmail is required" }, 400, req);
+  }
+  // Distinct message: the UI disables the generate button on bodyless replies,
+  // but a scripted caller deserves to know WHY this 400s rather than getting a
+  // generic complaint about fields it did send.
+  if (!inboundBody) {
+    return jsonResponse({ error: "this email has no body to draft a reply from" }, 400, req);
   }
 
   const ledger = getLedger();

--- a/apps/web/src/routes/inbox.tsx
+++ b/apps/web/src/routes/inbox.tsx
@@ -56,6 +56,10 @@ function InboxPage() {
 
   const replies = inbox.data?.replies ?? [];
   const error = inbox.data?.error;
+  // The server fetches a clamped window (newest 200 across all identities).
+  // When listInbox says there was more, every total gets a "+" so the page
+  // never presents the window as the whole mailbox.
+  const windowSuffix = inbox.data?.hasMore ? "+" : "";
   // Filter is purely client-side over the already-fetched list (the endpoint
   // takes no params). Counts are off the full list so the buttons show the split.
   const matchedCount = replies.filter((r) => r.matched != null).length;
@@ -88,8 +92,8 @@ function InboxPage() {
             {!inbox.data
               ? "…"
               : matchFilter === "all"
-                ? `${replies.length} repl${replies.length === 1 ? "y" : "ies"}`
-                : `${visible.length} of ${replies.length}`}
+                ? `${replies.length}${windowSuffix} repl${replies.length === 1 && !windowSuffix ? "y" : "ies"}`
+                : `${visible.length} of ${replies.length}${windowSuffix}`}
           </span>
           <Button
             variant="ghost"
@@ -129,7 +133,12 @@ function InboxPage() {
             {f.label}
             {/* opacity (not a fixed faint color) so the count stays legible on
                 the selected button's cream fill as well as the ghost ones. */}
-            {inbox.data && <span className="ml-1 font-mono opacity-60">{countFor(f.key)}</span>}
+            {inbox.data && (
+              <span className="ml-1 font-mono opacity-60">
+                {countFor(f.key)}
+                {f.key === "all" ? windowSuffix : ""}
+              </span>
+            )}
           </Button>
         ))}
       </div>
@@ -399,7 +408,8 @@ function ReplyComposer({ reply }: { reply: InboxReplyView }) {
         <Button
           variant="ghost"
           size="sm"
-          disabled={generate.isPending || send.isPending}
+          disabled={!reply.body || generate.isPending || send.isPending}
+          title={reply.body ? undefined : "this email has no body to draft a reply from"}
           onClick={() => generate.mutate()}
         >
           {generate.isPending ? (

--- a/apps/web/src/routes/inbox.tsx
+++ b/apps/web/src/routes/inbox.tsx
@@ -135,8 +135,10 @@ function InboxPage() {
                 the selected button's cream fill as well as the ghost ones. */}
             {inbox.data && (
               <span className="ml-1 font-mono opacity-60">
+                {/* Every count is computed over the truncated window, so every
+                    count is a lower bound when hasMore — not just "all". */}
                 {countFor(f.key)}
-                {f.key === "all" ? windowSuffix : ""}
+                {windowSuffix}
               </span>
             )}
           </Button>

--- a/packages/core/__tests__/gmail.test.ts
+++ b/packages/core/__tests__/gmail.test.ts
@@ -328,6 +328,18 @@ describe("listGmailReplies", () => {
     expect(body).toBe("plain wins");
   });
 
+  it("falls back to the snippet when the HTML converts to empty text (image-only mail)", async () => {
+    const body = await bodyFor(
+      {
+        mimeType: "text/html",
+        headers: [{ name: "From", value: "a@b.dev" }],
+        body: { data: b64('<div><img src="cid:logo"></div>') },
+      },
+      "the snippet says this",
+    );
+    expect(body).toBe("the snippet says this");
+  });
+
   it("falls back to Gmail's snippet when no part carries decodable data", async () => {
     const body = await bodyFor(
       {

--- a/packages/core/__tests__/gmail.test.ts
+++ b/packages/core/__tests__/gmail.test.ts
@@ -193,7 +193,7 @@ describe("listGmailReplies", () => {
     const internalDate = Date.UTC(2026, 5, 10, 12, 0, 0);
     const fetchMock = vi.fn(async (url: string | URL) => {
       const u = String(url);
-      if (u.includes("oauth2.googleapis.com")) return tokenResponse();
+      if (u.startsWith("https://oauth2.googleapis.com/")) return tokenResponse();
       if (u.includes("/messages?")) {
         return new Response(JSON.stringify({ messages: [{ id: "m1" }] }), { status: 200 });
       }
@@ -245,7 +245,7 @@ describe("listGmailReplies", () => {
 
   it("returns an empty result when the inbox has no matches", async () => {
     const fetchMock = vi.fn(async (url: string | URL) => {
-      if (String(url).includes("oauth2.googleapis.com")) return tokenResponse();
+      if (String(url).startsWith("https://oauth2.googleapis.com/")) return tokenResponse();
       return new Response(JSON.stringify({}), { status: 200 });
     });
     vi.stubGlobal("fetch", fetchMock);
@@ -264,7 +264,7 @@ describe("listGmailReplies", () => {
   async function bodyFor(payload: unknown, snippet?: string): Promise<string> {
     const fetchMock = vi.fn(async (url: string | URL) => {
       const u = String(url);
-      if (u.includes("oauth2.googleapis.com")) return tokenResponse();
+      if (u.startsWith("https://oauth2.googleapis.com/")) return tokenResponse();
       if (u.includes("/messages?")) {
         return new Response(JSON.stringify({ messages: [{ id: "m1" }] }), { status: 200 });
       }
@@ -343,7 +343,7 @@ describe("listGmailReplies", () => {
   it("reports has_more when Gmail returns a nextPageToken", async () => {
     const fetchMock = vi.fn(async (url: string | URL) => {
       const u = String(url);
-      if (u.includes("oauth2.googleapis.com")) return tokenResponse();
+      if (u.startsWith("https://oauth2.googleapis.com/")) return tokenResponse();
       if (u.includes("/messages?")) {
         return new Response(JSON.stringify({ messages: [{ id: "m1" }], nextPageToken: "tok" }), {
           status: 200,

--- a/packages/core/__tests__/gmail.test.ts
+++ b/packages/core/__tests__/gmail.test.ts
@@ -140,6 +140,10 @@ describe("missingGmailSecrets", () => {
   });
 });
 
+function b64(s: string): string {
+  return Buffer.from(s, "utf8").toString("base64url");
+}
+
 function tokenResponse(token = "at-1", expiresIn = 3600): Response {
   return new Response(JSON.stringify({ access_token: token, expires_in: expiresIn }), {
     status: 200,
@@ -248,5 +252,119 @@ describe("listGmailReplies", () => {
     const out = await listGmailReplies();
     expect(out.emails).toEqual([]);
     expect(out.count).toBe(0);
+  });
+
+  /**
+   * Serve one message with the given payload/snippet and return its extracted
+   * body. The body-extraction tiers below are the regression suite for the
+   * "(no body)" bug: our outbound is HTML-only, reply clients mirror the
+   * format, so HTML-only replies are the NORMAL case — and the old extractor
+   * only ever read text/plain.
+   */
+  async function bodyFor(payload: unknown, snippet?: string): Promise<string> {
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      const u = String(url);
+      if (u.includes("oauth2.googleapis.com")) return tokenResponse();
+      if (u.includes("/messages?")) {
+        return new Response(JSON.stringify({ messages: [{ id: "m1" }] }), { status: 200 });
+      }
+      return new Response(
+        JSON.stringify({
+          id: "m1",
+          threadId: "t1",
+          internalDate: String(Date.UTC(2026, 5, 10)),
+          ...(snippet ? { snippet } : {}),
+          payload,
+        }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const out = await listGmailReplies({ limit: 10 });
+    return out.emails[0]?.body ?? "";
+  }
+
+  it("extracts a single-part text/html body, de-tagged", async () => {
+    const body = await bodyFor({
+      mimeType: "text/html",
+      headers: [{ name: "From", value: "a@b.dev" }],
+      body: { data: b64("<div>Thursday works.<br>— Jane</div>") },
+    });
+    expect(body).toBe("Thursday works.\n— Jane");
+  });
+
+  it("extracts HTML from multipart/alternative that carries ONLY html", async () => {
+    const body = await bodyFor({
+      mimeType: "multipart/alternative",
+      headers: [{ name: "From", value: "a@b.dev" }],
+      parts: [{ mimeType: "text/html", body: { data: b64("<p>only html here</p>") } }],
+    });
+    expect(body).toBe("only html here");
+  });
+
+  it("finds HTML nested inside multipart/related", async () => {
+    const body = await bodyFor({
+      mimeType: "multipart/mixed",
+      headers: [{ name: "From", value: "a@b.dev" }],
+      parts: [
+        {
+          mimeType: "multipart/related",
+          parts: [{ mimeType: "text/html", body: { data: b64("<p>nested</p>") } }],
+        },
+      ],
+    });
+    expect(body).toBe("nested");
+  });
+
+  it("still prefers text/plain when both parts exist", async () => {
+    const body = await bodyFor({
+      mimeType: "multipart/alternative",
+      headers: [{ name: "From", value: "a@b.dev" }],
+      parts: [
+        { mimeType: "text/plain", body: { data: b64("plain wins") } },
+        { mimeType: "text/html", body: { data: b64("<p>html loses</p>") } },
+      ],
+    });
+    expect(body).toBe("plain wins");
+  });
+
+  it("falls back to Gmail's snippet when no part carries decodable data", async () => {
+    const body = await bodyFor(
+      {
+        mimeType: "multipart/mixed",
+        headers: [{ name: "From", value: "a@b.dev" }],
+        parts: [{ mimeType: "text/html", body: {} }],
+      },
+      "snippet preview text",
+    );
+    expect(body).toBe("snippet preview text");
+  });
+
+  it("reports has_more when Gmail returns a nextPageToken", async () => {
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      const u = String(url);
+      if (u.includes("oauth2.googleapis.com")) return tokenResponse();
+      if (u.includes("/messages?")) {
+        return new Response(JSON.stringify({ messages: [{ id: "m1" }], nextPageToken: "tok" }), {
+          status: 200,
+        });
+      }
+      return new Response(
+        JSON.stringify({
+          id: "m1",
+          threadId: "t1",
+          internalDate: String(Date.UTC(2026, 5, 10)),
+          payload: {
+            mimeType: "text/plain",
+            headers: [{ name: "From", value: "a@b.dev" }],
+            body: { data: Buffer.from("hi", "utf8").toString("base64url") },
+          },
+        }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const out = await listGmailReplies({ limit: 10 });
+    expect(out.has_more).toBe(true);
   });
 });

--- a/packages/core/__tests__/html-text.test.ts
+++ b/packages/core/__tests__/html-text.test.ts
@@ -80,6 +80,19 @@ describe("htmlToText", () => {
     expect(out).not.toContain("script");
   });
 
+  it("stays fast on input stuffed with comment openers (ReDoS guard)", () => {
+    const hostile = `${"<!--".repeat(40_000)}tail`;
+    const t0 = performance.now();
+    const out = htmlToText(hostile);
+    expect(performance.now() - t0).toBeLessThan(1_000);
+    // The first opener never closes, so everything after it is comment.
+    expect(out).toBe("");
+  });
+
+  it("drops an unclosed comment to end-of-input, per spec", () => {
+    expect(htmlToText("before<!-- never closed")).toBe("before");
+  });
+
   // Review findings on #33 — each of these destroyed or leaked real content.
   it("preserves comparison operators in prose", () => {
     expect(htmlToText("<p>Revenue < $1m and growth > 20%</p>")).toBe(

--- a/packages/core/__tests__/html-text.test.ts
+++ b/packages/core/__tests__/html-text.test.ts
@@ -79,4 +79,25 @@ describe("htmlToText", () => {
     expect(performance.now() - t0).toBeLessThan(1_000);
     expect(out).not.toContain("script");
   });
+
+  // Review findings on #33 — each of these destroyed or leaked real content.
+  it("preserves comparison operators in prose", () => {
+    expect(htmlToText("<p>Revenue < $1m and growth > 20%</p>")).toBe(
+      "Revenue < $1m and growth > 20%",
+    );
+  });
+
+  it("treats attribute-bearing <br> as a line break (Gmail emits these)", () => {
+    expect(htmlToText('Hello<br class="gmail_default">World')).toBe("Hello\nWorld");
+  });
+
+  it("does not let </scripture> close a script element", () => {
+    // Spec: script content runs until a real close tag; a false-prefix close
+    // would stop stripping early and leak script source into the body.
+    expect(htmlToText("<script>var x;</scripture>more code</script>after")).toBe("after");
+  });
+
+  it("still strips to end-of-input when only false-prefix closers exist", () => {
+    expect(htmlToText("before<script>var x;</scripture>leaked")).toBe("before");
+  });
 });

--- a/packages/core/__tests__/html-text.test.ts
+++ b/packages/core/__tests__/html-text.test.ts
@@ -46,4 +46,25 @@ describe("htmlToText", () => {
   it("leaves malformed numeric entities out rather than throwing", () => {
     expect(htmlToText("&#x110000; ok")).toBe("ok");
   });
+
+  // Hardening (CodeQL js/incomplete-multi-character-sanitization /
+  // js/bad-tag-filter): a single replace pass can reassemble the construct it
+  // just removed, and spec-legal end tags carry junk before the `>`.
+  it("removes script content even with a nested-tag reassembly trick", () => {
+    expect(htmlToText("<scr<script>x</script>ipt>alert(1)</scr</script>ipt>ok")).not.toContain(
+      "alert",
+    );
+  });
+
+  it("removes script blocks whose end tag carries whitespace and junk", () => {
+    expect(htmlToText("<script>var x = 1;</script\t\n bar>after")).toBe("after");
+  });
+
+  it("removes style blocks with attributes on the open tag", () => {
+    expect(htmlToText('<style type="text/css">.a{}</style >text')).toBe("text");
+  });
+
+  it("never leaves an assembled comment opener behind", () => {
+    expect(htmlToText("<!<!--- x --->--> visible")).not.toContain("<!--");
+  });
 });

--- a/packages/core/__tests__/html-text.test.ts
+++ b/packages/core/__tests__/html-text.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { htmlToText } from "../src/html-text.ts";
+
+describe("htmlToText", () => {
+  it("strips tags and keeps the text", () => {
+    expect(htmlToText("<b>Hey</b> there, <i>Mira</i>.")).toBe("Hey there, Mira.");
+  });
+
+  it("turns structural breaks into newlines", () => {
+    expect(htmlToText("<p>line one</p><p>line two</p>")).toBe("line one\nline two");
+    expect(htmlToText("first<br>second<br/>third")).toBe("first\nsecond\nthird");
+    expect(htmlToText("<div>a</div><div>b</div>")).toBe("a\nb");
+  });
+
+  it("decodes the entities that actually occur in mail", () => {
+    expect(htmlToText("Tom &amp; Jerry &lt;3 &quot;quotes&quot; &#39;apos&#39;&nbsp;end")).toBe(
+      "Tom & Jerry <3 \"quotes\" 'apos' end",
+    );
+    expect(htmlToText("&#8364;21 and &#x20AC;22")).toBe("€21 and €22");
+  });
+
+  it("drops script, style, head and comments entirely", () => {
+    const html =
+      "<head><title>t</title></head><style>.a{color:red}</style>" +
+      "<script>alert('x')</script><!-- hidden -->visible";
+    expect(htmlToText(html)).toBe("visible");
+  });
+
+  it("collapses runs of blank lines left by nested markup", () => {
+    const html = "<div><p>one</p></div>\n\n<div>\n<p>two</p>\n</div>";
+    expect(htmlToText(html)).toBe("one\n\ntwo");
+  });
+
+  it("survives a typical HTML-only reply", () => {
+    const html =
+      '<div dir="ltr">Thanks for reaching out!<br><br>Thursday works.<div><br></div>' +
+      "<div>— Jane</div></div>";
+    expect(htmlToText(html)).toBe("Thanks for reaching out!\n\nThursday works.\n\n— Jane");
+  });
+
+  it("returns empty for empty or tag-only input", () => {
+    expect(htmlToText("")).toBe("");
+    expect(htmlToText("<div><br/></div>")).toBe("");
+  });
+
+  it("leaves malformed numeric entities out rather than throwing", () => {
+    expect(htmlToText("&#x110000; ok")).toBe("ok");
+  });
+});

--- a/packages/core/__tests__/html-text.test.ts
+++ b/packages/core/__tests__/html-text.test.ts
@@ -67,4 +67,16 @@ describe("htmlToText", () => {
   it("never leaves an assembled comment opener behind", () => {
     expect(htmlToText("<!<!--- x --->--> visible")).not.toContain("<!--");
   });
+
+  it("drops an unclosed script block to end-of-input instead of leaking it", () => {
+    expect(htmlToText("before<script>var secret = 1;")).toBe("before");
+  });
+
+  it("stays fast on input stuffed with close-tag prefixes (ReDoS guard)", () => {
+    const hostile = `<script>${"</script".repeat(20_000)}`;
+    const t0 = performance.now();
+    const out = htmlToText(hostile);
+    expect(performance.now() - t0).toBeLessThan(1_000);
+    expect(out).not.toContain("script");
+  });
 });

--- a/packages/core/__tests__/inbox-body-fill.test.ts
+++ b/packages/core/__tests__/inbox-body-fill.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { fillInboxBody } from "../src/oneshot.ts";
+
+// The OneShot inbox returns both `body` and `body_html`; an HTML-only mail has
+// an empty body and nothing used to read body_html — so /inbox rendered
+// "(no body)" and triage prompted the LLM with nothing. fillInboxBody runs in
+// listInbox's annotate funnel for every source.
+describe("fillInboxBody", () => {
+  const base = { id: "e1", from: "a@b.dev", subject: "s", received_at: "2026-08-01T00:00:00Z" };
+
+  it("keeps an existing plain body untouched", () => {
+    const e = { ...base, body: "already here", body_html: "<p>ignored</p>" };
+    expect(fillInboxBody(e)).toBe(e);
+  });
+
+  it("converts body_html when body is missing", () => {
+    const out = fillInboxBody({ ...base, body_html: "<p>Thursday works.</p><p>— Jane</p>" });
+    expect(out.body).toBe("Thursday works.\n— Jane");
+  });
+
+  it("converts body_html when body is blank whitespace", () => {
+    const out = fillInboxBody({ ...base, body: "  \n ", body_html: "<b>hi</b>" });
+    expect(out.body).toBe("hi");
+  });
+
+  it("leaves the email alone when neither field has content", () => {
+    const e = { ...base };
+    expect(fillInboxBody(e)).toBe(e);
+  });
+});

--- a/packages/core/src/gmail.ts
+++ b/packages/core/src/gmail.ts
@@ -1,4 +1,5 @@
 import type { InboxEmail, InboxListResult } from "@oneshot-agent/sdk";
+import { htmlToText } from "./html-text.ts";
 import { parallelMap } from "./parallel.ts";
 import type { AuthVerdict, BounceKind, GmailPlacement } from "./types.ts";
 
@@ -253,6 +254,8 @@ export interface GmailMessageMeta {
   threadId: string;
   internalDate: string;
   payload?: GmailPayloadPart;
+  /** Google-rendered plain-text preview — the last-resort body when no part decodes. */
+  snippet?: string;
 }
 
 export interface GmailPayloadPart {
@@ -267,16 +270,40 @@ function header(msg: GmailMessageMeta, name: string): string {
   return h?.value ?? "";
 }
 
-function extractPlainText(part: GmailPayloadPart | undefined): string {
+/** DFS for the first part of `mimeType` that carries inline data, decoded. */
+function extractByMime(part: GmailPayloadPart | undefined, mimeType: string): string {
   if (!part) return "";
-  if (part.mimeType === "text/plain" && part.body?.data) {
+  if (part.mimeType === mimeType && part.body?.data) {
     return Buffer.from(part.body.data, "base64url").toString("utf8");
   }
   for (const child of part.parts ?? []) {
-    const text = extractPlainText(child);
+    const text = extractByMime(child, mimeType);
     if (text) return text;
   }
   return "";
+}
+
+function extractPlainText(part: GmailPayloadPart | undefined): string {
+  return extractByMime(part, "text/plain");
+}
+
+/**
+ * Best-effort readable body for a fetched message, in three tiers:
+ * text/plain part → text/html part (de-tagged) → Gmail's snippet.
+ *
+ * The HTML tier is not an edge case. Our own outbound is HTML-only
+ * (`buildRawMessage` emits `text/html` with no multipart/alternative), and
+ * reply clients mirror the format of the mail they answer — so HTML-only
+ * replies to our sends are the expected shape. Without this tier the /inbox
+ * page showed "(no body)" for exactly the replies the tool exists to catch.
+ * The snippet tier covers bodies stored behind `attachmentId` (not fetched).
+ */
+function extractBody(msg: GmailMessageMeta): string {
+  const plain = extractPlainText(msg.payload);
+  if (plain) return plain;
+  const html = extractByMime(msg.payload, "text/html");
+  if (html) return htmlToText(html);
+  return msg.snippet ?? "";
 }
 
 /**
@@ -299,7 +326,7 @@ export async function listGmailReplies(
     q: `in:inbox -from:me ${sinceClause}`,
     maxResults: String(opts?.limit ?? 50),
   });
-  const list = await gmailJson<{ messages?: Array<{ id: string }> }>(
+  const list = await gmailJson<{ messages?: Array<{ id: string }>; nextPageToken?: string }>(
     `/messages?${params}`,
     undefined,
     account,
@@ -322,12 +349,15 @@ export async function listGmailReplies(
         subject: header(msg, "Subject"),
         received_at: new Date(Number(msg.internalDate)).toISOString(),
         thread_id: msg.threadId,
-        body: extractPlainText(msg.payload),
+        body: extractBody(msg),
         ...(messageId ? { message_id: messageId } : {}),
       };
     },
   );
-  return { emails, count: emails.length, has_more: false, agent_id: "gmail" };
+  // has_more from Gmail's own paging: a nextPageToken means the query matched
+  // more than this window, so downstream counts must not present the window as
+  // the whole mailbox.
+  return { emails, count: emails.length, has_more: !!list.nextPageToken, agent_id: "gmail" };
 }
 
 /* ── Bounce (DSN) harvesting ─────────────────────────────────────────────────

--- a/packages/core/src/gmail.ts
+++ b/packages/core/src/gmail.ts
@@ -302,7 +302,12 @@ function extractBody(msg: GmailMessageMeta): string {
   const plain = extractPlainText(msg.payload);
   if (plain) return plain;
   const html = extractByMime(msg.payload, "text/html");
-  if (html) return htmlToText(html);
+  if (html) {
+    // The conversion itself can come up empty (image-only mail is all tags) —
+    // that must still fall through to the snippet, not return "".
+    const text = htmlToText(html);
+    if (text) return text;
+  }
   return msg.snippet ?? "";
 }
 

--- a/packages/core/src/html-text.ts
+++ b/packages/core/src/html-text.ts
@@ -90,6 +90,26 @@ function stripBlocks(s: string, tag: string): string {
   return s;
 }
 
+/**
+ * Remove HTML comments with indexOf scanning — `<!--[\s\S]*?-->` is polynomial
+ * on input stuffed with `<!--` openers and no closer (CodeQL
+ * js/polynomial-redos), the same trap as the block regexes. An unclosed
+ * comment runs to end-of-input, per spec. After a cut the scan backs up 3
+ * chars: removing a comment can butt `<!` against `--` and assemble a fresh
+ * opener, which must not survive.
+ */
+function stripComments(s: string): string {
+  let from = 0;
+  while (true) {
+    const open = s.indexOf("<!--", from);
+    if (open === -1) return s;
+    const close = s.indexOf("-->", open + 4);
+    const end = close === -1 ? s.length : close + 3;
+    s = s.slice(0, open) + s.slice(end);
+    from = Math.max(0, open - 3);
+  }
+}
+
 export function htmlToText(html: string): string {
   if (!html) return "";
   let s = html;
@@ -98,7 +118,7 @@ export function htmlToText(html: string): string {
   s = stripBlocks(s, "script");
   s = stripBlocks(s, "style");
   s = stripBlocks(s, "head");
-  s = removeAll(s, /<!--[\s\S]*?-->/g);
+  s = stripComments(s);
 
   // Structural breaks → newlines BEFORE stripping tags, so paragraphs survive.
   // <br\b[^>]*> — Gmail emits attribute-bearing breaks (<br class="gmail_default">)

--- a/packages/core/src/html-text.ts
+++ b/packages/core/src/html-text.ts
@@ -72,7 +72,17 @@ function stripBlocks(s: string, tag: string): string {
     const o = open.exec(s);
     if (!o) return s;
     const afterOpen = o.index + o[0].length;
-    const closeAt = s.toLowerCase().indexOf(closeToken, afterOpen);
+    // Per spec, `</script` only closes when followed by whitespace, `/` or
+    // `>` — `</scripture>` does NOT end a script element, and treating it as
+    // a close would stop stripping early and leak the rest of the script
+    // source into the "body". Scan forward past false-prefix candidates.
+    const lower = s.toLowerCase();
+    let closeAt = lower.indexOf(closeToken, afterOpen);
+    while (closeAt !== -1) {
+      const next = s[closeAt + closeToken.length] ?? ">";
+      if (next === ">" || next === "/" || /\s/.test(next)) break;
+      closeAt = lower.indexOf(closeToken, closeAt + closeToken.length);
+    }
     const gt = closeAt === -1 ? -1 : s.indexOf(">", closeAt + closeToken.length);
     const end = gt === -1 ? s.length : gt + 1;
     s = s.slice(0, o.index) + s.slice(end);
@@ -91,12 +101,17 @@ export function htmlToText(html: string): string {
   s = removeAll(s, /<!--[\s\S]*?-->/g);
 
   // Structural breaks → newlines BEFORE stripping tags, so paragraphs survive.
-  s = s.replace(/<br\s*\/?>/gi, "\n");
+  // <br\b[^>]*> — Gmail emits attribute-bearing breaks (<br class="gmail_default">)
+  // and a stricter pattern silently joined the words around them.
+  s = s.replace(/<br\b[^>]*>/gi, "\n");
   s = s.replace(/<\/(p|div|tr|li|h[1-6]|blockquote|pre|table)\s*>/gi, "\n");
 
-  // Everything else is formatting we don't need — to fixpoint, so nested
-  // brackets can't reassemble a tag from the pieces of a removed one.
-  s = removeAll(s, /<[^>]+>/g);
+  // Everything else TAG-SHAPED is formatting we don't need — to fixpoint, so
+  // nested brackets can't reassemble a tag from the pieces of a removed one.
+  // Tag-shaped means `</`, `<!` or `<letter…`: a bare `<` in prose
+  // ("Revenue < $1m and growth > 20%") is comparison text, and the old
+  // `<[^>]+>` ate everything between it and the next `>`.
+  s = removeAll(s, /<\/?[a-z!][^>]*>/gi);
 
   s = decodeEntities(s);
 

--- a/packages/core/src/html-text.ts
+++ b/packages/core/src/html-text.ts
@@ -1,0 +1,67 @@
+/**
+ * Dependency-free HTML → readable plain text, for email bodies.
+ *
+ * Exists because most reply clients mirror the format of the mail they answer,
+ * and our outbound is HTML-only (`buildRawMessage` sends `text/html` with no
+ * `multipart/alternative`) — so HTML-only replies are the NORMAL case for this
+ * tool, and anything that renders or feeds an inbound body (the /inbox page,
+ * reply drafting, triage) needs a text form. This is a preview-quality
+ * conversion, not an HTML parser: good enough to read and to prompt an LLM
+ * with, not a DOM.
+ */
+
+/** Named entities that actually occur in mail bodies; everything else numeric. */
+const NAMED_ENTITIES: Record<string, string> = {
+  amp: "&",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  nbsp: " ",
+};
+
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&#x([0-9a-f]+);/gi, (_, hex: string) => safeCodePoint(Number.parseInt(hex, 16)))
+    .replace(/&#(\d+);/g, (_, dec: string) => safeCodePoint(Number.parseInt(dec, 10)))
+    .replace(/&([a-z]+);/gi, (m, name: string) => NAMED_ENTITIES[name.toLowerCase()] ?? m);
+}
+
+function safeCodePoint(cp: number): string {
+  if (!Number.isFinite(cp) || cp <= 0 || cp > 0x10ffff) return "";
+  try {
+    return String.fromCodePoint(cp);
+  } catch {
+    return "";
+  }
+}
+
+export function htmlToText(html: string): string {
+  if (!html) return "";
+  let s = html;
+
+  // Invisible content first, so its text never leaks into the output.
+  s = s.replace(/<script\b[\s\S]*?<\/script\s*>/gi, "");
+  s = s.replace(/<style\b[\s\S]*?<\/style\s*>/gi, "");
+  s = s.replace(/<head\b[\s\S]*?<\/head\s*>/gi, "");
+  s = s.replace(/<!--[\s\S]*?-->/g, "");
+
+  // Structural breaks → newlines BEFORE stripping tags, so paragraphs survive.
+  s = s.replace(/<br\s*\/?>/gi, "\n");
+  s = s.replace(/<\/(p|div|tr|li|h[1-6]|blockquote|pre|table)\s*>/gi, "\n");
+
+  // Everything else is formatting we don't need.
+  s = s.replace(/<[^>]+>/g, "");
+
+  s = decodeEntities(s);
+
+  // Windows newlines, per-line trim of trailing space, collapse blank runs.
+  s = s.replace(/\r\n?/g, "\n");
+  s = s
+    .split("\n")
+    .map((line) => line.replace(/[ \t]+$/g, "").replace(/^[ \t]+/g, ""))
+    .join("\n");
+  s = s.replace(/\n{3,}/g, "\n\n");
+
+  return s.trim();
+}

--- a/packages/core/src/html-text.ts
+++ b/packages/core/src/html-text.ts
@@ -52,17 +52,42 @@ function removeAll(s: string, re: RegExp): string {
   return s;
 }
 
+/**
+ * Remove every `<tag …>…</tag …>` block, contents included. The close tag is
+ * located with two `indexOf` calls — the token, then the next `>` — because
+ * ANY close-side regex here goes polynomial on input stuffed with `</tag`
+ * prefixes (CodeQL js/polynomial-redos; `</script[^>]*>` retries `[^>]*` from
+ * every prefix), and email HTML is attacker-supplied. The span between the
+ * token and the first `>` is `[^>]*` by construction, so the semantics match
+ * the spec-lenient close tag (`</script\t\n bar>` closes). Re-scanning from
+ * the top after each removal is the fixpoint property: excising a block must
+ * not leave a reassembled opener standing. An unclosed opener (or a close
+ * token with no `>` after it) drops to end-of-input — raw script/style text
+ * must never leak into the "body".
+ */
+function stripBlocks(s: string, tag: string): string {
+  const open = new RegExp(`<${tag}\\b[^>]*>`, "i");
+  const closeToken = `</${tag}`;
+  for (let i = 0; i < 100; i++) {
+    const o = open.exec(s);
+    if (!o) return s;
+    const afterOpen = o.index + o[0].length;
+    const closeAt = s.toLowerCase().indexOf(closeToken, afterOpen);
+    const gt = closeAt === -1 ? -1 : s.indexOf(">", closeAt + closeToken.length);
+    const end = gt === -1 ? s.length : gt + 1;
+    s = s.slice(0, o.index) + s.slice(end);
+  }
+  return s;
+}
+
 export function htmlToText(html: string): string {
   if (!html) return "";
   let s = html;
 
-  // Invisible content first, so its text never leaks into the output. End tags
-  // are matched as `</script[^>]*>` — per the HTML spec a close tag may carry
-  // whitespace (including newlines) and junk before `>`, and a stricter
-  // pattern would leave the element's raw contents in the "text".
-  s = removeAll(s, /<script\b[^>]*>[\s\S]*?<\/script[^>]*>/gi);
-  s = removeAll(s, /<style\b[^>]*>[\s\S]*?<\/style[^>]*>/gi);
-  s = removeAll(s, /<head\b[^>]*>[\s\S]*?<\/head[^>]*>/gi);
+  // Invisible content first, so its text never leaks into the output.
+  s = stripBlocks(s, "script");
+  s = stripBlocks(s, "style");
+  s = stripBlocks(s, "head");
   s = removeAll(s, /<!--[\s\S]*?-->/g);
 
   // Structural breaks → newlines BEFORE stripping tags, so paragraphs survive.

--- a/packages/core/src/html-text.ts
+++ b/packages/core/src/html-text.ts
@@ -36,22 +36,42 @@ function safeCodePoint(cp: number): string {
   }
 }
 
+/**
+ * Replace-until-fixpoint. A single `.replace` pass over overlapping constructs
+ * can REASSEMBLE the pattern it just removed (`<scr<script>ipt>` → one pass
+ * leaves `<script>`), which is both a CodeQL incomplete-sanitization finding
+ * and a real extraction bug. Bounded so a pathological input can't loop
+ * forever; leftovers past the bound are caught by the final tag strip.
+ */
+function removeAll(s: string, re: RegExp): string {
+  for (let i = 0; i < 10; i++) {
+    const next = s.replace(re, "");
+    if (next === s) return next;
+    s = next;
+  }
+  return s;
+}
+
 export function htmlToText(html: string): string {
   if (!html) return "";
   let s = html;
 
-  // Invisible content first, so its text never leaks into the output.
-  s = s.replace(/<script\b[\s\S]*?<\/script\s*>/gi, "");
-  s = s.replace(/<style\b[\s\S]*?<\/style\s*>/gi, "");
-  s = s.replace(/<head\b[\s\S]*?<\/head\s*>/gi, "");
-  s = s.replace(/<!--[\s\S]*?-->/g, "");
+  // Invisible content first, so its text never leaks into the output. End tags
+  // are matched as `</script[^>]*>` — per the HTML spec a close tag may carry
+  // whitespace (including newlines) and junk before `>`, and a stricter
+  // pattern would leave the element's raw contents in the "text".
+  s = removeAll(s, /<script\b[^>]*>[\s\S]*?<\/script[^>]*>/gi);
+  s = removeAll(s, /<style\b[^>]*>[\s\S]*?<\/style[^>]*>/gi);
+  s = removeAll(s, /<head\b[^>]*>[\s\S]*?<\/head[^>]*>/gi);
+  s = removeAll(s, /<!--[\s\S]*?-->/g);
 
   // Structural breaks → newlines BEFORE stripping tags, so paragraphs survive.
   s = s.replace(/<br\s*\/?>/gi, "\n");
   s = s.replace(/<\/(p|div|tr|li|h[1-6]|blockquote|pre|table)\s*>/gi, "\n");
 
-  // Everything else is formatting we don't need.
-  s = s.replace(/<[^>]+>/g, "");
+  // Everything else is formatting we don't need — to fixpoint, so nested
+  // brackets can't reassemble a tag from the pieces of a removed one.
+  s = removeAll(s, /<[^>]+>/g);
 
   s = decodeEntities(s);
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export * from "./inflight.ts";
 export * from "./ledger.ts";
 export * from "./config.ts";
 export * from "./demo.ts";
+export * from "./html-text.ts";
 export * from "./events.ts";
 export * from "./telemetry.ts";
 export * from "./version.ts";

--- a/packages/core/src/oneshot.ts
+++ b/packages/core/src/oneshot.ts
@@ -20,6 +20,7 @@ import { createHash } from "node:crypto";
 import { getLedger } from "./ledger.ts";
 import { loadConfig, oneshotEnvReady } from "./config.ts";
 import { demoFixture, demoMode } from "./demo.ts";
+import { htmlToText } from "./html-text.ts";
 import { logEvent } from "./events.ts";
 import {
   type GmailBounce,
@@ -664,8 +665,27 @@ export interface AnnotatedInboxListResult extends InboxListResult {
   emails: AnnotatedInboxEmail[];
 }
 
+/**
+ * Ensure an inbound email has a readable `body`, falling back to a de-tagged
+ * `body_html`. The OneShot inbox returns both fields, and an HTML-only mail
+ * (the normal shape for replies to our HTML-only sends) has an empty `body` —
+ * nothing in the pipeline read `body_html`, so /inbox rendered "(no body)" and
+ * triage prompted the LLM with nothing. Applied in the annotate funnel so
+ * EVERY consumer of listInbox benefits, not just the dashboard route.
+ * Exported for tests.
+ */
+export function fillInboxBody(e: InboxEmail): InboxEmail {
+  if (e.body?.trim()) return e;
+  const html = e.body_html ?? "";
+  if (!html) return e;
+  return { ...e, body: htmlToText(html) };
+}
+
 function annotateInboxResult(r: InboxListResult, identityId: string): AnnotatedInboxListResult {
-  return { ...r, emails: r.emails.map((e) => ({ ...e, source_identity_id: identityId })) };
+  return {
+    ...r,
+    emails: r.emails.map((e) => ({ ...fillInboxBody(e), source_identity_id: identityId })),
+  };
 }
 
 /**
@@ -722,10 +742,15 @@ export async function listInbox(opts?: {
 
   if (sources.length === 1) {
     const only = sources[0]!;
-    return annotateInboxResult(
+    const result = annotateInboxResult(
       await withDeadline(only.fetch(), INBOX_SOURCE_TIMEOUT_MS, `inbox source '${only.label}'`),
       only.identityId,
     );
+    // Same post-processing as the multi-source branch below — without it the
+    // two branches disagree about count semantics (the single-source result
+    // came back unsliced, so `count` meant "fetched" there and "window" here),
+    // which is exactly the kind of drift that made the /inbox numbers lie.
+    return mergeInboxWindow([result], opts?.limit);
   }
 
   const results = await parallelMap(sources, 3, async (source) => {
@@ -751,19 +776,34 @@ export async function listInbox(opts?: {
   if (ok.length === 0) {
     throw new Error("all inbox sources failed — check doctor for identity auth status");
   }
+  return mergeInboxWindow(ok, opts?.limit);
+}
+
+/**
+ * Dedupe, sort newest-first and clamp source results to the requested window,
+ * with `has_more` true whenever the window is not the whole story — either a
+ * source said so itself, or the clamp dropped rows. Shared by BOTH listInbox
+ * branches so `count`/`has_more` mean the same thing regardless of how many
+ * identities are configured.
+ */
+function mergeInboxWindow(
+  results: AnnotatedInboxListResult[],
+  limit?: number,
+): AnnotatedInboxListResult {
+  const max = limit ?? 50;
   const seen = new Set<string>();
-  const emails = ok
+  const all = results
     .flatMap((r) => r.emails)
     .filter((e) => (seen.has(e.id) ? false : (seen.add(e.id), true)))
     .toSorted((a, b) =>
       a.received_at < b.received_at ? 1 : a.received_at > b.received_at ? -1 : 0,
-    )
-    .slice(0, opts?.limit ?? 50);
+    );
+  const emails = all.slice(0, max);
   return {
     emails,
     count: emails.length,
-    has_more: ok.some((r) => r.has_more),
-    agent_id: ok.map((r) => r.agent_id).join("+"),
+    has_more: results.some((r) => r.has_more) || all.length > max,
+    agent_id: results.map((r) => r.agent_id).join("+"),
   };
 }
 


### PR DESCRIPTION
## The bug

`/inbox` rendered **"(no body)"** for real replies. `extractPlainText` only ever read `text/plain` MIME parts — and HTML-only replies are the *normal* case here, because our own outbound goes out as `text/html` with no `multipart/alternative`, and reply clients mirror the format of the mail they answer. The OneShot source had the mirror-image blindness: the SDK returns `body_html` and nothing in the repo ever read it. Knock-on: `draft-reply` 400s on an empty body, so "generate with llm" was broken for exactly these replies.

The counts were also dishonest: the route hardcoded `hasMore: false` while presenting a clamped, post-filtered 200-mail window as the whole mailbox, and `listInbox`'s single-source branch skipped the dedupe/sort/clamp the multi-source branch applied, so `count` meant different things depending on how many identities you have.

## The fix

- **`htmlToText`** (new, dependency-free, in core): tags stripped, `<br>`/`</p>`/`</div>`… → newlines, entities decoded, script/style/head/comments dropped.
- **Gmail: three-tier extraction** — `text/plain` part → `text/html` part de-tagged → Gmail's `snippet` (covers `attachmentId`-only bodies). `nextPageToken` now feeds `has_more`.
- **OneShot: `fillInboxBody`** in `listInbox`'s annotate funnel converts `body_html` when `body` is empty — every consumer benefits (triage included), not just the dashboard.
- **Honest counts**: shared `mergeInboxWindow` for both `listInbox` branches (`has_more` true when a source says so *or* the clamp dropped rows); route passes it through; UI appends `+` to its totals when the window is truncated.
- **Legible empty-body failure**: distinct 400 message, and the generate button disables with a tooltip on genuinely bodyless mail.

## Verification

Live against the real mailbox (read-only): the exact screenshot repro (`Re: your ses setup` from aliyev.site) now extracts a **1731-char body**; `has_more: true` on the full 200-window; the only remaining bodyless mail is DMARC aggregate reports, which genuinely have no prose.

1548 tests / 119 files (24 new: HTML conversion, all four extraction tiers, text/plain priority, `nextPageToken` → `has_more`, `fillInboxBody`, route `hasMore` passthrough, empty-body 400). typecheck + oxlint + oxfmt clean.

Note: `apps/web` typecheck has a pre-existing unrelated error in `cadences.tsx` (present on a clean main checkout).

https://claude.ai/code/session_01WfjkhiBKFjEbkkL5TzmRLZ

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Extract HTML-only reply bodies and fix `hasMore`/count reporting in inbox
> - Adds dependency-free `htmlToText` utility ([html-text.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/33/files#diff-7b43c5e40c24c28ff956ac566566574df1cbac086bb6c33d4628dbe303087daf)) for stripping HTML email bodies to readable text, with entity decoding, structural breaks, script/style removal, and ReDoS guards.
> - `gmail.listGmailReplies` now uses `extractBody` with a three-tier fallback (text/plain → text/html via `htmlToText` → Gmail `snippet`), and sets `has_more` from `nextPageToken` instead of leaving it false.
> - `fillInboxBody` in [oneshot.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/33/files#diff-a75653098eb1094047ae1458ce831158ed4abd7e08122279a6827b46c0c2e9db) populates `body` from `body_html` when `body` is empty; `mergeInboxWindow` centralizes dedupe/sort/slice/`has_more` for both single- and multi-source inbox paths.
> - `listInboxRoute` ([inbox.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/33/files#diff-c315236e69a9fabdc312a22c5571ee4c28b9b0c7aad22590e519e92a47ffc591)) returns real `hasMore` from the underlying result; `draftReplyRoute` returns distinct 400 errors for missing `fromEmail` vs empty body. The web inbox appends `+` to counts when `hasMore` is true and disables the draft generate button for bodyless emails.
> - Risk: single-source `listInbox` now goes through `mergeInboxWindow`, which may change `has_more` and count semantics for existing callers of [oneshot.listInbox](https://github.com/oneshot-agent/oneshot-gtm/pull/33/files#diff-a75653098eb1094047ae1458ce831158ed4abd7e08122279a6827b46c0c2e9db); downstream code relying on hardcoded `false` `hasMore` will see different values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c2e18e5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->