### PR TITLE
chore: point npm packages and repo at oneshot-gtm.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 > Open-source GTM agent for technical founders. Pay-per-result, signed receipts, founder-led discipline encoded. Terminal CLI + local web dashboard over one SQLite ledger.
 
+**[oneshot-gtm.com](https://oneshot-gtm.com)** · [what a signed receipt is](https://oneshot-gtm.com/receipt) · [docs](https://docs.oneshotagent.com)
+
 ```bash
 bunx oneshot-gtm-server     # dashboard only — published, no clone
 ```

--- a/apps/cli/README.md
+++ b/apps/cli/README.md
@@ -1,0 +1,14 @@
+# oneshot-gtm
+
+Open-source GTM agent for technical founders. Pay-per-result, signed receipts, pre-PMF discipline encoded — it finds prospects from live signals, drafts founder-voice emails, sends from your own mailboxes, and receipts every action.
+
+```bash
+bunx oneshot-gtm --help
+```
+
+Prefer a UI? `bunx oneshot-gtm-server` boots the local dashboard over the same SQLite ledger.
+
+- Website: https://oneshot-gtm.com
+- Source & docs: https://github.com/oneshot-agent/oneshot-gtm
+
+MIT.

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -26,5 +26,11 @@
   },
   "devDependencies": {
     "@types/prompts": "^2.4.0"
+  },
+  "homepage": "https://oneshot-gtm.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oneshot-agent/oneshot-gtm",
+    "directory": "apps/cli"
   }
 }

--- a/apps/server/README.md
+++ b/apps/server/README.md
@@ -1,0 +1,15 @@
+# oneshot-gtm-server
+
+Local dashboard for [oneshot-gtm](https://oneshot-gtm.com) — the open-source GTM agent that tells you "not yet".
+
+```bash
+bunx oneshot-gtm-server
+```
+
+Boots `Bun.serve` and opens the dashboard over your local SQLite ledger. No clone, no cloud — state stays in your home directory.
+
+- Website: https://oneshot-gtm.com
+- Source & docs: https://github.com/oneshot-agent/oneshot-gtm
+- Full CLI: `bunx oneshot-gtm` (same ledger, 48 commands)
+
+MIT.

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -2,7 +2,7 @@
   "name": "oneshot-gtm-server",
   "version": "0.7.0",
   "description": "Local dashboard server for oneshot-gtm. Boots Bun.serve, opens the browser to your GTM operating state.",
-  "homepage": "https://github.com/oneshot-agent/oneshot-gtm",
+  "homepage": "https://oneshot-gtm.com",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,5 +9,11 @@
   },
   "dependencies": {
     "@oneshot-agent/sdk": "0.22.0"
+  },
+  "homepage": "https://oneshot-gtm.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oneshot-agent/oneshot-gtm",
+    "directory": "packages/core"
   }
 }

--- a/packages/doctor/package.json
+++ b/packages/doctor/package.json
@@ -8,5 +8,11 @@
   },
   "dependencies": {
     "@oneshot-gtm/core": "workspace:*"
+  },
+  "homepage": "https://oneshot-gtm.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oneshot-agent/oneshot-gtm",
+    "directory": "packages/doctor"
   }
 }

--- a/packages/find/package.json
+++ b/packages/find/package.json
@@ -10,5 +10,11 @@
     "@oneshot-gtm/core": "workspace:*",
     "@oneshot-gtm/intel": "workspace:*",
     "@oneshot-gtm/plays": "workspace:*"
+  },
+  "homepage": "https://oneshot-gtm.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oneshot-agent/oneshot-gtm",
+    "directory": "packages/find"
   }
 }

--- a/packages/intel/package.json
+++ b/packages/intel/package.json
@@ -8,5 +8,11 @@
   },
   "dependencies": {
     "@oneshot-gtm/core": "workspace:*"
+  },
+  "homepage": "https://oneshot-gtm.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oneshot-agent/oneshot-gtm",
+    "directory": "packages/intel"
   }
 }

--- a/packages/plays/package.json
+++ b/packages/plays/package.json
@@ -9,5 +9,11 @@
   "dependencies": {
     "@oneshot-gtm/core": "workspace:*",
     "@oneshot-gtm/intel": "workspace:*"
+  },
+  "homepage": "https://oneshot-gtm.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oneshot-agent/oneshot-gtm",
+    "directory": "packages/plays"
   }
 }

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -5,5 +5,11 @@
   "main": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts"
+  },
+  "homepage": "https://oneshot-gtm.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oneshot-agent/oneshot-gtm",
+    "directory": "packages/shared-types"
   }
 }


### PR DESCRIPTION
Now that https://oneshot-gtm.com is live:

- `homepage` -> https://oneshot-gtm.com on every publishable package (`repository` added where it was missing)
- Adds README.md to `oneshot-gtm` (CLI) and `oneshot-gtm-server` so their npm pages are no longer blank and link the site
- The GitHub repo About/homepage field was already flipped from docs.oneshotagent.com to oneshot-gtm.com via `gh repo edit`

https://claude.ai/code/session_01DV676i6x8Any5Czfq44Muh

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Point npm packages and repo docs at oneshot-gtm.com
> - Updates `homepage` in [apps/server/package.json](https://github.com/oneshot-agent/oneshot-gtm/pull/48/files#diff-fafe51f68c0409784dd523adb04b10cb09fe3b7d48c7646c325fecab5fb4ebd2) to the product site and adds `homepage` plus `repository` metadata to [packages/core/package.json](https://github.com/oneshot-agent/oneshot-gtm/pull/48/files#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7), [packages/doctor/package.json](https://github.com/oneshot-agent/oneshot-gtm/pull/48/files#diff-70ce829cb4fba59d9c62c3c4e109a7f66ee43d883deb9a8818d1d5503970dfa6), [packages/find/package.json](https://github.com/oneshot-agent/oneshot-gtm/pull/48/files#diff-e2b0cac112cbdce1163c6e50591e53a08033ac342a595e587159472ea8b2094f), [packages/intel/package.json](https://github.com/oneshot-agent/oneshot-gtm/pull/48/files#diff-840f7fedaec5d96430659cba7ecead6f0262b6fe9c9e129e809b2e44207671d7), [packages/plays/package.json](https://github.com/oneshot-agent/oneshot-gtm/pull/48/files#diff-7fc777ebba5a6bcea8554744b035d7623c78321e56cba0de0cda4280043e42a9), and [packages/shared-types/package.json](https://github.com/oneshot-agent/oneshot-gtm/pull/48/files#diff-86c0fb13f257a6d5e7f88a529945adf865f08a2c145f46cdd9d295db90d1c606)
> - Adds new READMEs for [apps/cli/README.md](https://github.com/oneshot-agent/oneshot-gtm/pull/48/files#diff-814f330f4d023072c7412643f20fea1745bfd132e3471ece07acc009a96c0c77) and [apps/server/README.md](https://github.com/oneshot-agent/oneshot-gtm/pull/48/files#diff-48427da47bcffeb297d96bc2e98c287eceff9282eac2628e5a095fe868cbb890) with usage docs and links to the product site and source
> - Adds product site links to the root [README.md](https://github.com/oneshot-agent/oneshot-gtm/pull/48/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ee95d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->