### PR TITLE
feat(cli): named workspaces — one isolated install per product

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ bun run --cwd apps/web build                    # one-time: build the SPA
 bun run cli -- ui                               # http://127.0.0.1:3030
 ```
 
-To call it from anywhere: `cd apps/cli && bun link && bun link oneshot-gtm && cd -`.
+To call it from anywhere: `cd apps/cli && bun link && bun link oneshot-gtm && cd -`. If you linked before workspaces landed, re-run that — the bin target moved to the bootstrap shim (`src/main.ts`).
 
 Prefer the dashboard without cloning? `bunx oneshot-gtm-server` downloads and boots it. Bun is still required — the bundle uses `bun:sqlite` and `Bun.serve`, and fails loudly with an install hint under plain `node`. The CLI itself is not published to npm.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ bun run cli -- find drain podcast-guest --dry-run  # preview approved /queue row
 bun run cli -- cadence advance                     # daily tick: poll inbox, fire follow-ups
 ```
 
-41 commands — eleven groups, plus `init`, `doctor` and `ui` at the top level. `bun run cli -- --help` (or `oneshot-gtm --help` once linked) is the reference:
+47 commands — twelve groups, plus `init`, `doctor` and `ui` at the top level. `bun run cli -- --help` (or `oneshot-gtm --help` once linked) is the reference:
 
 | Group                    | Commands                                                                                                                                                        |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -89,6 +89,7 @@ bun run cli -- cadence advance                     # daily tick: poll inbox, fir
 | `intel`                  | `advise` · `personalize` · `triage-replies` · `weekly-review`                                                                                                   |
 | `handoff`                | `readiness` · `templatize` · `first-ae`                                                                                                                         |
 | `demo`                   | `seed` · `ui` · `reset` — a fictional install for screenshots and video                                                                                         |
+| `workspace`              | `list` · `create <name>` · `use <name>` · `current` · `path <name>` · `remove <name>` — one isolated install per product; `--workspace <name>` on any command   |
 
 Spend, CAC, RoCS and outcome logging deliberately have no CLI group — they live on the dashboard's Measure and Cadences pages so there's one source of truth. The `/api/measure/*` routes are there if you'd rather script them.
 
@@ -133,6 +134,25 @@ What demo mode changes, and nothing else:
 - The in-process **scheduler idles**, so enabled triggers don't fire against the demo install and overwrite its state mid-screenshot.
 
 Nothing that sends, drafts or spends is faked. Under the flag, the demo home's `.env` is the **sole** source of secrets — real credentials inherited from your shell, your install, or a repo-root `.env` are overwritten or deleted — so a stray click on Run or Send fails at auth rather than doing something real. `demo seed` refuses to touch `~/.oneshot-gtm`, and `demo reset` only removes a directory it marked as its own.
+
+---
+
+## Workspaces
+
+One install is one product: one founder voice, one ICP, one product brief, one ledger, one sender pool. Selling two things — or running the OneShot motion _and_ the oneshot-gtm adoption motion — means two workspaces:
+
+```bash
+bun run cli -- workspace create gtm          # ~/.oneshot-gtm-workspaces/gtm, dashboard :3031
+bun run cli -- --workspace gtm init          # its own profile, keys, identities
+bun run cli -- --workspace gtm ui            # runs side by side with the default on :3030
+bun run cli -- workspace use gtm             # make it the default for runs without the flag
+```
+
+`--workspace` (or `ONESHOT_GTM_WORKSPACE`) is resolved by a bootstrap shim before anything else loads, so every command and the spawned dashboard see the right home. An explicit `ONESHOT_GTM_HOME` still wins — it's the escape hatch, and `workspace path <name>` prints a home for scripting (`ops/expandi-sync` reads it that way).
+
+What stays **shared** across workspaces lives in `~/.oneshot-gtm-shared/shared.sqlite`: the paid lookup caches (enrichment, LinkedIn — the same person is never bought twice) and contact touches. A workspace never first-touches someone another workspace emailed in the last 7 days: the draft holds with a `contacted-elsewhere` flag you can override on a manual send, while drain and cadence steps wait the window out.
+
+`doctor` warns when two workspaces share a sending domain (warm-up caps are per-workspace, so the domain's real budget silently doubles) or a Gmail account (both inbox pollers would see both products' replies), and the dashboard masthead names the workspace you're in.
 
 ---
 
@@ -219,7 +239,7 @@ Add a OneShot domain and mailbox from `/setup` or `identities add` — pick a pr
 
 ```
 apps/
-  cli/        41-command CLI (commander); src/demo/ seeds the demo install
+  cli/        47-command CLI (commander); src/demo/ seeds the demo install, src/main.ts picks the workspace
   server/     Bun.serve + SSE; tsdown bundle published as `oneshot-gtm-server`
   web/        Vite + React 19 + TanStack + Base UI — 9 pages, run form, strategist dock, privacy mode
 packages/
@@ -250,7 +270,7 @@ bun install
 bun run typecheck                  # tsc --noEmit across cli + server + packages
 bun run lint                       # oxlint
 bun run fmt                        # oxfmt --write   (fmt:check in CI)
-bun run test                       # vitest — 1518 cases across 117 files
+bun run test                       # vitest — 1621 cases across 126 files
 bun run cli -- doctor              # smoke check
 ```
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,8 @@
 # Status
 
-**Assume green unless it's listed below.** The 41 CLI commands, 14 plays, 10 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and, with the seven exceptions on this page, verified end to end against the live OneShot API.
+**Assume green unless it's listed below.** The 47 CLI commands, 14 plays, 10 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and, with the seven exceptions on this page, verified end to end against the live OneShot API.
 
-Last verified **2026-08-17** · Bun 1.3.13 · OneShot SDK 0.22.0 · 1518 tests / 117 files · typecheck + oxlint clean (301 files).
+Last verified **2026-08-17** · Bun 1.3.13 · OneShot SDK 0.22.0 · 1621 tests / 126 files · typecheck + oxlint clean (318 files).
 
 Updated by hand after each dogfood run. CI auto-update is on the roadmap.
 

--- a/apps/cli/__tests__/workspace-shim.test.ts
+++ b/apps/cli/__tests__/workspace-shim.test.ts
@@ -1,0 +1,77 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { createWorkspace } from "@oneshot-gtm/core/workspaces";
+
+// End-to-end: the bootstrap shim must pick the workspace BEFORE core loads.
+// Spawns the real CLI entrypoint in a child with an isolated registry.
+
+const MAIN = resolve(import.meta.dirname, "../src/main.ts");
+
+let wsDir: string;
+beforeEach(() => {
+  wsDir = mkdtempSync(join(tmpdir(), "oneshot-shim-"));
+  process.env["ONESHOT_GTM_WORKSPACES"] = wsDir;
+});
+afterEach(() => {
+  delete process.env["ONESHOT_GTM_WORKSPACES"];
+  rmSync(wsDir, { recursive: true, force: true });
+});
+
+function run(args: string[], extraEnv: Record<string, string | undefined> = {}) {
+  const env: Record<string, string> = {};
+  for (const [k, v] of Object.entries({ ...process.env, ...extraEnv })) {
+    if (typeof v === "string") env[k] = v;
+  }
+  // The child must decide its own home: don't leak the test runner's.
+  delete env["ONESHOT_GTM_HOME"];
+  delete env["ONESHOT_GTM_WORKSPACE"];
+  for (const [k, v] of Object.entries(extraEnv)) if (v !== undefined) env[k] = v;
+  env["ONESHOT_GTM_WORKSPACES"] = wsDir;
+  env["ONESHOT_GTM_SHARED"] = join(wsDir, "shared");
+  env["ONESHOT_GTM_TELEMETRY"] = "0";
+  const out = Bun.spawnSync(["bun", MAIN, ...args], { env, stdout: "pipe", stderr: "pipe" });
+  return {
+    code: out.exitCode,
+    stdout: new TextDecoder().decode(out.stdout),
+    stderr: new TextDecoder().decode(out.stderr),
+  };
+}
+
+describe("workspace bootstrap shim", () => {
+  it("--workspace selects the named home before core loads", () => {
+    const entry = createWorkspace("gtm");
+    const r = run(["--workspace", "gtm", "workspace", "current"]);
+    expect(r.code).toBe(0);
+    expect(r.stdout.trim()).toBe(`gtm\t${entry.home}`);
+  });
+
+  it("ONESHOT_GTM_WORKSPACE selects it too, and the flag wins over the env", () => {
+    createWorkspace("gtm");
+    createWorkspace("sdk");
+    expect(run(["workspace", "current"], { ONESHOT_GTM_WORKSPACE: "sdk" }).stdout).toMatch(
+      /^sdk\t/,
+    );
+    expect(
+      run(["--workspace", "gtm", "workspace", "current"], { ONESHOT_GTM_WORKSPACE: "sdk" }).stdout,
+    ).toMatch(/^gtm\t/);
+  });
+
+  it("an unknown workspace fails fast with exit 2 and a legible message", () => {
+    const r = run(["--workspace", "nope", "doctor"]);
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain("no workspace named 'nope'");
+  });
+
+  it("an explicit ONESHOT_GTM_HOME wins, and conflicts with --workspace", () => {
+    createWorkspace("gtm");
+    const home = join(wsDir, "explicit");
+    expect(run(["workspace", "current"], { ONESHOT_GTM_HOME: home }).stdout.trim()).toBe(
+      `explicit\t${home}`,
+    );
+    const r = run(["--workspace", "gtm", "workspace", "current"], { ONESHOT_GTM_HOME: home });
+    expect(r.code).toBe(2);
+    expect(r.stderr).toContain("conflicts");
+  });
+});

