### PR TITLE
fix(find): plumb show-hn minPoints through the trigger registry

### DIFF
--- a/packages/find/__tests__/registry-minpoints.test.ts
+++ b/packages/find/__tests__/registry-minpoints.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The registry must forward show-hn's `minPoints` config to the finder —
+// it silently ignored it before (config said 2, finder ran with default 5).
+
+const runShowHn = vi
+  .fn()
+  .mockResolvedValue({ source: "find:show-hn", candidates: 0, enqueued: 0, costUsd: 0 });
+vi.mock("../src/show-hn.ts", async () => {
+  const actual = await vi.importActual<typeof import("../src/show-hn.ts")>("../src/show-hn.ts");
+  return { ...actual, runShowHnFinder: runShowHn };
+});
+
+const { TRIGGERS } = await import("../src/registry.ts");
+
+describe("show-hn trigger config plumbing", () => {
+  it("forwards minPoints when set and omits it when absent", async () => {
+    const spec = TRIGGERS.find((t) => t.name === "show-hn")!;
+    await spec.run({ sinceDays: 3, limit: 10, maxCostUsd: 5, minPoints: 2 });
+    expect(runShowHn).toHaveBeenLastCalledWith(expect.objectContaining({ minPoints: 2 }));
+    await spec.run({ sinceDays: 3 });
+    expect(runShowHn.mock.calls.at(-1)![0]).not.toHaveProperty("minPoints");
+  });
+});

--- a/packages/find/src/registry.ts
+++ b/packages/find/src/registry.ts
@@ -94,13 +94,14 @@ export const TRIGGERS: TriggerSpec[] = [
     defaultIntervalMs: 6 * ONE_HOUR,
     defaultConfig: { sinceDays: 1, limit: 25, maxCostUsd: 5 },
     configBrief:
-      "Polls Hacker News Algolia for recent Show HN posts, ICP-filters them, enriches founder contact, and enqueues them for review. Config: `sinceDays` (lookback window, default 1), `limit` (max kept, default 25), `maxCostUsd` (per-run spend cap). Defaults work for most ICPs — bump sinceDays to 7+ if your ICP is niche enough that daily volume is thin.",
+      "Polls Hacker News Algolia for recent Show HN posts, ICP-filters them, enriches founder contact, and enqueues them for review. Config: `sinceDays` (lookback window, default 1), `limit` (max kept, default 25), `maxCostUsd` (per-run spend cap), `minPoints` (upvote floor, default 5 — posts below it drop as low-signal). Defaults work for most ICPs — bump sinceDays to 7+ if your ICP is niche enough that daily volume is thin. STRATEGIST NOTE: minPoints is a MOTION choice, not noise control — selling a paid product, keep ≥5 (traction = budget); driving adoption of a founder tool, drop to 1-2 (the quiet launch IS the pain signal).",
     run: (cfg) =>
       runShowHnFinder({
         dryRun: false,
         sinceDays: (cfg["sinceDays"] as number) ?? 1,
         limit: (cfg["limit"] as number) ?? 25,
         maxCostUsd: (cfg["maxCostUsd"] as number) ?? 5,
+        ...(typeof cfg["minPoints"] === "number" ? { minPoints: cfg["minPoints"] as number } : {}),
       }),
   },
   {


### PR DESCRIPTION
The show-hn finder has always accepted a `minPoints` upvote floor (default 5), but the trigger registry's run handler only forwarded `sinceDays`/`limit`/`maxCostUsd` — so a trigger config setting `minPoints` was silently ignored (verified live: config said 2, run summary still dropped 48/50 as low-signal).

One-line plumb-through + a regression test that the registry forwards it when set and omits it when absent, plus a configBrief update so the strategist knows the knob exists and that it's a motion choice (paid product → keep ≥5 for traction; adoption motion → 1–2, the quiet launch is the pain signal).

https://claude.ai/code/session_01WfjkhiBKFjEbkkL5TzmRLZ

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `show-hn` trigger to pass `minPoints` to `runShowHnFinder`
> The `show-hn` trigger in [registry.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/44/files#diff-bcee29f6661eb8b7924d1a73f646e38164b2cca444d2816330057b68b3e8b83d) now forwards `cfg.minPoints` to `runShowHnFinder` when it is a number, and omits it when absent. Adds tests to assert both paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 41393c8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->