### PR TITLE
Link the site from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > Open-source GTM agent for technical founders. Pay-per-result, signed receipts, founder-led discipline encoded. Terminal CLI + local web dashboard over one SQLite ledger.
 
+**[oneshot-gtm.com](https://oneshot-gtm.com)** · [what a signed receipt is](https://oneshot-gtm.com/receipt) · [docs](https://docs.oneshotagent.com)
+
 ```bash
 bunx oneshot-gtm-server     # dashboard only — published, no clone
 ```


### PR DESCRIPTION
oneshot-gtm.com is live. The README is where most people meet this project and it did not point at the site.

One line under the deck:

```
**[oneshot-gtm.com](https://oneshot-gtm.com)** · [what a signed receipt is](https://oneshot-gtm.com/receipt) · [docs](https://docs.oneshotagent.com)
```

The receipt page gets its own link because "what actually is a signed receipt" is the question the first paragraph raises, and the README only answers it in passing further down.

Both URLs verified live: apex and www return 200, Cloudflare nameservers, Cloud Run domain mapping.

https://claude.ai/code/session_014tm8CFaNMUBbFrMY2JJHKq

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add site, signed receipts, and docs links to README
> Inserts a new line after the project blurb in [README.md](https://github.com/oneshot-agent/oneshot-gtm/pull/47/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) linking to oneshot-gtm.com, the signed receipts page, and the docs site. No other content changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 15baf70.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->