### PR TITLE
feat(send): Smartlead as a third sending transport (send-only v1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ bun run cli -- cadence advance                     # daily tick: poll inbox, fir
 | `config`                 | `llm` · `founder` · `keys` · `telemetry on\|off`                                                                                                                |
 | `gmail`                  | `auth` (OAuth a sending account) · `placement` (inbox-placement canary)                                                                                         |
 | `identities`             | `list` · `add` · `remove <id>` — the sender pool                                                                                                                |
+| `smartlead`              | `connect` — API key + pick Smartlead mailboxes into the pool (send-only)                                                                                        |
 | `domains`                | `list` · `pause <domain>` · `resume <domain>` — provisioned OneShot domains                                                                                     |
 | `find`                   | `watch` · `drain <play>` · `enrich-linkedin`                                                                                                                    |
 | `motion`                 | `post-funding` `concierge` `demo-no-show` `competitor-switch` `hiring-signal` `podcast-guest` — each takes `--target <file>`; `breakup-revive` reads the ledger |
@@ -196,7 +197,7 @@ Most carry a cadence — a value follow-up, then a breakup, spread over roughly 
 
 ## Sending
 
-Outbound ships through a **sender identity pool** — any mix of OneShot wallet-owned sending domains (several domains, several mailboxes per domain) and your own Gmail / Workspace accounts.
+Outbound ships through a **sender identity pool** — any mix of OneShot wallet-owned sending domains (several domains, several mailboxes per domain), your own Gmail / Workspace accounts, and Smartlead-hosted mailboxes (bring-your-own cold-email infra at scale).
 
 - **Sticky threads.** Every email to a prospect comes from the identity that sent their first touch, across plays and cadence steps. In-flight conversations never switch From address.
 - **Warm-up caps, per domain.** A new identity ramps 10/day, +10/week, to a 50 ceiling — editable per identity on `/setup`. OneShot reputation is per-domain, so every mailbox on a domain shares one ramp and budget. Gmail accounts ramp per account.
@@ -204,7 +205,7 @@ Outbound ships through a **sender identity pool** — any mix of OneShot wallet-
 - **Two products, one founder, one inbox.** A workspace (see Workspaces) never first-touches someone another workspace emailed in the last 7 days: the draft is held with a `contacted-elsewhere` flag that you can override on a manual send, and auto paths (drain, cadence steps) wait the window out. Touches and the paid lookup caches live in one shared SQLite (`~/.oneshot-gtm-shared/`), so the same person is never researched twice across products.
 - **Replies follow the pool.** The inbox poll merges the OneShot inbox with every authorized Gmail account, so stop-on-reply works whichever identity sent. It walks everything since its last clean poll — a persisted watermark with an hour of overlap, paged newest-first, parking anything beyond one poll's page budget as a backlog the next ticks drain — so a reply is delayed by an outage, never lost to it. A reply you've already read and archived still counts. Answering from `/inbox` records the reply too, replies from the receiving identity, and threads on both transports — Gmail via `In-Reply-To`/`References`, OneShot via `reply_to_email_id`. Sends carry an idempotency key, so a retry after a timeout can't double-send.
 
-Add a OneShot domain and mailbox from `/setup` or `identities add` — pick a provisioned domain or type a new one to auto-provision on first send. Add a Gmail account with `gmail auth` (one-time OAuth; needs a Google Cloud _Desktop_ client with the Gmail API on). With no pool configured, behavior is the classic single OneShot identity.
+Add a OneShot domain and mailbox from `/setup` or `identities add` — pick a provisioned domain or type a new one to auto-provision on first send. Add a Gmail account with `gmail auth` (one-time OAuth; needs a Google Cloud _Desktop_ client with the Gmail API on). Add Smartlead mailboxes with `smartlead connect` (paste the workspace API key, pick from your connected accounts) or from `/setup` — Smartlead does the warmup and hosts the inboxes; the default ramp ceiling clamps to each mailbox's own Smartlead limit. **Send-only for now**: replies to Smartlead-sent mail appear in Smartlead's inbox, not `/inbox`, and its bounces aren't harvested — like OneShot identities, `doctor` reports them as not bounce-covered. With no pool configured, behavior is the classic single OneShot identity.
 
 ### Deliverability
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ bun run cli -- find drain podcast-guest --dry-run  # preview approved /queue row
 bun run cli -- cadence advance                     # daily tick: poll inbox, fire follow-ups
 ```
 
-47 commands — twelve groups, plus `init`, `doctor` and `ui` at the top level. `bun run cli -- --help` (or `oneshot-gtm --help` once linked) is the reference:
+48 commands — thirteen groups, plus `init`, `doctor` and `ui` at the top level. `bun run cli -- --help` (or `oneshot-gtm --help` once linked) is the reference:
 
 | Group                    | Commands                                                                                                                                                        |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # Status
 
-**Assume green unless it's listed below.** The 47 CLI commands, 14 plays, 10 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and, with the seven exceptions on this page, verified end to end against the live OneShot API.
+**Assume green unless it's listed below.** The 48 CLI commands, 14 plays, 10 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and, with the seven exceptions on this page, verified end to end against the live OneShot API.
 
 Last verified **2026-08-23** · Bun 1.3.13 · OneShot SDK 0.22.0 · 1698 tests / 127 files · typecheck + oxlint clean (318 files).
 
@@ -46,7 +46,8 @@ Five of those also stay **not ready** until you give them required config, and r
 
 ## Known limitations
 
-- **Bounce handling is Gmail-only.** DSNs are parsed from connected Gmail/Workspace mailboxes. Sends through OneShot domains have no equivalent feed yet, so their bounce rate reads as zero rather than unknown.
+- **Bounce handling is Gmail-only.** DSNs are parsed from connected Gmail/Workspace mailboxes. Sends through OneShot domains and Smartlead mailboxes have no equivalent feed yet; `doctor` names them as not covered rather than reporting a false zero.
+- **Smartlead is send-only.** `smartlead connect` (or `/setup`) registers Smartlead-hosted mailboxes as sending identities — rotation, warm-up caps (clamped to Smartlead's own per-mailbox limit at registration; later Smartlead-side changes aren't re-synced), sticky threads, suppression, and the cross-workspace hold all apply — but replies land in Smartlead's inbox, not `/inbox`, and there is no bounce feed or send idempotency (a timeout-then-retry can double-send, same as Gmail). Follow-ups: an inbox source + threaded replies, bounce/warmup ingestion, per-domain cap groups. The one live-unverified piece is the send round trip itself (`/send-email/initiate` against a real key).
 - **`oneshot-gtm-server` requires Bun.** `bun:sqlite`, `Bun.serve`, and `Bun.stdin` are Bun-native; a runtime check in `dist/bin.mjs` fails loudly under plain `node`. A self-contained `bun build --compile` binary is a future option.
 - **The CLI is not on npm.** Only `oneshot-gtm-server` is published (0.7.0). The CLI needs a repo clone plus `bun link`.
 - **No public benchmarks page.** The telemetry endpoint is live and verified; the surface that renders aggregates from it is still roadmap.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # Status
 
-**Assume green unless it's listed below.** The 48 CLI commands, 14 plays, 10 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and, with the seven exceptions on this page, verified end to end against the live OneShot API.
+**Assume green unless it's listed below.** The 48 CLI commands, 14 plays, 10 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and, with the exceptions on this page, verified end to end against the live OneShot API.
 
 Last verified **2026-08-23** · Bun 1.3.13 · OneShot SDK 0.22.0 · 1698 tests / 127 files · typecheck + oxlint clean (318 files).
 

--- a/apps/cli/src/commands/smartlead.ts
+++ b/apps/cli/src/commands/smartlead.ts
@@ -1,0 +1,119 @@
+import {
+  listSmartleadAccounts,
+  loadConfig,
+  registerSmartleadIdentity,
+  resolveIdentities,
+  saveSecrets,
+  secretsPath,
+  smartleadApiKey,
+  type SmartleadAccount,
+} from "@oneshot-gtm/core";
+import prompts from "prompts";
+import { c, header, note, ok, warn } from "../output.ts";
+
+/**
+ * `smartlead connect` — store the workspace API key and add Smartlead-hosted
+ * mailboxes to the sender rotation pool. Send-only: Smartlead does the warmup
+ * and hosts the inboxes; replies to Smartlead-sent mail are read in
+ * Smartlead's own UI. The key is validated against the accounts API BEFORE it
+ * is saved, so a typo never lands in .env.
+ */
+export async function commandSmartleadConnect(): Promise<void> {
+  header("Connect Smartlead");
+
+  let key = smartleadApiKey();
+  let keyIsNew = false;
+  if (key) {
+    note("Using the stored SMARTLEAD_API_KEY.");
+  } else {
+    const answer = await prompts(
+      {
+        type: "password",
+        name: "key",
+        message: "Smartlead API key (Smartlead → Settings → API)",
+        validate: (v: string) => (v.trim().length > 0 ? true : "required"),
+      },
+      { onCancel: () => process.exit(0) },
+    );
+    key = ((answer["key"] as string) ?? "").trim();
+    if (!key) {
+      warn("No key provided.");
+      return;
+    }
+    keyIsNew = true;
+  }
+
+  let accounts: SmartleadAccount[];
+  try {
+    accounts = await listSmartleadAccounts(key);
+  } catch (err) {
+    warn(`Smartlead rejected the request: ${(err as Error).message}`);
+    if (keyIsNew) note("The key was NOT saved.");
+    return;
+  }
+  if (keyIsNew) {
+    saveSecrets({ SMARTLEAD_API_KEY: key });
+    ok(`Key validated and saved to ${secretsPath()} (chmod 600).`);
+  }
+
+  if (accounts.length === 0) {
+    warn(
+      "No email accounts connected in this Smartlead workspace yet — add mailboxes there first.",
+    );
+    return;
+  }
+
+  const registered = new Set(
+    resolveIdentities(loadConfig())
+      .filter((i) => i.provider === "smartlead")
+      .map((i) => i.address?.trim().toLowerCase()),
+  );
+
+  const choices = accounts.map((a) => {
+    const inPool = registered.has(a.fromEmail);
+    const broken = !a.isSmtpSuccess;
+    const detail = [
+      a.messagePerDay != null ? `${a.messagePerDay}/day` : "no cap",
+      a.warmupStatus
+        ? `warmup ${a.warmupStatus.toLowerCase()}${a.warmupReputation ? ` (${a.warmupReputation})` : ""}`
+        : "warmup unknown",
+    ].join(" · ");
+    return {
+      title: `${a.fromEmail} — ${detail}${inPool ? " — already in pool" : ""}${broken ? " — SMTP broken" : ""}`,
+      value: a,
+      disabled: inPool || broken,
+    };
+  });
+  const picked = await prompts(
+    {
+      type: "multiselect",
+      name: "accounts",
+      message: "Mailboxes to add to the rotation pool",
+      choices,
+      hint: "space to select · enter to confirm",
+    },
+    { onCancel: () => process.exit(0) },
+  );
+  const selection = (picked["accounts"] as SmartleadAccount[] | undefined) ?? [];
+  if (selection.length === 0) {
+    note("Nothing selected — the pool is unchanged.");
+    return;
+  }
+
+  for (const a of selection) {
+    const { identityId, created } = registerSmartleadIdentity({
+      address: a.fromEmail,
+      label: a.fromName,
+      providerMessagePerDay: a.messagePerDay,
+    });
+    if (created) {
+      const cap = Math.min(50, a.messagePerDay && a.messagePerDay > 0 ? a.messagePerDay : 50);
+      ok(`+ ${c.cyan(identityId)} (cap ${cap}/day, warm-up 10 +10/wk)`);
+    } else {
+      note(`= ${identityId} already in the pool (caps unchanged)`);
+    }
+  }
+  note(
+    "Send-only for now: replies to Smartlead-sent mail appear in Smartlead's inbox, not /inbox.",
+  );
+}

--- a/apps/cli/src/commands/smartlead.ts
+++ b/apps/cli/src/commands/smartlead.ts
@@ -21,21 +21,25 @@ import { c, header, note, ok, warn } from "../output.ts";
 export async function commandSmartleadConnect(): Promise<void> {
   header("Connect Smartlead");
 
+  async function promptForKey(message: string): Promise<string> {
+    const answer = await prompts(
+      {
+        type: "password",
+        name: "key",
+        message,
+        validate: (v: string) => (v.trim().length > 0 ? true : "required"),
+      },
+      { onCancel: () => process.exit(0) },
+    );
+    return ((answer["key"] as string) ?? "").trim();
+  }
+
   let key = smartleadApiKey();
   let keyIsNew = false;
   if (key) {
     note("Using the stored SMARTLEAD_API_KEY.");
   } else {
-    const answer = await prompts(
-      {
-        type: "password",
-        name: "key",
-        message: "Smartlead API key (Smartlead → Settings → API)",
-        validate: (v: string) => (v.trim().length > 0 ? true : "required"),
-      },
-      { onCancel: () => process.exit(0) },
-    );
-    key = ((answer["key"] as string) ?? "").trim();
+    key = await promptForKey("Smartlead API key (Smartlead → Settings → API)");
     if (!key) {
       warn("No key provided.");
       return;
@@ -43,13 +47,30 @@ export async function commandSmartleadConnect(): Promise<void> {
     keyIsNew = true;
   }
 
-  let accounts: SmartleadAccount[];
+  let accounts: SmartleadAccount[] | null = null;
   try {
     accounts = await listSmartleadAccounts(key);
   } catch (err) {
     warn(`Smartlead rejected the request: ${(err as Error).message}`);
-    if (keyIsNew) note("The key was NOT saved.");
-    return;
+    if (keyIsNew) {
+      note("The key was NOT saved.");
+      return;
+    }
+    // The STORED key failed (revoked, expired, wrong workspace). Without this
+    // re-prompt the command is a dead end: every rerun reads the same bad key.
+    key = await promptForKey("Stored key rejected — paste a replacement key (esc to cancel)");
+    if (!key) {
+      warn("No key provided.");
+      return;
+    }
+    keyIsNew = true;
+    try {
+      accounts = await listSmartleadAccounts(key);
+    } catch (err2) {
+      warn(`Smartlead rejected the replacement too: ${(err2 as Error).message}`);
+      note("The key was NOT saved.");
+      return;
+    }
   }
   if (keyIsNew) {
     saveSecrets({ SMARTLEAD_API_KEY: key });

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -31,6 +31,7 @@ import {
 } from "./commands/handoff.ts";
 import { commandCadenceAdvance } from "./commands/cadence.ts";
 import { commandGmailAuth, commandGmailPlacement } from "./commands/gmail.ts";
+import { commandSmartleadConnect } from "./commands/smartlead.ts";
 import {
   commandDomainsList,
   commandDomainsPause,
@@ -228,6 +229,16 @@ gmail
   .option("--play <name>", "replay this play's most recent real email as the canary body")
   .option("-y, --yes", "skip the send confirmation")
   .action(runOrFail(commandGmailPlacement));
+
+// Smartlead: bring-your-own cold-email infra (send-only). Smartlead hosts +
+// warms the mailboxes; we send through their API. Replies stay in their UI.
+const smartlead = program
+  .command("smartlead")
+  .description("Smartlead send path (send-only; replies stay in Smartlead's UI)");
+smartlead
+  .command("connect")
+  .description("Store the Smartlead API key and add its mailboxes to the rotation pool")
+  .action(runOrFail(commandSmartleadConnect));
 
 // Identities: manage the OneShot sender rotation pool (multiple wallet-owned
 // domains + multiple mailboxes per domain). Gmail accounts join via `gmail auth`.

--- a/apps/server/__tests__/smartlead-route.test.ts
+++ b/apps/server/__tests__/smartlead-route.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SmartleadAccount } from "@oneshot-gtm/core";
+
+// /api/smartlead/accounts: key resolution (pasted > stored), sanitized
+// pass-through with alreadyRegistered, and upstream-failure mapping. The core
+// client is mocked — its own paging/sanitization is covered in core tests.
+
+const listMock = vi.fn();
+const registerSmartleadMock = vi.fn().mockReturnValue({ identityId: "smartlead:x", created: true });
+const registerOneShotMock = vi.fn().mockReturnValue({ identityId: "oneshot:x", created: true });
+let storedKey: string | null = null;
+let identities: Array<{ id: string; provider: string; address?: string | null }> = [];
+
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    listSmartleadAccounts: (key?: string) => listMock(key),
+    smartleadApiKey: () => storedKey,
+    registerSmartleadIdentity: registerSmartleadMock,
+    registerOneShotIdentity: registerOneShotMock,
+    loadConfig: () => ({ ...actual.loadConfig(), emailIdentities: identities }),
+  };
+});
+
+const { smartleadAccountsRoute } = await import("../src/api/smartlead.ts");
+const { setup } = await import("../src/api/setup.ts");
+
+function req(body?: unknown): Request {
+  return new Request("http://localhost/api/smartlead/accounts", {
+    method: "POST",
+    headers: { "content-type": "application/json", host: "127.0.0.1:3030" },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+}
+
+const ACCOUNT: SmartleadAccount = {
+  id: 7,
+  fromEmail: "jane@acme.com",
+  fromName: "Jane",
+  messagePerDay: 30,
+  dailySentCount: 2,
+  isSmtpSuccess: true,
+  type: "SMTP",
+  warmupStatus: "ACTIVE",
+  warmupReputation: "95%",
+};
+
+beforeEach(() => {
+  listMock.mockReset();
+  registerSmartleadMock.mockClear();
+  registerOneShotMock.mockClear();
+  storedKey = null;
+  identities = [];
+});
+afterEach(() => vi.clearAllMocks());
+
+describe("smartleadAccountsRoute", () => {
+  it("400s when no key is pasted and none is stored", async () => {
+    const res = await smartleadAccountsRoute(req({}));
+    expect(res.status).toBe(400);
+    expect(listMock).not.toHaveBeenCalled();
+  });
+
+  it("uses a pasted key from the body (browse before saving)", async () => {
+    listMock.mockResolvedValue([ACCOUNT]);
+    const res = await smartleadAccountsRoute(req({ apiKey: " pasted-key " }));
+    expect(res.status).toBe(200);
+    expect(listMock).toHaveBeenCalledWith("pasted-key");
+  });
+
+  it("falls back to the stored key on an empty body", async () => {
+    storedKey = "stored-key";
+    listMock.mockResolvedValue([]);
+    const res = await smartleadAccountsRoute(req());
+    expect(res.status).toBe(200);
+    expect(listMock).toHaveBeenCalledWith("stored-key");
+  });
+
+  it("marks accounts already in the pool and passes sanitized fields through", async () => {
+    storedKey = "k";
+    identities = [
+      { id: "smartlead:jane@acme.com", provider: "smartlead", address: "Jane@Acme.com" },
+    ];
+    listMock.mockResolvedValue([ACCOUNT, { ...ACCOUNT, id: 8, fromEmail: "new@acme.com" }]);
+    const res = await smartleadAccountsRoute(req({}));
+    const body = (await res.json()) as { accounts: Array<Record<string, unknown>> };
+    expect(body.accounts).toHaveLength(2);
+    expect(body.accounts[0]).toMatchObject({ fromEmail: "jane@acme.com", alreadyRegistered: true });
+    expect(body.accounts[1]).toMatchObject({ fromEmail: "new@acme.com", alreadyRegistered: false });
+    expect(JSON.stringify(body)).not.toContain("password");
+  });
+
+  it("maps an upstream failure to 502 with the sanitized message", async () => {
+    storedKey = "k";
+    listMock.mockRejectedValue(new Error("Smartlead API /email-accounts/ failed (401): bad key"));
+    const res = await smartleadAccountsRoute(req({}));
+    expect(res.status).toBe(502);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("401");
+    expect(body.error).not.toContain("api_key=");
+  });
+});
+
+function setupReq(body: unknown): Request {
+  return new Request("http://localhost/api/setup", {
+    method: "POST",
+    headers: { "content-type": "application/json", host: "127.0.0.1:3030" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("setup route addIdentities smartlead branch", () => {
+  it("routes smartlead adds to registerSmartleadIdentity, oneshot adds to registerOneShotIdentity", async () => {
+    const res = await setup(
+      setupReq({
+        addIdentities: [
+          {
+            provider: "smartlead",
+            address: "jane@acme.com",
+            label: "Jane",
+            providerMessagePerDay: 30,
+          },
+          { provider: "oneshot", sendingDomain: "acme.email" },
+        ],
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(registerSmartleadMock).toHaveBeenCalledWith(
+      expect.objectContaining({ address: "jane@acme.com", providerMessagePerDay: 30 }),
+    );
+    expect(registerOneShotMock).toHaveBeenCalledWith(
+      expect.objectContaining({ sendingDomain: "acme.email" }),
+    );
+  });
+
+  it("skips a smartlead add with a blank address", async () => {
+    const res = await setup(
+      setupReq({ addIdentities: [{ provider: "smartlead", address: "  " }] }),
+    );
+    expect(res.status).toBe(200);
+    expect(registerSmartleadMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/api/setup.ts
+++ b/apps/server/src/api/setup.ts
@@ -4,6 +4,7 @@ import {
   listSendingDomains,
   loadConfig,
   registerOneShotIdentity,
+  registerSmartleadIdentity,
   resolveIdentities,
   saveConfig,
   saveSecrets,
@@ -104,6 +105,7 @@ export async function getSetupStatus(req: Request): Promise<Response> {
         GMAIL_CLIENT_ID: secretSource("GMAIL_CLIENT_ID"),
         GMAIL_CLIENT_SECRET: secretSource("GMAIL_CLIENT_SECRET"),
         GMAIL_REFRESH_TOKEN: secretSource("GMAIL_REFRESH_TOKEN"),
+        SMARTLEAD_API_KEY: secretSource("SMARTLEAD_API_KEY"),
       },
     },
     200,
@@ -190,6 +192,16 @@ export async function setup(req: Request): Promise<Response> {
   // freshly-persisted config (so it sees the cap/removal edits above and any
   // legacy-pool materialization) before appending. Validated already.
   for (const add of adds) {
+    if (add.provider === "smartlead") {
+      if (!add.address?.trim()) continue;
+      registerSmartleadIdentity({
+        address: add.address,
+        label: add.label,
+        ...("maxPerDay" in add ? { maxPerDay: add.maxPerDay ?? null } : {}),
+        providerMessagePerDay: add.providerMessagePerDay ?? null,
+      });
+      continue;
+    }
     if (!add.sendingDomain?.trim()) continue;
     registerOneShotIdentity({
       sendingDomain: add.sendingDomain,

--- a/apps/server/src/api/smartlead.ts
+++ b/apps/server/src/api/smartlead.ts
@@ -1,0 +1,55 @@
+import {
+  listSmartleadAccounts,
+  loadConfig,
+  resolveIdentities,
+  smartleadApiKey,
+} from "@oneshot-gtm/core";
+import type { SmartleadAccountView } from "@oneshot-gtm/shared-types";
+import { jsonResponse } from "../server.ts";
+
+/**
+ * POST /api/smartlead/accounts — list the Smartlead workspace's connected
+ * mailboxes so /setup can offer them as identities. POST (not GET) on
+ * purpose: the body may carry a just-pasted, not-yet-saved API key, and a key
+ * must never ride a URL (server logs, proxies, history). Doubles as key
+ * validation — a bad key surfaces here before anything is persisted.
+ * Responses are sanitized in core (no passwords) and error messages never
+ * contain the key.
+ */
+export async function smartleadAccountsRoute(req: Request): Promise<Response> {
+  let pastedKey: string | undefined;
+  try {
+    const body = (await req.json()) as { apiKey?: string };
+    pastedKey = typeof body.apiKey === "string" ? body.apiKey : undefined;
+  } catch {
+    // empty body is fine — fall back to the stored key
+  }
+  const key = pastedKey?.trim() || smartleadApiKey();
+  if (!key) {
+    return jsonResponse(
+      { error: "no Smartlead API key — paste one, or save SMARTLEAD_API_KEY on /setup" },
+      400,
+      req,
+    );
+  }
+  let accounts;
+  try {
+    accounts = await listSmartleadAccounts(key);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return jsonResponse({ error: message }, 502, req);
+  }
+  const registered = new Set(
+    resolveIdentities(loadConfig())
+      .filter((i) => i.provider === "smartlead")
+      .map((i) => i.address?.trim().toLowerCase())
+      .filter(Boolean),
+  );
+  const views: SmartleadAccountView[] = accounts.map((a) => {
+    const view: SmartleadAccountView = Object.assign({}, a, {
+      alreadyRegistered: registered.has(a.fromEmail),
+    });
+    return view;
+  });
+  return jsonResponse({ accounts: views }, 200, req);
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -18,6 +18,7 @@ import { listPlays, setCadenceRoute } from "./api/plays.ts";
 import { measureCac, measureRocs, measureRocsByGoal, recordOutcome } from "./api/measure.ts";
 import { setup, getSetupStatus } from "./api/setup.ts";
 import { gmailAuthCallbackRoute, startGmailAuthRoute } from "./api/gmail-auth.ts";
+import { smartleadAccountsRoute } from "./api/smartlead.ts";
 import { deriveBriefRoute } from "./api/derive-brief.ts";
 import { deriveIcpRoute } from "./api/derive-icp.ts";
 import { strategistRoute } from "./api/strategist.ts";
@@ -94,6 +95,7 @@ const routes: RouteEntry[] = [
   route("POST", "/api/domains/pause", pauseDomainRoute),
   route("GET", "/api/gmail/auth/start", startGmailAuthRoute),
   route("GET", "/api/gmail/auth/callback", gmailAuthCallbackRoute),
+  route("POST", "/api/smartlead/accounts", smartleadAccountsRoute),
   route("POST", "/api/setup/derive-icp", deriveIcpRoute),
   route("POST", "/api/setup/derive-brief", deriveBriefRoute),
   route("POST", "/api/strategist/stream", strategistRoute),

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -31,6 +31,7 @@ import type {
   RunTriggerResult,
   SenderIdentityView,
   SetupRequest,
+  SmartleadAccountView,
   SpendByPlay,
   TriggerView,
 } from "@oneshot-gtm/shared-types";
@@ -133,6 +134,12 @@ export const api = {
   doctor: () => getJson<{ checks: DoctorCheck[] }>("/doctor"),
   resumeDomain: (domain: string) => postJson<DomainActionResult>("/domains/resume", { domain }),
   pauseDomain: (domain: string) => postJson<DomainActionResult>("/domains/pause", { domain }),
+  // POST so a just-pasted (not yet saved) key rides the body, never a URL.
+  smartleadAccounts: (apiKey?: string) =>
+    postJson<{ accounts: SmartleadAccountView[] }>(
+      "/smartlead/accounts",
+      apiKey?.trim() ? { apiKey: apiKey.trim() } : {},
+    ),
   setupStatus: () =>
     getJson<{
       identities: SenderIdentityView[];

--- a/apps/web/src/routes/inbox.tsx
+++ b/apps/web/src/routes/inbox.tsx
@@ -260,6 +260,7 @@ function reSubject(subject: string): string {
 /** "gmail:jn@x.com" → "jn@x.com"; legacy/synthesized ids get a friendly label. */
 function identityAddress(id: string): string {
   if (id.startsWith("gmail:")) return id.slice("gmail:".length);
+  if (id.startsWith("smartlead:")) return id.slice("smartlead:".length);
   if (id === "legacy-gmail") return "your Gmail";
   if (id === "legacy-oneshot") return "OneShot";
   return id;

--- a/apps/web/src/routes/setup.tsx
+++ b/apps/web/src/routes/setup.tsx
@@ -793,112 +793,6 @@ function SetupPage() {
                   prospects pinned to it until it's restored.
                 </span>
 
-                {/* Smartlead accounts: bring-your-own cold-email infra. Paste
-                    the workspace API key, load the connected mailboxes, stage
-                    picks into the rotation pool (applied on Save). Send-only —
-                    replies to Smartlead-sent mail live in Smartlead's own UI. */}
-                <div className="mt-3 flex flex-col gap-2">
-                  <span className="ln-eyebrow">Smartlead accounts</span>
-                  <Field
-                    label="SMARTLEAD_API_KEY"
-                    hint={hintFor(sources["SMARTLEAD_API_KEY"])}
-                    className="max-w-md"
-                  >
-                    <Input
-                      type="password"
-                      placeholder={sources["SMARTLEAD_API_KEY"] ? "(unchanged)" : ""}
-                      value={secrets["SMARTLEAD_API_KEY"] ?? ""}
-                      onChange={(e) => setSecret("SMARTLEAD_API_KEY", e.target.value)}
-                      autoComplete="new-password"
-                    />
-                  </Field>
-                  <div className="flex flex-wrap items-center gap-3">
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      disabled={!smartleadKeyReady || loadSmartlead.isPending}
-                      onClick={() => loadSmartlead.mutate()}
-                    >
-                      {loadSmartlead.isPending ? "Loading…" : "Load Smartlead accounts"}
-                    </Button>
-                    <span className="text-[12px] text-ink-faint">
-                      {smartleadKeyReady
-                        ? "Lists the mailboxes connected to your Smartlead workspace — Smartlead does the warmup, this pool does the sending."
-                        : "Paste your Smartlead API key first (Smartlead → Settings → API)."}
-                    </span>
-                  </div>
-                  {smartleadAccounts && smartleadAccounts.length === 0 && (
-                    <span className="text-[12px] text-ink-faint">
-                      No email accounts connected in Smartlead yet.
-                    </span>
-                  )}
-                  {smartleadAccounts?.map((a) => {
-                    const staged = pendingSmartleadAdds.some((p) => p.address === a.fromEmail);
-                    const blocked = !a.isSmtpSuccess;
-                    return (
-                      <div
-                        key={a.id}
-                        className="flex items-center gap-3 border border-ink-rule rounded-[var(--radius-sm)] px-3 py-2"
-                      >
-                        <div className="flex min-w-0 flex-col">
-                          <span className="truncate text-[13px] text-ink-cream">{a.fromEmail}</span>
-                          <span className="ln-mono text-[11px] text-ink-muted">
-                            {a.messagePerDay != null ? `${a.messagePerDay}/day` : "no cap"}
-                            {a.warmupStatus
-                              ? ` · warmup ${a.warmupStatus.toLowerCase()}${a.warmupReputation ? ` (${a.warmupReputation})` : ""}`
-                              : ""}
-                            {blocked ? " · SMTP broken — reconnect in Smartlead" : ""}
-                          </span>
-                        </div>
-                        <div className="ml-auto">
-                          {a.alreadyRegistered ? (
-                            <span className="ln-mono text-[11px] text-ink-faint">in pool</span>
-                          ) : staged ? (
-                            <Button
-                              type="button"
-                              variant="secondary"
-                              className="h-7 px-2 text-[11px]"
-                              onClick={() =>
-                                setPendingSmartleadAdds((p) =>
-                                  p.filter((x) => x.address !== a.fromEmail),
-                                )
-                              }
-                            >
-                              Undo
-                            </Button>
-                          ) : (
-                            <Button
-                              type="button"
-                              variant="secondary"
-                              className="h-7 px-2 text-[11px]"
-                              disabled={blocked}
-                              onClick={() =>
-                                setPendingSmartleadAdds((p) => [
-                                  ...p,
-                                  {
-                                    address: a.fromEmail,
-                                    label: a.fromName ?? "",
-                                    providerMessagePerDay: a.messagePerDay,
-                                  },
-                                ])
-                              }
-                            >
-                              Add
-                            </Button>
-                          )}
-                        </div>
-                      </div>
-                    );
-                  })}
-                  {pendingSmartleadAdds.length > 0 && (
-                    <span className="text-[12px] text-ink-faint">
-                      {pendingSmartleadAdds.length} Smartlead mailbox
-                      {pendingSmartleadAdds.length === 1 ? "" : "es"} staged — applied on Save with
-                      the cold-start warm-up ramp (capped at Smartlead's own per-mailbox limit).
-                    </span>
-                  )}
-                </div>
-
                 {/* Provisioned domains: the wallet's OneShot sending-domain pool
                     with live status. A paused domain sends nothing until resumed
                     (doctor flags it); resume/pause act on it in place. */}
@@ -1066,6 +960,123 @@ function SetupPage() {
                 </div>
               </div>
             )}
+            {/* Smartlead lives OUTSIDE the identities guard: with an empty
+                pool there are no identity rows, but connecting Smartlead is
+                exactly how you rebuild one. */}
+            <div className="md:col-span-2 flex flex-col gap-2">
+              {/* Smartlead accounts: bring-your-own cold-email infra. Paste
+                  the workspace API key, load the connected mailboxes, stage
+                  picks into the rotation pool (applied on Save). Send-only —
+                  replies to Smartlead-sent mail live in Smartlead's own UI. */}
+              <div className="mt-3 flex flex-col gap-2">
+                <span className="ln-eyebrow">Smartlead accounts</span>
+                <Field
+                  label="SMARTLEAD_API_KEY"
+                  hint={hintFor(sources["SMARTLEAD_API_KEY"])}
+                  className="max-w-md"
+                >
+                  <Input
+                    type="password"
+                    placeholder={sources["SMARTLEAD_API_KEY"] ? "(unchanged)" : ""}
+                    value={secrets["SMARTLEAD_API_KEY"] ?? ""}
+                    onChange={(e) => {
+                      setSecret("SMARTLEAD_API_KEY", e.target.value);
+                      // A different key = a different Smartlead workspace: the
+                      // loaded list and any staged picks belong to the OLD key
+                      // and would register mailboxes the new key can't send as.
+                      setSmartleadAccounts(null);
+                      setPendingSmartleadAdds([]);
+                    }}
+                    autoComplete="new-password"
+                  />
+                </Field>
+                <div className="flex flex-wrap items-center gap-3">
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    disabled={!smartleadKeyReady || loadSmartlead.isPending}
+                    onClick={() => loadSmartlead.mutate()}
+                  >
+                    {loadSmartlead.isPending ? "Loading…" : "Load Smartlead accounts"}
+                  </Button>
+                  <span className="text-[12px] text-ink-faint">
+                    {smartleadKeyReady
+                      ? "Lists the mailboxes connected to your Smartlead workspace — Smartlead does the warmup, this pool does the sending."
+                      : "Paste your Smartlead API key first (Smartlead → Settings → API)."}
+                  </span>
+                </div>
+                {smartleadAccounts && smartleadAccounts.length === 0 && (
+                  <span className="text-[12px] text-ink-faint">
+                    No email accounts connected in Smartlead yet.
+                  </span>
+                )}
+                {smartleadAccounts?.map((a) => {
+                  const staged = pendingSmartleadAdds.some((p) => p.address === a.fromEmail);
+                  const blocked = !a.isSmtpSuccess;
+                  return (
+                    <div
+                      key={a.id}
+                      className="flex items-center gap-3 border border-ink-rule rounded-[var(--radius-sm)] px-3 py-2"
+                    >
+                      <div className="flex min-w-0 flex-col">
+                        <span className="truncate text-[13px] text-ink-cream">{a.fromEmail}</span>
+                        <span className="ln-mono text-[11px] text-ink-muted">
+                          {a.messagePerDay != null ? `${a.messagePerDay}/day` : "no cap"}
+                          {a.warmupStatus
+                            ? ` · warmup ${a.warmupStatus.toLowerCase()}${a.warmupReputation ? ` (${a.warmupReputation})` : ""}`
+                            : ""}
+                          {blocked ? " · SMTP broken — reconnect in Smartlead" : ""}
+                        </span>
+                      </div>
+                      <div className="ml-auto">
+                        {a.alreadyRegistered ? (
+                          <span className="ln-mono text-[11px] text-ink-faint">in pool</span>
+                        ) : staged ? (
+                          <Button
+                            type="button"
+                            variant="secondary"
+                            className="h-7 px-2 text-[11px]"
+                            onClick={() =>
+                              setPendingSmartleadAdds((p) =>
+                                p.filter((x) => x.address !== a.fromEmail),
+                              )
+                            }
+                          >
+                            Undo
+                          </Button>
+                        ) : (
+                          <Button
+                            type="button"
+                            variant="secondary"
+                            className="h-7 px-2 text-[11px]"
+                            disabled={blocked}
+                            onClick={() =>
+                              setPendingSmartleadAdds((p) => [
+                                ...p,
+                                {
+                                  address: a.fromEmail,
+                                  label: a.fromName ?? "",
+                                  providerMessagePerDay: a.messagePerDay,
+                                },
+                              ])
+                            }
+                          >
+                            Add
+                          </Button>
+                        )}
+                      </div>
+                    </div>
+                  );
+                })}
+                {pendingSmartleadAdds.length > 0 && (
+                  <span className="text-[12px] text-ink-faint">
+                    {pendingSmartleadAdds.length} Smartlead mailbox
+                    {pendingSmartleadAdds.length === 1 ? "" : "es"} staged — applied on Save with
+                    the cold-start warm-up ramp (capped at Smartlead's own per-mailbox limit).
+                  </span>
+                )}
+              </div>
+            </div>
             {!isLegacyPool && !gmailCredsReady && (
               <>
                 <Field label="GMAIL_CLIENT_ID" hint={hintFor(sources["GMAIL_CLIENT_ID"])}>

--- a/apps/web/src/routes/setup.tsx
+++ b/apps/web/src/routes/setup.tsx
@@ -3,6 +3,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { Mail, Save, Wand2 } from "lucide-react";
 import { useEffect, useState, type ReactNode, useRef } from "react";
 import { toast } from "sonner";
+import type { SetupRequest, SmartleadAccountView } from "@oneshot-gtm/shared-types";
 import { api } from "../api/client.ts";
 import { Badge } from "../components/primitives/Badge.tsx";
 import { Button } from "../components/primitives/Button.tsx";
@@ -29,6 +30,7 @@ const SECRET_LABELS: Record<string, string> = {
   GMAIL_CLIENT_ID: "GMAIL_CLIENT_ID",
   GMAIL_CLIENT_SECRET: "GMAIL_CLIENT_SECRET",
   GMAIL_REFRESH_TOKEN: "GMAIL_REFRESH_TOKEN",
+  SMARTLEAD_API_KEY: "Smartlead API key",
 };
 
 function SetupPage() {
@@ -62,6 +64,11 @@ function SetupPage() {
   // domain + mailbox local-part; cap blank = cold-start warm-up ramp.
   const [pendingAdds, setPendingAdds] = useState<
     Array<{ sendingDomain: string; mailbox: string; maxPerDay: string }>
+  >([]);
+  // Pending Smartlead mailboxes to add on Save (picked from the loaded account
+  // list; providerMessagePerDay clamps the default warm-up ceiling server-side).
+  const [pendingSmartleadAdds, setPendingSmartleadAdds] = useState<
+    Array<{ address: string; label: string; providerMessagePerDay: number | null }>
   >([]);
   const [addDomain, setAddDomain] = useState("");
   const [addMailbox, setAddMailbox] = useState("");
@@ -104,6 +111,16 @@ function SetupPage() {
     setWalletMode(c.walletMode);
     setEmailProvider(c.emailProvider);
   }, [status.data?.cfg]);
+
+  // Load the Smartlead workspace's connected mailboxes. Uses the just-typed
+  // key when present (browse before saving), else the server falls back to the
+  // stored SMARTLEAD_API_KEY. The key rides the POST body, never a URL.
+  const [smartleadAccounts, setSmartleadAccounts] = useState<SmartleadAccountView[] | null>(null);
+  const loadSmartlead = useMutation({
+    mutationFn: () => api.smartleadAccounts(secrets["SMARTLEAD_API_KEY"]),
+    onSuccess: (res) => setSmartleadAccounts(res.accounts),
+    onError: (err: Error) => toast.error(`Smartlead: ${err.message}`),
+  });
 
   const deriveIcp = useMutation({
     mutationFn: (domain: string) => api.deriveIcp(domain),
@@ -176,7 +193,7 @@ function SetupPage() {
         const n = Number.parseInt(raw, 10);
         return { id, maxPerDay: Number.isFinite(n) && n >= 0 ? n : null };
       });
-      const addIdentities = pendingAdds.map((a) => {
+      const addIdentities: NonNullable<SetupRequest["addIdentities"]> = pendingAdds.map((a) => {
         const n = Number.parseInt(a.maxPerDay, 10);
         return {
           provider: "oneshot" as const,
@@ -186,6 +203,14 @@ function SetupPage() {
           ...(a.maxPerDay.trim() && Number.isFinite(n) && n >= 0 ? { maxPerDay: n } : {}),
         };
       });
+      for (const a of pendingSmartleadAdds) {
+        addIdentities.push({
+          provider: "smartlead" as const,
+          address: a.address,
+          ...(a.label.trim() ? { label: a.label.trim() } : {}),
+          providerMessagePerDay: a.providerMessagePerDay,
+        });
+      }
       await api.setup({
         ...(identityUpdates.length > 0 ? { identityUpdates } : {}),
         ...(addIdentities.length > 0 ? { addIdentities } : {}),
@@ -215,6 +240,7 @@ function SetupPage() {
       setCapEdits({});
       setRemovedIdentityIds([]);
       setPendingAdds([]);
+      setPendingSmartleadAdds([]);
       setAddDomain("");
       setAddMailbox("");
       setAddCap("");
@@ -239,6 +265,10 @@ function SetupPage() {
   const isLegacyPool = status.data?.identities?.[0]?.legacy ?? true;
   // The Connect button needs the shared OAuth-app creds saved first.
   const gmailCredsReady = Boolean(sources["GMAIL_CLIENT_ID"] && sources["GMAIL_CLIENT_SECRET"]);
+  // Smartlead can be browsed with a just-typed key before it's ever saved.
+  const smartleadKeyReady = Boolean(
+    sources["SMARTLEAD_API_KEY"] || (secrets["SMARTLEAD_API_KEY"] ?? "").trim(),
+  );
 
   // Round-trip result from the browser OAuth flow (/api/gmail/auth/callback
   // redirects back here with ?gmailAuth=ok:<address> | error:<reason>).
@@ -687,7 +717,15 @@ function SetupPage() {
                       key={i.id}
                       className="flex items-center gap-3 border border-ink-rule rounded-[var(--radius-sm)] px-3 py-2"
                     >
-                      <Badge tone={i.provider === "gmail" ? "signal" : "receipt"}>
+                      <Badge
+                        tone={
+                          i.provider === "gmail"
+                            ? "signal"
+                            : i.provider === "smartlead"
+                              ? "spend"
+                              : "receipt"
+                        }
+                      >
                         {i.provider}
                       </Badge>
                       <div className="flex min-w-0 flex-col">
@@ -754,6 +792,112 @@ function SetupPage() {
                   . Cap and removal changes apply on Save. Removing an identity blocks sends to
                   prospects pinned to it until it's restored.
                 </span>
+
+                {/* Smartlead accounts: bring-your-own cold-email infra. Paste
+                    the workspace API key, load the connected mailboxes, stage
+                    picks into the rotation pool (applied on Save). Send-only —
+                    replies to Smartlead-sent mail live in Smartlead's own UI. */}
+                <div className="mt-3 flex flex-col gap-2">
+                  <span className="ln-eyebrow">Smartlead accounts</span>
+                  <Field
+                    label="SMARTLEAD_API_KEY"
+                    hint={hintFor(sources["SMARTLEAD_API_KEY"])}
+                    className="max-w-md"
+                  >
+                    <Input
+                      type="password"
+                      placeholder={sources["SMARTLEAD_API_KEY"] ? "(unchanged)" : ""}
+                      value={secrets["SMARTLEAD_API_KEY"] ?? ""}
+                      onChange={(e) => setSecret("SMARTLEAD_API_KEY", e.target.value)}
+                      autoComplete="new-password"
+                    />
+                  </Field>
+                  <div className="flex flex-wrap items-center gap-3">
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      disabled={!smartleadKeyReady || loadSmartlead.isPending}
+                      onClick={() => loadSmartlead.mutate()}
+                    >
+                      {loadSmartlead.isPending ? "Loading…" : "Load Smartlead accounts"}
+                    </Button>
+                    <span className="text-[12px] text-ink-faint">
+                      {smartleadKeyReady
+                        ? "Lists the mailboxes connected to your Smartlead workspace — Smartlead does the warmup, this pool does the sending."
+                        : "Paste your Smartlead API key first (Smartlead → Settings → API)."}
+                    </span>
+                  </div>
+                  {smartleadAccounts && smartleadAccounts.length === 0 && (
+                    <span className="text-[12px] text-ink-faint">
+                      No email accounts connected in Smartlead yet.
+                    </span>
+                  )}
+                  {smartleadAccounts?.map((a) => {
+                    const staged = pendingSmartleadAdds.some((p) => p.address === a.fromEmail);
+                    const blocked = !a.isSmtpSuccess;
+                    return (
+                      <div
+                        key={a.id}
+                        className="flex items-center gap-3 border border-ink-rule rounded-[var(--radius-sm)] px-3 py-2"
+                      >
+                        <div className="flex min-w-0 flex-col">
+                          <span className="truncate text-[13px] text-ink-cream">{a.fromEmail}</span>
+                          <span className="ln-mono text-[11px] text-ink-muted">
+                            {a.messagePerDay != null ? `${a.messagePerDay}/day` : "no cap"}
+                            {a.warmupStatus
+                              ? ` · warmup ${a.warmupStatus.toLowerCase()}${a.warmupReputation ? ` (${a.warmupReputation})` : ""}`
+                              : ""}
+                            {blocked ? " · SMTP broken — reconnect in Smartlead" : ""}
+                          </span>
+                        </div>
+                        <div className="ml-auto">
+                          {a.alreadyRegistered ? (
+                            <span className="ln-mono text-[11px] text-ink-faint">in pool</span>
+                          ) : staged ? (
+                            <Button
+                              type="button"
+                              variant="secondary"
+                              className="h-7 px-2 text-[11px]"
+                              onClick={() =>
+                                setPendingSmartleadAdds((p) =>
+                                  p.filter((x) => x.address !== a.fromEmail),
+                                )
+                              }
+                            >
+                              Undo
+                            </Button>
+                          ) : (
+                            <Button
+                              type="button"
+                              variant="secondary"
+                              className="h-7 px-2 text-[11px]"
+                              disabled={blocked}
+                              onClick={() =>
+                                setPendingSmartleadAdds((p) => [
+                                  ...p,
+                                  {
+                                    address: a.fromEmail,
+                                    label: a.fromName ?? "",
+                                    providerMessagePerDay: a.messagePerDay,
+                                  },
+                                ])
+                              }
+                            >
+                              Add
+                            </Button>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                  {pendingSmartleadAdds.length > 0 && (
+                    <span className="text-[12px] text-ink-faint">
+                      {pendingSmartleadAdds.length} Smartlead mailbox
+                      {pendingSmartleadAdds.length === 1 ? "" : "es"} staged — applied on Save with
+                      the cold-start warm-up ramp (capped at Smartlead's own per-mailbox limit).
+                    </span>
+                  )}
+                </div>
 
                 {/* Provisioned domains: the wallet's OneShot sending-domain pool
                     with live status. A paused domain sends nothing until resumed

--- a/packages/core/__tests__/identities-smartlead.test.ts
+++ b/packages/core/__tests__/identities-smartlead.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OneShotConfig } from "../src/types.ts";
+
+// registerSmartleadIdentity: defaults, provider-cap clamp, explicit caps,
+// dedupe, and legacy-pool materialization. Config is mocked stateful so no
+// real ~/.oneshot-gtm is touched.
+
+let cfg: OneShotConfig;
+
+vi.mock("../src/config.ts", async () => {
+  const actual = await vi.importActual<typeof import("../src/config.ts")>("../src/config.ts");
+  return {
+    ...actual,
+    loadConfig: () => cfg,
+    saveConfig: (next: OneShotConfig) => {
+      cfg = next;
+    },
+  };
+});
+
+const { registerSmartleadIdentity, LEGACY_ONESHOT_ID } = await import("../src/identities.ts");
+
+const BASE: OneShotConfig = {
+  walletMode: "cdp",
+  llmProvider: "openrouter",
+  llmModel: "x",
+  telemetryEnabled: true,
+  founderName: "Jane Doe",
+  founderEmail: null,
+  productOneLiner: null,
+  productDomain: null,
+  sendingDomain: "legacy.com",
+  emailProvider: "oneshot",
+  emailIdentities: null,
+  icpOneLiner: null,
+  cadenceOverrides: null,
+  founderCredentials: null,
+  productPortfolio: null,
+  partners: null,
+  founderAdmission: null,
+  productBrief: null,
+  mobileSignature: false,
+  clientId: null,
+};
+
+beforeEach(() => {
+  cfg = { ...BASE };
+});
+
+describe("registerSmartleadIdentity", () => {
+  it("materializes the legacy pool on first add and normalizes the id", () => {
+    const { identityId, created } = registerSmartleadIdentity({ address: " Jane@ACME.com " });
+    expect(created).toBe(true);
+    expect(identityId).toBe("smartlead:jane@acme.com");
+    const ids = cfg.emailIdentities!.map((i) => i.id);
+    expect(ids).toContain(LEGACY_ONESHOT_ID);
+    expect(ids).toContain("smartlead:jane@acme.com");
+    const added = cfg.emailIdentities!.find((i) => i.id === identityId)!;
+    expect(added.provider).toBe("smartlead");
+    expect(added.address).toBe("jane@acme.com");
+  });
+
+  it("defaults to the warm-up ramp with the 50/day ceiling", () => {
+    registerSmartleadIdentity({ address: "a@x.com" });
+    const added = cfg.emailIdentities!.find((i) => i.id === "smartlead:a@x.com")!;
+    expect(added.maxPerDay).toBe(50);
+    expect(added.warmup).toEqual({ startPerDay: 10, incrementPerWeek: 10 });
+  });
+
+  it("clamps the DEFAULT ceiling to Smartlead's message_per_day when lower", () => {
+    registerSmartleadIdentity({ address: "low@x.com", providerMessagePerDay: 30 });
+    expect(cfg.emailIdentities!.find((i) => i.id === "smartlead:low@x.com")!.maxPerDay).toBe(30);
+    registerSmartleadIdentity({ address: "high@x.com", providerMessagePerDay: 200 });
+    expect(cfg.emailIdentities!.find((i) => i.id === "smartlead:high@x.com")!.maxPerDay).toBe(50);
+    registerSmartleadIdentity({ address: "none@x.com", providerMessagePerDay: null });
+    expect(cfg.emailIdentities!.find((i) => i.id === "smartlead:none@x.com")!.maxPerDay).toBe(50);
+  });
+
+  it("an explicit maxPerDay overrides the provider clamp; the ramp is kept", () => {
+    registerSmartleadIdentity({ address: "cap@x.com", maxPerDay: 80, providerMessagePerDay: 30 });
+    const added = cfg.emailIdentities!.find((i) => i.id === "smartlead:cap@x.com")!;
+    expect(added.maxPerDay).toBe(80);
+    expect(added.warmup).toEqual({ startPerDay: 10, incrementPerWeek: 10 });
+  });
+
+  it("explicit null = truly uncapped, ramp cleared", () => {
+    registerSmartleadIdentity({ address: "inf@x.com", maxPerDay: null });
+    const added = cfg.emailIdentities!.find((i) => i.id === "smartlead:inf@x.com")!;
+    expect(added.maxPerDay).toBeNull();
+    expect(added.warmup).toBeNull();
+  });
+
+  it("re-adding a known address is a no-op that keeps tuned caps", () => {
+    registerSmartleadIdentity({ address: "dup@x.com", maxPerDay: 12 });
+    const { created } = registerSmartleadIdentity({ address: "DUP@x.com" });
+    expect(created).toBe(false);
+    const dupes = cfg.emailIdentities!.filter((i) => i.id === "smartlead:dup@x.com");
+    expect(dupes).toHaveLength(1);
+    expect(dupes[0]!.maxPerDay).toBe(12);
+  });
+
+  it("rejects a blank address", () => {
+    expect(() => registerSmartleadIdentity({ address: "  " })).toThrow(/needs an address/);
+  });
+});

--- a/packages/core/__tests__/oneshot-smartlead-dispatch.test.ts
+++ b/packages/core/__tests__/oneshot-smartlead-dispatch.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EmailIdentity } from "../src/types.ts";
+
+// Provider dispatch: a smartlead identity must route through the Smartlead
+// REST path (mocked fetch) and NEVER fall through to the paid OneShot SDK
+// agent; unknown providers must throw; replies from smartlead must throw.
+// Config + ledger are mocked so no real ~/.oneshot-gtm is touched.
+
+const recordReceipt = vi.fn().mockReturnValue(42);
+const assignSender = vi.fn((_email: string, identityId: string) => identityId);
+let identities: EmailIdentity[] = [];
+
+vi.mock("../src/config.ts", async () => {
+  const actual = await vi.importActual<typeof import("../src/config.ts")>("../src/config.ts");
+  return {
+    ...actual,
+    loadConfig: () => ({
+      ...actual.loadConfig(),
+      founderName: "Jane Doe",
+      emailIdentities: identities,
+    }),
+  };
+});
+
+vi.mock("../src/ledger.ts", async () => {
+  const actual = await vi.importActual<typeof import("../src/ledger.ts")>("../src/ledger.ts");
+  return {
+    ...actual,
+    getLedger: () => ({
+      suppressionFor: () => null,
+      recordReceipt,
+      getSenderAssignment: () => null,
+      hasPriorEmailSend: () => false,
+      assignSender,
+      countEmailSendsSince: () => 0,
+      firstEmailSendAt: () => null,
+    }),
+  };
+});
+
+const { sendEmail, replyEmail } = await import("../src/oneshot.ts");
+
+const SL_IDENTITY: EmailIdentity = {
+  id: "smartlead:jane@acme.com",
+  provider: "smartlead",
+  label: "Jane",
+  address: "jane@acme.com",
+  maxPerDay: 50,
+  warmup: null,
+};
+
+const fetchMock = vi.fn();
+let keySnapshot: string | undefined;
+
+beforeEach(() => {
+  keySnapshot = process.env["SMARTLEAD_API_KEY"];
+  process.env["SMARTLEAD_API_KEY"] = "sl-test-key";
+  identities = [SL_IDENTITY];
+  recordReceipt.mockClear();
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  if (keySnapshot === undefined) delete process.env["SMARTLEAD_API_KEY"];
+  else process.env["SMARTLEAD_API_KEY"] = keySnapshot;
+  vi.unstubAllGlobals();
+});
+
+function sendOk() {
+  fetchMock.mockResolvedValueOnce(
+    new Response(
+      JSON.stringify({ success: true, data: { message: "Email sent", message_id: "msg_1" } }),
+      { status: 200 },
+    ),
+  );
+}
+
+describe("dispatch via smartlead", () => {
+  it("routes to the Smartlead API and records a truthful receipt", async () => {
+    sendOk();
+    const { result, receiptId } = await sendEmail(
+      { to: "founder@startup.com", subject: "hey", body: "line one\nline two" },
+      { playName: "test-play" },
+    );
+    expect(receiptId).toBe(42);
+    expect(result.request_id).toBe("msg_1");
+    expect(result.cost).toBe(0);
+    // The only network call is Smartlead's — the SDK was never constructed.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0]![0])).toContain("/send-email/initiate");
+    const payload = JSON.parse(String((fetchMock.mock.calls[0]![1] as RequestInit).body)) as {
+      fromEmail: string;
+      body: string;
+    };
+    expect(payload.fromEmail).toBe("jane@acme.com");
+    expect(payload.body).toContain("<br>"); // plain text was HTML-ified
+    const receipt = recordReceipt.mock.calls[0]![0] as {
+      callType: string;
+      senderIdentity: string;
+      oneshotRequestId: string;
+      signedReceipt: Record<string, unknown>;
+    };
+    expect(receipt.callType).toBe("email.send");
+    expect(receipt.senderIdentity).toBe("smartlead:jane@acme.com");
+    expect(receipt.oneshotRequestId).toBe("msg_1");
+    expect(receipt.signedReceipt["provider"]).toBe("smartlead");
+    expect(JSON.stringify(receipt)).not.toContain("sl-test-key");
+  });
+
+  it("hard-fails without the API key instead of falling through to the SDK", async () => {
+    delete process.env["SMARTLEAD_API_KEY"];
+    await expect(
+      sendEmail({ to: "a@b.com", subject: "s", body: "b" }, { playName: "test-play" }),
+    ).rejects.toThrow(/SMARTLEAD_API_KEY not set/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("hard-fails on a smartlead identity without an address", async () => {
+    identities = [{ ...SL_IDENTITY, address: null }];
+    await expect(
+      sendEmail({ to: "a@b.com", subject: "s", body: "b" }, { playName: "test-play" }),
+    ).rejects.toThrow(/no address on Smartlead sender identity/);
+  });
+
+  it("an unknown provider throws instead of silently using the OneShot wallet", async () => {
+    identities = [{ ...SL_IDENTITY, id: "mystery:x", provider: "mystery" as never }];
+    await expect(
+      sendEmail({ to: "a@b.com", subject: "s", body: "b" }, { playName: "test-play" }),
+    ).rejects.toThrow(/unknown email provider 'mystery'/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("replyEmail with a smartlead identity", () => {
+  it("throws (send-only v1) rather than routing through the OneShot wallet", async () => {
+    await expect(
+      replyEmail(
+        {
+          identityId: "smartlead:jane@acme.com",
+          to: "founder@startup.com",
+          subject: "Re: hey",
+          body: "thanks!",
+        },
+        { playName: "inbox" },
+      ),
+    ).rejects.toThrow(/aren't supported yet/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/__tests__/send-routing-smartlead.test.ts
+++ b/packages/core/__tests__/send-routing-smartlead.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { capGroupKey } from "../src/send-routing.ts";
+import type { EmailIdentity } from "../src/types.ts";
+
+// Smartlead cap-grouping: per-account budgets (Smartlead's own
+// message_per_day is per-mailbox), so each identity is its own group even
+// when two mailboxes share a From-domain.
+
+function sl(id: string, address: string): EmailIdentity {
+  return { id, provider: "smartlead", address, maxPerDay: 50, warmup: null };
+}
+
+describe("capGroupKey for smartlead", () => {
+  it("keys each smartlead identity by its own id", () => {
+    const a = sl("smartlead:a@acme.com", "a@acme.com");
+    const b = sl("smartlead:b@acme.com", "b@acme.com");
+    expect(capGroupKey(a)).toBe("id:smartlead:a@acme.com");
+    expect(capGroupKey(b)).toBe("id:smartlead:b@acme.com");
+    expect(capGroupKey(a)).not.toBe(capGroupKey(b)); // same domain, separate budgets
+  });
+});

--- a/packages/core/__tests__/smartlead.test.ts
+++ b/packages/core/__tests__/smartlead.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { listSmartleadAccounts, sendViaSmartlead } from "../src/smartlead.ts";
+
+// Smartlead REST client: paging, response sanitization (the raw rows carry
+// base64 mailbox passwords), key-never-in-errors, and the send contract.
+
+const KEY = "sk-test-SECRETKEY-123";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function rawAccount(id: number, email: string, extra: Record<string, unknown> = {}) {
+  return {
+    id,
+    from_email: email,
+    from_name: "Jane",
+    message_per_day: 30,
+    daily_sent_count: 3,
+    is_smtp_success: true,
+    type: "SMTP",
+    // The fields that must NEVER survive sanitization:
+    password: "cGFzc3dvcmQtc2VjcmV0",
+    smtp_password: "c210cC1zZWNyZXQ=",
+    warmup_details: { status: "ACTIVE", warmup_reputation: "95%", reply_rate: 40 },
+    ...extra,
+  };
+}
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("listSmartleadAccounts", () => {
+  it("pages until a short page and concatenates", async () => {
+    const page1 = Array.from({ length: 100 }, (_, i) => rawAccount(i, `a${i}@x.com`));
+    const page2 = [rawAccount(200, "tail@x.com")];
+    fetchMock.mockResolvedValueOnce(jsonResponse(page1)).mockResolvedValueOnce(jsonResponse(page2));
+    const accounts = await listSmartleadAccounts(KEY);
+    expect(accounts).toHaveLength(101);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    const firstUrl = String(fetchMock.mock.calls[0]![0]);
+    expect(firstUrl).toContain("/email-accounts/");
+    expect(firstUrl).toContain("offset=0");
+    expect(String(fetchMock.mock.calls[1]![0])).toContain("offset=100");
+  });
+
+  it("strips password fields — the serialized result never contains them", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse([rawAccount(1, "jane@acme.com")]));
+    const accounts = await listSmartleadAccounts(KEY);
+    const serialized = JSON.stringify(accounts);
+    expect(serialized).not.toContain("password");
+    expect(serialized).not.toContain("cGFzc3dvcmQtc2VjcmV0");
+    expect(serialized).not.toContain("c210cC1zZWNyZXQ=");
+    expect(accounts[0]).toEqual({
+      id: 1,
+      fromEmail: "jane@acme.com",
+      fromName: "Jane",
+      messagePerDay: 30,
+      dailySentCount: 3,
+      isSmtpSuccess: true,
+      type: "SMTP",
+      warmupStatus: "ACTIVE",
+      warmupReputation: "95%",
+    });
+  });
+
+  it("lowercases from_email and drops rows without id/from_email", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse([rawAccount(1, "Jane@ACME.com"), { junk: true }, rawAccount(2, "")]),
+    );
+    const accounts = await listSmartleadAccounts(KEY);
+    expect(accounts.map((a) => a.fromEmail)).toEqual(["jane@acme.com"]);
+  });
+
+  it("errors carry the HTTP status but never the api key", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: "bad key" }, 401));
+    const err = await listSmartleadAccounts(KEY).catch((e: Error) => e);
+    expect(err).toBeInstanceOf(Error);
+    expect((err as Error).message).toContain("401");
+    expect((err as Error).message).toContain("/email-accounts/");
+    expect((err as Error).message).not.toContain(KEY);
+    expect((err as Error).message).not.toContain("SECRETKEY");
+  });
+
+  it("throws without any key", async () => {
+    const prev = process.env["SMARTLEAD_API_KEY"];
+    delete process.env["SMARTLEAD_API_KEY"];
+    try {
+      await expect(listSmartleadAccounts()).rejects.toThrow(/no Smartlead API key/);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      if (prev !== undefined) process.env["SMARTLEAD_API_KEY"] = prev;
+    }
+  });
+
+  it("times out a hung fetch with a deadline error (no key in the message)", async () => {
+    vi.useFakeTimers();
+    fetchMock.mockReturnValueOnce(new Promise(() => {}));
+    const pending = listSmartleadAccounts(KEY);
+    const settled = pending.catch((e: Error) => e);
+    await vi.advanceTimersByTimeAsync(31_000);
+    const err = await settled;
+    expect((err as Error).message).toMatch(/deadline exceeded/);
+    expect((err as Error).message).not.toContain(KEY);
+  });
+});
+
+describe("sendViaSmartlead", () => {
+  it("POSTs to /send-email/initiate with the documented field names", async () => {
+    fetchMock.mockResolvedValueOnce(
+      jsonResponse({ success: true, data: { message: "Email sent", message_id: "msg_abc" } }),
+    );
+    const res = await sendViaSmartlead(
+      {
+        to: "founder@startup.com",
+        subject: "hey",
+        htmlBody: "<p>hi</p>",
+        fromEmail: "jane@acme.com",
+        fromName: "Jane Doe",
+      },
+      KEY,
+    );
+    expect(res.messageId).toBe("msg_abc");
+    const [url, init] = fetchMock.mock.calls[0]! as [string, RequestInit];
+    expect(String(url)).toContain("/send-email/initiate");
+    expect(init.method).toBe("POST");
+    const payload = JSON.parse(String(init.body)) as Record<string, unknown>;
+    expect(payload).toEqual({
+      to: "founder@startup.com",
+      subject: "hey",
+      body: "<p>hi</p>",
+      fromEmail: "jane@acme.com",
+      fromName: "Jane Doe",
+    });
+  });
+
+  it("falls back to a unique smartlead: id when the response has no message id", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ success: true }));
+    const res = await sendViaSmartlead(
+      { to: "a@b.com", subject: "s", htmlBody: "b", fromEmail: "jane@acme.com" },
+      KEY,
+    );
+    expect(res.messageId).toMatch(/^smartlead:[0-9a-f-]{36}$/);
+  });
+
+  it("surfaces upstream failures with status, without the key", async () => {
+    fetchMock.mockResolvedValueOnce(jsonResponse({ error: "quota" }, 429));
+    const err = await sendViaSmartlead(
+      { to: "a@b.com", subject: "s", htmlBody: "b", fromEmail: "jane@acme.com" },
+      KEY,
+    ).catch((e: Error) => e);
+    expect((err as Error).message).toContain("429");
+    expect((err as Error).message).not.toContain(KEY);
+  });
+});

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -24,6 +24,7 @@ export const SECRET_KEYS = [
   "GMAIL_CLIENT_ID",
   "GMAIL_CLIENT_SECRET",
   "GMAIL_REFRESH_TOKEN",
+  "SMARTLEAD_API_KEY",
 ] as const;
 export type SecretKey = (typeof SECRET_KEYS)[number];
 

--- a/packages/core/src/identities.ts
+++ b/packages/core/src/identities.ts
@@ -98,6 +98,56 @@ export function registerGmailIdentity(input: { address: string; refreshToken: st
 }
 
 /**
+ * Add a Smartlead-connected mailbox to the rotation pool. No credential is
+ * stored per identity — sends resolve the workspace-wide SMARTLEAD_API_KEY and
+ * pin the From by address. Default caps are the standard warm-up ramp, with
+ * the DEFAULT ceiling clamped down to Smartlead's own `message_per_day` when
+ * the caller passes it (an explicitly chosen `maxPerDay` — including null for
+ * uncapped — is respected as-is, same trust model as OneShot caps).
+ * Re-adding a known address is a no-op: tuned caps are left alone.
+ */
+export function registerSmartleadIdentity(input: {
+  address: string;
+  label?: string | null;
+  maxPerDay?: number | null;
+  /** Smartlead's per-mailbox message_per_day, from the accounts listing. */
+  providerMessagePerDay?: number | null;
+}): { identityId: string; created: boolean } {
+  const address = input.address.trim().toLowerCase();
+  if (!address) throw new Error("smartlead identity needs an address");
+  const identityId = `smartlead:${address}`;
+  const cfg = loadConfig();
+  const pool: EmailIdentity[] = cfg.emailIdentities
+    ? [...cfg.emailIdentities]
+    : resolveIdentities(cfg);
+  if (pool.some((i) => i.id === identityId)) return { identityId, created: false };
+  let caps: Pick<EmailIdentity, "maxPerDay" | "warmup">;
+  if ("maxPerDay" in input) {
+    const maxPerDay = input.maxPerDay ?? null;
+    // Explicit ceiling keeps the ramp toward it; explicit null = truly
+    // uncapped, so the ramp is cleared too (warmupCap would re-impose 50).
+    caps =
+      maxPerDay == null ? { maxPerDay: null, warmup: null } : { ...WARMUP_DEFAULTS, maxPerDay };
+  } else {
+    const provider = input.providerMessagePerDay;
+    const ceiling =
+      typeof provider === "number" && Number.isFinite(provider) && provider > 0
+        ? Math.min(WARMUP_DEFAULTS.maxPerDay ?? provider, provider)
+        : WARMUP_DEFAULTS.maxPerDay;
+    caps = { ...WARMUP_DEFAULTS, maxPerDay: ceiling };
+  }
+  pool.push({
+    id: identityId,
+    provider: "smartlead",
+    label: input.label?.trim() || address,
+    address,
+    ...caps,
+  });
+  saveConfig({ ...cfg, emailIdentities: pool });
+  return { identityId, created: true };
+}
+
+/**
  * Founder-name-derived default local-part (first token, normalized) — the
  * mailbox used when an OneShot identity is added without an explicit one. Falls
  * back to "agent". Mirrors `fromLocalpart` in oneshot.ts but lives here to keep

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export * from "./telemetry.ts";
 export * from "./version.ts";
 export * from "./json.ts";
 export * from "./gmail.ts";
+export * from "./smartlead.ts";
 export * from "./canary.ts";
 export * from "./identities.ts";
 export * from "./send-routing.ts";

--- a/packages/core/src/oneshot.ts
+++ b/packages/core/src/oneshot.ts
@@ -31,6 +31,7 @@ import {
   sendGmailMessage,
 } from "./gmail.ts";
 import { gmailAccountFor, resolveIdentities } from "./identities.ts";
+import { sendViaSmartlead, smartleadApiKey } from "./smartlead.ts";
 import { parallelMap, withDeadline } from "./parallel.ts";
 import {
   isTransientToolError,
@@ -311,6 +312,60 @@ async function sendEmailViaGmail(input: SendEmailInput, ctx: CallContext, identi
   return { result, receiptId };
 }
 
+/**
+ * Smartlead-path send. Same return contract as the Gmail path: cost 0 (the
+ * Smartlead subscription is out-of-band), Smartlead's message id as request
+ * id (which also dedupes receipt re-records). Smartlead documents no
+ * idempotency mechanism, so — like Gmail — a timeout-then-retry can
+ * double-send; the OneShot path is the only transport with a true
+ * idempotency key.
+ */
+async function sendEmailViaSmartlead(
+  input: SendEmailInput,
+  ctx: CallContext,
+  identity: EmailIdentity,
+) {
+  const cfg = loadConfig();
+  const fromEmail = identity.address?.trim().toLowerCase();
+  if (!fromEmail) {
+    throw new Error(
+      `no address on Smartlead sender identity '${identity.id}' — re-add it (bun run cli -- smartlead connect)`,
+    );
+  }
+  if (!smartleadApiKey()) {
+    throw new Error("SMARTLEAD_API_KEY not set — store it with: bun run cli -- smartlead connect");
+  }
+  const sent = await sendViaSmartlead({
+    to: input.to,
+    subject: input.subject,
+    htmlBody: toHtmlBody(input.body),
+    fromEmail,
+    fromName: cfg.founderName,
+  });
+  const result: EmailResult = {
+    status: "sent",
+    request_id: sent.messageId,
+    cost: 0,
+    email: { id: sent.messageId, provider_message_id: sent.messageId, status: "sent" },
+  };
+  const receiptId = recordCallReceipt({
+    ctx,
+    callType: "email.send",
+    signedReceipt: {
+      provider: "smartlead",
+      message_id: sent.messageId,
+      from: fromEmail,
+      to: input.to,
+      subject: input.subject,
+      memo: ctx.memo ?? `${ctx.playName} email.send`,
+    },
+    costUsd: 0,
+    oneshotRequestId: sent.messageId,
+    senderIdentity: identity.id,
+  });
+  return { result, receiptId };
+}
+
 async function dispatchEmail(input: SendEmailInput, ctx: CallContext) {
   // Suppression backstop, ahead of everything else: a previously hard-bounced
   // address can only fail again, and the send is billed before dispatch. Every
@@ -329,6 +384,14 @@ async function dispatchEmail(input: SendEmailInput, ctx: CallContext) {
   const identity = resolveSenderIdentity(input.to);
   if (identity.provider === "gmail") {
     return sendEmailViaGmail(input, ctx, identity);
+  }
+  if (identity.provider === "smartlead") {
+    return sendEmailViaSmartlead(input, ctx, identity);
+  }
+  // Explicit guard: a provider this branch doesn't know must NEVER fall
+  // through to the paid OneShot SDK path below.
+  if (identity.provider !== "oneshot") {
+    throw new Error(`unknown email provider '${identity.provider}' for identity '${identity.id}'`);
   }
   const agent = await getAgent();
   const cfg = loadConfig();
@@ -494,6 +557,18 @@ export async function replyEmail(input: ReplyEmailInput, ctx: CallContext) {
     });
     recordContactTouch(input.to, ctx.playName);
     return { result, receiptId };
+  }
+
+  // Send-only v1: Smartlead identities produce no inbox rows, so no UI path
+  // reaches here — this guard exists so a future inbox source can't silently
+  // route a "reply" through the paid OneShot wallet from the wrong domain.
+  if (identity.provider === "smartlead") {
+    throw new Error(
+      `replies from Smartlead identity '${identity.id}' aren't supported yet — reply in Smartlead's own inbox`,
+    );
+  }
+  if (identity.provider !== "oneshot") {
+    throw new Error(`unknown email provider '${identity.provider}' for identity '${identity.id}'`);
   }
 
   const agent = await getAgent();

--- a/packages/core/src/send-routing.ts
+++ b/packages/core/src/send-routing.ts
@@ -145,6 +145,9 @@ export function warmupCap(
  * budget. Gmail accounts are independent — Google warms per-account — so each
  * Gmail identity is its own group keyed by id (this also keeps two Gmail
  * accounts on one Workspace domain from sharing a cap, matching prior behavior).
+ * Smartlead mailboxes are likewise per-account (Smartlead's own
+ * message_per_day is per-mailbox), so each is its own group keyed by id;
+ * grouping them by From-domain is a possible follow-up.
  */
 export function capGroupKey(identity: EmailIdentity): string {
   if (identity.provider === "oneshot") {

--- a/packages/core/src/smartlead.ts
+++ b/packages/core/src/smartlead.ts
@@ -1,0 +1,187 @@
+import { randomUUID } from "node:crypto";
+import { withDeadline } from "./parallel.ts";
+
+/**
+ * Smartlead REST transport (send-only v1). Smartlead hosts + warms the
+ * mailboxes; we send one-off emails through their API choosing the From
+ * account by address. One workspace-wide API key (SMARTLEAD_API_KEY) — there
+ * is no per-mailbox credential on our side.
+ *
+ * Security invariants:
+ *  - Smartlead authenticates via an `api_key` QUERY PARAM. The key must never
+ *    appear in thrown errors, logs, receipts, or telemetry — error messages
+ *    are built from a pre-computed path with the query string stripped.
+ *  - The accounts listing response includes base64 mailbox passwords. Rows are
+ *    whitelist-destructured into SmartleadAccount at parse time; the raw
+ *    objects never escape this module.
+ */
+const SMARTLEAD_API = "https://server.smartlead.ai/api/v1";
+const SMARTLEAD_TIMEOUT_MS = 30_000;
+const ACCOUNTS_PAGE_SIZE = 100;
+
+/** Sanitized view of one Smartlead-connected mailbox. */
+export interface SmartleadAccount {
+  id: number;
+  fromEmail: string;
+  fromName: string | null;
+  /** Smartlead's own per-mailbox daily send limit. */
+  messagePerDay: number | null;
+  dailySentCount: number;
+  /** False = the SMTP connection is broken on Smartlead's side; sends will fail. */
+  isSmtpSuccess: boolean;
+  /** GMAIL | OUTLOOK | SMTP */
+  type: string;
+  /** ACTIVE | INACTIVE | PAUSED (null when Smartlead omits warmup details). */
+  warmupStatus: string | null;
+  /** e.g. "95%" */
+  warmupReputation: string | null;
+}
+
+/** The stored workspace-wide key, or null when unset/blank. */
+export function smartleadApiKey(): string | null {
+  const key = process.env["SMARTLEAD_API_KEY"]?.trim();
+  return key || null;
+}
+
+function resolveKey(apiKey?: string): string {
+  const key = apiKey?.trim() || smartleadApiKey();
+  if (!key) {
+    throw new Error(
+      "no Smartlead API key — set SMARTLEAD_API_KEY (bun run cli -- smartlead connect)",
+    );
+  }
+  return key;
+}
+
+/**
+ * Fetch JSON from the Smartlead API. `path` must be query-free; params are
+ * appended via URLSearchParams with `api_key` LAST, and every error message
+ * uses the bare path so the key can never leak through a throw.
+ */
+async function smartleadJson<T>(
+  path: string,
+  apiKey: string,
+  params: Record<string, string> = {},
+  init?: RequestInit,
+): Promise<T> {
+  const search = new URLSearchParams(params);
+  search.set("api_key", apiKey);
+  const res = await withDeadline(
+    fetch(`${SMARTLEAD_API}${path}?${search}`, init),
+    SMARTLEAD_TIMEOUT_MS,
+    `Smartlead API ${path}`,
+  );
+  const body = await res.text();
+  if (!res.ok) {
+    throw new Error(`Smartlead API ${path} failed (${res.status}): ${body.slice(0, 200)}`);
+  }
+  try {
+    return JSON.parse(body) as T;
+  } catch {
+    throw new Error(`Smartlead API ${path} returned non-JSON (${res.status})`);
+  }
+}
+
+function num(v: unknown): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+function str(v: unknown): string | null {
+  return typeof v === "string" && v.trim() ? v.trim() : null;
+}
+
+/**
+ * Whitelist-destructure one raw account row. The raw object carries mailbox
+ * passwords (base64) — only the fields below may survive. Returns null for
+ * rows without a usable id + from_email.
+ */
+function sanitizeAccount(raw: Record<string, unknown>): SmartleadAccount | null {
+  const id = num(raw["id"]);
+  const fromEmail = str(raw["from_email"])?.toLowerCase() ?? null;
+  if (id == null || !fromEmail) return null;
+  const warmup =
+    raw["warmup_details"] && typeof raw["warmup_details"] === "object"
+      ? (raw["warmup_details"] as Record<string, unknown>)
+      : null;
+  return {
+    id,
+    fromEmail,
+    fromName: str(raw["from_name"]),
+    messagePerDay: num(raw["message_per_day"]),
+    dailySentCount: num(raw["daily_sent_count"]) ?? 0,
+    isSmtpSuccess: raw["is_smtp_success"] !== false,
+    type: str(raw["type"]) ?? "SMTP",
+    warmupStatus: warmup ? str(warmup["status"]) : null,
+    warmupReputation: warmup ? str(warmup["warmup_reputation"]) : null,
+  };
+}
+
+/**
+ * Every email account connected to the Smartlead workspace, sanitized.
+ * Pages until a short page; a workspace with thousands of mailboxes is
+ * clamped at 50 pages (5k accounts) as a runaway guard.
+ */
+export async function listSmartleadAccounts(apiKey?: string): Promise<SmartleadAccount[]> {
+  const key = resolveKey(apiKey);
+  const out: SmartleadAccount[] = [];
+  for (let page = 0; page < 50; page++) {
+    const rows = await smartleadJson<Record<string, unknown>[]>("/email-accounts/", key, {
+      offset: String(page * ACCOUNTS_PAGE_SIZE),
+      limit: String(ACCOUNTS_PAGE_SIZE),
+    });
+    if (!Array.isArray(rows)) {
+      throw new Error("Smartlead API /email-accounts/ returned an unexpected shape");
+    }
+    for (const raw of rows) {
+      const account = sanitizeAccount(raw);
+      if (account) out.push(account);
+    }
+    if (rows.length < ACCOUNTS_PAGE_SIZE) break;
+  }
+  return out;
+}
+
+export interface SmartleadSendInput {
+  to: string;
+  subject: string;
+  /** Pre-rendered HTML (Smartlead renders `body` as HTML). */
+  htmlBody: string;
+  /** The connected account to send as — must match a Smartlead from_email. */
+  fromEmail: string;
+  fromName?: string | null;
+}
+
+/**
+ * One-off send via POST /send-email/initiate. Returns Smartlead's message id
+ * for the ledger receipt (`oneshot_request_id`, which also dedupes re-records).
+ * Smartlead documents no idempotency mechanism, so — like the Gmail path — a
+ * timeout-then-retry can double-send. When the response carries no id we fall
+ * back to a UUID: receipts stay unique, retry-dedupe is lost for that send.
+ */
+export async function sendViaSmartlead(
+  input: SmartleadSendInput,
+  apiKey?: string,
+): Promise<{ messageId: string }> {
+  const key = resolveKey(apiKey);
+  const res = await smartleadJson<Record<string, unknown>>(
+    "/send-email/initiate",
+    key,
+    {},
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        to: input.to,
+        subject: input.subject,
+        body: input.htmlBody,
+        fromEmail: input.fromEmail,
+        ...(input.fromName?.trim() ? { fromName: input.fromName.trim() } : {}),
+      }),
+    },
+  );
+  const data =
+    res["data"] && typeof res["data"] === "object" ? (res["data"] as Record<string, unknown>) : res;
+  const messageId =
+    str(data["message_id"]) ?? str(data["messageId"]) ?? str(data["id"]) ?? str(res["message_id"]);
+  return { messageId: messageId ?? `smartlead:${randomUUID()}` };
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -30,13 +30,17 @@ export interface ReceiptRecord {
 export interface EmailIdentity {
   /** Stable key, e.g. "legacy-oneshot", "gmail:jn@freebutter.ai". Referenced by sender_assignments rows — never rename a live id. */
   id: string;
-  provider: "oneshot" | "gmail";
+  provider: "oneshot" | "gmail" | "smartlead";
   label?: string | null;
   /** OneShot only: wallet-owned From domain. */
   sendingDomain?: string | null;
   /** OneShot only: From localpart override (default: founder first name). */
   mailbox?: string | null;
-  /** Gmail only: the account address (informational; the OAuth token decides the real From). */
+  /**
+   * Gmail/Smartlead: the account address. For Gmail it is informational (the
+   * OAuth token decides the real From); for Smartlead it is the literal
+   * `fromEmail` the send API pins, so it must match a connected account.
+   */
   address?: string | null;
   /** Hard daily ceiling. Null = uncapped (only sensible for OneShot identities). */
   maxPerDay: number | null;

--- a/packages/doctor/__tests__/workspace-checks.test.ts
+++ b/packages/doctor/__tests__/workspace-checks.test.ts
@@ -201,3 +201,47 @@ describe("fourth-round review findings (#38)", () => {
     expect(checks.some((c) => c.name === "sending domain acme.email")).toBe(false);
   });
 });
+
+describe("smartlead identities in doctor", () => {
+  const SL = {
+    id: "smartlead:jane@acme.com",
+    provider: "smartlead",
+    address: "jane@acme.com",
+    maxPerDay: 50,
+    warmup: null,
+  };
+
+  it("warns when another workspace registered the same Smartlead mailbox", async () => {
+    cfgOverride = { emailIdentities: [SL] };
+    otherWorkspace("sdk", { emailIdentities: [{ ...SL }] });
+    const checks = await runDoctor();
+    const hit = checks.find((c) => c.name === "smartlead jane@acme.com");
+    expect(hit?.severity).toBe("warn");
+    expect(hit?.message).toContain("'sdk'");
+  });
+
+  it("no warning when only this workspace has the mailbox", async () => {
+    cfgOverride = { emailIdentities: [SL] };
+    otherWorkspace("sdk", { emailIdentities: [] });
+    const checks = await runDoctor();
+    expect(checks.some((c) => c.name === "smartlead jane@acme.com")).toBe(false);
+  });
+
+  it("counts smartlead in the bounce-blind bucket and fails the sender line without a key", async () => {
+    const prev = process.env["SMARTLEAD_API_KEY"];
+    delete process.env["SMARTLEAD_API_KEY"];
+    try {
+      cfgOverride = { emailIdentities: [SL] };
+      const checks = await runDoctor();
+      const blind = checks.find(
+        (c) => c.name === "deliverability" && c.message.includes("not covered"),
+      );
+      expect(blind?.message).toContain("smartlead");
+      const sender = checks.find((c) => c.name === "sender smartlead:jane@acme.com");
+      expect(sender?.severity).toBe("fail");
+      expect(sender?.message).toContain("SMARTLEAD_API_KEY not set");
+    } finally {
+      if (prev !== undefined) process.env["SMARTLEAD_API_KEY"] = prev;
+    }
+  });
+});

--- a/packages/doctor/src/check.ts
+++ b/packages/doctor/src/check.ts
@@ -11,8 +11,11 @@ import {
   gmailAccountFor,
   identityCapacities,
   listSendingDomains,
+  listSmartleadAccounts,
   llmApiKey,
   loadConfig,
+  smartleadApiKey,
+  type SmartleadAccount,
   missingGmailSecrets,
   oneshotEnvReady,
   resolveIdentities,
@@ -73,15 +76,17 @@ function deliverabilityChecks(): CheckResult[] {
 
     // Bounce detection reads DSNs out of a mailbox we can authenticate to, so
     // it only covers Gmail identities. A OneShot send's return path belongs to
-    // the platform and surfaces nothing in its inbox API — those identities are
-    // structurally invisible here. Saying so matters: silence about an
-    // unmonitored sender reads as "no bounces" when it means "we can't tell".
-    const blind = identities.filter((i) => i.provider === "oneshot");
+    // the platform, and Smartlead hosts its mailboxes — neither surfaces DSNs
+    // to us, so those identities are structurally invisible here. Saying so
+    // matters: silence about an unmonitored sender reads as "no bounces" when
+    // it means "we can't tell".
+    const blind = identities.filter((i) => i.provider !== "gmail");
     if (blind.length > 0) {
+      const providers = [...new Set(blind.map((i) => i.provider))].join(", ");
       results.push({
         name: "deliverability",
         severity: "warn",
-        message: `${blind.length} OneShot identit${blind.length === 1 ? "y" : "ies"} not covered — bounce detection reads DSNs from Gmail mailboxes only`,
+        message: `${blind.length} identit${blind.length === 1 ? "y" : "ies"} not covered (${providers}) — bounce detection reads DSNs from Gmail mailboxes only`,
       });
     }
 
@@ -100,7 +105,7 @@ function deliverabilityChecks(): CheckResult[] {
       return results;
     }
     for (const identity of identities) {
-      if (identity.provider === "oneshot") continue; // reported once above, as uncovered
+      if (identity.provider !== "gmail") continue; // reported once above, as uncovered
       const s = stats.get(identity.id);
       const sent = ledger.countEmailSendsSince(
         identity.id,
@@ -266,6 +271,12 @@ function workspaceChecks(cfg: ReturnType<typeof loadConfig>): CheckResult[] {
       .filter((a): a is string => !!a)
       .map((a) => a.toLowerCase()),
   );
+  const mySmartlead = new Set(
+    myIdentities
+      .map((i) => (i.provider === "smartlead" ? i.address : null))
+      .filter((a): a is string => !!a)
+      .map((a) => a.toLowerCase()),
+  );
   const portsSeen = new Map<number, string>();
   for (const [other, entry] of all) {
     if (entry.port && portsSeen.has(entry.port)) {
@@ -330,6 +341,22 @@ function workspaceChecks(cfg: ReturnType<typeof loadConfig>): CheckResult[] {
           severity: "warn",
           message: `also authorized in workspace '${other}' — both inbox pollers will see both products' replies`,
           hint: "use a separate Gmail account per workspace",
+        });
+      }
+    }
+    const theirSmartlead = new Set(
+      (theirCfg.emailIdentities ?? [])
+        .map((i) => (i.provider === "smartlead" ? i.address : null))
+        .filter((a): a is string => !!a)
+        .map((a) => a.toLowerCase()),
+    );
+    for (const a of mySmartlead) {
+      if (theirSmartlead.has(a)) {
+        out.push({
+          name: `smartlead ${a}`,
+          severity: "warn",
+          message: `also registered in workspace '${other}' — caps are per-workspace, so the mailbox's real daily budget is doubled`,
+          hint: "register each Smartlead mailbox in only one workspace",
         });
       }
     }
