### PR TITLE
chore: oxfmt key order for package.json fields (#48 follow-up)

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -2,7 +2,13 @@
   "name": "oneshot-gtm",
   "version": "0.7.0",
   "description": "Open-source GTM agent for technical founders. Pay-per-result, signed receipts.",
+  "homepage": "https://oneshot-gtm.com",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oneshot-agent/oneshot-gtm",
+    "directory": "apps/cli"
+  },
   "bin": {
     "oneshot-gtm": "./src/main.ts"
   },
@@ -26,11 +32,5 @@
   },
   "devDependencies": {
     "@types/prompts": "^2.4.0"
-  },
-  "homepage": "https://oneshot-gtm.com",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/oneshot-agent/oneshot-gtm",
-    "directory": "apps/cli"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,12 @@
 {
   "name": "@oneshot-gtm/core",
   "version": "0.7.0",
+  "homepage": "https://oneshot-gtm.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oneshot-agent/oneshot-gtm",
+    "directory": "packages/core"
+  },
   "type": "module",
   "main": "./src/index.ts",
   "exports": {
@@ -9,11 +15,5 @@
   },
   "dependencies": {
     "@oneshot-agent/sdk": "0.22.0"
-  },
-  "homepage": "https://oneshot-gtm.com",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/oneshot-agent/oneshot-gtm",
-    "directory": "packages/core"
   }
 }

--- a/packages/doctor/package.json
+++ b/packages/doctor/package.json
@@ -1,6 +1,12 @@
 {
   "name": "@oneshot-gtm/doctor",
   "version": "0.7.0",
+  "homepage": "https://oneshot-gtm.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oneshot-agent/oneshot-gtm",
+    "directory": "packages/doctor"
+  },
   "type": "module",
   "main": "./src/index.ts",
   "exports": {
@@ -8,11 +14,5 @@
   },
   "dependencies": {
     "@oneshot-gtm/core": "workspace:*"
-  },
-  "homepage": "https://oneshot-gtm.com",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/oneshot-agent/oneshot-gtm",
-    "directory": "packages/doctor"
   }
 }

--- a/packages/find/package.json
+++ b/packages/find/package.json
@@ -1,6 +1,12 @@
 {
   "name": "@oneshot-gtm/find",
   "version": "0.7.0",
+  "homepage": "https://oneshot-gtm.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oneshot-agent/oneshot-gtm",
+    "directory": "packages/find"
+  },
   "type": "module",
   "main": "./src/index.ts",
   "exports": {
@@ -10,11 +16,5 @@
     "@oneshot-gtm/core": "workspace:*",
     "@oneshot-gtm/intel": "workspace:*",
     "@oneshot-gtm/plays": "workspace:*"
-  },
-  "homepage": "https://oneshot-gtm.com",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/oneshot-agent/oneshot-gtm",
-    "directory": "packages/find"
   }
 }

--- a/packages/intel/package.json
+++ b/packages/intel/package.json
@@ -1,6 +1,12 @@
 {
   "name": "@oneshot-gtm/intel",
   "version": "0.7.0",
+  "homepage": "https://oneshot-gtm.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oneshot-agent/oneshot-gtm",
+    "directory": "packages/intel"
+  },
   "type": "module",
   "main": "./src/index.ts",
   "exports": {
@@ -8,11 +14,5 @@
   },
   "dependencies": {
     "@oneshot-gtm/core": "workspace:*"
-  },
-  "homepage": "https://oneshot-gtm.com",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/oneshot-agent/oneshot-gtm",
-    "directory": "packages/intel"
   }
 }

--- a/packages/plays/package.json
+++ b/packages/plays/package.json
@@ -1,6 +1,12 @@
 {
   "name": "@oneshot-gtm/plays",
   "version": "0.7.0",
+  "homepage": "https://oneshot-gtm.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/oneshot-agent/oneshot-gtm",
+    "directory": "packages/plays"
+  },
   "type": "module",
   "main": "./src/index.ts",
   "exports": {
@@ -9,11 +15,5 @@
   "dependencies": {
     "@oneshot-gtm/core": "workspace:*",
     "@oneshot-gtm/intel": "workspace:*"
-  },
-  "homepage": "https://oneshot-gtm.com",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/oneshot-agent/oneshot-gtm",
-    "directory": "packages/plays"
   }
 }

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@oneshot-gtm/shared-types",
   "version": "0.7.0",
-  "type": "module",
-  "main": "./src/index.ts",
-  "exports": {
-    ".": "./src/index.ts"
-  },
   "homepage": "https://oneshot-gtm.com",
   "repository": {
     "type": "git",
     "url": "https://github.com/oneshot-agent/oneshot-gtm",
     "directory": "packages/shared-types"
+  },
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
   }
 }


### PR DESCRIPTION
#48 appended homepage/repository at the end of each package.json; oxfmt wants them in conventional key order, which failed the Format step on main. This is `bun run fmt` output, no content change.

https://claude.ai/code/session_01DV676i6x8Any5Czfq44Muh

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reorder `package.json` fields to match `oxfmt` key order
> - Applies `oxfmt` key ordering rules to `package.json` manifests across the monorepo.
> - Moves `homepage` and `repository` fields to the top in `apps/cli` and multiple `packages/` manifests.
> - Shifts `type`, `main`, and `exports` later in [packages/shared-types/package.json](https://github.com/oneshot-agent/oneshot-gtm/pull/49/files#diff-86c0fb13f257a6d5e7f88a529945adf865f08a2c145f46cdd9d295db90d1c606).
> - Behavioral Change: No field values are modified; only key ordering changes for formatting compliance.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7e144fe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->