--- a/apps/cli/__tests__/workspace-shim.test.ts
+++ b/apps/cli/__tests__/workspace-shim.test.ts
@@ -67,9 +67,11 @@ describe("workspace bootstrap shim", () => {
   it("an explicit ONESHOT_GTM_HOME wins, and conflicts with --workspace", () => {
     createWorkspace("gtm");
     const home = join(wsDir, "explicit");
-    expect(run(["workspace", "current"], { ONESHOT_GTM_HOME: home }).stdout.trim()).toBe(
-      `explicit\t${home}`,
-    );
+    // Unregistered homes are identified by canonical path (review finding on
+    // #37): two installs named the same must not collapse into one workspace.
+    const out = run(["workspace", "current"], { ONESHOT_GTM_HOME: home }).stdout.trim();
+    expect(out.startsWith("home:")).toBe(true);
+    expect(out.endsWith(`\t${home}`)).toBe(true);
     const r = run(["--workspace", "gtm", "workspace", "current"], { ONESHOT_GTM_HOME: home });
     expect(r.code).toBe(2);
     expect(r.stderr).toContain("conflicts");

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -4,7 +4,7 @@
   "description": "Open-source GTM agent for technical founders. Pay-per-result, signed receipts.",
   "license": "MIT",
   "bin": {
-    "oneshot-gtm": "./src/index.ts"
+    "oneshot-gtm": "./src/main.ts"
   },
   "files": [
     "src"

--- a/apps/cli/src/commands/demo.ts
+++ b/apps/cli/src/commands/demo.ts
@@ -104,6 +104,9 @@ export async function commandDemoUi(opts: DemoUiOpts): Promise<void> {
   scrubInheritedSecrets(process.env);
   process.env["ONESHOT_GTM_HOME"] = home;
   process.env["ONESHOT_GTM_DEMO"] = "1";
+  // Not a workspace: the shim may have set a real one, and the demo's masthead
+  // and touch attribution must not claim to be it.
+  process.env["ONESHOT_GTM_WORKSPACE"] = "demo";
   // The shared cross-workspace DB must not leak real caches/touches into a
   // demo, nor record the demo's clicks as real contact history.
   process.env["ONESHOT_GTM_SHARED"] = join(home, "shared");

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -1,3 +1,4 @@
+import { join } from "node:path";
 import {
   llmApiKey,
   loadConfig,
@@ -5,6 +6,7 @@ import {
   saveConfig,
   saveSecrets,
   secretsPath,
+  configDir,
 } from "@oneshot-gtm/core";
 import prompts from "prompts";
 import { box, c, header, note, ok, warn } from "../output.ts";
@@ -132,7 +134,7 @@ export async function runInit(): Promise<void> {
     // and the next loadConfig() would mint a fresh one.
     clientId: cfg.clientId,
   });
-  ok(`Saved profile to ${c.dim("~/.oneshot-gtm/config.json")}`);
+  ok(`Saved profile to ${c.dim(join(configDir(), "config.json"))}`);
 
   // Phase 2: collect secrets interactively (saved chmod 600 to ~/.oneshot-gtm/.env)
   process.stdout.write(

--- a/apps/cli/src/commands/ui.ts
+++ b/apps/cli/src/commands/ui.ts
@@ -2,7 +2,7 @@ import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-import { BASE_PORT, currentWorkspaceName, listWorkspaces } from "@oneshot-gtm/core";
+import { BASE_PORT, configDir, currentWorkspaceName, portForHome } from "@oneshot-gtm/core";
 import { CommandExit, c, fail, header, note, ok } from "../output.ts";
 
 interface UiOpts {
@@ -12,22 +12,20 @@ interface UiOpts {
   dev: boolean;
 }
 
-/** The port this workspace registered at `workspace create`, so two dashboards don't collide. */
-function workspacePort(): number {
-  try {
-    const name = currentWorkspaceName();
-    const entry = listWorkspaces().find(([n]) => n === name)?.[1];
-    return entry?.port ?? BASE_PORT;
-  } catch {
-    // A corrupt registry is doctor's problem, not a reason to refuse to boot.
-    return BASE_PORT;
-  }
-}
-
 function locateRepoRoot(): string {
   // apps/cli/src/commands/ui.ts → repo root is 4 levels up
   const here = dirname(fileURLToPath(import.meta.url));
   return resolve(here, "..", "..", "..", "..");
+}
+
+/** The registered port for the HOME this process is bound to (see portForHome); 3030 otherwise. */
+function workspacePort(): number {
+  try {
+    return portForHome(configDir());
+  } catch {
+    // A corrupt registry is doctor's problem, not a reason to refuse to boot.
+    return BASE_PORT;
+  }
 }
 
 export async function commandUi(opts: UiOpts): Promise<void> {

--- a/apps/cli/src/commands/ui.ts
+++ b/apps/cli/src/commands/ui.ts
@@ -2,12 +2,21 @@ import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { BASE_PORT, currentWorkspaceName, listWorkspaces } from "@oneshot-gtm/core";
 import { CommandExit, c, fail, header, note, ok } from "../output.ts";
 
 interface UiOpts {
-  port: number;
+  /** Explicit --port; otherwise the workspace's registered port (3030 for `default`). */
+  port?: number;
   noBrowser: boolean;
   dev: boolean;
+}
+
+/** The port this workspace registered at `workspace create`, so two dashboards don't collide. */
+function workspacePort(): number {
+  const name = currentWorkspaceName();
+  const entry = listWorkspaces().find(([n]) => n === name)?.[1];
+  return entry?.port ?? BASE_PORT;
 }
 
 function locateRepoRoot(): string {
@@ -17,7 +26,11 @@ function locateRepoRoot(): string {
 }
 
 export async function commandUi(opts: UiOpts): Promise<void> {
-  header(`oneshot-gtm ui ${opts.dev ? c.dim("(dev — vite + server)") : ""}`);
+  const port = opts.port ?? workspacePort();
+  const ws = currentWorkspaceName();
+  header(
+    `oneshot-gtm ui ${ws !== "default" ? c.cyan(`[${ws}] `) : ""}${opts.dev ? c.dim("(dev — vite + server)") : ""}`,
+  );
 
   const root = locateRepoRoot();
   const serverBin = join(root, "apps", "server", "src", "bin.ts");
@@ -34,12 +47,12 @@ export async function commandUi(opts: UiOpts): Promise<void> {
 
   const env: NodeJS.ProcessEnv = {
     ...process.env,
-    PORT: String(opts.port),
+    PORT: String(port),
     ...(opts.noBrowser ? { ONESHOT_GTM_NO_BROWSER: "1" } : {}),
   };
 
   if (opts.dev) {
-    note(`Starting Vite dev (5173) + API server (${opts.port})...`);
+    note(`Starting Vite dev (5173) + API server (${port})...`);
     env["VITE_DEV_SERVER_URL"] = "http://127.0.0.1:5173";
 
     const vite = spawn("bun", ["run", "--cwd", join(root, "apps", "web"), "dev"], {
@@ -63,7 +76,7 @@ export async function commandUi(opts: UiOpts): Promise<void> {
     };
     process.on("SIGINT", shutdown);
     process.on("SIGTERM", shutdown);
-    ok(`Web: http://127.0.0.1:5173    API: http://127.0.0.1:${opts.port}/api`);
+    ok(`Web: http://127.0.0.1:5173    API: http://127.0.0.1:${port}/api`);
     return new Promise<void>(() => {
       // never resolve; handlers above will exit on signal
     });

--- a/apps/cli/src/commands/ui.ts
+++ b/apps/cli/src/commands/ui.ts
@@ -14,9 +14,14 @@ interface UiOpts {
 
 /** The port this workspace registered at `workspace create`, so two dashboards don't collide. */
 function workspacePort(): number {
-  const name = currentWorkspaceName();
-  const entry = listWorkspaces().find(([n]) => n === name)?.[1];
-  return entry?.port ?? BASE_PORT;
+  try {
+    const name = currentWorkspaceName();
+    const entry = listWorkspaces().find(([n]) => n === name)?.[1];
+    return entry?.port ?? BASE_PORT;
+  } catch {
+    // A corrupt registry is doctor's problem, not a reason to refuse to boot.
+    return BASE_PORT;
+  }
 }
 
 function locateRepoRoot(): string {

--- a/apps/cli/src/commands/workspace.ts
+++ b/apps/cli/src/commands/workspace.ts
@@ -1,0 +1,75 @@
+import {
+  configDir,
+  createWorkspace,
+  currentWorkspaceName,
+  listWorkspaces,
+  loadRegistry,
+  removeWorkspace,
+  resolveWorkspaceHome,
+  setDefaultWorkspace,
+  WorkspaceError,
+} from "@oneshot-gtm/core";
+import { bail, c, header, note, ok, warn } from "../output.ts";
+
+function guarded<T>(fn: () => T): T {
+  try {
+    return fn();
+  } catch (err) {
+    if (err instanceof WorkspaceError) bail(err.message);
+    throw err;
+  }
+}
+
+export async function commandWorkspaceList(): Promise<void> {
+  header("oneshot-gtm workspaces");
+  const reg = loadRegistry();
+  const current = currentWorkspaceName();
+  for (const [name, entry] of listWorkspaces(reg)) {
+    const marks = [
+      name === current ? c.green("current") : null,
+      name === reg.default ? c.dim("default") : null,
+    ]
+      .filter(Boolean)
+      .join(" · ");
+    note(`  ${name.padEnd(18)} :${entry.port}  ${entry.home}${marks ? `  ${marks}` : ""}`);
+  }
+  note("");
+  note(
+    `Select one per run with ${c.cyan("--workspace <name>")}, or persist it with ${c.cyan("workspace use <name>")}.`,
+  );
+}
+
+export async function commandWorkspaceCreate(name: string): Promise<void> {
+  header(`oneshot-gtm workspace create ${name}`);
+  const entry = guarded(() => createWorkspace(name));
+  ok(`created ${c.cyan(name)} at ${entry.home} (dashboard port ${entry.port})`);
+  note("");
+  note("It's an empty install. Set it up like any other, scoped with --workspace:");
+  note(`  ${c.cyan(`bun run cli -- --workspace ${name} init`)}`);
+  note(`  ${c.cyan(`bun run cli -- --workspace ${name} ui`)}`);
+  warn("Give it its own sending domain and Gmail account — sharing either with another");
+  warn("workspace doubles the domain's daily budget and cross-wires reply detection.");
+}
+
+export async function commandWorkspaceUse(name: string): Promise<void> {
+  guarded(() => setDefaultWorkspace(name));
+  ok(`default workspace is now ${c.cyan(name)} — runs without --workspace use it`);
+}
+
+export async function commandWorkspaceCurrent(): Promise<void> {
+  // configDir() is the home this process is actually bound to — which, under
+  // an explicit ONESHOT_GTM_HOME, needn't be a registered workspace at all.
+  process.stdout.write(`${currentWorkspaceName()}	${configDir()}
+`);
+}
+
+export async function commandWorkspacePath(name: string): Promise<void> {
+  // Bare path on stdout, for scripts: ONESHOT_GTM_HOME=$(oneshot-gtm workspace path gtm) …
+  process.stdout.write(`${guarded(() => resolveWorkspaceHome(name))}\n`);
+}
+
+export async function commandWorkspaceRemove(name: string): Promise<void> {
+  const entry = guarded(() => removeWorkspace(name));
+  ok(`forgot workspace ${c.cyan(name)}`);
+  note(`Its files were left in place — remove them yourself if you mean it: ${entry.home}`);
+}

--- a/apps/cli/src/demo/seed.ts
+++ b/apps/cli/src/demo/seed.ts
@@ -10,7 +10,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
-import { Ledger } from "@oneshot-gtm/core";
+import { Ledger, workspaceNameForHome } from "@oneshot-gtm/core";
 import { buildDemoDataset, type DemoDataset } from "./dataset.ts";
 
 /** Written into every demo home. `demo reset` refuses to delete a dir without it. */
@@ -94,6 +94,13 @@ export function seedDemoHome(opts: { home?: string; anchor?: Date; force?: boole
   if (home === canonicalize(realHome())) {
     throw new DemoSeedError(
       `refusing to seed into your real install (${home}). Pass --home with a different directory.`,
+    );
+  }
+  // Named workspaces are real installs too.
+  const owner = workspaceNameForHome(home);
+  if (owner) {
+    throw new DemoSeedError(
+      `refusing to seed into workspace '${owner}' (${home}). Pass --home with a different directory.`,
     );
   }
   if (process.env["ONESHOT_GTM_HOME"] && home === canonicalize(process.env["ONESHOT_GTM_HOME"])) {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -78,7 +78,12 @@ program
     "Open-source GTM agent for technical founders. Pay-per-result. Signed receipts.\n" +
       "The CLI is a thin headless layer; ad-hoc target discovery + review + send happens in the dashboard (oneshot-gtm ui).",
   )
-  .version(CLI_VERSION);
+  .version(CLI_VERSION)
+  // Documentation only: main.ts consumes this flag BEFORE commander runs (the
+  // home must be chosen before core is imported), so it never reaches here.
+  // Declared so `--help` shows it and a stray occurrence isn't an "unknown
+  // option" error.
+  .option("-w, --workspace <name>", "run against a named workspace (see: workspace list)");
 
 // Bootstrap + launcher
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -46,6 +46,14 @@ import {
   commandDemoUi,
   DEFAULT_DEMO_HOME,
 } from "./commands/demo.ts";
+import {
+  commandWorkspaceCreate,
+  commandWorkspaceCurrent,
+  commandWorkspaceList,
+  commandWorkspacePath,
+  commandWorkspaceRemove,
+  commandWorkspaceUse,
+} from "./commands/workspace.ts";
 import { commandEnrichLinkedIn } from "./commands/enrich-linkedin.ts";
 import { commandFindDrain, commandFindWatch } from "./commands/find.ts";
 import {
@@ -80,16 +88,19 @@ program
   .command("ui")
   .option(
     "--port <n>",
-    "port for the API server (default 3030)",
+    "port for the API server (default: the workspace's registered port; 3030 for `default`)",
     (v) => Number.parseInt(v, 10),
-    3030,
   )
   .option("--no-browser", "do not auto-open the browser")
   .option("--dev", "use vite dev server (5173) + API server", false)
   .description("Open the local dashboard at http://127.0.0.1:<port>")
   .action(
-    runOrFail(async (opts: { port: number; browser: boolean; dev: boolean }) => {
-      await commandUi({ port: opts.port, noBrowser: !opts.browser, dev: opts.dev });
+    runOrFail(async (opts: { port?: number; browser: boolean; dev: boolean }) => {
+      await commandUi({
+        ...(opts.port != null ? { port: opts.port } : {}),
+        noBrowser: !opts.browser,
+        dev: opts.dev,
+      });
     }),
   );
 
@@ -145,6 +156,37 @@ demo
     }),
   );
 
+// Workspaces: named, fully isolated installs (one product each). Selection
+// (--workspace / ONESHOT_GTM_WORKSPACE / registry default) happens in main.ts
+// BEFORE core is imported — by the time these actions run the home is fixed.
+const workspace = program
+  .command("workspace")
+  .description("Named isolated installs — one per product you're selling");
+workspace
+  .command("list")
+  .description("Show every workspace, the current and the default")
+  .action(runOrFail(commandWorkspaceList));
+workspace
+  .command("create <name>")
+  .description("Create an empty workspace (then: --workspace <name> init)")
+  .action(runOrFail(commandWorkspaceCreate));
+workspace
+  .command("use <name>")
+  .description("Make a workspace the default for runs without --workspace")
+  .action(runOrFail(commandWorkspaceUse));
+workspace
+  .command("current")
+  .description("Print the active workspace name and home")
+  .action(runOrFail(commandWorkspaceCurrent));
+workspace
+  .command("path <name>")
+  .description("Print a workspace's home dir (for ONESHOT_GTM_HOME=$(…) scripting)")
+  .action(runOrFail(commandWorkspacePath));
+workspace
+  .command("remove <name>")
+  .description("Forget a workspace (files are left in place)")
+  .action(runOrFail(commandWorkspaceRemove));
+
 // Config (founder profile + LLM + secrets only; ICP lives in the dashboard)
 const config = program.command("config").description("Configure providers and profile");
 config.command("llm").description("Pick LLM provider and model").action(runOrFail(configLlm));
@@ -155,7 +197,7 @@ config
 config
   .command("keys")
   .description(
-    "Set or update API keys (LLM + OneShot wallet) — saved chmod 600 to ~/.oneshot-gtm/.env",
+    "Set or update API keys (LLM + OneShot wallet) — saved chmod 600 to the workspace's .env",
   )
   .action(runOrFail(configKeys));
 config
@@ -169,9 +211,7 @@ const gmail = program
   .description("Gmail / Google Workspace send path (alternate email provider)");
 gmail
   .command("auth")
-  .description(
-    "Authorize Gmail via OAuth and store the refresh token (chmod 600 ~/.oneshot-gtm/.env)",
-  )
+  .description("Authorize Gmail via OAuth and store the refresh token (chmod 600, workspace .env)")
   .action(runOrFail(commandGmailAuth));
 gmail
   .command("placement")

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1,0 +1,42 @@
+#!/usr/bin/env bun
+/**
+ * Bootstrap shim — the real bin target.
+ *
+ * core's config.ts captures ONESHOT_GTM_HOME at module load and auto-loads
+ * that home's .env on import, and ESM hoists imports, so by the time commander
+ * could parse a `--workspace` flag the install is already chosen. This file
+ * therefore imports only node builtins and the builtin-only workspaces module,
+ * decides the home, sets the env, and only THEN imports the CLI proper.
+ *
+ * Resolution: `--workspace <name>` > ONESHOT_GTM_WORKSPACE > registry default.
+ * An explicit ONESHOT_GTM_HOME wins over all of them (and combining it with
+ * --workspace is an error). Every child this process spawns (the dashboard
+ * server) inherits the decision through process.env.
+ */
+import {
+  extractWorkspaceFlag,
+  loadRegistry,
+  resolveWorkspaceSelection,
+  WorkspaceError,
+} from "@oneshot-gtm/core/workspaces";
+
+try {
+  const { flag, argv } = extractWorkspaceFlag(process.argv.slice(2));
+  const selection = resolveWorkspaceSelection({
+    flag,
+    envWorkspace: process.env["ONESHOT_GTM_WORKSPACE"],
+    envHome: process.env["ONESHOT_GTM_HOME"],
+    registry: loadRegistry(),
+  });
+  process.env["ONESHOT_GTM_HOME"] = selection.home;
+  process.env["ONESHOT_GTM_WORKSPACE"] = selection.name;
+  process.argv = [process.argv[0]!, process.argv[1]!, ...argv];
+} catch (err) {
+  if (err instanceof WorkspaceError) {
+    process.stderr.write(`  ✗ ${err.message}\n`);
+    process.exit(2);
+  }
+  throw err;
+}
+
+await import("./index.ts");

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -82,6 +82,11 @@ function RootLayout() {
     refetchInterval: 60_000,
   });
 
+  // Doctor's first check names the workspace: "<name> · <home>".
+  const workspaceName =
+    (doctor.data?.checks ?? []).find((c) => c.name === "workspace")?.message.split(" · ")[0] ??
+    null;
+
   const alerts: Record<NonNullable<NavItem["alert"]>, boolean> = {
     "queue-pending": (queueQuery.data?.counts.pending ?? 0) > 0,
     "doctor-fail": (doctor.data?.checks ?? []).some((c) => c.severity === "fail"),
@@ -192,7 +197,14 @@ function RootLayout() {
 
         <header className="flex items-center justify-between border-b border-ink-rule bg-ink-bg/70 px-6 py-2.5 backdrop-blur-[2px]">
           <div className="text-[11.5px] text-ink-faint ln-mono">
-            single user · local-first · bound to <span className="text-ink-muted">127.0.0.1</span>
+            {workspaceName && workspaceName !== "default" ? (
+              <>
+                workspace <span className="text-ink-cream">{workspaceName}</span> ·{" "}
+              </>
+            ) : (
+              "single user · "
+            )}
+            local-first · bound to <span className="text-ink-muted">127.0.0.1</span>
           </div>
           <div className="flex items-center gap-3">
             <PrivacyToggle />

--- a/apps/web/src/routes/setup.tsx
+++ b/apps/web/src/routes/setup.tsx
@@ -224,6 +224,8 @@ function SetupPage() {
   });
 
   const sources = status.data?.sources ?? {};
+  // Workspace-aware: the server already reports the real secrets path.
+  const homeDir = status.data?.secretsPath?.replace(/\/\.env$/, "") ?? "~/.oneshot-gtm";
   const provisionedDomains = status.data?.provisionedDomains ?? [];
   // Default mailbox shown as a placeholder — founder's first name, normalized.
   const founderLocalpart =
@@ -287,7 +289,7 @@ function SetupPage() {
           </h1>
         </div>
         <span className="text-[11px] text-ink-faint ln-mono">
-          saved to <span className="text-ink-muted">~/.oneshot-gtm/config.json</span> ·{" "}
+          saved to <span className="text-ink-muted">{homeDir}/config.json</span> ·{" "}
           <span className="text-ink-muted">.env</span> · chmod 600
         </span>
       </section>
@@ -574,7 +576,7 @@ function SetupPage() {
                 sources[llmSecretKey] === "env"
                   ? "Currently from shell env. Leaving blank keeps the env value."
                   : sources[llmSecretKey] === "file"
-                    ? "Currently from ~/.oneshot-gtm/.env. Leave blank to keep."
+                    ? "Currently from this workspace's .env. Leave blank to keep."
                     : "Not set. Paste it here to save (chmod 600)."
               }
               className="md:col-span-2"
@@ -592,7 +594,7 @@ function SetupPage() {
 
         <LedgerSection
           eyebrow="05 · Wallet"
-          lede="Keys live only in ~/.oneshot-gtm/.env chmod 600. Nothing leaves your machine."
+          lede={`Keys live only in ${homeDir}/.env chmod 600. Nothing leaves your machine.`}
         >
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             <Field label="Wallet mode" className="md:col-span-2">
@@ -1062,6 +1064,6 @@ function LedgerSection({
 
 function hintFor(source: "env" | "file" | null | undefined): string {
   if (source === "env") return "Currently from shell env. Leave blank to keep.";
-  if (source === "file") return "Currently from ~/.oneshot-gtm/.env. Leave blank to keep.";
+  if (source === "file") return "Currently from this workspace's .env. Leave blank to keep.";
   return "Not set yet.";
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "lint": "oxlint --report-unused-disable-directives",
     "fmt": "oxfmt",
     "fmt:check": "oxfmt --check",
-    "cli": "bun run apps/cli/src/index.ts",
+    "cli": "bun run apps/cli/src/main.ts",
     "ui": "bun run apps/server/src/bin.ts",
     "release:server": "VER=$(node -p \"require('./apps/server/package.json').version\") && git tag -a \"v$VER\" -m \"oneshot-gtm-server v$VER\" && git push --follow-tags"
   },

--- a/packages/core/__tests__/workspaces.test.ts
+++ b/packages/core/__tests__/workspaces.test.ts
@@ -1,0 +1,155 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  createWorkspace,
+  DEFAULT_WORKSPACE,
+  extractWorkspaceFlag,
+  legacyHome,
+  listWorkspaces,
+  loadRegistry,
+  removeWorkspace,
+  resolveWorkspaceHome,
+  resolveWorkspaceSelection,
+  setDefaultWorkspace,
+  WorkspaceError,
+  workspaceNameForHome,
+} from "../src/workspaces.ts";
+
+let dir: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "oneshot-ws-"));
+  process.env["ONESHOT_GTM_WORKSPACES"] = dir;
+});
+afterEach(() => {
+  delete process.env["ONESHOT_GTM_WORKSPACES"];
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("registry", () => {
+  it("starts with only the implicit default pointing at the legacy home", () => {
+    const all = listWorkspaces();
+    expect(all).toHaveLength(1);
+    expect(all[0]?.[0]).toBe(DEFAULT_WORKSPACE);
+    expect(all[0]?.[1].home).toBe(legacyHome());
+    expect(loadRegistry().default).toBe(DEFAULT_WORKSPACE);
+  });
+
+  it("creates a workspace under the container with the next free port", () => {
+    const a = createWorkspace("gtm");
+    const b = createWorkspace("sdk");
+    expect(a.home).toBe(join(dir, "gtm"));
+    expect(a.port).toBe(3031);
+    expect(b.port).toBe(3032);
+    expect(resolveWorkspaceHome("sdk")).toBe(b.home);
+  });
+
+  it("rejects bad names, duplicates and the reserved default", () => {
+    expect(() => createWorkspace("Bad Name")).toThrow(WorkspaceError);
+    createWorkspace("gtm");
+    expect(() => createWorkspace("gtm")).toThrow(/already exists/);
+    expect(() => createWorkspace("default")).toThrow(/built-in/);
+  });
+
+  it("use/remove update the default and never delete files", () => {
+    const e = createWorkspace("gtm");
+    setDefaultWorkspace("gtm");
+    expect(loadRegistry().default).toBe("gtm");
+    const removed = removeWorkspace("gtm");
+    expect(removed.home).toBe(e.home);
+    expect(loadRegistry().default).toBe(DEFAULT_WORKSPACE);
+    expect(() => removeWorkspace("default")).toThrow(WorkspaceError);
+  });
+
+  it("maps a home back to its workspace name, following symlink-free canonical paths", () => {
+    const e = createWorkspace("gtm");
+    expect(workspaceNameForHome(e.home)).toBe("gtm");
+    expect(workspaceNameForHome(`${e.home}/`)).toBe("gtm");
+    expect(workspaceNameForHome(join(dir, "nope"))).toBeNull();
+  });
+});
+
+describe("selection (what the bootstrap shim does)", () => {
+  it("flag > env > registry default", () => {
+    createWorkspace("gtm");
+    createWorkspace("sdk");
+    setDefaultWorkspace("sdk");
+    const reg = loadRegistry();
+    expect(
+      resolveWorkspaceSelection({
+        flag: "gtm",
+        envWorkspace: "sdk",
+        envHome: undefined,
+        registry: reg,
+      }).name,
+    ).toBe("gtm");
+    expect(
+      resolveWorkspaceSelection({
+        flag: null,
+        envWorkspace: "gtm",
+        envHome: undefined,
+        registry: reg,
+      }).name,
+    ).toBe("gtm");
+    expect(
+      resolveWorkspaceSelection({
+        flag: null,
+        envWorkspace: undefined,
+        envHome: undefined,
+        registry: reg,
+      }).name,
+    ).toBe("sdk");
+  });
+
+  it("an explicit ONESHOT_GTM_HOME wins, and conflicts with --workspace", () => {
+    const reg = loadRegistry();
+    const sel = resolveWorkspaceSelection({
+      flag: null,
+      envWorkspace: undefined,
+      envHome: join(dir, "elsewhere"),
+      registry: reg,
+    });
+    expect(sel.home).toBe(join(dir, "elsewhere"));
+    expect(() =>
+      resolveWorkspaceSelection({
+        flag: "gtm",
+        envWorkspace: undefined,
+        envHome: join(dir, "elsewhere"),
+        registry: reg,
+      }),
+    ).toThrow(/conflicts/);
+  });
+
+  it("an unknown name is a legible error listing what exists", () => {
+    createWorkspace("gtm");
+    expect(() =>
+      resolveWorkspaceSelection({
+        flag: "nope",
+        envWorkspace: undefined,
+        envHome: undefined,
+        registry: loadRegistry(),
+      }),
+    ).toThrow(/no workspace named 'nope' \(known: default, gtm\)/);
+  });
+});
+
+describe("extractWorkspaceFlag", () => {
+  it("strips --workspace in both spellings and leaves the rest of argv intact", () => {
+    expect(extractWorkspaceFlag(["--workspace", "gtm", "ui", "--port", "4"])).toEqual({
+      flag: "gtm",
+      argv: ["ui", "--port", "4"],
+    });
+    expect(extractWorkspaceFlag(["ui", "--workspace=sdk"])).toEqual({ flag: "sdk", argv: ["ui"] });
+    expect(extractWorkspaceFlag(["-w", "gtm", "doctor"])).toEqual({
+      flag: "gtm",
+      argv: ["doctor"],
+    });
+    expect(extractWorkspaceFlag(["doctor"])).toEqual({ flag: null, argv: ["doctor"] });
+  });
+
+  it("rejects a missing name", () => {
+    expect(() => extractWorkspaceFlag(["--workspace"])).toThrow(/needs a name/);
+    expect(() => extractWorkspaceFlag(["--workspace", "--port"])).toThrow(/needs a name/);
+  });
+});

--- a/packages/core/__tests__/workspaces.test.ts
+++ b/packages/core/__tests__/workspaces.test.ts
@@ -1,14 +1,16 @@
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
+  BASE_PORT,
   createWorkspace,
   DEFAULT_WORKSPACE,
   extractWorkspaceFlag,
   legacyHome,
   listWorkspaces,
   loadRegistry,
+  portForHome,
   removeWorkspace,
   resolveWorkspaceHome,
   resolveWorkspaceSelection,
@@ -151,5 +153,52 @@ describe("extractWorkspaceFlag", () => {
   it("rejects a missing name", () => {
     expect(() => extractWorkspaceFlag(["--workspace"])).toThrow(/needs a name/);
     expect(() => extractWorkspaceFlag(["--workspace", "--port"])).toThrow(/needs a name/);
+  });
+});
+
+describe("second-round review findings (#37)", () => {
+  it("an empty ONESHOT_GTM_WORKSPACE falls back to the registry default", () => {
+    expect(
+      resolveWorkspaceSelection({
+        flag: null,
+        envWorkspace: "  ",
+        envHome: undefined,
+        registry: loadRegistry(),
+      }).name,
+    ).toBe(DEFAULT_WORKSPACE);
+  });
+
+  it("unregistered homes are identified by canonical path, not basename", () => {
+    const reg = loadRegistry();
+    const a = resolveWorkspaceSelection({
+      flag: null,
+      envWorkspace: undefined,
+      envHome: join(dir, "a", "gtm"),
+      registry: reg,
+    });
+    const b = resolveWorkspaceSelection({
+      flag: null,
+      envWorkspace: undefined,
+      envHome: join(dir, "b", "gtm"),
+      registry: reg,
+    });
+    expect(a.name).not.toBe(b.name);
+    expect(a.name.startsWith("home:")).toBe(true);
+  });
+
+  it("a relative ONESHOT_GTM_WORKSPACES is stored absolute", () => {
+    process.env["ONESHOT_GTM_WORKSPACES"] = "./rel-ws-" + process.pid;
+    try {
+      const e = createWorkspace("gtm");
+      expect(e.home.startsWith("/")).toBe(true);
+    } finally {
+      rmSync(resolve("./rel-ws-" + process.pid), { recursive: true, force: true });
+    }
+  });
+
+  it("portForHome keys on the home, so a same-basename unregistered home gets the fallback", () => {
+    const e = createWorkspace("gtm");
+    expect(portForHome(e.home)).toBe(e.port);
+    expect(portForHome(join(dir, "elsewhere", "gtm"))).toBe(BASE_PORT);
   });
 });

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "main": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./workspaces": "./src/workspaces.ts"
   },
   "dependencies": {
     "@oneshot-agent/sdk": "0.22.0"

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@ export * from "./ledger.ts";
 export * from "./config.ts";
 export * from "./demo.ts";
 export * from "./shared-db.ts";
+export * from "./workspaces.ts";
 export * from "./html-text.ts";
 export * from "./events.ts";
 export * from "./telemetry.ts";

--- a/packages/core/src/workspaces.ts
+++ b/packages/core/src/workspaces.ts
@@ -39,8 +39,10 @@ export interface WorkspaceRegistry {
 export class WorkspaceError extends Error {}
 
 export function workspacesDir(): string {
-  return (
-    process.env["ONESHOT_GTM_WORKSPACES"]?.trim() || join(homedir(), ".oneshot-gtm-workspaces")
+  // Absolute, so a relative override doesn't persist homes that resolve
+  // differently from another working directory.
+  return resolve(
+    process.env["ONESHOT_GTM_WORKSPACES"]?.trim() || join(homedir(), ".oneshot-gtm-workspaces"),
   );
 }
 
@@ -176,6 +178,20 @@ export function workspaceNameForHome(
 }
 
 /**
+ * Dashboard port for the install at `home`: the registered port when that
+ * exact home is a workspace, else BASE_PORT. Keyed by home rather than by the
+ * derived name, so an unregistered ONESHOT_GTM_HOME can never borrow a
+ * registered workspace's port and collide with its running dashboard.
+ */
+export function portForHome(home: string, reg: WorkspaceRegistry = loadRegistry()): number {
+  const target = canonicalPath(home);
+  for (const [, entry] of listWorkspaces(reg)) {
+    if (canonicalPath(entry.home) === target) return entry.port;
+  }
+  return BASE_PORT;
+}
+
+/**
  * What the bootstrap shim does: decide the home for this process from
  * `--workspace` (already stripped from argv by the caller), the env, or the
  * registry default. An explicit ONESHOT_GTM_HOME wins outright — it is the
@@ -195,12 +211,17 @@ export function resolveWorkspaceSelection(input: {
         `--workspace '${input.flag}' conflicts with ONESHOT_GTM_HOME=${explicitHome} — set one, not both`,
       );
     }
+    // An unregistered home must not collide with a registered one — or with
+    // another unregistered home of the same basename — in the shared DB's
+    // touch attribution, or the cross-workspace hold would treat two installs
+    // as one. Identity is the canonical path.
     return {
-      name: workspaceNameForHome(explicitHome, input.registry) ?? basename(explicitHome),
+      name:
+        workspaceNameForHome(explicitHome, input.registry) ?? `home:${canonicalPath(explicitHome)}`,
       home: explicitHome,
     };
   }
-  const name = input.flag ?? input.envWorkspace?.trim() ?? input.registry.default;
+  const name = input.flag ?? (input.envWorkspace?.trim() || input.registry.default);
   return { name, home: resolveWorkspaceHome(name, input.registry) };
 }
 

--- a/packages/core/src/workspaces.ts
+++ b/packages/core/src/workspaces.ts
@@ -1,0 +1,229 @@
+/**
+ * Named workspaces — fully isolated installs (one ONESHOT_GTM_HOME each).
+ *
+ * This module imports ONLY node builtins, on purpose: the CLI's bootstrap
+ * shim must resolve `--workspace <name>` to a home dir BEFORE core's config.ts
+ * is evaluated (it captures ONESHOT_GTM_HOME at module load), so anything
+ * this file imported from core would defeat the whole point. It is exposed as
+ * the `@oneshot-gtm/core/workspaces` subpath for that reason.
+ *
+ * Layout:
+ *   ~/.oneshot-gtm                        the `default` workspace (legacy home)
+ *   ~/.oneshot-gtm-workspaces/registry.json
+ *   ~/.oneshot-gtm-workspaces/<name>/     every named workspace
+ *
+ * `ONESHOT_GTM_WORKSPACES` relocates the container (tests, demos).
+ */
+import { existsSync, mkdirSync, readFileSync, realpathSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, dirname, join, resolve } from "node:path";
+
+export const DEFAULT_WORKSPACE = "default";
+/** Port the default workspace's dashboard binds; named ones get the next free slot. */
+export const BASE_PORT = 3030;
+
+export interface WorkspaceEntry {
+  /** Absolute home dir (config.json, ledger.sqlite, .env, …). */
+  home: string;
+  /** Dashboard port this workspace uses by default, so several can run side by side. */
+  port: number;
+  createdAt: string;
+}
+
+export interface WorkspaceRegistry {
+  /** Which workspace `oneshot-gtm` uses when no --workspace / env is given. */
+  default: string;
+  workspaces: Record<string, WorkspaceEntry>;
+}
+
+export class WorkspaceError extends Error {}
+
+export function workspacesDir(): string {
+  return (
+    process.env["ONESHOT_GTM_WORKSPACES"]?.trim() || join(homedir(), ".oneshot-gtm-workspaces")
+  );
+}
+
+export function legacyHome(): string {
+  return join(homedir(), ".oneshot-gtm");
+}
+
+function registryPath(): string {
+  return join(workspacesDir(), "registry.json");
+}
+
+const NAME_RE = /^[a-z0-9][a-z0-9-]{0,31}$/;
+
+export function assertValidName(name: string): void {
+  if (!NAME_RE.test(name)) {
+    throw new WorkspaceError(
+      `invalid workspace name '${name}' — use 1-32 lowercase letters, digits or hyphens`,
+    );
+  }
+}
+
+export function loadRegistry(): WorkspaceRegistry {
+  const p = registryPath();
+  if (!existsSync(p)) return { default: DEFAULT_WORKSPACE, workspaces: {} };
+  try {
+    const raw = JSON.parse(readFileSync(p, "utf8")) as Partial<WorkspaceRegistry>;
+    return {
+      default: typeof raw.default === "string" ? raw.default : DEFAULT_WORKSPACE,
+      workspaces: raw.workspaces && typeof raw.workspaces === "object" ? raw.workspaces : {},
+    };
+  } catch {
+    throw new WorkspaceError(`workspace registry at ${p} is not valid JSON — fix or delete it`);
+  }
+}
+
+export function saveRegistry(reg: WorkspaceRegistry): void {
+  const p = registryPath();
+  if (!existsSync(dirname(p))) mkdirSync(dirname(p), { recursive: true });
+  writeFileSync(p, `${JSON.stringify(reg, null, 2)}\n`);
+}
+
+/** Every workspace incl. the implicit default, as (name, entry) — for listing and guardrails. */
+export function listWorkspaces(
+  reg: WorkspaceRegistry = loadRegistry(),
+): Array<[string, WorkspaceEntry]> {
+  const all: Array<[string, WorkspaceEntry]> = [
+    [DEFAULT_WORKSPACE, { home: legacyHome(), port: BASE_PORT, createdAt: "" }],
+  ];
+  for (const [name, entry] of Object.entries(reg.workspaces)) {
+    if (name !== DEFAULT_WORKSPACE) all.push([name, entry]);
+  }
+  return all;
+}
+
+/** Resolve a name to its home, or throw a legible error. */
+export function resolveWorkspaceHome(
+  name: string,
+  reg: WorkspaceRegistry = loadRegistry(),
+): string {
+  if (name === DEFAULT_WORKSPACE) return legacyHome();
+  const entry = reg.workspaces[name];
+  if (!entry) {
+    const known = listWorkspaces(reg)
+      .map(([n]) => n)
+      .join(", ");
+    throw new WorkspaceError(`no workspace named '${name}' (known: ${known})`);
+  }
+  return entry.home;
+}
+
+export function createWorkspace(name: string): WorkspaceEntry {
+  assertValidName(name);
+  if (name === DEFAULT_WORKSPACE) {
+    throw new WorkspaceError(`'${DEFAULT_WORKSPACE}' is the built-in workspace at ${legacyHome()}`);
+  }
+  const reg = loadRegistry();
+  if (reg.workspaces[name]) throw new WorkspaceError(`workspace '${name}' already exists`);
+  const home = join(workspacesDir(), name);
+  const used = new Set(listWorkspaces(reg).map(([, e]) => e.port));
+  let port = BASE_PORT + 1;
+  while (used.has(port)) port += 1;
+  const entry: WorkspaceEntry = { home, port, createdAt: new Date().toISOString() };
+  mkdirSync(home, { recursive: true });
+  reg.workspaces[name] = entry;
+  saveRegistry(reg);
+  return entry;
+}
+
+export function setDefaultWorkspace(name: string): void {
+  const reg = loadRegistry();
+  resolveWorkspaceHome(name, reg); // throws if unknown
+  reg.default = name;
+  saveRegistry(reg);
+}
+
+/** Forget a workspace. Files are NOT deleted — the path is printed for the founder to remove. */
+export function removeWorkspace(name: string): WorkspaceEntry {
+  if (name === DEFAULT_WORKSPACE)
+    throw new WorkspaceError("the default workspace can't be removed");
+  const reg = loadRegistry();
+  const entry = reg.workspaces[name];
+  if (!entry) throw new WorkspaceError(`no workspace named '${name}'`);
+  delete reg.workspaces[name];
+  if (reg.default === name) reg.default = DEFAULT_WORKSPACE;
+  saveRegistry(reg);
+  return entry;
+}
+
+/** Symlink-following path identity, so two spellings of one dir compare equal. */
+export function canonicalPath(p: string): string {
+  let base = resolve(p);
+  const tail: string[] = [];
+  while (!existsSync(base)) {
+    const parent = dirname(base);
+    if (parent === base) break;
+    tail.unshift(basename(base));
+    base = parent;
+  }
+  const real = existsSync(base) ? realpathSync(base) : base;
+  return tail.length > 0 ? join(real, ...tail) : real;
+}
+
+/** Name of the workspace whose home is `home`, if any (used by doctor / the masthead). */
+export function workspaceNameForHome(
+  home: string,
+  reg: WorkspaceRegistry = loadRegistry(),
+): string | null {
+  const target = canonicalPath(home);
+  for (const [name, entry] of listWorkspaces(reg)) {
+    if (canonicalPath(entry.home) === target) return name;
+  }
+  return null;
+}
+
+/**
+ * What the bootstrap shim does: decide the home for this process from
+ * `--workspace` (already stripped from argv by the caller), the env, or the
+ * registry default. An explicit ONESHOT_GTM_HOME wins outright — it is the
+ * lower-level escape hatch — and combining it with --workspace is an error,
+ * since they would disagree about where the install is.
+ */
+export function resolveWorkspaceSelection(input: {
+  flag: string | null;
+  envWorkspace: string | undefined;
+  envHome: string | undefined;
+  registry: WorkspaceRegistry;
+}): { name: string; home: string } {
+  const explicitHome = input.envHome?.trim();
+  if (explicitHome) {
+    if (input.flag) {
+      throw new WorkspaceError(
+        `--workspace '${input.flag}' conflicts with ONESHOT_GTM_HOME=${explicitHome} — set one, not both`,
+      );
+    }
+    return {
+      name: workspaceNameForHome(explicitHome, input.registry) ?? basename(explicitHome),
+      home: explicitHome,
+    };
+  }
+  const name = input.flag ?? input.envWorkspace?.trim() ?? input.registry.default;
+  return { name, home: resolveWorkspaceHome(name, input.registry) };
+}
+
+/** Pull `--workspace <name>` / `--workspace=<name>` out of argv. Returns the cleaned argv. */
+export function extractWorkspaceFlag(argv: string[]): { flag: string | null; argv: string[] } {
+  const out: string[] = [];
+  let flag: string | null = null;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i]!;
+    if (a === "--workspace" || a === "-w") {
+      flag = argv[i + 1] ?? null;
+      if (!flag || flag.startsWith("-")) {
+        throw new WorkspaceError("--workspace needs a name");
+      }
+      i += 1;
+      continue;
+    }
+    if (a.startsWith("--workspace=")) {
+      flag = a.slice("--workspace=".length);
+      if (!flag) throw new WorkspaceError("--workspace needs a name");
+      continue;
+    }
+    out.push(a);
+  }
+  return { flag, argv: out };
+}

--- a/packages/doctor/__tests__/workspace-checks.test.ts
+++ b/packages/doctor/__tests__/workspace-checks.test.ts
@@ -1,0 +1,127 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Cross-workspace guardrails: doctor reads OTHER workspaces' homes by path and
+// warns when this one shares a sending domain or a Gmail account with them.
+
+let cfgOverride: Record<string, unknown> = {};
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    loadConfig: () => ({ ...actual.loadConfig(), ...cfgOverride }),
+  };
+});
+
+const { runDoctor } = await import("../src/check.ts");
+const { createWorkspace } = await import("@oneshot-gtm/core");
+
+let wsDir: string;
+beforeEach(() => {
+  wsDir = mkdtempSync(join(tmpdir(), "oneshot-doctor-ws-"));
+  process.env["ONESHOT_GTM_WORKSPACES"] = wsDir;
+  process.env["ONESHOT_GTM_WORKSPACE"] = "gtm";
+  createWorkspace("gtm");
+  cfgOverride = {};
+});
+afterEach(() => {
+  delete process.env["ONESHOT_GTM_WORKSPACES"];
+  delete process.env["ONESHOT_GTM_WORKSPACE"];
+  rmSync(wsDir, { recursive: true, force: true });
+});
+
+function otherWorkspace(name: string, config: unknown, tokens?: unknown): void {
+  const entry = createWorkspace(name);
+  mkdirSync(entry.home, { recursive: true });
+  writeFileSync(join(entry.home, "config.json"), JSON.stringify(config));
+  if (tokens) writeFileSync(join(entry.home, "gmail-tokens.json"), JSON.stringify(tokens));
+}
+
+describe("doctor workspace checks", () => {
+  it("names the current workspace first", async () => {
+    const checks = await runDoctor();
+    expect(checks[0]).toMatchObject({ name: "workspace", severity: "ok" });
+    expect(checks[0]?.message.startsWith("gtm · ")).toBe(true);
+  });
+
+  it("warns when another workspace uses the same sending domain", async () => {
+    cfgOverride = {
+      emailIdentities: [
+        {
+          id: "oneshot:me@acme.email",
+          provider: "oneshot",
+          sendingDomain: "acme.email",
+          maxPerDay: 50,
+          warmup: null,
+        },
+      ],
+    };
+    otherWorkspace("sdk", {
+      emailIdentities: [
+        {
+          id: "oneshot:hi@acme.email",
+          provider: "oneshot",
+          sendingDomain: "ACME.email",
+          maxPerDay: 50,
+          warmup: null,
+        },
+      ],
+    });
+    const checks = await runDoctor();
+    const hit = checks.find((c) => c.name === "sending domain acme.email");
+    expect(hit?.severity).toBe("warn");
+    expect(hit?.message).toContain("workspace 'sdk'");
+  });
+
+  it("warns when another workspace authorized the same Gmail account (via its token store)", async () => {
+    cfgOverride = {
+      emailIdentities: [
+        {
+          id: "gmail:me@gmail.com",
+          provider: "gmail",
+          address: "me@gmail.com",
+          maxPerDay: 50,
+          warmup: null,
+        },
+      ],
+    };
+    otherWorkspace(
+      "sdk",
+      { emailIdentities: [] },
+      { "gmail:me@gmail.com": { refreshToken: "rt", address: "Me@Gmail.com" } },
+    );
+    const checks = await runDoctor();
+    expect(checks.find((c) => c.name === "gmail me@gmail.com")?.severity).toBe("warn");
+  });
+
+  it("stays quiet when workspaces are properly separated", async () => {
+    cfgOverride = {
+      emailIdentities: [
+        {
+          id: "oneshot:me@gtm.email",
+          provider: "oneshot",
+          sendingDomain: "gtm.email",
+          maxPerDay: 50,
+          warmup: null,
+        },
+      ],
+    };
+    otherWorkspace("sdk", {
+      emailIdentities: [
+        {
+          id: "oneshot:me@sdk.email",
+          provider: "oneshot",
+          sendingDomain: "sdk.email",
+          maxPerDay: 50,
+          warmup: null,
+        },
+      ],
+    });
+    const checks = await runDoctor();
+    expect(
+      checks.some((c) => c.name.startsWith("sending domain") || c.name.startsWith("gmail ")),
+    ).toBe(false);
+  });
+});

--- a/packages/doctor/__tests__/workspace-checks.test.ts
+++ b/packages/doctor/__tests__/workspace-checks.test.ts
@@ -125,3 +125,33 @@ describe("doctor workspace checks", () => {
     ).toBe(false);
   });
 });
+
+describe("second-round review findings (#37)", () => {
+  it("an other workspace with an EMPTY identity pool still collides via its sendingDomain", async () => {
+    cfgOverride = {
+      emailIdentities: [
+        {
+          id: "oneshot:me@acme.email",
+          provider: "oneshot",
+          sendingDomain: "acme.email",
+          maxPerDay: 50,
+          warmup: null,
+        },
+      ],
+    };
+    otherWorkspace("sdk", { sendingDomain: "acme.email", emailIdentities: [] });
+    const checks = await runDoctor();
+    expect(checks.find((c) => c.name === "sending domain acme.email")?.severity).toBe("warn");
+  });
+
+  it("reports a port collision even when the current workspace is the later entry", async () => {
+    // gtm (current) got :3031 in beforeEach; give sdk the same port by editing the registry.
+    const { loadRegistry, saveRegistry } = await import("@oneshot-gtm/core");
+    otherWorkspace("sdk", { emailIdentities: [] });
+    const reg = loadRegistry();
+    reg.workspaces["sdk"]!.port = reg.workspaces["gtm"]!.port;
+    saveRegistry(reg);
+    const checks = await runDoctor();
+    expect(checks.some((c) => c.name.startsWith("workspace port"))).toBe(true);
+  });
+});

--- a/packages/doctor/src/check.ts
+++ b/packages/doctor/src/check.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   capGroupKey,
@@ -17,6 +17,8 @@ import {
   oneshotEnvReady,
   resolveIdentities,
   secretSource,
+  currentWorkspaceName,
+  listWorkspaces,
 } from "@oneshot-gtm/core";
 
 type CheckSeverity = "ok" | "warn" | "fail";
@@ -216,9 +218,126 @@ function placementCheck(): CheckResult {
   }
 }
 
+/**
+ * Workspace identity + cross-workspace guardrails. Other workspaces' homes are
+ * read by PATH (config.json / gmail-tokens.json) — core's config is bound to
+ * THIS home at import time and can't be re-pointed. Sharing a sending domain
+ * across workspaces silently doubles its daily budget (caps are per-ledger);
+ * sharing a Gmail account cross-wires reply detection (both pollers see both
+ * products' replies).
+ */
+function workspaceChecks(cfg: ReturnType<typeof loadConfig>): CheckResult[] {
+  const out: CheckResult[] = [];
+  const name = currentWorkspaceName();
+  let all: ReturnType<typeof listWorkspaces> = [];
+  try {
+    all = listWorkspaces();
+  } catch (err) {
+    out.push({
+      name: "workspace",
+      severity: "warn",
+      message: `${name} · ${configDir()}`,
+      hint: `workspace registry unreadable: ${(err as Error).message}`,
+    });
+    return out;
+  }
+  const mine = all.find(([n]) => n === name)?.[1];
+  out.push({
+    name: "workspace",
+    severity: "ok",
+    message: `${name} · ${configDir()}${mine ? ` · port ${mine.port}` : ""}`,
+  });
+
+  const myIdentities = resolveIdentities(cfg);
+  const myDomains = new Set(
+    myIdentities
+      .map((i) => (i.provider === "oneshot" ? (i.sendingDomain ?? cfg.sendingDomain) : null))
+      .filter((d): d is string => !!d)
+      .map((d) => d.toLowerCase()),
+  );
+  const myGmail = new Set(
+    myIdentities
+      .map((i) => (i.provider === "gmail" ? i.address : null))
+      .filter((a): a is string => !!a)
+      .map((a) => a.toLowerCase()),
+  );
+  const portsSeen = new Map<number, string>();
+  for (const [other, entry] of all) {
+    if (entry.port && portsSeen.has(entry.port) && other !== name) {
+      out.push({
+        name: `workspace port ${entry.port}`,
+        severity: "warn",
+        message: `'${other}' and '${portsSeen.get(entry.port)}' both default to :${entry.port}`,
+        hint: "run one with --port, or recreate the workspace",
+      });
+    }
+    if (entry.port) portsSeen.set(entry.port, other);
+    if (other === name) continue;
+    const theirCfg = readJson<{
+      sendingDomain?: string | null;
+      emailIdentities?: Array<{
+        provider: string;
+        sendingDomain?: string | null;
+        address?: string | null;
+      }> | null;
+    }>(join(entry.home, "config.json"));
+    const theirTokens = readJson<Record<string, { address?: string }>>(
+      join(entry.home, "gmail-tokens.json"),
+    );
+    if (!theirCfg) continue;
+    const theirDomains = new Set(
+      (theirCfg.emailIdentities ?? [])
+        .map((i) => (i.provider === "oneshot" ? (i.sendingDomain ?? theirCfg.sendingDomain) : null))
+        .concat(theirCfg.emailIdentities == null ? [theirCfg.sendingDomain ?? null] : [])
+        .filter((d): d is string => !!d)
+        .map((d) => d.toLowerCase()),
+    );
+    const theirGmail = new Set(
+      [
+        ...(theirCfg.emailIdentities ?? []).map((i) => (i.provider === "gmail" ? i.address : null)),
+        ...Object.values(theirTokens ?? {}).map((t) => t.address ?? null),
+      ]
+        .filter((a): a is string => !!a)
+        .map((a) => a.toLowerCase()),
+    );
+    for (const d of myDomains) {
+      if (theirDomains.has(d)) {
+        out.push({
+          name: `sending domain ${d}`,
+          severity: "warn",
+          message: `also used by workspace '${other}' — caps are per-workspace, so the domain's real daily budget is doubled`,
+          hint: "give each workspace its own sending domain (oneshot-gtm identities add)",
+        });
+      }
+    }
+    for (const a of myGmail) {
+      if (theirGmail.has(a)) {
+        out.push({
+          name: `gmail ${a}`,
+          severity: "warn",
+          message: `also authorized in workspace '${other}' — both inbox pollers will see both products' replies`,
+          hint: "use a separate Gmail account per workspace",
+        });
+      }
+    }
+  }
+  return out;
+}
+
+function readJson<T>(path: string): T | null {
+  try {
+    if (!existsSync(path)) return null;
+    return JSON.parse(readFileSync(path, "utf8")) as T;
+  } catch {
+    return null;
+  }
+}
+
 export async function runDoctor(): Promise<CheckResult[]> {
   const cfg = loadConfig();
   const results: CheckResult[] = [];
+
+  results.push(...workspaceChecks(cfg));
 
   results.push({
     name: "config dir",

--- a/packages/doctor/src/check.ts
+++ b/packages/doctor/src/check.ts
@@ -263,7 +263,7 @@ function workspaceChecks(cfg: ReturnType<typeof loadConfig>): CheckResult[] {
   );
   const portsSeen = new Map<number, string>();
   for (const [other, entry] of all) {
-    if (entry.port && portsSeen.has(entry.port) && other !== name) {
+    if (entry.port && portsSeen.has(entry.port)) {
       out.push({
         name: `workspace port ${entry.port}`,
         severity: "warn",
@@ -288,7 +288,12 @@ function workspaceChecks(cfg: ReturnType<typeof loadConfig>): CheckResult[] {
     const theirDomains = new Set(
       (theirCfg.emailIdentities ?? [])
         .map((i) => (i.provider === "oneshot" ? (i.sendingDomain ?? theirCfg.sendingDomain) : null))
-        .concat(theirCfg.emailIdentities == null ? [theirCfg.sendingDomain ?? null] : [])
+        .concat(
+          // Mirror resolveIdentities: no pool OR an empty pool sends via sendingDomain.
+          theirCfg.emailIdentities == null || theirCfg.emailIdentities.length === 0
+            ? [theirCfg.sendingDomain ?? null]
+            : [],
+        )
         .filter((d): d is string => !!d)
         .map((d) => d.toLowerCase()),
     );


### PR DESCRIPTION
Stacked on #36 (shared DB + `contacted-elsewhere` hold). Merge that first; this rebases to one commit on main.

## Why

Two products run by one founder need two installs — one config is one voice, one ICP, one product brief, one ledger, one sender pool. `ONESHOT_GTM_HOME` already isolates an install (demo mode proved it); this is the ergonomics on top, with **no ledger schema change**.

## What

- **Registry + layout** (`packages/core/src/workspaces.ts`, node-builtins-only, also the `@oneshot-gtm/core/workspaces` subpath): `~/.oneshot-gtm-workspaces/registry.json`, homes under it, `default` = the legacy `~/.oneshot-gtm`, a dashboard port per workspace.
- **Bootstrap shim** (`apps/cli/src/main.ts`, the new bin target): `--workspace <name>` > `ONESHOT_GTM_WORKSPACE` > registry default, applied *before* core is imported — `config.ts` captures the home at module load, so a commander flag would be too late. Explicit `ONESHOT_GTM_HOME` wins; combining it with `--workspace` errors.
- **CLI**: `workspace list|create|use|current|path|remove`; `ui` defaults to the workspace's port so two dashboards run side by side; masthead shows the workspace name.
- **Doctor guardrails**: warns when another workspace (read by path) shares a **sending domain** (caps are per-workspace → the domain's real budget doubles) or a **Gmail account** (both inbox pollers see both products' replies); port collisions.
- `demo seed` refuses any registered workspace home; hardcoded `~/.oneshot-gtm` strings in init/setup/help now derive from the bound home.

## Tests

18 new: registry CRUD/ports/validation, selection precedence + the `ONESHOT_GTM_HOME` conflict, argv flag extraction, doctor domain/Gmail/quiet cases, and an end-to-end shim test that spawns the real entrypoint with an isolated registry. 1621 total, gate clean.

https://claude.ai/code/session_01WfjkhiBKFjEbkkL5TzmRLZ

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add named workspaces to CLI for isolated per-product installs
> - Adds [workspaces.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/37/files#diff-5616d955489739bf6915a353a890a9519048fd9098ee58d689a43af3bde0e250) in core, a Node-builtins-only module providing a workspace registry, selection resolution (`resolveWorkspaceSelection`), per-workspace port mapping, and CRUD operations.
> - Adds a bootstrap shim in [main.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/37/files#diff-a6a6c2b6ebdf48e63a7253e4c798b1781b5a5e79a9c3cd94f1c7f70bd5be80a4) that strips `--workspace` from argv, resolves the active workspace (flag > env > registry default), sets `ONESHOT_GTM_HOME`/`ONESHOT_GTM_WORKSPACE`, then dynamically imports the CLI. All CLI invocations and the `bun run cli` script now route through this shim.
> - Adds a `workspace` command group ([workspace.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/37/files#diff-d84bd4f5668bab86ea4aa12f0ba2276dfe5380aad2f5aef4f920ca1ebf27d7ec)) with `list`, `create`, `use`, `current`, `path`, and `remove` subcommands.
> - Updates `doctor` ([check.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/37/files#diff-d2c91f825714de9a0d3059003c50a802666e81ce6d17545bd384de76cbae66ff)) to report the current workspace and warn on cross-workspace conflicts: shared sending domains, shared Gmail accounts, and port collisions.
> - UI command defaults to the workspace's registered port; dashboard masthead and setup page show the active workspace name and path when not `default`.
> - Behavioral Change: `package.json` bin entry and `bun run cli` script switched from `index.ts` to `main.ts`. Conflicting `--workspace` and `ONESHOT_GTM_HOME` exit with code 2. Demo seeding refuses to write into a registered workspace home.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f2793ec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->