### PR TITLE
fix(web): reset the main scroll offset on every route change

### DIFF
--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { Outlet, createRootRouteWithContext, Link } from "@tanstack/react-router";
+import { Outlet, createRootRouteWithContext, Link, useRouterState } from "@tanstack/react-router";
 import type { QueryClient } from "@tanstack/react-query";
 import {
   Activity,
@@ -12,7 +12,7 @@ import {
   Settings,
   UserPlus,
 } from "lucide-react";
-import { useState, type ComponentType } from "react";
+import { useEffect, useRef, useState, type ComponentType } from "react";
 import { Toaster } from "sonner";
 import { api } from "../api/client.ts";
 import { CommandPalette } from "../components/shell/CommandPalette.tsx";
@@ -81,6 +81,18 @@ function RootLayout() {
     queryFn: api.doctor,
     refetchInterval: 60_000,
   });
+
+  // <main> is the scroll container and it persists across routes, so without
+  // this a navigation inherits the previous page's scroll offset: scroll down
+  // the Home feed, click Queue, and Queue opens 1000px in — the top of the
+  // list (and the triggers card) are above the fold, which reads as "only
+  // some of the prospects show until I refresh". Every route change starts
+  // at the top, the way a full page load does.
+  const mainRef = useRef<HTMLElement | null>(null);
+  const pathname = useRouterState({ select: (s) => s.location.pathname });
+  useEffect(() => {
+    mainRef.current?.scrollTo({ top: 0 });
+  }, [pathname]);
 
   // Doctor's first check names the workspace: "<name> · <home>".
   const workspaceName =
@@ -212,7 +224,7 @@ function RootLayout() {
           </div>
         </header>
 
-        <main className="overflow-y-auto px-6 py-6">
+        <main ref={mainRef} className="overflow-y-auto px-6 py-6">
           <Outlet />
         </main>
 


### PR DESCRIPTION
## Bug

"Clicking the Queue page only reveals some of the prospects; I have to refresh to see all and scroll down."

## Root cause

`<main>` is the app's scroll container and it persists across client-side routes, so a navigation inherits the previous page's scroll offset. Reproduced in the browser: scroll the Home feed down, click **Queue** → `main.scrollTop` is `1032` on arrival, the page header / triggers card / top of the list are above the fold, and the first visible row is #8302 mid-list. A full reload resets the container to 0, which is why refresh "fixed" it.

Not a data problem — the queue query (`limit: 200`, 5s stale, 20s refetch) returned all 41 pending rows within ~500ms of the click in the same measurement.

## Fix

A `useEffect` on the router's pathname scrolls `main` to the top on every route change (`apps/web/src/routes/__root.tsx`), matching full-page-load behaviour.

https://claude.ai/code/session_01WfjkhiBKFjEbkkL5TzmRLZ

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reset main scroll offset to top on route changes in `RootLayout`
> The `RootLayout` component now tracks the current `pathname` via `useRouterState` and calls `mainRef.current?.scrollTo({ top: 0 })` in a `useEffect` whenever it changes. This ensures the main content area starts at the top on every navigation. See [__root.tsx](https://github.com/oneshot-agent/oneshot-gtm/pull/40/files#diff-9cf47cc915a8ae96883f175e43540fd214a10fa797409a128613573c92b47100).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 234989b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->