@@ -450,6 +477,22 @@ export async function runDoctor(): Promise<CheckResult[]> {
       }
     }
 
+    // Smartlead account list, fetched once and only when it can matter (a key
+    // exists AND at least one smartlead identity to report on). Null = the API
+    // was unreachable → per-identity lines say "unverified" rather than fail.
+    let smartleadByAddress: Map<string, SmartleadAccount> | null = null;
+    if (smartleadApiKey() && identities.some((i) => i.provider === "smartlead")) {
+      try {
+        smartleadByAddress = new Map((await listSmartleadAccounts()).map((a) => [a.fromEmail, a]));
+      } catch (err) {
+        results.push({
+          name: "smartlead",
+          severity: "warn",
+          message: `could not verify Smartlead accounts: ${(err as Error).message}`,
+        });
+      }
+    }
+
     for (const identity of identities) {
       const c = caps.get(identity.id);
       const capStr = c && Number.isFinite(c.capToday) ? String(c.capToday) : "∞";
@@ -482,6 +525,50 @@ export async function runDoctor(): Promise<CheckResult[]> {
             severity: "fail",
             message: `auth check failed: ${(err as Error).message}`,
             hint: GMAIL_AUTH_HINT,
+          });
+        }
+      } else if (identity.provider === "smartlead") {
+        const address = identity.address?.trim().toLowerCase() ?? "";
+        const account = address ? smartleadByAddress?.get(address) : undefined;
+        if (!smartleadApiKey()) {
+          results.push({
+            name,
+            severity: "fail",
+            message: "SMARTLEAD_API_KEY not set — sends from this identity will fail",
+            hint: "Store it with: bun run cli -- smartlead connect",
+          });
+        } else if (smartleadByAddress && !account) {
+          results.push({
+            name,
+            severity: "fail",
+            message: `${address || identity.id} is no longer connected in Smartlead`,
+            hint: "Reconnect the mailbox in Smartlead, or remove the identity from the pool.",
+          });
+        } else if (account && !account.isSmtpSuccess) {
+          results.push({
+            name,
+            severity: "fail",
+            message: `${address} SMTP connection broken in Smartlead — reconnect it there · ${usage}`,
+          });
+        } else if (account && account.warmupStatus && account.warmupStatus !== "ACTIVE") {
+          results.push({
+            name,
+            severity: "warn",
+            message: `sending as ${address} · warmup ${account.warmupStatus.toLowerCase()} in Smartlead · ${usage}`,
+          });
+        } else if (account) {
+          const rep = account.warmupReputation ? ` (${account.warmupReputation})` : "";
+          const warm = account.warmupStatus ? ` · warmup active${rep}` : "";
+          results.push({
+            name,
+            severity: "ok",
+            message: `sending as ${address}${warm} · ${usage}`,
+          });
+        } else {
+          results.push({
+            name,
+            severity: "warn",
+            message: `sending as ${address || identity.id} · unverified (Smartlead API unreachable) · ${usage}`,
           });
         }
       } else {

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -227,18 +227,29 @@ export interface SetupRequest {
   /** Per-identity daily-cap edits ({ id, maxPerDay }). Null maxPerDay = uncapped. */
   identityUpdates?: Array<{ id: string; maxPerDay: number | null }>;
   /**
-   * New OneShot sending identities to add to the pool (a wallet-owned domain +
-   * a mailbox local-part). `sendingDomain` must be one returned by the
-   * provisioned-domain pool. Omit `maxPerDay` to take the cold-start warm-up
-   * ramp; pass `null` to add uncapped.
+   * New sending identities to add to the pool. OneShot: a wallet-owned domain
+   * (must be one returned by the provisioned-domain pool) + a mailbox
+   * local-part. Smartlead: a connected account's address (from the accounts
+   * listing), with `providerMessagePerDay` carrying Smartlead's own cap so the
+   * default ceiling clamps to it. Omit `maxPerDay` to take the cold-start
+   * warm-up ramp; pass `null` to add uncapped.
    */
-  addIdentities?: Array<{
-    provider: "oneshot";
-    sendingDomain: string;
-    mailbox?: string;
-    label?: string;
-    maxPerDay?: number | null;
-  }>;
+  addIdentities?: Array<
+    | {
+        provider: "oneshot";
+        sendingDomain: string;
+        mailbox?: string;
+        label?: string;
+        maxPerDay?: number | null;
+      }
+    | {
+        provider: "smartlead";
+        address: string;
+        label?: string;
+        maxPerDay?: number | null;
+        providerMessagePerDay?: number | null;
+      }
+  >;
   /** Identities to drop from the rotation pool. Existing prospect pins to a removed id will refuse to send until restored. */
   removeIdentityIds?: string[];
   icpOneLiner?: string;
@@ -269,7 +280,8 @@ export interface SetupRequest {
       | "AGENT_PRIVATE_KEY"
       | "GMAIL_CLIENT_ID"
       | "GMAIL_CLIENT_SECRET"
-      | "GMAIL_REFRESH_TOKEN",
+      | "GMAIL_REFRESH_TOKEN"
+      | "SMARTLEAD_API_KEY",
       string
     >
   >;
@@ -295,10 +307,33 @@ export interface DomainActionResult {
   poolStatus: "active" | "paused";
 }
 
+/**
+ * One Smartlead-connected mailbox as seen by the browser/CLI — sanitized
+ * (Smartlead's raw rows carry mailbox passwords; those never leave core).
+ */
+export interface SmartleadAccountView {
+  id: number;
+  fromEmail: string;
+  fromName: string | null;
+  /** Smartlead's own per-mailbox daily send limit. */
+  messagePerDay: number | null;
+  dailySentCount: number;
+  /** False = SMTP connection broken on Smartlead's side; sends will fail. */
+  isSmtpSuccess: boolean;
+  /** GMAIL | OUTLOOK | SMTP */
+  type: string;
+  /** ACTIVE | INACTIVE | PAUSED */
+  warmupStatus: string | null;
+  /** e.g. "95%" */
+  warmupReputation: string | null;
+  /** Already in this workspace's rotation pool. */
+  alreadyRegistered: boolean;
+}
+
 /** One sender identity as shown on /setup: pool entry + today's usage. */
 export interface SenderIdentityView {
   id: string;
-  provider: "oneshot" | "gmail";
+  provider: "oneshot" | "gmail" | "smartlead";
   label: string | null;
   address: string | null;
   sendingDomain: string | null;
@@ -483,7 +518,7 @@ export interface InboxReplyView {
   /** Sender identity whose mailbox received this email — the reply goes out from it. Null on legacy/unattributed rows. */
   sourceIdentityId: string | null;
   /** Provider of the receiving identity. Gmail replies thread properly; oneshot replies are best-effort fresh sends (paid, subject-threading only). */
-  sourceProvider: "gmail" | "oneshot" | null;
+  sourceProvider: "gmail" | "oneshot" | "smartlead" | null;
   /** Gmail thread id (gmail sources only) — passed back on send to thread the reply. */
   threadId: string | null;
   /** RFC 2822 Message-ID of the inbound email (gmail sources only) — In-Reply-To on the reply. */


### PR DESCRIPTION
## Why

Ramping both GTM motions to 1k+/day needs ~60 warmed mailboxes. OneShot transport caps per-domain (100/day, warmup-seat-bound upstream) and Gmail doesn't scale past a handful of OAuth accounts. Smartlead ($94/mo) hosts + warms unlimited mailboxes and exposes exactly the two API calls gtm needs: list connected accounts, send a one-off from a chosen account.

## What

**v1 is send-only** (agreed scope): Smartlead mailboxes become pool identities with full rotation/warm-up-cap/sticky-thread/suppression/cross-workspace-hold semantics. Replies stay in Smartlead's UI; inbox source + threaded replies + bounce ingestion are follow-ups (tracked in STATUS.md).

- `packages/core/src/smartlead.ts` — REST client. Accounts listing is paged and **whitelist-sanitized at parse** (Smartlead's raw rows include base64 mailbox passwords; a test asserts the serialized result never contains them). Sends go to `POST /send-email/initiate` keyed by `fromEmail`; the returned `data.message_id` becomes the ledger receipt's request id (dedupe), with a UUID fallback. All calls carry a 30s deadline; error messages carry the HTTP status (so `isTransientToolError` classifies 429/5xx) but **never the api_key** (Smartlead auths via query param — paths are query-stripped in errors).
- **Dispatch hardening**: `dispatchEmail`/`replyEmail` used to route any non-gmail provider into the *paid OneShot SDK path*; both now branch explicitly and throw on unknown providers. `replyEmail` for smartlead throws (unreachable from the UI in v1 — smartlead produces no inbox rows).
- `registerSmartleadIdentity` — id `smartlead:<address>`, warm-up defaults with the *default* ceiling clamped to the account's own `message_per_day` (explicit caps pass through, same trust model as OneShot).
- Server `POST /api/smartlead/accounts` — POST so a just-pasted key rides the body, never a URL; doubles as key validation before anything is saved.
- Web `/setup` — Smartlead panel: key field, "Load Smartlead accounts", rows with warmup status/reputation, SMTP-broken and already-registered rows disabled, staged adds applied on Save.
- CLI `smartlead connect` — validates the key against the API **before** `saveSecrets`, then multiselect-registers mailboxes.
- Doctor — the bounce-blind set is now "everything except gmail" and names providers (the old arithmetic assumed exactly two providers and would have reported smartlead as monitored); per-identity smartlead checks verify the account still exists / SMTP healthy / warmup active against one cached listing; a Smartlead mailbox registered in two workspaces warns like a shared Gmail account.

## Tests

1730 pass (32 new): client paging/sanitization/key-leak/deadline/send-contract, register defaults + clamp matrix, dispatch routing (SDK never touched; unknown provider throws; reply throws), capGroupKey, accounts route (400/pasted-key/alreadyRegistered/502, no password in payload), setup adds branch, doctor blind-set + sender line + workspace overlap.

## Known limits (documented in STATUS.md)

No bounce feed, no send idempotency (Gmail path shares both), Smartlead-side cap changes aren't re-synced after registration, and the live `/send-email/initiate` round trip is the one unverified-against-production piece (endpoint + shapes verified against their API docs).

https://claude.ai/code/session_01WfjkhiBKFjEbkkL5TzmRLZ

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `smartlead` as a send-only sending transport
> - Introduces `smartlead` send-only transport with `sendViaSmartlead` and `listSmartleadAccounts` REST wrappers in [smartlead.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/42/files#diff-b70dbab33ad7f7a106233cbad5bb9f31996978471dafdb49492b95ae4542f70b)
> - Extends `dispatchEmail` in [oneshot.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/42/files#diff-a75653098eb1094047ae1458ce831158ed4abd7e08122279a6827b46c0c2e9db) to route `smartlead` identities and throw on unknown providers instead of falling through to OneShot
> - Adds `smartlead connect` CLI command and web setup UI to stage and register Smartlead mailboxes via `registerSmartleadIdentity`
> - Updates `doctor` to validate Smartlead identities (API key, SMTP status, warmup) and warn on cross-workspace mailbox overlap
> - Risk: `replyEmail` in [oneshot.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/42/files#diff-a75653098eb1094047ae1458ce831158ed4abd7e08122279a6827b46c0c2e9db) throws for `smartlead` identities (send-only v1) and unknown providers instead of routing through OneShot
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b01ef80.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->