### PR TITLE
docs: person-level ICP gate + workspace switcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,9 @@ bun run cli -- workspace use gtm             # make it the default for runs with
 
 What stays **shared** across workspaces lives in `~/.oneshot-gtm-shared/shared.sqlite`: the paid lookup caches (enrichment, LinkedIn — the same person is never bought twice) and contact touches. A workspace never first-touches someone another workspace emailed in the last 7 days: the draft holds with a `contacted-elsewhere` flag you can override on a manual send, while drain and cadence steps wait the window out.
 
-`doctor` warns when two workspaces share a sending domain (warm-up caps are per-workspace, so the domain's real budget silently doubles) or a Gmail account (both inbox pollers would see both products' replies), and the dashboard masthead names the workspace you're in.
+`doctor` warns when two workspaces share a sending domain (warm-up caps are per-workspace, so the domain's real budget silently doubles) or a Gmail account (both inbox pollers would see both products' replies).
+
+The dashboard always knows where it is: a masthead chip names the workspace and its port (each name gets a stable colour, so `gtm` always looks like `gtm`). Clicking the chip — or `⌘K → Workspaces` — lists every registered workspace with a live status dot: running ones open in a new tab, stopped ones **start and then open** (the server is spawned detached with no supervisor; the status dots are the truth about what's up, and a launch that doesn't come up within 15s falls back to a copyable `--workspace <name> ui` command).
 
 ---
 
@@ -180,6 +182,8 @@ Ten **finders** discover prospects, ICP-filter them, and enqueue into `/queue` f
 Only `show-hn` and `post-funding-auto` are on by default; enable the rest from `/queue`. A trigger missing required config reads as **not ready** — the toggle and Run button disable with the reason, and the API returns `409`, so scripted callers can't bypass the gate either.
 
 Before any paid `findEmail`, a prescreen skips dud domains (`*.vercel.app`, social hosts, link aggregators, personal email providers) and inputs whose "name" is obviously a username. LinkedIn URLs are captured on every finder path and verified to belong to the person before they're stored.
+
+Two ICP gates run per candidate, not one. The **topic gate** judges the source — the repo, event, or announcement — and keeps whole categories of noise out before any spend. The **person gate** judges the human's role, staged by cost: free role text the finder already holds (an event bio, an extracted title), then the job title off the enrichment every verified email already pays for, then — only when still ambiguous and a LinkedIn URL exists — one extra ~$0.005 lookup. It judges capability to build and self-adopt, not job-title seniority: students shipping hackathon projects and consultants building agent systems for clients pass; a Marketing Manager at a brilliant AI company doesn't. Only a _positive_ reject drops a candidate — ambiguity escalates or proceeds, never silently discards. Rejections land in `/queue` as auditable `auto: role — <reason>` rows you can override, count as `role-drop` on trigger cards, and a prospect judged off-ICP after contact stops receiving cadence follow-ups (terminal status `off-icp`).
 
 The dashboard server runs an in-process scheduler, so enabling a trigger is enough — no separate daemon. `find watch` stays useful for cron and headless boxes. Approved rows ship via the **Drain** button or `find drain <play>`.
 
@@ -295,7 +299,8 @@ Every install writes a structured event log to `~/.oneshot-gtm/events.jsonl` —
 ```bash
 tail -f ~/.oneshot-gtm/events.jsonl | jq -c '{t:.ts, k:.kind, ctx:.ctx}'          # condensed
 tail -f ~/.oneshot-gtm/events.jsonl | jq -c 'select(.kind|startswith("llm."))'    # LLM calls
-tail -f ~/.oneshot-gtm/events.jsonl | jq -c 'select(.kind=="icp.decision")'       # why rejects happened
+tail -f ~/.oneshot-gtm/events.jsonl | jq -c 'select(.kind=="icp.decision")'       # topic-gate rejects
+tail -f ~/.oneshot-gtm/events.jsonl | jq -c 'select(.kind=="icp.person_decision")' # person-gate verdicts
 tail -f ~/.oneshot-gtm/events.jsonl | jq -c 'select(.level=="error" or .level=="warn")'
 tail -2000 ~/.oneshot-gtm/events.jsonl | jq -c 'select(.run_id=="PASTE-HERE")'    # one run
 DEBUG=oneshot:* oneshot-gtm find watch --once                                     # mirror to stderr

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,9 @@
 
 **Assume green unless it's listed below.** The 48 CLI commands, 14 plays, 10 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and, with the exceptions on this page, verified end to end against the live OneShot API.
 
-Last verified **2026-08-23** · Bun 1.3.13 · OneShot SDK 0.22.0 · 1698 tests / 127 files · typecheck + oxlint clean (318 files).
+Last verified **2026-08-25** · Bun 1.3.13 · OneShot SDK 0.22.0 · 1777 tests / 137 files · typecheck + oxlint clean.
+
+The person-level ICP gate (#45) was calibrated against 84 real LinkedIn titles (all 13 known off-ICP prospects caught, zero false rejects among 44 builders) and the history audit ran live `enrichProfile` for 111 titles. The workspace switcher's auto-start was live-verified in both directions (default ↔ gtm).
 
 Reply detection was verified on 2026-08-23 against the real mailboxes: a sliced sweep of all four inboxes from the first send onward (4,833 inbound, every slice fully covered) found exactly the replies the live poll then recorded on restart.
 


### PR DESCRIPTION
Follow-up to #45 — README's finder pipeline now describes both ICP gates (topic + person, staged by cost, positive-reject-only) and the workspace section covers the masthead chip and one-click auto-start switcher. STATUS.md counts refreshed (1777 tests / 137 files, 2026-08-25) with the live-verification notes for the gate calibration and the switcher.

https://claude.ai/code/session_01DV676i6x8Any5Czfq44Muh

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Document person-level ICP gate and workspace switcher in README and STATUS
> - Adds README documentation for a two-stage ICP gate: a topic gate and a staged person gate (free role text → enrichment job title → optional LinkedIn lookup), with decision criteria for builder/self-adopt capability vs seniority, ambiguity escalation (never silent discard), reject auditing in `/queue` with `auto: role — <reason>`, a `role-drop` metric, and terminal `off-icp` status to stop cadence follow-ups.
> - Documents the dashboard masthead workspace chip: shows workspace name and port with a stable color per name; click or ⌘K → Workspaces lists all workspaces with live status; running workspaces open in a new tab, stopped ones auto-start then open; launch falls back after 15s to a copyable `--workspace <name> ui` command; server spawns detached with no supervisor.
> - Adds new event log filter example for `icp.person_decision` and clarifies `icp.decision` as topic-gate rejects.
> - Updates STATUS.md verification date to 2026-08-25 with Bun 1.3.13, OneShot SDK 0.22.0, 1777 tests / 137 files, and notes ICP gate calibration against 84 LinkedIn titles plus a live audit of `enrichProfile` for 111 titles.
> - Removes the old README clause about the dashboard masthead naming the current workspace.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c935b9c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->