### PR TITLE
chore: condense verbose comments to their load-bearing constraints

### DIFF
--- a/apps/cli/src/commands/demo.ts
+++ b/apps/cli/src/commands/demo.ts
@@ -14,20 +14,11 @@ import { commandUi } from "./ui.ts";
 
 /**
  * Strip every real credential from an env before it reaches the demo server.
- *
- * The CLI process imports core, and core's `applySecretsToEnv()` fills blank
- * `process.env` vars from the REAL home's `.env` at import time — before this
- * command ever runs. `commandUi` spawns the server with `...process.env`, and
- * the child's own secrets-loader only fills vars that are still blank, so
- * without this scrub the inherited real wallet/LLM/Gmail keys would SHADOW the
- * demo home's placeholders. That is the exact failure the demo exists to
- * prevent: a stray Run or Send click spending real money from a "demo".
- * Deleting them here lets the child re-load from the demo `.env`, whose
- * placeholder values cannot authenticate.
- *
- * GITHUB_TOKEN / LUMA_SESSION_COOKIE aren't in SECRET_KEYS (they're read
- * straight from env, never stored), but a demo "Run now" shouldn't act with the
- * founder's real tokens either.
+ * core's `applySecretsToEnv()` fills blank env vars from the REAL home's .env
+ * at import time, and the spawned child's loader only fills vars still blank —
+ * so without this scrub the inherited real keys would SHADOW the demo home's
+ * placeholders and a demo "Send" could spend real money. Also drops
+ * GITHUB_TOKEN / LUMA_SESSION_COOKIE, which live only in env.
  */
 export function scrubInheritedSecrets(env: NodeJS.ProcessEnv): void {
   for (const key of [...SECRET_KEYS, "GITHUB_TOKEN", "LUMA_SESSION_COOKIE"]) {

--- a/apps/cli/src/commands/enrich-linkedin.ts
+++ b/apps/cli/src/commands/enrich-linkedin.ts
@@ -3,14 +3,9 @@ import { findLinkedInUrl, isCircuitOpen, looksLikeOrgName } from "@oneshot-gtm/f
 import { c, header, note, ok, warn } from "../output.ts";
 
 /**
- * Backfill LinkedIn URLs onto prospects that were emailed before the finders
- * captured them.
- *
- * Why this exists: `upsertProspect` is insert-or-return-existing, so a prospect
- * created without a LinkedIn URL could never acquire one — the finder fixes
- * only help people found from now on. This walks the existing rows and fills
- * the gap via the same `findLinkedInUrl` resolver the finders use, so results
- * are cached and billed identically.
+ * Backfill LinkedIn URLs onto existing prospects. `upsertProspect` is
+ * insert-or-return-existing, so a row created without a URL never acquires one;
+ * this fills the gap via the finders' own `findLinkedInUrl` (same cache/billing).
  */
 
 export interface EnrichLinkedInOpts {
@@ -23,12 +18,9 @@ export interface EnrichLinkedInOpts {
 }
 
 /**
- * True when a name looks like something a LinkedIn profile search could match.
- *
- * GitHub display names are frequently handles (`yijin840`), single tokens
- * (`Demin`) or non-Latin (`麦奇`). Searching those burns ~$0.01 for a
- * near-certain miss — roughly 90 of the 317 unresolved repo-interest rows.
- * Requires two Latin-script tokens.
+ * True when a name looks like something a LinkedIn profile search could match:
+ * two Latin-script tokens. GitHub display names are often handles, single
+ * tokens, or non-Latin — searching those is a paid near-certain miss.
  */
 export function looksLikeRealName(name: string | null | undefined): boolean {
   if (!name) return false;
@@ -46,13 +38,9 @@ export function looksLikeRealName(name: string | null | undefined): boolean {
 
 /**
  * Turn a stored `company` into a search token, or null if it isn't usable.
- *
- * Each disambiguator becomes a *quoted* token in the query, so it's an exact
- * phrase requirement. A GitHub `company` field is free text — "Co-Founder/CTO @
- * Floramis | Product @ Vilota", "Open to Work 😎", "Software Enginneer at
- * @iFood" — and requiring any of those verbatim guarantees zero results, i.e. a
- * paid call that could never have hit. Take the first company-looking segment
- * and drop anything still too free-form to be a company name.
+ * Disambiguators become *quoted* (exact-phrase) query tokens, and GitHub
+ * `company` is free text — requiring it verbatim guarantees a paid zero-result
+ * search. Take the first company-looking segment, drop anything free-form.
  */
 export function cleanCompanyToken(company: string | null | undefined): string | null {
   if (!company) return null;
@@ -80,12 +68,9 @@ export function cleanCompanyToken(company: string | null | undefined): string | 
 }
 
 /**
- * How many candidates this run may search, or undefined for "no cap".
- *
- * Every candidate costs a paid webSearch, so a bad `--limit` must never widen
- * the run: `slice(0, -1)` on a negative value returns everything but the last
- * row, billing the whole ledger when asked for less than nothing. A
- * non-numeric flag arrives as NaN and collapses to 0 for the same reason.
+ * How many candidates this run may search, or undefined for "no cap". A bad
+ * `--limit` must never widen the paid run: negative values would slice() to
+ * nearly the whole ledger, and NaN collapses to 0.
  */
 export function resolveCap(limit: number | undefined): number | undefined {
   if (limit === undefined) return undefined;

--- a/apps/cli/src/demo/dataset.ts
+++ b/apps/cli/src/demo/dataset.ts
@@ -1,26 +1,12 @@
 import { cadenceGoalId } from "@oneshot-gtm/core";
 
 /**
- * The demo install, as pure data. No I/O — `seed.ts` writes it.
- *
- * Two rules hold this file together:
- *
- * 1. **Deterministic.** Every timestamp is an offset from the anchor the caller
- *    passes, and there is no `Math.random` anywhere. Seeding twice with the same
- *    anchor produces the same ledger, so a re-shoot matches the first take and
- *    the tests can assert on exact rows.
- *
- * 2. **Two timestamp formats, matched to what production writes.** Columns whose
- *    value comes from the `datetime('now')` DEFAULT (`created_at`, `found_at`,
- *    `enrolled_at`, `recorded_at`, …) get SQLite's `YYYY-MM-DD HH:MM:SS`; columns
- *    the app writes with `toISOString()` (`next_due_at`, `reviewed_at`,
- *    `triggers.last_polled_at`, `runs.started_at`, `bounced_at`, …) get ISO.
- *    Mixing them silently breaks the string comparisons those columns are read
- *    with — `next_due_at <= ?` and friends.
- *
- * The cast extends the one already in `examples/*.json` (Jane Founder / Acme,
- * Sam Builder / Beacon, Rae Kim / Stellar, Jordan Lee / Acme Data, Priya Shah /
- * Northstar AI) so the sample target files and the demo tell one story.
+ * The demo install, as pure data — `seed.ts` writes it. Deterministic: every
+ * timestamp is an offset from the caller's anchor, no randomness, so the same
+ * anchor yields the same ledger. Per-column timestamp format must match what
+ * production writes (`datetime('now')` columns: SQLite `YYYY-MM-DD HH:MM:SS`;
+ * `toISOString()` columns: ISO) — mixing silently breaks string comparisons
+ * like `next_due_at <= ?`.
  */
 
 const DAY_MS = 86_400_000;
@@ -47,9 +33,7 @@ function jitter(i: number): number {
   return (i * 37) % 60;
 }
 
-// ---------------------------------------------------------------------------
 // Founder
-// ---------------------------------------------------------------------------
 
 // A fictional dev-tools founder, deliberately selling something OTHER than
 // OneShot so a viewer never confuses the demo product with the tool being demoed.
@@ -100,9 +84,7 @@ const IDENTITIES = [
   },
 ];
 
-// ---------------------------------------------------------------------------
 // Cast
-// ---------------------------------------------------------------------------
 
 type CadenceStatus = "active" | "replied" | "breakup" | "completed" | "bounced";
 
@@ -556,9 +538,7 @@ const PEOPLE: DemoPerson[] = [
   },
 ];
 
-// ---------------------------------------------------------------------------
 // Cost model
-// ---------------------------------------------------------------------------
 
 // Plausible per-call USD, in the same order of magnitude as real OneShot calls.
 // The whole 30-day install lands around $6 of spend, which is the point of the
@@ -575,9 +555,7 @@ const COST: Record<string, number> = {
 /** Follow-up spacing, in days after the intro. */
 const STEP_OFFSETS = [0, 3, 7];
 
-// ---------------------------------------------------------------------------
 // Row shapes
-// ---------------------------------------------------------------------------
 
 export interface DemoReceipt {
   id: number;
@@ -738,9 +716,7 @@ export interface DemoDataset {
   };
 }
 
-// ---------------------------------------------------------------------------
 // Builder
-// ---------------------------------------------------------------------------
 
 export function buildDemoDataset(anchor: Date): DemoDataset {
   const prospects: DemoProspectRow[] = [];
@@ -937,9 +913,7 @@ export function buildDemoDataset(anchor: Date): DemoDataset {
   };
 }
 
-// ---------------------------------------------------------------------------
 // Config + secrets
-// ---------------------------------------------------------------------------
 
 // Deliberately non-functional. They exist so `doctor`'s pure-env checks
 // (llmApiKey, oneshotEnvReady) read green without a network call, and so an
@@ -982,9 +956,7 @@ function buildConfig(): Record<string, unknown> {
   };
 }
 
-// ---------------------------------------------------------------------------
 // Copy
-// ---------------------------------------------------------------------------
 
 function subjectFor(p: DemoPerson, step: number): string {
   if (step === 0) return `${p.company} + background job traces`;
@@ -1027,9 +999,7 @@ function bodyFor(p: DemoPerson, step: number): string {
   ].join("\n");
 }
 
-// ---------------------------------------------------------------------------
 // Signed receipts
-// ---------------------------------------------------------------------------
 
 function signedReceiptFor(callType: string, p: DemoPerson, id: number): unknown {
   const base = {
@@ -1070,9 +1040,7 @@ function outcomeValueTag(outcome: NonNullable<DemoPerson["outcome"]>): unknown {
   }
 }
 
-// ---------------------------------------------------------------------------
 // Queue
-// ---------------------------------------------------------------------------
 
 function buildQueue(anchor: Date): DemoDataset["queue"] {
   // Rows the finders surfaced but that haven't shipped yet — the founder's
@@ -1299,9 +1267,7 @@ function buildQueue(anchor: Date): DemoDataset["queue"] {
   return rows;
 }
 
-// ---------------------------------------------------------------------------
 // Triggers
-// ---------------------------------------------------------------------------
 
 function buildTriggers(anchor: Date): DemoDataset["triggers"] {
   // Config values mirror each finder's defaultConfig shape in
@@ -1436,9 +1402,7 @@ function buildTriggers(anchor: Date): DemoDataset["triggers"] {
   ];
 }
 
-// ---------------------------------------------------------------------------
 // Runs
-// ---------------------------------------------------------------------------
 
 function buildRuns(anchor: Date, receipts: DemoReceipt[]): DemoDataset["runs"] {
   // Receipt ids are assigned globally while iterating PEOPLE, so a run's send
@@ -1497,9 +1461,7 @@ function buildRuns(anchor: Date, receipts: DemoReceipt[]): DemoDataset["runs"] {
   ];
 }
 
-// ---------------------------------------------------------------------------
 // Deliverability
-// ---------------------------------------------------------------------------
 
 function buildBounces(anchor: Date, prospects: DemoProspectRow[]): DemoDataset["bounces"] {
   const byEmail = (email: string): number => prospects.find((p) => p.email === email)?.id ?? 0;
@@ -1551,9 +1513,7 @@ function buildCanaries(anchor: Date): DemoDataset["canaries"] {
   ];
 }
 
-// ---------------------------------------------------------------------------
 // Inbox
-// ---------------------------------------------------------------------------
 
 /** Everyone in the cast who replied, in the order the fixture should list them. */
 function repliers(): DemoPerson[] {
@@ -1645,9 +1605,7 @@ function buildInboxSent(anchor: Date): DemoDataset["inboxSent"] {
   ];
 }
 
-// ---------------------------------------------------------------------------
 // Interviews
-// ---------------------------------------------------------------------------
 
 function buildInterviews(anchor: Date): DemoDataset["interviews"] {
   return [
@@ -1673,9 +1631,7 @@ function buildInterviews(anchor: Date): DemoDataset["interviews"] {
   ];
 }
 
-// ---------------------------------------------------------------------------
 // Platform RoCS rollup
-// ---------------------------------------------------------------------------
 
 /**
  * Keyed by period ("7" / "30" / "all") because the Measure page's range chips
@@ -1731,9 +1687,7 @@ function rocsForWindow(receipts: DemoReceipt[]): unknown {
     }));
 }
 
-// ---------------------------------------------------------------------------
 // Domain pool
-// ---------------------------------------------------------------------------
 
 function buildDomainsFixture(anchor: Date): unknown {
   return [

--- a/apps/cli/src/demo/seed.ts
+++ b/apps/cli/src/demo/seed.ts
@@ -24,12 +24,10 @@ function realHome(): string {
 }
 
 /**
- * Resolve a path with symlinks followed, not just lexically. `resolve()` alone
- * would let `--home some-symlink-to-the-real-install` slip past the guards
- * below and write through the link into `~/.oneshot-gtm`. A path that doesn't
- * exist yet can't be realpath'd directly, so canonicalize the nearest existing
- * ancestor and re-append the rest — that also catches a symlinked PARENT
- * directory pointing into the real install's parent.
+ * Resolve a path with symlinks followed, not just lexically — `resolve()`
+ * alone would let a symlinked `--home` (or a symlinked parent) slip past the
+ * guards below and write into the real install. Nonexistent paths canonicalize
+ * via the nearest existing ancestor plus the remainder.
  */
 export function canonicalize(p: string): string {
   let base = resolve(p);
@@ -78,12 +76,10 @@ export interface SeedResult {
 }
 
 /**
- * Build a complete, self-contained demo install at `home`.
- *
- * Deliberately does NOT use `saveConfig()` or `getLedger()`. `CONFIG_DIR` is
- * captured at module load (packages/core/src/config.ts), so in this process both
- * point at the founder's REAL home — the whole point of the demo is that it
- * never touches that. Everything here is written through explicit paths.
+ * Build a complete, self-contained demo install at `home`. Deliberately avoids
+ * `saveConfig()`/`getLedger()` — CONFIG_DIR is captured at module load and
+ * points at the founder's REAL home, which the demo must never touch; all
+ * writes go through explicit paths.
  */
 export function seedDemoHome(opts: { home?: string; anchor?: Date; force?: boolean }): SeedResult {
   // Canonical (symlink-followed) on BOTH sides of every comparison, and used
@@ -150,19 +146,10 @@ export function seedDemoHome(opts: { home?: string; anchor?: Date; force?: boole
 
 /**
  * Open the ledger once through `Ledger` so `migrate()` builds the real schema,
- * then write rows with raw SQL.
- *
- * Raw SQL is not a shortcut here. `created_at` and its siblings are filled by a
- * `datetime('now')` column DEFAULT and no public method accepts a value for
- * them, so backdated history — which is what makes the Home KPIs, the Measure
- * ranges and the Receipts day-groups render at all — can only be written
- * directly. Tests use the same escape hatch (packages/core/__tests__/send-routing.test.ts).
- *
- * A re-seed clears the tables rather than deleting the file. Deleting it would
- * strand the open handle of a dashboard already running against this home —
- * every page would go blank and doctor would read `ledger fail` until the server
- * restarted. Truncating in place means you can re-seed mid-session and just
- * refresh the browser.
+ * then write rows with raw SQL — required because `datetime('now')` column
+ * DEFAULTs can't be backdated through any public method. A re-seed truncates
+ * tables rather than deleting the file, so a dashboard's open handle survives
+ * and a mid-session re-seed only needs a browser refresh.
  */
 function writeLedger(dbPath: string, data: DemoDataset): Record<string, number> {
   const migrator = new Ledger(dbPath);

--- a/apps/cli/src/main.ts
+++ b/apps/cli/src/main.ts
@@ -1,17 +1,11 @@
 #!/usr/bin/env bun
 /**
- * Bootstrap shim — the real bin target.
- *
- * core's config.ts captures ONESHOT_GTM_HOME at module load and auto-loads
- * that home's .env on import, and ESM hoists imports, so by the time commander
- * could parse a `--workspace` flag the install is already chosen. This file
- * therefore imports only node builtins and the builtin-only workspaces module,
- * decides the home, sets the env, and only THEN imports the CLI proper.
- *
- * Resolution: `--workspace <name>` > ONESHOT_GTM_WORKSPACE > registry default.
- * An explicit ONESHOT_GTM_HOME wins over all of them (and combining it with
- * --workspace is an error). Every child this process spawns (the dashboard
- * server) inherits the decision through process.env.
+ * Bootstrap shim — the real bin target. core's config.ts captures
+ * ONESHOT_GTM_HOME at module load and ESM hoists imports, so the home must be
+ * decided and set in env BEFORE importing the CLI proper; this file imports
+ * only builtins until then. Resolution: `--workspace` > ONESHOT_GTM_WORKSPACE
+ * > registry default; explicit ONESHOT_GTM_HOME wins over all (combining it
+ * with --workspace is an error). Children inherit via process.env.
  */
 import {
   extractWorkspaceFlag,

--- a/apps/server/src/api/_reply-research.ts
+++ b/apps/server/src/api/_reply-research.ts
@@ -28,19 +28,10 @@ export interface ReplyContext {
 }
 
 /**
- * Assemble everything the reply drafter can know about the sender, cheapest
- * first:
- *
- * 1. Free — the prospect's stored dossier (finders/Add-Prospect already paid
- *    for it) and the founder's own prior replies in this thread.
- * 2. Paid, only when no dossier exists — enrich the sender's email (~$0.05,
- *    30d cache) and read their apex domain (~$0.01, cached here under
- *    `webread:<domain>`), both gated by isDudDomain so a gmail.com sender
- *    costs nothing.
- *
- * Best-effort throughout: research failing for ANY reason degrades to the
- *  free tiers — it must never block the draft (this also keeps demo mode
- * harmless, where placeholder keys fail at auth).
+ * Assemble sender context cheapest-first: (1) free — stored dossier + prior
+ * replies in this thread; (2) paid, only when no dossier exists — enrich the
+ * email and read the apex domain, both gated by isDudDomain. Best-effort
+ * throughout: research failing for ANY reason must never block the draft.
  */
 export async function gatherReplyContext(input: {
   fromEmail: string;
@@ -123,10 +114,8 @@ function bestEffort(fn: () => void): void {
 }
 
 /**
- * Mail is routinely hosted on a subdomain (person@mail.example.com) whose
- * hostname serves MX, not a website — reading it misses the company site and
- * can bill a failed fetch. Strip the well-known mail-ish first label; a full
- * public-suffix list is deliberately out of scope (zero-dep repo), so
+ * Strip a well-known mail-ish first label (mail.example.com serves MX, not a
+ * website). A full public-suffix list is deliberately out of scope, so
  * multi-label TLDs pass through unchanged.
  */
 const MAIL_SUBDOMAINS = new Set(["mail", "email", "smtp", "mx", "mta", "mailer", "send", "post"]);
@@ -136,16 +125,12 @@ export function siteDomainFor(domain: string): string {
 }
 
 /**
- * Read the sender's site (the aliyev.site call), cached in enrichment_cache
- * under `webread:<domain>` — the PK is a plain string, and reusing the table
- * gets us the 30d TTL + negative-cache semantics safeEnrich already
- * established. Returns null on any failure; transient errors are not
- * negative-cached (an outage must not suppress research for a month).
- *
- * The cache write rides the LIVE promise, not the deadline race — same pattern
- * (and same reason) as safeEnrich: a read that settles after the deadline was
- * still PAID for, and discarding it means the next draft pays again. The late
- * result can't reach this draft's costUsd, but it must reach the cache.
+ * Read the sender's site, cached in enrichment_cache under `webread:<domain>`
+ * (30d TTL + negative-cache semantics). Returns null on any failure;
+ * transient errors are NOT negative-cached (an outage must not suppress
+ * research for a month). The cache write rides the LIVE promise, not the
+ * deadline race — a read settling after the deadline was still PAID for and
+ * must reach the cache.
  */
 async function readSenderSite(
   domain: string,

--- a/apps/server/src/api/cadences.ts
+++ b/apps/server/src/api/cadences.ts
@@ -20,25 +20,16 @@ import { jsonResponse } from "../server.ts";
 import { reportServerExecution } from "../telemetry.ts";
 
 /**
- * In-flight cadence sends are tracked on the cadence_state row's
- * `sending_started_at` column (claimed atomically by
- * `ledger.claimCadenceSendingMarker` before the background SDK send fires,
- * cleared on success via `advanceCadence` and on failure in the catch).
- *
- * History: this used to be an in-memory Set. Under `bun --watch` a file save
- * killed the background promise mid-SDK-call, leaving the founder with no
- * "sending" UI signal AND no email delivered. The DB-backed marker survives
- * restarts; the cold-boot sweeper recovers stranded rows.
- *
- * Stale-cutoff window: a fresh Send click can reclaim a marker older than
- * this. Set to MAX_SEND_AGE_MS to match the cold-boot sweeper threshold —
- * the only way the marker is older is if a previous send was killed.
+ * In-flight cadence sends are tracked on the row's `sending_started_at`
+ * column (claimed atomically before the background SDK send, cleared on
+ * success by `advanceCadence`, on failure in the catch) — DB-backed so it
+ * survives restarts; the cold-boot sweeper recovers stranded rows. A fresh
+ * Send click can reclaim a marker older than this cutoff.
  */
 const MAX_SEND_AGE_MS = 5 * 60 * 1000;
 
 /**
- * Per-play info that doesn't change between rows of the same play. Computed
- * once per unique play_name and reused for every row to avoid re-walking the
+ * Per-play info computed once per unique play_name — avoids re-walking the
  * sequence registry + re-reading config from disk per row.
  */
 interface PlayInfo {
@@ -81,8 +72,7 @@ function toView(
       const parsed = JSON.parse(row.next_step_draft_json) as CadenceNextStepDraft & {
         payload?: unknown;
       };
-      // Strip `payload` from the wire view — internal envelope only the
-      // send route reads. UI only needs subject/body/flags/draftedAt.
+      // Strip `payload` from the wire view — only the send route reads it.
       nextStepDraft = {
         subject: parsed.subject,
         body: parsed.body,
@@ -128,12 +118,9 @@ function toView(
 function viewsForRows(
   rows: ReadonlyArray<ReturnType<ReturnType<typeof getLedger>["listAllCadences"]>[number]>,
 ): CadenceView[] {
-  // Single SQL fetch for ALL (prospect_id, play_name) pairs — replaces the
-  // N+1 of one listSequenceEventsForProspectPlay per row.
+  // Single SQL fetch for ALL (prospect_id, play_name) pairs — avoids N+1.
   const pairs = rows.map((r) => ({ prospectId: r.prospect_id, playName: r.play_name }));
   const priorByKey = getPriorStepsBulk(pairs);
-  // Compute play-level info (nextStepInfo + playFollowupCount) once per
-  // unique play_name — each calls effectiveSequence → loadConfig (readFileSync).
   const playInfo = buildPlayInfoMap(rows);
   return rows.map((r) => toView(r, priorByKey, playInfo));
 }
@@ -141,27 +128,22 @@ function viewsForRows(
 export function listCadences(req: Request): Response {
   const url = new URL(req.url);
   const all = url.searchParams.get("all") === "1";
-  // Optional `?sinceRun=N` filter — the /run-page → /cadences deep-link from
-  // run-complete mode. Resolves `runs.prospect_emails_json` for run N and
-  // filters cadences to that prospect set (matched by canonicalized email).
-  // Falls back to all-cadences when the run id is malformed or unknown.
+  // Optional `?sinceRun=N` — the /run → /cadences deep-link; filters to run
+  // N's prospect set. Malformed run ids fall back to all-cadences.
   const sinceRunRaw = url.searchParams.get("sinceRun");
   const sinceRunId =
     sinceRunRaw && Number.isFinite(Number.parseInt(sinceRunRaw, 10))
       ? Number.parseInt(sinceRunRaw, 10)
       : null;
   const ledger = getLedger();
-  // Full status-complete set for the summary tiles. The active/all toggle only
-  // narrows the TABLE; the tiles must reflect every status (else REPLIED reads 0
-  // whenever the default "active" filter is on). Both derive from this one set.
+  // The active/all toggle only narrows the TABLE; the summary tiles must
+  // reflect every status (else REPLIED reads 0 under the default filter).
   const allRows = ledger.listAllCadences();
   let countRows = allRows;
   let rows = all ? allRows : allRows.filter((r) => r.status === "active");
   if (sinceRunId != null) {
     const run = ledger.getRun(sinceRunId);
-    // Unknown runId → return zero rows. The UI shows "0 cadences filtered to
-    // run #N" with a [clear filter] CTA, which is clearer than silently
-    // ignoring the filter and showing everything.
+    // Unknown runId → zero rows (clearer than silently ignoring the filter).
     const wantedEmails = new Set(
       (run?.prospectEmails ?? []).map((e) => e.trim().toLowerCase()).filter((e) => e.length > 0),
     );
@@ -285,11 +267,8 @@ export async function sendCadenceStepRoute(
   }
   const parsed = parseProspectAndPlay(req, params);
   if (parsed instanceof Response) return parsed;
-  // Verify the preview exists synchronously so we can 409 the founder
-  // immediately if they clicked Send without a persisted draft — but the
-  // actual send is fire-and-forget. SDK email send takes ~2 min; blocking
-  // the modal that long is bad UX, especially since the founder already
-  // approved by confirming. Mirrors POST /api/cadences/send-batch.
+  // 409 synchronously when no persisted draft exists, but the actual send is
+  // fire-and-forget — an SDK send takes ~2 min and must not block the modal.
   const ledger = getLedger();
   try {
     const draft = ledger.getCadenceDraft(parsed);
@@ -299,9 +278,8 @@ export async function sendCadenceStepRoute(
   } catch (err) {
     return jsonResponse({ error: (err as Error).message ?? "send failed" }, 500, req);
   }
-  // Atomic claim — survives server restart. `staleCutoffIso` lets a fresh
-  // click reclaim a marker stranded by a previous restart (the cold-boot
-  // sweep also clears these, but a fast retry shouldn't have to wait).
+  // Atomic claim — survives restart; `staleCutoffIso` lets a fresh click
+  // reclaim a stranded marker without waiting for the cold-boot sweep.
   const nowIso = new Date().toISOString();
   const staleCutoffIso = new Date(Date.now() - MAX_SEND_AGE_MS).toISOString();
   const claimed = ledger.claimCadenceSendingMarker({
@@ -321,8 +299,7 @@ export async function sendCadenceStepRoute(
   void (async () => {
     try {
       await sendCadenceStep(parsed);
-      // Success path: advanceCadence inside sendCadenceStep already cleared
-      // sending_started_at as part of its UPDATE. Nothing to do here.
+      // advanceCadence already cleared sending_started_at in its UPDATE.
       void reportServerExecution("server.cadence.send", {
         outcome: "ok",
         durationMs: performance.now() - sendStartedAt,
@@ -341,12 +318,11 @@ export async function sendCadenceStepRoute(
         },
         "error",
       );
-      // Failure path: advanceCadence never ran, so the marker is stuck.
-      // Release it so the founder can re-Send without waiting for the sweep.
+      // advanceCadence never ran — release the stuck marker for a re-Send.
       try {
         ledger.clearCadenceSendingMarker(parsed);
       } catch {
-        // Ledger write failing is the sweeper's problem; not worth re-throwing.
+        // sweeper safety net
       }
     }
   })();
@@ -392,9 +368,8 @@ export async function sendCadenceBatchRoute(req: Request): Promise<Response> {
   const itemsOrErr = await parseBatchItems(req);
   if (itemsOrErr instanceof Response) return itemsOrErr;
   const items = itemsOrErr;
-  // Claim each row's marker atomically. Rows that fail to claim (already
-  // sending) are dropped from the batch — `accepted` reflects the actual
-  // attempt count.
+  // Claim each row's marker atomically; unclaimable rows (already sending)
+  // are dropped, so `accepted` reflects the actual attempt count.
   const ledger = getLedger();
   const nowIso = new Date().toISOString();
   const staleCutoffIso = new Date(Date.now() - MAX_SEND_AGE_MS).toISOString();
@@ -418,10 +393,8 @@ export async function sendCadenceBatchRoute(req: Request): Promise<Response> {
   const batchStartedAt = performance.now();
   void (async () => {
     try {
-      // Per-item callback: clear the marker on each settled row. The serial
-      // sendCadenceStepBatch already calls advanceCadence on success (which
-      // clears the marker as part of the same UPDATE), so this catches the
-      // failure path only — defensive clear is idempotent.
+      // Per-item marker clear — success already clears via advanceCadence,
+      // so this catches the failure path only; the clear is idempotent.
       await sendCadenceStepBatch(claimed, (item) => {
         try {
           ledger.clearCadenceSendingMarker(item);
@@ -438,9 +411,8 @@ export async function sendCadenceBatchRoute(req: Request): Promise<Response> {
         outcome: "error",
         durationMs: performance.now() - batchStartedAt,
       });
-      // Belt-and-suspenders: the wrapper catches per-item; this catch only
-      // fires if the wrapper itself throws. Release everything so the founder
-      // can retry without waiting for the sweep.
+      // Only fires if the wrapper itself throws — release every marker so a
+      // retry needn't wait for the sweep.
       for (const item of claimed) {
         try {
           ledger.clearCadenceSendingMarker(item);

--- a/apps/server/src/api/inbox.ts
+++ b/apps/server/src/api/inbox.ts
@@ -31,11 +31,9 @@ function normalizeFrom(raw: string): string {
 }
 
 /**
- * Cadence-status priority for "which play represents this prospect's reply":
- * a `replied` cadence wins, then `active`, then anything else. Shared by the
- * list route (badge) and the draft route (prior-email context) so the play
- * shown and the play whose history feeds the LLM never diverge for a prospect
- * enrolled in several plays. Ties keep the first row seen.
+ * Cadence-status priority: `replied` wins, then `active`. Shared by the list
+ * and draft routes so the play shown and the play whose history feeds the LLM
+ * never diverge. Ties keep the first row seen.
  */
 function cadenceRank(status: string): number {
   if (status === "replied") return 2;
@@ -55,16 +53,12 @@ export async function listInboxRoute(req: Request): Promise<Response> {
   let emails: Awaited<ReturnType<typeof listInbox>>["emails"];
   let hasMore = false;
   try {
-    // Fetch a wide window (not just the newest handful): mailboxes fill with
-    // newsletters/bounces/DMARC noise, and matching only runs over what's
-    // fetched — too small a window buries a genuine prospect reply (and its
-    // match) below the noise. The UI defaults to the `matched` filter to surface
-    // those; this gives it enough history to find them.
+    // Wide window: matching only runs over what's fetched, and mailbox noise
+    // would bury a genuine prospect reply in a small one.
     const result = await listInbox({ limit: 200 });
     emails = result.emails;
-    // Truthful truncation signal: listInbox says whether this window is the
-    // whole story. The UI turns it into a "+" on its counts — the page must
-    // never present a clamped window as the entire mailbox.
+    // Truthful truncation signal — the page must never present a clamped
+    // window as the entire mailbox.
     hasMore = result.has_more;
   } catch (err) {
     logEvent(
@@ -76,9 +70,8 @@ export async function listInboxRoute(req: Request): Promise<Response> {
     return jsonResponse(out, 200, req);
   }
 
-  // Cadence-backed prospects (multi-touch plays) carry play + status + name/co
-  // in one JOIN. Index by normalized email; prefer a `replied`/`active` cadence
-  // when a prospect has several.
+  // Index cadence-backed prospects by normalized email; prefer a
+  // `replied`/`active` cadence when a prospect has several.
   const byEmail = new Map<
     string,
     { name: string | null; company: string | null; playName: string; status: string }
@@ -98,8 +91,8 @@ export async function listInboxRoute(req: Request): Promise<Response> {
     }
   }
 
-  // Identity provider per id — the UI needs to know whether a reply will be a
-  // threaded Gmail send or a best-effort (paid, unthreaded) OneShot send.
+  // Provider per identity — the UI shows whether a reply threads (gmail) or
+  // is a best-effort OneShot send.
   const cfg = loadConfig();
   const providerById = new Map(resolveIdentities(cfg).map((i) => [i.id, i.provider]));
 
@@ -143,15 +136,12 @@ export async function listInboxRoute(req: Request): Promise<Response> {
     };
   });
 
-  // Drop mail from the founder's own sending domain — the mailbox accumulates
-  // the agent's own sends + platform/system test mail (agent@/info@<domain>),
-  // which are never genuine prospect replies. Then newest-first.
+  // Drop mail from the founder's own sending domain (agent's own sends +
+  // system test mail are never prospect replies). Then newest-first.
   const selfDomain = (cfg.sendingDomain ?? "").trim().toLowerCase();
-  // Gmail self-sends: the Gmail query already excludes `from:me`, but
-  // belt-and-braces against forwarded copies of the founder's own address.
-  // Pool identities carry their address in config — no network call needed.
-  // Only the legacy synthesized identity (no address field) needs a live
-  // profile lookup, and that failing shouldn't break the replies page.
+  // Gmail self-sends: belt-and-braces on top of the query's `-from:me`. Only
+  // the legacy synthesized identity (no address in config) needs a live
+  // profile lookup, and that failing must not break the replies page.
   const gmailIdentities = resolveIdentities(cfg).filter((i) => i.provider === "gmail");
   const selfAddresses = new Set(
     gmailIdentities.map((i) => (i.address ?? "").trim().toLowerCase()).filter((a) => a.length > 0),
@@ -174,9 +164,8 @@ export async function listInboxRoute(req: Request): Promise<Response> {
 
 /**
  * Generate an LLM reply draft for an inbound email. The client sends the
- * email content it already has (re-fetching the live inbox here would add a
- * multi-second round-trip per draft). Prospect/play context is re-resolved
- * from the ledger by sender address — same matching as the list route.
+ * email content it already has (re-fetching the inbox costs seconds);
+ * prospect/play context is re-resolved from the ledger by sender address.
  */
 export async function draftReplyRoute(req: Request): Promise<Response> {
   let body: Partial<InboxDraftReplyRequest>;
@@ -191,9 +180,7 @@ export async function draftReplyRoute(req: Request): Promise<Response> {
   if (!fromEmail) {
     return jsonResponse({ error: "fromEmail is required" }, 400, req);
   }
-  // Distinct message: the UI disables the generate button on bodyless replies,
-  // but a scripted caller deserves to know WHY this 400s rather than getting a
-  // generic complaint about fields it did send.
+  // Distinct message so a scripted caller knows WHY this 400s.
   if (!inboundBody) {
     return jsonResponse({ error: "this email has no body to draft a reply from" }, 400, req);
   }
@@ -202,8 +189,7 @@ export async function draftReplyRoute(req: Request): Promise<Response> {
   const prospect = ledger.getProspectByEmail(fromEmail);
   let matched: Parameters<typeof draftInboxReply>[0]["matched"] = null;
   if (prospect) {
-    // Same ranking as the list route's badge (cadenceRank) so the play whose
-    // prior emails feed the draft matches the one the founder sees.
+    // Same ranking as the list route's badge (cadenceRank).
     const cadences = ledger.listCadencesForProspect(prospect.id);
     const best = cadences.reduce<(typeof cadences)[number] | undefined>(
       (acc, c) => (!acc || cadenceRank(c.status) > cadenceRank(acc.status) ? c : acc),
@@ -217,9 +203,8 @@ export async function draftReplyRoute(req: Request): Promise<Response> {
     };
   }
 
-  // Research before drafting: free tiers always (stored dossier, this thread's
-  // sent replies), paid tier only for senders we know nothing about. Wrapped —
-  // research failing must degrade the draft, never block it.
+  // Research before drafting: free tiers always, paid tier only for unknown
+  // senders. Research failing must degrade the draft, never block it.
   let context: Awaited<ReturnType<typeof gatherReplyContext>> = {
     dossier: null,
     threadSent: [],
@@ -266,9 +251,8 @@ export async function draftReplyRoute(req: Request): Promise<Response> {
 }
 
 /**
- * Persist the in-progress reply draft for a thread (debounced auto-save from
- * the composer). Distinct from `/api/inbox/draft-reply`, which only generates
- * an LLM draft and stores nothing. Upsert-by-thread-key so typing overwrites.
+ * Persist the in-progress reply draft for a thread (debounced auto-save).
+ * Upsert-by-thread-key so typing overwrites.
  */
 export async function saveDraftRoute(req: Request): Promise<Response> {
   let body: Partial<InboxSaveDraftRequest>;
@@ -285,8 +269,7 @@ export async function saveDraftRoute(req: Request): Promise<Response> {
   }
 
   const ledger = getLedger();
-  // An emptied composer clears the persisted draft rather than storing a blank
-  // one, so deleting all text and refreshing doesn't resurrect the old draft.
+  // An emptied composer clears the draft so a refresh can't resurrect it.
   if ((body.body ?? "").trim() === "") {
     ledger.clearInboxDraft(threadKey);
   } else {
@@ -306,8 +289,7 @@ export async function saveDraftRoute(req: Request): Promise<Response> {
 /**
  * Send a (possibly founder-edited) reply from the identity whose mailbox
  * received the inbound email. Gmail sources thread properly; oneshot sources
- * are a best-effort fresh send (no threading API — verified against the
- * platform's OpenAPI spec).
+ * are a best-effort fresh send (the platform has no threading API).
  */
 export async function sendReplyRoute(req: Request): Promise<Response> {
   if (isDraining()) {
@@ -347,8 +329,7 @@ export async function sendReplyRoute(req: Request): Promise<Response> {
         { playName: "inbox-reply", memo: `manual inbox reply to ${to}` },
       ),
     );
-    // Persist the sent reply (append to thread history, clear the draft) so the
-    // founder can see what they sent after a refresh.
+    // Persist the sent reply (append to thread history, clear the draft).
     const ledger = getLedger();
     ledger.recordInboxSent({
       threadKey,
@@ -358,10 +339,9 @@ export async function sendReplyRoute(req: Request): Promise<Response> {
       identityId,
       requestId: result.request_id ?? null,
     });
-    // Answering someone is proof they replied. The background poll usually
-    // records it first, but it can miss (source timeout, watermark gap) — the
-    // human is the detector of last resort. Idempotent, and never allowed to
-    // fail a send that already happened.
+    // Answering someone is proof they replied — the human is the detector of
+    // last resort when the background poll misses. Idempotent, and never
+    // allowed to fail a send that already happened.
     try {
       const prospect = ledger.findProspectByEmail(to);
       if (prospect) ledger.recordProspectReply(prospect.id, { subject });

--- a/apps/server/src/api/queue.ts
+++ b/apps/server/src/api/queue.ts
@@ -40,8 +40,7 @@ function toView(row: QueueRow): QueueRowView {
   if (row.last_draft_json) {
     try {
       const parsed = JSON.parse(row.last_draft_json) as Partial<LastDraft>;
-      // Defensive shape check — older rows or future schema drift
-      // shouldn't crash the queue listing.
+      // Shape check — schema drift must not crash the queue listing.
       if (parsed && typeof parsed.subject === "string" && typeof parsed.body === "string") {
         lastDraft = {
           subject: parsed.subject,
@@ -80,9 +79,9 @@ export function listQueueRoute(req: Request): Response {
   const url = new URL(req.url);
   const playName = url.searchParams.get("play") ?? undefined;
   const status = (url.searchParams.get("status") ?? undefined) as QueueStatus | undefined;
-  // `?ids=1,2,3` — an explicit row pick (the /queue "drain selected" path).
-  // A present-but-unusable value yields `[]`, NOT `undefined`: falling back to
-  // the unscoped batch would hand the caller rows it never picked.
+  // `?ids=1,2,3` — explicit row pick. A present-but-unusable value yields
+  // `[]`, NOT `undefined`: falling back to the unscoped batch would hand the
+  // caller rows it never picked.
   const ids = parseQueueIds(url.searchParams.get("ids"));
   const limit = Math.min(500, Number.parseInt(url.searchParams.get("limit") ?? "200", 10) || 200);
   const ledger = getLedger();
@@ -98,7 +97,7 @@ export function listQueueRoute(req: Request): Response {
   const rows = ledger.listQueue(filterArgs);
   const counts: QueueCounts = ledger.queueCounts();
   // Unfiltered on purpose — the drain button needs per-play approved counts
-  // even while the page is showing, say, only pending rows.
+  // regardless of the page's current filter.
   const body: QueueListResponse = {
     rows: rows.map(toView),
     counts,
@@ -192,10 +191,7 @@ export async function drainQueueRoute(req: Request): Promise<Response> {
 /**
  * Re-draft a single queue row in PREVIEW mode and overwrite its persisted
  * draft. Always dry-run: enrichment is skipped and nothing is sent, even
- * when the fresh draft is lint-clean. Lets the founder re-roll a held or
- * unsatisfying draft from /queue without leaving the page or risking a
- * send. The new draft replaces `last_draft_json` so the UI shows it on the
- * next queue refetch.
+ * when the fresh draft is lint-clean.
  */
 export async function regenerateDraftRoute(
   req: Request,
@@ -206,12 +202,10 @@ export async function regenerateDraftRoute(
   const ledger = getLedger();
   const row = ledger.getQueueRow(id);
   if (!row) return jsonResponse({ error: `row #${id} not found` }, 404, req);
-  // Once sent, last_draft_json IS the frozen sent content — never overwrite it
-  // with a fresh dry-run draft. Mirrors the guard in sendDraftRoute.
+  // Once sent, last_draft_json IS the frozen sent content — never overwrite it.
   if (row.status === "sent") return jsonResponse({ error: "row already sent" }, 400, req);
   // A send claimed the row but hasn't flipped status yet — refuse to start a
-  // regenerate that would race it. Mirrors the claimQueueSendingMarker
-  // primitive sendDraftRoute uses. Catches Scenario B (send started first).
+  // regenerate that would race it.
   if (row.send_started_at != null) {
     return jsonResponse({ error: "send in flight, can't regenerate" }, 409, req);
   }
@@ -223,9 +217,8 @@ export async function regenerateDraftRoute(
     return jsonResponse({ error: "row payload is not valid JSON" }, 400, req);
   }
 
-  // Carry through any per-play extras the payload happens to hold. Only
-  // accelerator-batch needs senderCohort, which usually isn't on the row —
-  // dispatchPlay then throws a clear error, surfaced here as a 400.
+  // Carry through per-play extras the payload happens to hold; a missing
+  // required one makes dispatchPlay throw, surfaced here as a 400.
   const payloadObj = (target && typeof target === "object" ? target : {}) as Record<
     string,
     unknown
@@ -250,10 +243,9 @@ export async function regenerateDraftRoute(
   const draft = drafted[0];
   if (!draft) return jsonResponse({ error: "no draft produced" }, 500, req);
 
-  // TOCTOU close: re-read the row after the multi-second dispatchPlay await.
-  // Catches Scenario A — a concurrent send completed during our LLM call.
-  // Without this, setQueueDraft below would overwrite the canonical sent
-  // body + wipe the receiptIds list.
+  // TOCTOU close: re-read after the multi-second dispatchPlay await — a
+  // concurrent send completing mid-LLM-call must not get its canonical sent
+  // body/receiptIds overwritten below.
   const fresh = ledger.getQueueRow(id);
   if (!fresh || fresh.status === "sent" || fresh.send_started_at != null) {
     return jsonResponse({ error: "send completed (or started) during regenerate" }, 409, req);
@@ -286,13 +278,9 @@ export async function regenerateDraftRoute(
 }
 
 /**
- * Send the row's already-reviewed draft VERBATIM — the persisted
- * `last_draft_json` subject/body, no LLM re-roll. This is the review-then-send
- * model: the founder regenerates until the draft is clean, then sends exactly
- * that. Routes through `sendDraftedEmail` (the canonical send: core sendEmail
- * applies HTML + from_name formatting, records the sequence event, upserts the
- * prospect), then enrolls the cadence and flips the row to `sent`. Requires a
- * clean (lint-flag-free), not-yet-sent draft.
+ * Send the row's already-reviewed draft VERBATIM (no LLM re-roll) via
+ * `sendDraftedEmail`, then enroll the cadence and flip the row to `sent`.
+ * Requires a clean (lint-flag-free), not-yet-sent draft.
  */
 export async function sendDraftRoute(
   req: Request,
@@ -300,8 +288,7 @@ export async function sendDraftRoute(
 ): Promise<Response> {
   const id = Number.parseInt(params["id"] ?? "", 10);
   if (!Number.isFinite(id)) return jsonResponse({ error: "bad id" }, 400, req);
-  // Server is draining for shutdown — don't start a new send that the drain
-  // would then have to wait on or abandon. Retry once it's back.
+  // Server is draining for shutdown — don't start a new send.
   if (isDraining()) {
     return jsonResponse({ error: "server restarting — retry in a moment" }, 503, req);
   }
@@ -325,9 +312,8 @@ export async function sendDraftRoute(
   if (!subject || !body) {
     return jsonResponse({ error: "stored draft is empty — regenerate first" }, 400, req);
   }
-  // Soft review flags (e.g. stale-event) hold a draft from auto-send but are
-  // founder-overridable here — this IS the review-then-send step. Only genuine
-  // blocking flags (lint, dedup) refuse a manual send.
+  // Soft review flags are founder-overridable here — this IS the
+  // review-then-send step. Only blocking flags refuse a manual send.
   if (blockingFlags(flags).length > 0) {
     return jsonResponse(
       { error: "draft has lint flags — regenerate to clear them before sending" },
@@ -337,11 +323,9 @@ export async function sendDraftRoute(
   }
   if (parsed.sent === true) return jsonResponse({ error: "draft already sent" }, 400, req);
 
-  // Atomic claim of the sending marker — survives server restart so the UI's
-  // spinner doesn't get stranded by a `bun --watch` reload mid-SDK-call. Stale
-  // cutoff matches the cadence-send window (5 min); past that, a fresh click
-  // can reclaim. Cleared automatically on success by setQueueStatus('sent',…);
-  // explicitly in the catch on failure.
+  // Atomic claim of the sending marker. Stale cutoff matches the cadence-send
+  // window (5 min); past that, a fresh click can reclaim. Cleared on success
+  // by setQueueStatus('sent'); explicitly in the catch on failure.
   const QUEUE_SEND_MAX_AGE_MS = 5 * 60 * 1000;
   const claimed = ledger.claimQueueSendingMarker({
     id,
@@ -367,9 +351,8 @@ export async function sendDraftRoute(
   const email = str("email") ?? str("founderEmail");
   if (!email) return jsonResponse({ error: "row has no recipient email" }, 400, req);
 
-  // Telemetry: emit exactly one event for this send attempt, regardless of
-  // which terminal path we take. Declared here (after pre-send validation) so
-  // bad-request / not-found returns above don't count as executions.
+  // Exactly one telemetry event per send attempt; declared after pre-send
+  // validation so bad-request returns don't count as executions.
   const t0 = performance.now();
   const done = (outcome: TelemetryOutcome, res: Response): Response => {
     void reportServerExecution("server.queue.send", {
@@ -379,9 +362,8 @@ export async function sendDraftRoute(
     return res;
   };
 
-  // sendDraftedEmail pushes dedup outcomes ("already-enrolled" / "already-
-  // contacted") onto this array, so we can tell a deliberate skip apart from a
-  // genuine send failure below.
+  // sendDraftedEmail pushes dedup outcomes here — distinguishes a deliberate
+  // skip from a genuine send failure below.
   const sendFlags: string[] = [];
   let result: Awaited<ReturnType<typeof sendDraftedEmail>>;
   try {
@@ -394,52 +376,41 @@ export async function sendDraftRoute(
         name: str("name") ?? str("founderName"),
         email,
         company: str("company"),
-        // Falls back to twitter/github URL so a profile-intro prospect added
-        // from an X or GitHub URL keeps its profile link (mirrors the play's own
-        // prospectMeta); the column is the de-facto social-profile URL.
+        // Falls back to twitter/github URL — the column is the de-facto
+        // social-profile URL (mirrors the play's own prospectMeta).
         linkedin_url: str("linkedinUrl") ?? str("twitterUrl") ?? str("githubUrl"),
         phone: str("phone"),
         source: row.play_name,
-        // Mirrors each play's own prospectMeta. Read generically so any finder
-        // that sets it on the payload gets it persisted without a change here.
+        // Read generically so any finder that sets it gets it persisted.
         source_profile_url: str("sourceProfileUrl") ?? str("githubUrl") ?? str("twitterUrl"),
         // Stamped on the payload by the person-level ICP gate in the finders.
         title: str("title"),
       },
-      // The play's evidence metadata (`repo`, `eventTitle`, `vendorStack`, …),
-      // from the same per-play functions the play defs use. This route used to
-      // omit it entirely, which left step-0 rows without their evidence key —
-      // and silently broke everything that reads it (expandi-sync's signal
-      // routing mis-assigned 19 prospects to the wrong A/B arm).
+      // The play's evidence metadata (`repo`, `eventTitle`, `vendorStack`, …)
+      // MUST be included — step-0 rows without their evidence key silently
+      // break everything downstream that reads it.
       metadata: playMetadata(row.play_name, payload),
       dryRun: false,
-      // This route IS the review-then-send override: the founder has seen any
-      // `contacted-elsewhere` hold on the draft and clicked send regardless.
+      // This route IS the review-then-send override for `contacted-elsewhere`.
       allowContactedElsewhere: true,
     });
   } catch (err) {
-    // Release the marker so the founder can retry without waiting for the
-    // cold-boot sweep. setQueueStatus would also clear it, but we only run
-    // that on success.
+    // Release the marker so a retry needn't wait for the cold-boot sweep.
     try {
       ledger.clearQueueSendingMarker(id);
     } catch {
       /* sweeper safety net */
     }
-    // Daily caps exhausted — not a failure. Row stays approved with its
-    // reviewed draft; 429 tells the UI "try again tomorrow".
+    // Daily caps exhausted — not a failure; row stays approved.
     if (isSendDeferred(err)) {
       return done("ok", jsonResponse({ error: (err as Error).message, deferred: true }, 429, req));
     }
-    // Shouldn't reach here (this route passes the override), but a race with a
-    // touch recorded mid-send is a hold, not a failure: keep the row approved.
+    // A race with a touch recorded mid-send is a hold, not a failure.
     if (isRecentlyContacted(err)) {
       return done("ok", jsonResponse({ error: (err as Error).message, held: true }, 409, req));
     }
-    // The 400 body carries only `err.message`, which for an SDK ToolError is
-    // the generic "Tool request failed" — the founder sees "couldn't send ·
-    // 400 Bad Request: {"error":"Tool request failed"}" and has nothing to act
-    // on. Log the status + response body so the real reason is recoverable.
+    // The 400 body carries only the SDK's generic message; log the status +
+    // response body so the real reason is recoverable.
     logTargetError({ playName: row.play_name, to: email, err });
     return done(
       "error",
@@ -452,10 +423,8 @@ export async function sendDraftRoute(
     } catch {
       /* sweeper safety net */
     }
-    // Deliberate dedup skip (not a failure): this person was already first-
-    // touched (same play, or another play via the cross-play guard). Mark the
-    // row rejected with the reason so it leaves the actionable queue and the
-    // founder isn't stuck re-clicking a Send that will never go through.
+    // Deliberate dedup skip: mark the row rejected with the reason so it
+    // leaves the actionable queue instead of inviting endless re-clicks.
     const dedup = sendFlags.find((f) => f === "already-contacted" || f === "already-enrolled");
     if (dedup) {
       const reason =

--- a/apps/server/src/api/run.ts
+++ b/apps/server/src/api/run.ts
@@ -26,19 +26,15 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
     return jsonResponse({ error: "targets must be a non-empty array" }, 400, req);
   }
 
-  // Create a runs row up-front so the UI gets a runId to navigate to + can
-  // resume on nav-back via GET /api/runs/:id. Every SSE event we emit below
-  // is also appended to the row's events_json so the resume view rebuilds
-  // accurately. Marked 'done' at the end of the try (success) or the catch
-  // (failure); cold-boot sweep flips any stranded 'running' rows to
-  // 'interrupted'.
+  // Create a runs row up-front so the UI gets a runId and can resume on
+  // nav-back; every SSE event below is also appended to events_json.
+  // Cold-boot sweep flips any stranded 'running' rows to 'interrupted'.
   const { runId, startedAt } = getLedger().createRun({
     playName,
     dryRun: body.dryRun,
     targets: body.targets,
   });
-  // Track which emails actually sent successfully so the UI can deep-link
-  // to /cadences?sinceRun=N filtered to just-enrolled prospects.
+  // Emails that actually sent, for the /cadences?sinceRun=N deep-link.
   const sentEmails: string[] = [];
 
   const stream = new ReadableStream<Uint8Array>({
@@ -50,10 +46,8 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
       let runOutcome: TelemetryOutcome = "ok";
       let fromQueue = false;
       const send = (event: RunPlayEvent): void => {
-        // Persist FIRST — even if the client has disconnected, the resume
-        // view needs every event. SSE write second; swallow if the client
-        // is gone (closed tab, navigation, or timeout). The server-side
-        // work (incl. any real send) still happened — no false pipeline_error.
+        // Persist FIRST — the resume view needs every event even after a
+        // client disconnect. SSE write second; swallow if the client is gone.
         try {
           ledger.appendRunEvent({ runId, event });
         } catch {
@@ -70,12 +64,9 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
       send({ kind: "runStarted", runId, startedAt });
 
       try {
-        // Build email → dedupeKey map BEFORE the verify filter potentially
-        // drops rows. The verify pass changes target indices but not target
-        // emails, so we can recover the dedupe key per drafted target by
-        // looking up the email later. Manual /run entries (no fromQueue)
-        // omit `dedupeKeys`; the map stays empty and the persist hook is
-        // a no-op.
+        // Build email → dedupeKey map BEFORE the verify filter drops rows —
+        // verify changes target indices but not emails. Manual /run entries
+        // omit `dedupeKeys`; the map stays empty and persistence is a no-op.
         const emailToDedupeKey = new Map<string, string>();
         if (body.dedupeKeys && body.dedupeKeys.length === body.targets.length) {
           body.targets.forEach((t, i) => {
@@ -86,12 +77,9 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
           });
         }
 
-        // Verify all target emails BEFORE dispatching to the play, so
-        // undeliverable rows are dropped before we spend on LLM drafting.
-        // Skipped on dryRun (no real spend during preview), AND skipped for
-        // queue-sourced runs (dedupeKeys present) — those rows were already
-        // verified at finder-enqueue time, so re-verifying just adds latency.
-        // The verify event tells the UI which rows were dropped + why.
+        // Verify emails BEFORE dispatch so undeliverable rows are dropped
+        // before LLM spend. Skipped on dryRun and for queue-sourced runs
+        // (already verified at finder-enqueue time).
         const inputCount = body.targets.length;
         fromQueue =
           Array.isArray(body.dedupeKeys) && body.dedupeKeys.length === body.targets.length;
@@ -114,10 +102,8 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
             dropped: verify.dropped.map((d) => ({ email: d.email, reason: d.reason })),
           });
         }
-        // If verify dropped every target, skip dispatch entirely — no point
-        // calling the play with an empty array (the play would either
-        // return empty drafted[] or throw on a "founder profile incomplete"
-        // pre-check that's irrelevant when there's nothing to send).
+        // If verify dropped every target, skip dispatch entirely — the play
+        // could throw an irrelevant pre-check error on an empty array.
         if (verify.verified.length === 0 && inputCount > 0) {
           send({ kind: "done", total: 0, sent: 0 });
           return;
@@ -126,10 +112,8 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
 
         send({ kind: "stage", stage: body.dryRun ? "drafting" : "drafting + sending" });
         let sentCount = 0;
-        // Per-target callback installed by dispatchPlay → play.run → parallelMap.
-        // Fires the draft + (optional) send events live so the runs row's
-        // counters and the UI tick from 0/N → N/N as each target completes,
-        // instead of jumping at the end.
+        // Per-target callback: fires draft/send events live so counters tick
+        // per target instead of jumping at the end.
         const drafted = await dispatchPlay(playName, filteredBody, (index, d) => {
           send({ kind: "draft", index, subject: d.subject, body: d.body, flags: d.flags });
           if (d.receiptIds.length > 0) {
@@ -137,8 +121,7 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
           }
           if (d.sent) {
             sentCount++;
-            // Pull the email back out of the verified target so /cadences?sinceRun
-            // can later resolve "what was just sent" without re-parsing events.
+            // Recover the email for the /cadences?sinceRun resolution.
             const t = verify.verified[index] as
               | { email?: string; founderEmail?: string }
               | undefined;
@@ -148,10 +131,8 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
         });
         send({ kind: "done", total: drafted.length, sent: sentCount });
 
-        // Persist drafts to their originating queue rows so the founder can
-        // review subject/body/flags later via /queue. Best-effort — the
-        // SSE stream has already finished by here, so a SQLite hiccup
-        // shouldn't surface as a user-visible error.
+        // Persist drafts to their originating queue rows for /queue review.
+        // Best-effort — a SQLite hiccup here must not surface to the user.
         if (emailToDedupeKey.size > 0) {
           persistDraftsToQueue({
             playName,
@@ -163,10 +144,9 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
         }
       } catch (err) {
         runOutcome = "error";
-        // Log the full error server-side — the SSE error event only carries a
-        // short message (e.g. the SDK's generic "Tool request failed"), which
-        // is useless for diagnosis. The stack reveals which call failed
-        // (sendEmail / enrichProfile / verifyEmail in oneshot.ts).
+        // Log the full error server-side — the SSE event only carries a short
+        // message, and the SDK's generic "Tool request failed" is useless
+        // without status/body/stack.
         const e = err as Error & {
           cause?: unknown;
           statusCode?: number;
@@ -179,8 +159,7 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
           {
             play: playName,
             message_200: (e?.message ?? "").slice(0, 200),
-            // OneShot SDK ToolError carries the failing call's HTTP status +
-            // server response body — the actual reason, vs the generic message.
+            // SDK ToolError carries the failing call's HTTP status + body.
             status_code: typeof e?.statusCode === "number" ? e.statusCode : null,
             response_body_400:
               typeof e?.responseBody === "string" ? e.responseBody.slice(0, 400) : null,
@@ -189,9 +168,8 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
           },
           "error",
         );
-        // Surface the real reason to the UI. The SDK's bare "Tool request
-        // failed" is useless; the server response body carries the actual
-        // error (e.g. {"error":"domain_not_owned","message":"…"}).
+        // Surface the real reason to the UI from the response body
+        // (e.g. {"error":"domain_not_owned"}).
         let uiMessage = e?.message ?? "run failed";
         if (typeof e?.statusCode === "number") {
           let detail = "";
@@ -208,10 +186,8 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
         }
         send({ kind: "error", index: -1, message: uiMessage });
       } finally {
-        // Flip the runs row to 'done' regardless of success/failure — the
-        // per-event counters on the row are already accurate. Cold-boot sweep
-        // only sees rows still stuck at 'running', so a clean shutdown here
-        // means no false-positive `interrupted` next boot.
+        // Flip the runs row to 'done' regardless of success/failure so the
+        // cold-boot sweep never sees a false 'running'.
         try {
           getLedger().markRunComplete({ runId, status: "done", sentEmails });
         } catch {
@@ -234,10 +210,8 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
     },
   });
 
-  // Loopback-only CORS for SSE. The outer fetch handler already enforces
-  // a loopback Host check before this runs, so we just mirror the origin
-  // when it's loopback and otherwise omit the header (browser refuses
-  // cross-origin response reads).
+  // Loopback-only CORS for SSE: mirror loopback origins, omit the header
+  // otherwise (the outer fetch handler already enforces a loopback Host).
   const origin = req.headers.get("origin") ?? "";
   const isLoopback =
     origin === "" ||
@@ -261,11 +235,9 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
 }
 
 /**
- * After the SSE stream completes, write each generated draft to its
- * originating `target_queue` row. Best-effort: a SQL hiccup during
- * persistence is logged via `error.swallowed` and doesn't affect what the
- * UI already saw on the wire. Indices match because `verifiedTargets[i]`
- * corresponds to `drafted[i]` (both come from the same dispatch).
+ * Write each generated draft to its originating `target_queue` row.
+ * Best-effort (logged via `error.swallowed`). Indices match because
+ * `verifiedTargets[i]` corresponds to `drafted[i]`.
  */
 function persistDraftsToQueue(input: {
   playName: string;
@@ -298,10 +270,8 @@ function persistDraftsToQueue(input: {
           ...(draft.enrichmentFailed ? { enrichmentFailed: true } : {}),
         },
       });
-      // A real, successful send must leave the approved pool — otherwise the
-      // row stays `approved` and every subsequent drain (esp. limit 1) re-loads
-      // the same first approved target forever. Held drafts (lint flags →
-      // sent:false) and dry-run previews intentionally stay approved.
+      // A real send must leave the approved pool or every drain re-loads the
+      // same row forever. Held drafts and dry-runs intentionally stay approved.
       if (draft.sent && !input.dryRun) {
         ledger.setQueueStatus({ id: row.id, status: "sent" });
       }

--- a/apps/server/src/api/workspace.ts
+++ b/apps/server/src/api/workspace.ts
@@ -10,17 +10,10 @@ import type { WorkspaceInfo } from "@oneshot-gtm/shared-types";
 import { jsonResponse } from "../server.ts";
 
 /**
- * Workspace identity + roster for the dashboard shell.
- *
- * Each workspace is a hermetic install serving its own dashboard on its own
- * port, so "switching" in the UI means opening ANOTHER server's tab — which is
- * only possible if the browser can learn (a) which workspace this server is,
- * and (b) which others exist and whether they are up. Until this route, the
- * browser's entire workspace knowledge was a string-split of the doctor
- * check's message.
- *
- * `running` is probed HERE, server-side, so the web app stays same-origin
- * (client.ts BASE = "/api") and the switcher has a single polling surface.
+ * Workspace identity + roster for the dashboard shell. Each workspace is a
+ * hermetic install on its own port, so "switching" means opening another
+ * server's tab. `running` is probed HERE, server-side, so the web app stays
+ * same-origin and the switcher has a single polling surface.
  */
 
 /** The port this server is actually bound to (bin.ts reads the same env). */
@@ -105,12 +98,8 @@ export function _setLaunchSpawn(fn?: LaunchSpawn): void {
 
 /**
  * POST /api/workspace/launch {name} — start another workspace's dashboard
- * server in the background, so the switcher's click can open it.
- *
- * Deliberately unsupervised: no PID file, no lifecycle management. The spawned
- * server runs until killed manually or the machine restarts — an accepted
- * trade-off for one-click switching on a single-user local tool. The roster's
- * `running` probe is the source of truth for what is actually up.
+ * server in the background. Deliberately unsupervised (no PID file, no
+ * lifecycle management); the roster's `running` probe is the source of truth.
  */
 export async function workspaceLaunch(req: Request): Promise<Response> {
   let name = "";

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -41,26 +41,12 @@ if (cache.__oneshotGtmServer) {
   });
   process.stdout.write(`\n  oneshot-gtm dashboard: http://127.0.0.1:${port}  (reloaded)\n\n`);
 } else {
-  // Cold boot only — sweep any trigger rows that were marked running by a
-  // previous process that never got to call updateTriggerLastPoll
-  // (bun --watch re-exec, OS reboot, OOM kill, hung SDK call when the
-  // process was killed). Writes a `killed_by_restart` last_run_summary so
-  // the UI shows the truth instead of frozen-from-an-hour-ago state.
-  //
-  // `maxAgeMs: 0` is intentional and important. At cold boot, any non-null
-  // `running_started_at` is by definition a zombie — the previous process is
-  // gone and an async finder run can't outlive its process. The MAX_RUN_AGE_MS
-  // freshness gate (4h) is for live UI reads where a long-running finder
-  // shouldn't disappear from the spinner mid-run. Applying it to the boot
-  // sweep would let a row that crashed 30 minutes ago survive across reboots
-  // and block re-runs with `409 already running` — exactly the bug we hit.
-  //
-  // Hot reload (the if-branch above) skips the sweep because it preserves
-  // the event loop, so any genuinely in-flight run continues.
-  //
-  // Wrapped — a SQL hiccup here must not take down the server. Boot
-  // continuing on stale ledger state is strictly better than refusing to
-  // start because of a cleanup detail.
+  // Cold boot only (hot reload preserves the event loop, so in-flight runs
+  // continue) — sweep trigger rows left marked running by a dead process.
+  // `maxAgeMs: 0` is intentional and important: at cold boot any non-null
+  // `running_started_at` is a zombie; applying the 4h UI freshness gate here
+  // would block re-runs with `409 already running`. Wrapped — a SQL hiccup
+  // must not take down the server.
   try {
     const swept = getLedger().sweepStaleRunningTriggers({
       now: new Date(),
@@ -79,13 +65,9 @@ if (cache.__oneshotGtmServer) {
     process.stderr.write(`  warn: stale-run sweep failed: ${(err as Error).message}\n`);
   }
 
-  // Same idea for fire-and-forget cadence sends. Any cadence_state row whose
-  // `sending_started_at` predates this process was either (a) the previous
-  // process succeeded — in which case the sequence_events row landed and the
-  // sweep just clears the now-meaningless marker, or (b) the previous process
-  // died mid-SDK-call — in which case the marker is stranded, the draft is
-  // still there, and the founder can re-click Send. The sweeper logs both
-  // cases so the founder can see "send was lost" in events.jsonl.
+  // Same sweep for cadence sends: a pre-boot `sending_started_at` marker is
+  // cleared whether the send landed (sequence_events row exists) or was lost
+  // mid-SDK-call (draft survives for a re-click); both cases are logged.
   try {
     const swept = getLedger().sweepStaleCadenceSends({
       now: new Date(),
@@ -117,11 +99,8 @@ if (cache.__oneshotGtmServer) {
     process.stderr.write(`  warn: stale-send sweep failed: ${(err as Error).message}\n`);
   }
 
-  // Mirror of the cadence sweep for `target_queue.send_started_at`. A queue
-  // row with a marker from a previous process either (a) had its SDK call
-  // complete before the kill — `status === 'sent'`, we just clear the marker —
-  // or (b) was stranded mid-call — clear the marker, the draft is still on the
-  // row for retry. Either way: cold boot wipes every existing marker.
+  // Mirror of the cadence sweep for `target_queue.send_started_at` — cold
+  // boot wipes every existing marker; drafts survive for retry.
   try {
     const swept = getLedger().sweepStaleQueueSends({
       now: new Date(),
@@ -152,12 +131,8 @@ if (cache.__oneshotGtmServer) {
     process.stderr.write(`  warn: stale queue-send sweep failed: ${(err as Error).message}\n`);
   }
 
-  // Cold-boot sweep for /run dispatches: any run still marked 'running' from
-  // a previous process is a zombie — the SSE stream is gone, the dispatch was
-  // killed. Flipping to 'interrupted' lets the /run page show a truthful
-  // banner instead of an eternal "running" view. Counters on the row are
-  // already accurate from the per-event appends, so the founder still sees
-  // what landed before the crash.
+  // Cold-boot sweep for /run dispatches: flip zombie 'running' rows to
+  // 'interrupted'; per-event counters on the row stay accurate.
   try {
     const swept = getLedger().sweepStaleRuns({ now: new Date(), maxAgeMs: 0 });
     for (const s of swept) {
@@ -182,14 +157,9 @@ if (cache.__oneshotGtmServer) {
   const { url, server } = await startServer({ port });
   cache.__oneshotGtmServer = server;
 
-  // Background trigger scheduler — polls due triggers, fires them, sleeps
-  // for `nextSleepMs` between ticks. Replaces the need to run a separate
-  // `bun run cli -- find watch` daemon. Survives `bun --hot` re-execs by
-  // staying anchored to globalThis.
-  //
-  // Wrapped: scheduler init failure must not take down the server (founder
-  // can still drive triggers manually via /queue Run). The cold-boot sweep
-  // pattern above does the same thing for ledger-init resilience.
+  // Background trigger scheduler; survives `bun --hot` re-execs via the
+  // globalThis anchor. Wrapped: scheduler init failure must not take down
+  // the server (triggers can still be run manually via /queue Run).
   let scheduler: SchedulerHandle | null = null;
   try {
     scheduler = startScheduler();
@@ -213,11 +183,9 @@ if (cache.__oneshotGtmServer) {
     }
   }
 
-  // Graceful drain: on a signal, stop taking new sends and wait for any
-  // in-flight send to finish writing its sequence_events row before exiting —
-  // closing the window where a sent-but-unrecorded email could be re-sent on
-  // retry. A SIGKILL skips this; the cold-boot sweep above is the backstop.
-  // Default 30s; a long voice call past that is force-exited and reconciled.
+  // Graceful drain: on a signal, wait for in-flight sends to finish writing
+  // their sequence_events rows — closes the sent-but-unrecorded re-send
+  // window. SIGKILL skips this; the cold-boot sweep is the backstop.
   const drainTimeoutMs = Number.parseInt(
     process.env["ONESHOT_GTM_DRAIN_TIMEOUT_MS"] ?? "30000",
     10,

--- a/apps/server/src/scheduler.ts
+++ b/apps/server/src/scheduler.ts
@@ -19,28 +19,13 @@ export function triggerOutcome(o: TriggerRunOutcome): TelemetryOutcome {
 }
 
 /**
- * Background scheduler that polls registered triggers on their interval and
- * fires due ones. Runs inside the dashboard server process so the founder
- * doesn't have to keep `bun run cli -- find watch` open in a second terminal
- * for enabled triggers to actually execute.
- *
- * Safety:
- * - Per-trigger atomic claim (in `runDueTriggers`) prevents double-spend if
- *   a manual /api/triggers/:name/run click races with a scheduled tick.
- * - Tick-level try/catch keeps a corrupted ledger row or unexpected throw
- *   from permanently killing the loop; backs off 60s before retrying.
- * - In-flight finder runs that haven't returned when the process exits get
- *   killed mid-run; the cold-boot `sweepStaleRunningTriggers` cleans up
- *   the orphaned `running_started_at` markers on the next start.
- *
- * The tick also polls the inbox for prospect replies and stops their cadences
- * (`pollInboxReplies`), and for delivery failures (`pollInboxBounces`). Both
- * otherwise only ran when the founder manually advanced a cadence, so a reply
- * could sit unrecognized — or a dead address keep receiving paid sends — for
- * days while the sequence kept emailing. Both are read-only apart from the
- * status flip — no step is sent — so neither spends. Tick cadence is clamped to
- * REPLY_POLL_MAX so both surface within minutes even when no trigger is due for
- * an hour.
+ * Background scheduler: polls registered triggers on their interval and fires
+ * due ones inside the dashboard server process. Safety: per-trigger atomic
+ * claim (in `runDueTriggers`) prevents double-spend when a manual run races a
+ * tick; tick-level try/catch backs off 60s so one throw can't kill the loop;
+ * runs orphaned by process exit are reconciled by the cold-boot sweep. The
+ * tick also polls inbox replies and bounces (both non-spending); tick cadence
+ * is clamped to REPLY_POLL_MAX so they surface within minutes.
  */
 export interface SchedulerHandle {
   stop(): void;
@@ -50,20 +35,15 @@ const FIRST_TICK_DELAY_MS = 5_000;
 const ERROR_BACKOFF_MS = 60_000;
 const REPLY_POLL_MAX_MS = 5 * 60_000;
 /**
- * Bounces are swept far less often than replies. A reply is time-sensitive —
- * every minute it goes unnoticed is a minute the cadence might send again. A
- * bounce has already happened and the sweep re-reads a 30-day window, so
- * running it at reply cadence would re-fetch and re-parse the same DSNs a
- * couple of hundred times a day for no new information.
+ * Bounces are swept far less often than replies: the sweep re-reads a 30-day
+ * DSN window, so reply-cadence polling would re-parse the same data for
+ * nothing, while replies are time-sensitive (cadence might send again).
  */
 const BOUNCE_POLL_INTERVAL_MS = 30 * 60_000;
 
 export function startScheduler(): SchedulerHandle {
-  // A seeded demo home is a still life: the scheduler would fire its enabled
-  // triggers against placeholder credentials and overwrite the very
-  // last_run_summary / last_polled_at values that make the dashboard look alive,
-  // mid-take. Idle instead — demo mode is for capture, and nothing in it is
-  // waiting on new signal.
+  // Demo mode idles: firing triggers would hit placeholder credentials and
+  // overwrite the seeded last_run_summary / last_polled_at values.
   if (demoMode()) {
     logEvent("demo.scheduler_idle");
     return { stop: () => {} };
@@ -79,9 +59,7 @@ export function startScheduler(): SchedulerHandle {
     try {
       const outcomes = await runDueTriggers();
       const fired = outcomes.filter((o) => o.fired).length;
-      // One anonymous telemetry event per trigger that actually ran this tick.
-      // Best-effort and detached — must not delay the next tick or the reply
-      // poll below.
+      // Telemetry per fired trigger — detached, must not delay the tick.
       for (const o of outcomes) {
         if (!o.fired) continue;
         void reportServerExecution(`server.trigger.${o.name}`, {
@@ -102,10 +80,7 @@ export function startScheduler(): SchedulerHandle {
           "warn",
         );
       }
-      // Bounce detection, isolated for the same reasons as the reply poll.
-      // Also non-spending: it records delivery failures and stops the cadences
-      // of hard-bounced addresses, so the founder stops paying to email
-      // mailboxes the receiving server has already refused.
+      // Bounce detection, isolated like the reply poll; non-spending.
       let bouncesRecorded = 0;
       if (Date.now() - lastBouncePollAt >= BOUNCE_POLL_INTERVAL_MS) {
         // Stamped before the await, not after: a slow or failing sweep must not

--- a/apps/server/src/telemetry.ts
+++ b/apps/server/src/telemetry.ts
@@ -1,30 +1,17 @@
 import { readPackageVersion, reportTelemetryEvent, type TelemetryOutcome } from "@oneshot-gtm/core";
 
 /**
- * Server-side telemetry — the dashboard analogue of the CLI's per-command
- * event (see apps/cli/src/index.ts `sendTelemetry`). The server executes the
- * same kinds of work (plays, cadence sends, queue drains, scheduled triggers)
- * but never passes through the CLI's `runOrFail`, so it reports here instead.
- *
- * Delegates the gate + payload + send to `reportTelemetryEvent` in core (the
- * shared path the CLI also uses); this wrapper only supplies the server's own
- * `version` and an empty-flags default. Two deliberate differences from the
- * CLI path:
- *
- *  1. `outcome` is passed in explicitly rather than read from the
- *     `markTelemetryOutcome` global — that singleton is unsafe in a concurrent
- *     server where many executions overlap.
- *  2. `command` is prefixed `server.` so the events table can separate CLI
- *     and server channels (filter on a `server.` prefix).
- *
- * Best-effort and non-blocking: `reportTelemetryEvent` never throws and has its
- * own timeout, so a telemetry failure can't affect a request or the scheduler.
+ * Server-side telemetry, delegating to core's `reportTelemetryEvent`. Differs
+ * from the CLI path in two deliberate ways: `outcome` is passed explicitly
+ * (the `markTelemetryOutcome` global is unsafe under concurrent executions),
+ * and `command` carries a `server.` prefix to separate the channels.
+ * Best-effort and non-blocking — a telemetry failure must never affect a
+ * request or the scheduler.
  */
 
-// Resolved lazily (on first emit) rather than at module load: this module is
-// imported by routes/scheduler whose tests sometimes mock @oneshot-gtm/core
-// wholesale, and a top-level call to a (possibly-mocked-away) core export would
-// throw during import. Inside reportServerExecution it's covered by the catch.
+// Resolved lazily (on first emit) rather than at module load: tests mock
+// @oneshot-gtm/core wholesale, and a top-level call to a mocked-away export
+// would throw during import.
 let serverVersion: string | undefined;
 
 export interface ServerExecutionOpts {
@@ -42,9 +29,7 @@ export async function reportServerExecution(
   command: string,
   opts: ServerExecutionOpts,
 ): Promise<void> {
-  // Defensive: every call site `void`s this, so it must never reject —
-  // `reportTelemetryEvent` is already best-effort, but this guards the
-  // delegation itself (e.g. a partially-mocked core in tests).
+  // Every call site `void`s this, so it must never reject.
   try {
     serverVersion ??= readPackageVersion(import.meta.url);
     await reportTelemetryEvent({

--- a/apps/web/src/components/shell/StrategistPanel.tsx
+++ b/apps/web/src/components/shell/StrategistPanel.tsx
@@ -41,7 +41,6 @@ export default function StrategistPanel({ open, onClose }: { open: boolean; onCl
 
   return (
     <AssistantRuntimeProvider runtime={runtime}>
-      {/* Backdrop — clickable to close, dims the page when open */}
       {open && (
         <div
           className="fixed inset-0 z-40 bg-ink-bg/60 backdrop-blur-sm"
@@ -102,7 +101,6 @@ function ChatBody() {
         />
       </ThreadPrimitive.Viewport>
 
-      {/* Suggestion chips */}
       <div className="flex flex-wrap gap-2 border-t border-ink-rule/60 px-5 py-2">
         {SUGGESTIONS.map((s) => (
           <ThreadPrimitive.Suggestion
@@ -116,7 +114,6 @@ function ChatBody() {
         ))}
       </div>
 
-      {/* Composer */}
       <div className="border-t border-ink-rule px-5 py-3">
         <ComposerPrimitive.Root className="flex items-center gap-2">
           <ComposerPrimitive.Input

--- a/apps/web/src/lib/drainButton.ts
+++ b/apps/web/src/lib/drainButton.ts
@@ -1,8 +1,6 @@
 /**
- * State of /queue's single drain button, derived from the PLAY filter chips
- * above it. One button instead of one-per-play: the play is already chosen by
- * the filter, and a disabled button should say *why* it's disabled rather than
- * just dimming out.
+ * State of /queue's single drain button, derived from the play filter chips —
+ * a disabled button says *why* it's disabled.
  *
  *   { playFilter: "all" }                        → "drain — pick a play above"
  *   { playFilter: "luma-events", approved: 145 } → "drain luma-events · 145"
@@ -55,12 +53,9 @@ export function drainButtonState(input: {
 }
 
 /**
- * State of the selection bar's "drain selected" button.
- *
- * Draining runs through /run, which is per-play and only accepts approved
- * rows — so a selection that spans two plays, or holds nothing approved, can't
- * be drained as one batch. Rather than silently draining a subset, the button
- * disables and names the reason.
+ * State of the selection bar's "drain selected" button. Draining runs through
+ * /run — per-play, approved rows only — so a mixed or unapproved selection
+ * disables the button and names the reason rather than draining a subset.
  *
  *   3 approved luma-events rows          → "drain 3 selected"
  *   2 luma-events + 1 repo-interest      → "drain selected · spans 2 plays"
@@ -102,12 +97,8 @@ export function drainSelectionState(input: {
 
 /**
  * Fold the currently-visible rows into the session's id → {play, status} map.
- *
- * /queue's selection is a Set of row ids that survives filter changes, but
- * `rows` only ever holds the current filtered page. Without this memory, a
- * selection spanning two plays looks single-play the moment you filter to one
- * of them — and "drain selected" would quietly act on the visible subset.
- *
+ * The selection Set survives filter changes but `rows` holds only the current
+ * page — without this memory a cross-play selection would look single-play.
  * Returns the previous map unchanged when nothing moved, so it's safe to call
  * from an effect keyed on `rows`.
  */

--- a/apps/web/src/lib/humanInterval.ts
+++ b/apps/web/src/lib/humanInterval.ts
@@ -1,9 +1,5 @@
 /**
- * Format a millisecond duration in interval-sized units — minutes/hours/
- * days rather than seconds/minutes. Use for trigger intervals, "next due
- * in N", "overdue N" — anything where the number is naturally on the
- * order of hours or days.
- *
+ * Format a millisecond duration in interval-sized units (minutes/hours/days).
  * For sub-minute spinner countups use `humanDuration` in `triggerRunState.ts`.
  *
  *   45_000          → "45s"

--- a/apps/web/src/lib/strategistAction.ts
+++ b/apps/web/src/lib/strategistAction.ts
@@ -1,9 +1,6 @@
 /**
- * Pure parser for strategist ACTION markers. Lives outside the React
- * component so it can be unit-tested without rendering anything — and so
- * the regex's correctness is locked down (a previous version excluded `-`
- * from the trigger-name capture, silently breaking every multi-word
- * trigger).
+ * Pure parser for strategist ACTION markers, outside the React component so it
+ * can be unit-tested without rendering.
  */
 
 type StrategistActionKind = "enable" | "disable" | "apply-config";
@@ -28,10 +25,8 @@ export interface ParsedStrategistAction {
 const ACTION_RE = /<!--ACTION:(enable|disable|apply-config):([^:>]+?)(?::([\s\S]*?))?-->/;
 
 /**
- * Looser match for partial markers mid-stream. Used to strip "<!--ACTION:..."
- * fragments from displayed text before the closing `-->` arrives, so the
- * founder doesn't see marker scaffolding flicker into view as the SSE
- * stream paints chunk by chunk.
+ * Looser match for partial markers mid-stream — strips "<!--ACTION:..." fragments
+ * from displayed text before the closing `-->` arrives.
  */
 const PARTIAL_ACTION_RE = /<!--ACTION:[\s\S]*$/;
 

--- a/apps/web/src/lib/summarizeRun.ts
+++ b/apps/web/src/lib/summarizeRun.ts
@@ -8,10 +8,6 @@
  *   2. `halted · <reason>` — finder returned `halted: "..."`
  *   3. counter breakdown: `cand=N · kept=M · icp=K · low=L · $X.YY`
  *   4. `—` when summary exists but has no usable fields
- *
- * Used by:
- *   - `/queue` Triggers table (run column)
- *   - `/home` SchedulerStrip (last run column)
  */
 export function summarizeRun(summary: unknown): string {
   if (!summary || typeof summary !== "object") return "—";
@@ -45,10 +41,8 @@ export function summarizeRun(summary: unknown): string {
 }
 
 /**
- * Format the per-cohort sweep breakdown for SchedulerStrip. Cohorts with
- * non-zero records come first (sorted by record count desc), zero-result
- * cohorts collapse into a trailing summary like `+3 empty (spc-2026-1, …)`
- * so the one-line layout doesn't blow out when the sweep is wide.
+ * Per-cohort sweep breakdown: non-zero cohorts first (desc), zero-result
+ * cohorts collapse into a trailing `+3 empty (…)` summary.
  */
 function formatPerCohort(perCohort: unknown[]): string {
   type Row = { cohort: string; records: number; error: string | null };

--- a/apps/web/src/routes/add-prospect.tsx
+++ b/apps/web/src/routes/add-prospect.tsx
@@ -38,7 +38,6 @@ function AddProspectPage() {
 
   return (
     <div className="-mx-6 -my-6 flex flex-col">
-      {/* Masthead */}
       <section className="flex items-end justify-between gap-4 border-b border-ink-rule px-6 pb-5 pt-6">
         <div>
           <div className="ln-eyebrow">The Ledger · Add Prospect</div>

--- a/apps/web/src/routes/cadences.tsx
+++ b/apps/web/src/routes/cadences.tsx
@@ -289,7 +289,6 @@ function CadencesPage() {
 
   return (
     <div className="-mx-6 -my-6 flex flex-col">
-      {/* Masthead */}
       <section className="flex items-end justify-between gap-4 border-b border-ink-rule px-6 pb-5 pt-6">
         <div>
           <div className="ln-eyebrow">The Ledger · Cadences</div>
@@ -337,10 +336,8 @@ function CadencesPage() {
         </section>
       )}
 
-      {/* Aggregate strip — 4 columns divided by vertical hairlines, 5 once any
-          cadence has bounced. The bounced tile only appears when there's
-          something to report: a permanent 0 would read as reassurance on
-          installs that have never had bounce detection run at all. */}
+      {/* The bounced tile appears only once any cadence has bounced — a permanent 0
+          would read as reassurance on installs that never ran bounce detection. */}
       <section
         className={cn(
           "grid grid-cols-2 divide-x divide-ink-rule border-b border-ink-rule",
@@ -376,7 +373,6 @@ function CadencesPage() {
         )}
       </section>
 
-      {/* Meta strip */}
       <section className="flex items-baseline justify-between border-b border-ink-rule px-6 py-2.5">
         <div className="ln-eyebrow">
           {cadences.data ? (
@@ -402,7 +398,6 @@ function CadencesPage() {
         </div>
       </section>
 
-      {/* Bulk-action bar — visible when at least one active row is selected. */}
       {selectedRows.length > 0 && (
         <section className="flex items-center justify-between gap-3 border-b border-ink-rule bg-ink-surface/40 px-6 py-2.5">
           <div className="font-mono text-[12px] text-ink-cream-2">
@@ -448,7 +443,6 @@ function CadencesPage() {
         </section>
       )}
 
-      {/* Cadence ledger */}
       <section>
         {cadences.isLoading ? (
           <div>
@@ -714,10 +708,8 @@ function CadencesPage() {
                                 </>
                               );
                             })()}
-                          {/* Chevron also for NON-active rows that still have history
-                            (breakup / replied / completed / paused / bounced). The active-status
-                            block already renders its own chevron above when there's a
-                            draft OR history; this one covers the non-active case. */}
+                          {/* Chevron for non-active rows with history — the active-status
+                            block renders its own above. */}
                           {c.status !== "active" &&
                             c.priorSteps.length > 0 &&
                             (() => {

--- a/apps/web/src/routes/inbox.tsx
+++ b/apps/web/src/routes/inbox.tsx
@@ -70,7 +70,6 @@ function InboxPage() {
 
   return (
     <div className="-mx-6 -my-6 flex flex-col">
-      {/* Masthead */}
       <section className="flex items-end justify-between gap-4 border-b border-ink-rule px-6 pb-5 pt-6">
         <div>
           <div className="ln-eyebrow">The Ledger · Replies</div>
@@ -118,9 +117,7 @@ function InboxPage() {
         </div>
       </section>
 
-      {/* Match-status filter — most inbox mail is unmatched noise (newsletters,
-          bounces, system mail); filtering to `matched` surfaces real prospect
-          replies. Mirrors the queue page's filter-bar style. */}
+      {/* Match-status filter — most inbox mail is unmatched noise; `matched` = real prospect replies. */}
       <div className="flex flex-wrap items-center gap-2 border-b border-ink-rule/60 px-6 py-3">
         <span className="ln-eyebrow">show</span>
         {MATCH_FILTERS.map((f) => (
@@ -131,12 +128,10 @@ function InboxPage() {
             onClick={() => setMatchFilter(f.key)}
           >
             {f.label}
-            {/* opacity (not a fixed faint color) so the count stays legible on
-                the selected button's cream fill as well as the ghost ones. */}
+            {/* opacity, not a fixed faint color, so the count stays legible on any button fill. */}
             {inbox.data && (
               <span className="ml-1 font-mono opacity-60">
-                {/* Every count is computed over the truncated window, so every
-                    count is a lower bound when hasMore — not just "all". */}
+                {/* Counts are computed over the truncated window — lower bounds when hasMore. */}
                 {countFor(f.key)}
                 {windowSuffix}
               </span>

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -40,7 +40,6 @@ function HomePage() {
 
   return (
     <div className="-mx-6 -my-6 flex flex-col">
-      {/* Masthead — newspaper-style, no card */}
       <section className="border-b border-ink-rule px-6 pb-5 pt-6">
         <div className="flex items-end justify-between gap-6">
           <div>
@@ -73,7 +72,6 @@ function HomePage() {
       {/* Onboarding nudge — disappears when ICP set + finder run + drain done. */}
       <NextStep />
 
-      {/* KPI strip — 4 columns divided by vertical hairlines. No cards. */}
       <section className="grid grid-cols-2 divide-x divide-ink-rule border-b border-ink-rule lg:grid-cols-4">
         <LedgerNumber
           label="Replied · 7d"
@@ -110,10 +108,8 @@ function HomePage() {
         limit={10}
       />
 
-      {/* Scheduler — per-trigger last-run + next-due strip */}
       <SchedulerStrip />
 
-      {/* Receipts ledger — full-bleed table, no card, newspaper-style */}
       <section className="flex flex-col border-b border-ink-rule">
         <div className="flex items-baseline justify-between px-6 pb-2 pt-5">
           <div className="ln-eyebrow">Recent receipts</div>
@@ -178,7 +174,6 @@ function HomePage() {
         )}
       </section>
 
-      {/* Editorial footnote — the "why" of spend, no card */}
       <section className="grid grid-cols-1 gap-8 px-6 py-8 lg:grid-cols-[1fr_280px]">
         <div className="max-w-[58ch]">
           <div className="ln-eyebrow">Editor's note</div>

--- a/apps/web/src/routes/measure.tsx
+++ b/apps/web/src/routes/measure.tsx
@@ -61,7 +61,6 @@ function MeasurePage() {
 
   return (
     <div className="-mx-6 -my-6 flex flex-col">
-      {/* Masthead */}
       <section className="flex items-end justify-between gap-4 border-b border-ink-rule px-6 pb-5 pt-6">
         <div>
           <div className="ln-eyebrow">The Ledger · Measure</div>
@@ -92,7 +91,6 @@ function MeasurePage() {
         </div>
       </section>
 
-      {/* Aggregate strip */}
       <section className="grid grid-cols-2 divide-x divide-ink-rule border-b border-ink-rule md:grid-cols-4">
         <Summary
           label="Total spend"
@@ -121,7 +119,6 @@ function MeasurePage() {
         />
       </section>
 
-      {/* CAC table */}
       <section className="border-b border-ink-rule">
         <div className="flex items-baseline justify-between px-6 pb-2 pt-5">
           <div className="ln-eyebrow">CAC by play · signed receipts</div>
@@ -206,7 +203,6 @@ function MeasurePage() {
         )}
       </section>
 
-      {/* RoCS table */}
       <section className="border-b border-ink-rule">
         <div className="flex items-baseline justify-between px-6 pb-2 pt-5">
           <div className="ln-eyebrow">RoCS · return on cognitive spend</div>

--- a/apps/web/src/routes/plays.tsx
+++ b/apps/web/src/routes/plays.tsx
@@ -134,7 +134,6 @@ function PlaysPage() {
 
   return (
     <div className="-mx-6 -my-6 flex flex-col">
-      {/* Masthead */}
       <section className="flex items-end justify-between gap-4 border-b border-ink-rule px-6 pb-5 pt-6">
         <div>
           <div className="ln-eyebrow">The Ledger · Plays</div>
@@ -150,13 +149,7 @@ function PlaysPage() {
           >
             The motion catalogue.
           </h1>
-          {/*
-            Counts come from the data. This copy used to hardcode "Ten motion
-            plays" while the badge beside it rendered the real length, so the
-            page contradicted itself the moment a play was added. The old "six
-            queue-drain plays" was wrong too — DASHBOARD_PLAYS holds one — so
-            that claim is gone rather than replaced with another fixed number.
-          */}
+          {/* Counts come from the data — never hardcode play counts in this copy. */}
           <p className="ln-note mt-2 max-w-[64ch] text-[13px] text-ink-cream-2">
             {plays.data ? `${plays.data.plays.length} motion plays` : "Motion plays"}. Each one is a
             known signal you can act on — trigger, cadence, anti-slop lint, signed receipt. Run them
@@ -174,7 +167,6 @@ function PlaysPage() {
         </div>
       </section>
 
-      {/* Plays ledger — one rich row per play */}
       <section>
         {plays.isLoading ? (
           <div>
@@ -200,7 +192,6 @@ function PlaysPage() {
                     i % 2 === 1 && "bg-ink-surface/20",
                   )}
                 >
-                  {/* Left: name + channel chips + receipt badge */}
                   <div className="flex flex-col gap-2.5">
                     <div className="flex items-baseline gap-2">
                       <code
@@ -245,7 +236,6 @@ function PlaysPage() {
                     </div>
                   </div>
 
-                  {/* Middle: description + cadence timeline + CLI */}
                   <div className="flex flex-col gap-3 min-w-0">
                     {meta?.description && (
                       <p className="ln-note text-[13px] text-ink-cream-2">{meta.description}</p>
@@ -262,7 +252,6 @@ function PlaysPage() {
                     </code>
                   </div>
 
-                  {/* Right: actions */}
                   <div className="flex flex-col items-end gap-1.5">
                     {runnable && (
                       <Link

--- a/apps/web/src/routes/queue.tsx
+++ b/apps/web/src/routes/queue.tsx
@@ -283,7 +283,6 @@ function QueuePage() {
 
   return (
     <div className="-mx-6 -my-6 flex flex-col">
-      {/* Masthead */}
       <section className="flex items-end justify-between gap-4 border-b border-ink-rule px-6 pb-5 pt-6">
         <div>
           <div className="ln-eyebrow">The Ledger · Queue</div>
@@ -311,11 +310,7 @@ function QueuePage() {
 
       <TriggersCard />
 
-      {/* Target Queue — the candidates themselves. A heavier rule + explicit
-          section header separates this from the Triggers table above (which
-          was reading as a seamless continuation of the same list). Play
-          filter lives inline here: it narrows the rows in this table
-          specifically, so it belongs next to them, not in the global bar. */}
+      {/* Target Queue. The play filter is inline because it narrows this table only. */}
       <section className="border-t-2 border-ink-rule">
         <div className="flex flex-wrap items-center justify-between gap-3 px-6 pb-3 pt-5">
           <div className="flex items-baseline gap-3">
@@ -329,9 +324,7 @@ function QueuePage() {
           <div className="font-mono text-[11px] text-ink-faint">refresh · 20s</div>
         </div>
 
-        {/* Status + play filters, inline with the table they scope. Status
-            is first (it narrows far more rows than play) and the two are
-            visually separated by a thin rule for scannability. */}
+        {/* Status + play filters, scoped to this table. */}
         <div className="flex flex-wrap items-center gap-2 border-b border-ink-rule/60 px-6 pb-3">
           <span className="ln-eyebrow">status</span>
           {STATUSES.map((s) => (
@@ -365,9 +358,7 @@ function QueuePage() {
           ))}
         </div>
 
-        {/* Bulk actions — approve-all + drain. Colocated with the table they
-            act on; both respect the current play filter, so the chips above
-            are the only play selector on the page. */}
+        {/* Approve-all + drain both respect the current play filter. */}
         <div className="flex flex-wrap items-center gap-2 border-b border-ink-rule/60 bg-ink-surface/30 px-6 py-3">
           <Button
             variant="secondary"
@@ -459,7 +450,6 @@ function QueuePage() {
         )}
       </section>
 
-      {/* Sticky bulk-action bar — only when something is selected */}
       {someSelected && (
         <div className="sticky bottom-0 z-20 flex items-center justify-between gap-4 border-b border-t border-ink-rule bg-ink-bg/95 px-6 py-3 backdrop-blur-[2px]">
           <div className="flex items-center gap-3">
@@ -568,8 +558,7 @@ function QueuePage() {
         }
       >
         <div className="flex flex-col gap-3">
-          {/* A selection IS the limit — showing a second, contradictory number
-              here would just invite "limit 10 of my 3 selected rows". */}
+          {/* A selection IS the limit — never show a second, contradictory number. */}
           {drainModal?.ids ? (
             <p className="text-[13px] text-ink-cream-2">
               Draining the {drainModal.ids.length} approved{" "}

--- a/apps/web/src/routes/receipts.tsx
+++ b/apps/web/src/routes/receipts.tsx
@@ -96,7 +96,6 @@ function ReceiptsPage() {
 
   return (
     <div className="-mx-6 -my-6 flex flex-col">
-      {/* Masthead */}
       <section className="flex items-end justify-between gap-4 border-b border-ink-rule px-6 pb-5 pt-6">
         <div>
           <div className="ln-eyebrow">The Ledger · Receipts</div>
@@ -131,8 +130,7 @@ function ReceiptsPage() {
         </div>
       </section>
 
-      {/* Value filter — "valued" surfaces the calls a reply/meeting/deal tied
-          value to. Mirrors the inbox/queue filter-bar style. */}
+      {/* Value filter — "valued" = calls a reply/meeting/deal tied value to. */}
       <div className="flex flex-wrap items-center gap-2 border-b border-ink-rule/60 px-6 py-3">
         <span className="ln-eyebrow">show</span>
         {VALUE_FILTERS.map((f) => (
@@ -148,7 +146,6 @@ function ReceiptsPage() {
         ))}
       </div>
 
-      {/* Receipts timeline — grouped by day, newest day first */}
       <section>
         {receipts.isLoading ? (
           <div>
@@ -230,7 +227,6 @@ function DaySection({ group, onClickRow }: { group: DayGroup; onClickRow: (id: n
   const { masked } = usePrivacy();
   return (
     <div>
-      {/* Day header — sticky so you always know which day you're scrolling through. */}
       <div className="sticky top-0 z-10 flex items-baseline justify-between border-b border-ink-rule/80 bg-ink-bg/95 px-6 py-2.5 backdrop-blur-[2px]">
         <div className="ln-eyebrow text-ink-cream-2">{group.label}</div>
         <div className="font-mono text-[11px] text-ink-faint">

--- a/apps/web/src/routes/run.$playName.tsx
+++ b/apps/web/src/routes/run.$playName.tsx
@@ -94,11 +94,9 @@ function RunPage() {
   // Cross-route navigation (e.g. to /cadences for the deep-link from done mode).
   const globalNavigate = useNavigate();
 
-  // Run state machine: edit | progress | done | interrupted. Driven by
-  // `search.runId`. When set, we fetch GET /api/runs/:id and re-render the
-  // per-target view from server-persisted events — so the page is fully
-  // resumable across nav-away-and-back AND across server restarts (the
-  // cold-boot sweep flips stranded runs to 'interrupted').
+  // Run state machine (edit | progress | done | interrupted), driven by `search.runId`.
+  // Rendering from server-persisted events keeps the page resumable across nav-away
+  // and server restarts (the cold-boot sweep flips stranded runs to 'interrupted').
   const runQuery = useQuery({
     queryKey: ["run", search.runId],
     queryFn: () => (search.runId ? api.run(search.runId) : Promise.resolve(null)),
@@ -140,16 +138,9 @@ function RunPage() {
   // founder isn't confused by the schema's default empty row.
   const [hydrationEmpty, setHydrationEmpty] = useState(false);
 
-  // Mount-only hydrate-from-queue.
-  //
-  // StrictMode (dev) double-invokes this effect; we use a closure-scoped
-  // `cancelled` flag so the first invocation's fetch resolves into a no-op
-  // and the second invocation's fetch is the one that updates state. A
-  // `useRef`-based "ran-once" guard would persist across the remount and
-  // make the SECOND invocation skip — leaving state un-hydrated even though
-  // we ran a fetch (silent dev-only failure).
-  //
-  // Net cost: 1 extra GET in dev StrictMode; 1 GET total in production.
+  // Mount-only hydrate-from-queue. StrictMode double-invokes this effect: the
+  // closure-scoped `cancelled` flag must stay (a useRef ran-once guard would
+  // persist across the remount and leave state un-hydrated).
   const hydrateFromQueue = useCallback(
     async (cancelledRef?: { cancelled: boolean }): Promise<void> => {
       if (!schema) return;
@@ -385,11 +376,9 @@ function RunPage() {
             const ev = JSON.parse(line.slice(5).trim()) as RunPlayEvent;
             streamedEvents.push(ev);
             setEvents((prev) => [...prev, ev]);
-            // First frame is always { kind: "runStarted", runId }. Navigate
-            // to the same page with `?runId=N` so the page is now in
-            // progress mode AND survives nav-away (the URL is the durable
-            // handle). The SSE stream keeps feeding `setEvents` for instant
-            // updates; `runQuery` takes over once the user returns later.
+            // First frame is always { kind: "runStarted", runId }. Navigating to
+            // `?runId=N` makes the URL the durable handle; SSE keeps feeding
+            // `setEvents`, `runQuery` takes over after nav-away.
             if (ev.kind === "runStarted") {
               void navigate({ search: (prev) => ({ ...prev, runId: ev.runId }) });
             }
@@ -419,7 +408,6 @@ function RunPage() {
 
   return (
     <div className="-mx-6 -my-6 flex flex-col">
-      {/* Masthead */}
       <section className="border-b border-ink-rule px-6 pb-5 pt-6">
         <Link
           to="/plays"
@@ -574,7 +562,6 @@ function RunPage() {
         </div>
       </RunLedgerSection>
 
-      {/* Action bar — sticky. The visible controls + label depend on `mode`. */}
       <section className="sticky bottom-0 z-10 flex flex-wrap items-center justify-between gap-3 border-b border-t border-ink-rule bg-ink-bg/90 px-6 py-3 backdrop-blur-[2px]">
         {mode === "edit" && (
           <button
@@ -719,7 +706,6 @@ function RunPage() {
                         : "border-ink-rule",
                   )}
                 >
-                  {/* Receipt seal — appears only on successfully sent drafts. */}
                   {d.receiptIds && d.receiptIds.length > 0 && (
                     <span
                       aria-hidden="true"

--- a/apps/web/src/routes/setup.tsx
+++ b/apps/web/src/routes/setup.tsx
@@ -304,7 +304,6 @@ function SetupPage() {
 
   return (
     <div className="-mx-6 -my-6 flex flex-col">
-      {/* Masthead */}
       <section className="flex items-end justify-between gap-4 border-b border-ink-rule px-6 pb-5 pt-6">
         <div>
           <div className="ln-eyebrow">The Ledger · Setup</div>
@@ -793,9 +792,7 @@ function SetupPage() {
                   prospects pinned to it until it's restored.
                 </span>
 
-                {/* Provisioned domains: the wallet's OneShot sending-domain pool
-                    with live status. A paused domain sends nothing until resumed
-                    (doctor flags it); resume/pause act on it in place. */}
+                {/* Provisioned OneShot domains — a paused domain sends nothing until resumed. */}
                 {provisionedDomains.length > 0 && (
                   <div className="mt-3 flex flex-col gap-2 border-t border-ink-rule pt-3">
                     <span className="ln-eyebrow">Provisioned domains</span>
@@ -840,9 +837,7 @@ function SetupPage() {
                   </div>
                 )}
 
-                {/* Add OneShot sender: a wallet-owned domain + a mailbox local-part.
-                    Multiple domains, and multiple mailboxes within one domain, all
-                    join the rotation pool. Applied on Save. */}
+                {/* Add OneShot sender — domain + mailbox join the rotation pool on Save. */}
                 <div className="mt-3 flex flex-col gap-2 border-t border-ink-rule pt-3">
                   <span className="ln-eyebrow">Add OneShot sender</span>
                   {pendingAdds.length > 0 && (
@@ -873,8 +868,7 @@ function SetupPage() {
                   )}
                   <div className="flex flex-wrap items-end gap-2">
                     <Field label="Domain" className="min-w-[200px]">
-                      {/* Free text + suggestions: pick a warmed domain or type a
-                          new one (it auto-provisions on first send). */}
+                      {/* Pick a warmed domain or type a new one (auto-provisions on first send). */}
                       <Input
                         list="oneshot-domains"
                         placeholder="acme.com"
@@ -927,8 +921,7 @@ function SetupPage() {
                       Add
                     </Button>
                   </div>
-                  {/* Cold-domain warning: a typed domain that isn't in the warmed
-                      pool will go out cold (pinned sends bypass server warm-up). */}
+                  {/* A domain outside the warmed pool goes out cold — pinned sends bypass warm-up. */}
                   {addDomain.trim() &&
                     provisionedDomains.length > 0 &&
                     !provisionedDomains.some(
@@ -940,8 +933,7 @@ function SetupPage() {
                         client ramp below is your only throttle.
                       </span>
                     )}
-                  {/* Shared-reputation note when stacking a 2nd mailbox on a domain
-                      already in the pool — reputation + send limits are per-domain. */}
+                  {/* Reputation + send limits are per-domain, not per-mailbox. */}
                   {addDomain.trim() &&
                     (status.data?.identities ?? []).some(
                       (i) => i.sendingDomain?.toLowerCase() === addDomain.trim().toLowerCase(),
@@ -960,14 +952,10 @@ function SetupPage() {
                 </div>
               </div>
             )}
-            {/* Smartlead lives OUTSIDE the identities guard: with an empty
-                pool there are no identity rows, but connecting Smartlead is
-                exactly how you rebuild one. */}
+            {/* Smartlead lives OUTSIDE the identities guard — connecting it is how an
+                empty pool gets rebuilt. */}
             <div className="md:col-span-2 flex flex-col gap-2">
-              {/* Smartlead accounts: bring-your-own cold-email infra. Paste
-                  the workspace API key, load the connected mailboxes, stage
-                  picks into the rotation pool (applied on Save). Send-only —
-                  replies to Smartlead-sent mail live in Smartlead's own UI. */}
+              {/* Smartlead accounts — send-only; replies live in Smartlead's own UI. */}
               <div className="mt-3 flex flex-col gap-2">
                 <span className="ln-eyebrow">Smartlead accounts</span>
                 <Field

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -79,15 +79,10 @@ export function loadConfig(): OneShotConfig {
 let cachedConfig: OneShotConfig | null = null;
 
 /**
- * Process-memoized `loadConfig` for hot, read-only callers like the telemetry
- * send path (`reportTelemetryEvent`), which otherwise does a `readFileSync` on
- * every emit — once per fired trigger in the server's scheduler loop. The cache
- * is busted by `saveConfig`, so an in-process write (e.g. the dashboard's
- * `config telemetry off`) is reflected on the next read. A config edit from a
- * *separate* process (CLI `config telemetry off`) propagates to a long-running
- * server on its next own write or on restart; the `ONESHOT_GTM_TELEMETRY=0` env
- * kill switch (checked live, uncached, in `shouldSendTelemetry`) is the
- * immediate override for that case.
+ * Process-memoized `loadConfig` for hot read-only callers (telemetry emit).
+ * Busted by `saveConfig`; a write from a SEPARATE process only propagates on
+ * this process's next write or restart — the ONESHOT_GTM_TELEMETRY=0 env kill
+ * switch (checked live in `shouldSendTelemetry`) is the immediate override.
  */
 export function loadConfigCached(): OneShotConfig {
   return (cachedConfig ??= loadConfig());
@@ -99,10 +94,8 @@ export function _resetConfigCacheForTests(): void {
 }
 
 /**
- * Pure helper for the clientId bootstrap path — extracted so it can be
- * unit-tested without touching the user's real config file. Mints a fresh
- * UUID when `cfg.clientId` is null/empty, otherwise returns the input
- * unchanged. `minted: true` signals the caller to persist.
+ * Mint a clientId when null/empty; `minted: true` signals the caller to
+ * persist. Pure so it's testable without the real config file.
  */
 export function bootstrapClientId(cfg: OneShotConfig): {
   cfg: OneShotConfig;
@@ -153,23 +146,18 @@ function loadSecretsFile(): Record<string, string> {
 }
 
 /**
- * Env-only credentials that are never stored in `.env` via saveSecrets but are
- * read directly from the environment by finders. Demo mode must neutralize
- * these too — a demo "Run now" acting with the founder's real GitHub token is
- * the same category of leak as a real wallet key.
+ * Env-only credentials read directly from the environment by finders. Demo
+ * mode must neutralize these too — same leak category as a real wallet key.
  */
 const ENV_ONLY_SECRET_KEYS = ["GITHUB_TOKEN", "LUMA_SESSION_COOKIE"] as const;
 
 function applySecretsToEnv(): void {
   const stored = loadSecretsFile();
 
-  // Demo mode (`ONESHOT_GTM_DEMO=1`, checked inline — importing demo.ts here
-  // would be circular): this home's .env is the SOLE source of secrets, not a
-  // fallback for blanks. Two real-credential leak paths make fill-the-blanks
-  // insufficient: the CLI parent inherits the real install's secrets into
-  // process.env before spawning the demo server, and Bun auto-loads a repo-root
-  // .env into every `bun run` child — both would shadow the demo placeholders
-  // and hand a "demo" a live wallet. Overwrite-or-delete closes both.
+  // Demo mode (checked inline — importing demo.ts would be circular): this
+  // home's .env is the SOLE secret source, never a fallback for blanks. The
+  // CLI parent's inherited env and Bun's auto-loaded repo-root .env would both
+  // shadow demo placeholders with live keys — overwrite-or-delete closes both.
   if (process.env["ONESHOT_GTM_DEMO"] === "1") {
     for (const k of [...SECRET_KEYS, ...ENV_ONLY_SECRET_KEYS]) {
       const v = stored[k];

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -4,28 +4,13 @@ import { join } from "node:path";
 import { configDir } from "./config.ts";
 
 /**
- * Local-only structured event log.
+ * Local-only structured event log — one JSON line per event appended to
+ * ~/.oneshot-gtm/events.jsonl (`tail -f … | jq` to watch).
  *
- * Every interesting moment (LLM call, ICP filter decision, finder lifecycle,
- * swallowed errors) appends one JSON line to ~/.oneshot-gtm/events.jsonl.
- * Tail it with `tail -f ~/.oneshot-gtm/events.jsonl | jq` while iterating.
- *
- * ## Privacy boundary
- *
- * `ctx` may contain primitives, counters, durations, category labels, error
- * class names, hostname/domain. It must NEVER contain user-typed values like
- * email addresses or ICP one-liner text, prospect data, or LLM completions
- * verbatim. This is the same boundary that will apply when an opt-in HTTP
- * sink is added later — keeping the rule tight today means schema reuse
- * tomorrow.
- *
- * Not enforced programmatically. Code-review discipline at the call sites.
- *
- * ## Failure mode
- *
- * Logging never throws. A logging bug must not break the caller. If the
- * filesystem is read-only or the config dir doesn't exist, the event is
- * dropped silently.
+ * Privacy boundary (call-site discipline, not enforced programmatically):
+ * `ctx` may carry primitives, counters, durations, labels, error class names,
+ * hostname/domain — NEVER user-typed values, prospect data, or verbatim LLM
+ * completions. Logging never throws; on any failure the event drops silently.
  */
 
 type EventLevel = "debug" | "info" | "warn" | "error";
@@ -86,12 +71,9 @@ export function logEvent(
 }
 
 /**
- * Pure builder for a single JSONL line. Extracted for testability — the
- * call site supplies `now`, `runId`, `clientId` so tests can pin them
- * without touching the module-level singletons or the filesystem.
- *
- * Includes the trailing newline so the caller can append in a single
- * fs syscall.
+ * Pure builder for one JSONL line (trailing newline included, so the caller
+ * appends in a single syscall). `now`/`runId`/`clientId` are parameters so
+ * tests can pin them.
  */
 export function buildEventLine(
   kind: string,
@@ -113,17 +95,12 @@ export function buildEventLine(
 }
 
 /**
- * Read the clientId straight from config.json instead of going through
- * loadConfig() — that would create a circular import (config doesn't depend
- * on events today; we keep it that way). Survives the case where the file
- * doesn't exist yet: returns null and the event ships without a client_id.
- * Cached for the process lifetime once non-null.
+ * Reads clientId straight from config.json — loadConfig() would create a
+ * circular import. Returns null when the file doesn't exist yet.
  */
 function resolveClientId(): string | null {
-  // First call resolves and caches, subsequent calls return the cached value
-  // even if it's null. The previous `clientIdResolved && cachedClientId` check
-  // re-read the config file on every event when bootstrap hadn't finished
-  // yet — turning the once-per-process cost into a per-event syscall.
+  // First call resolves and caches — even a null result — so a missing config
+  // never becomes a per-event file read.
   if (clientIdResolved) return cachedClientId;
   clientIdResolved = true;
   try {

--- a/packages/core/src/gmail.ts
+++ b/packages/core/src/gmail.ts
@@ -4,11 +4,9 @@ import { parallelMap } from "./parallel.ts";
 import type { AuthVerdict, BounceKind, GmailPlacement } from "./types.ts";
 
 /**
- * Gmail / Google Workspace send + reply path. Plain-fetch OAuth2 + Gmail REST
- * — no googleapis dependency. Credentials come from three secrets minted by
- * `bun run cli -- gmail auth`: GMAIL_CLIENT_ID, GMAIL_CLIENT_SECRET,
- * GMAIL_REFRESH_TOKEN (stored in ~/.oneshot-gtm/.env, applied to process.env
- * by config.ts on import).
+ * Gmail / Google Workspace send + reply path — plain-fetch OAuth2 + Gmail
+ * REST, no googleapis dependency. Credentials are the three GMAIL_* secrets
+ * minted by `gmail auth` (in ~/.oneshot-gtm/.env, applied by config.ts).
  */
 
 const TOKEN_URL = "https://oauth2.googleapis.com/token";
@@ -80,9 +78,8 @@ export function missingGmailSecrets(): string[] {
 
 /**
  * One authorized Gmail account in the rotation pool. `id` keys the token /
- * profile caches; `refreshToken` comes from the gmail-tokens.json store (or
- * the legacy GMAIL_REFRESH_TOKEN secret). Omitted account = legacy
- * single-account mode reading the env secret directly.
+ * profile caches. Omitted account = legacy single-account mode reading the
+ * GMAIL_REFRESH_TOKEN env secret directly.
  */
 export interface GmailAccount {
   id: string;
@@ -288,15 +285,10 @@ function extractPlainText(part: GmailPayloadPart | undefined): string {
 }
 
 /**
- * Best-effort readable body for a fetched message, in three tiers:
- * text/plain part → text/html part (de-tagged) → Gmail's snippet.
- *
- * The HTML tier is not an edge case. Our own outbound is HTML-only
- * (`buildRawMessage` emits `text/html` with no multipart/alternative), and
- * reply clients mirror the format of the mail they answer — so HTML-only
- * replies to our sends are the expected shape. Without this tier the /inbox
- * page showed "(no body)" for exactly the replies the tool exists to catch.
- * The snippet tier covers bodies stored behind `attachmentId` (not fetched).
+ * Best-effort readable body, in three tiers: text/plain → text/html
+ * (de-tagged) → Gmail's snippet. HTML-only replies are the expected shape
+ * (our own outbound is HTML-only, and reply clients mirror format); the
+ * snippet tier covers bodies stored behind `attachmentId` (not fetched).
  */
 function extractBody(msg: GmailMessageMeta): string {
   const plain = extractPlainText(msg.payload);
@@ -314,17 +306,10 @@ function extractBody(msg: GmailMessageMeta): string {
 }
 
 /**
- * Inbox replies, mapped to the OneShot InboxListResult contract so
- * advanceCadence (stop-on-reply) and the /inbox route work unchanged.
- * `-from:me` excludes the founder's own sends at the query level — the
- * Gmail-mode equivalent of the OneShot path's self-domain filter.
- *
- * Deliberately NOT `in:inbox`: a reply the founder has already read and
- * archived from their phone is still a reply, and with the ledger's reply
- * signal lagging the mailbox by up to a poll interval, "handled, then
- * archived" was the normal fate of a real reply. Spam and trash stay out —
- * the API already excludes them unless `includeSpamTrash` is set; the explicit
- * terms are there so nobody "widens" this to `in:anywhere`.
+ * Inbox replies, mapped to the OneShot InboxListResult contract. `-from:me`
+ * excludes the founder's own sends. Deliberately NOT `in:inbox` — an archived
+ * reply is still a reply. Spam/trash are already excluded by the API; the
+ * explicit terms are there so nobody "widens" this to `in:anywhere`.
  */
 export async function listGmailReplies(
   opts?: {
@@ -380,13 +365,10 @@ export async function listGmailReplies(
 }
 
 /* ── Bounce (DSN) harvesting ─────────────────────────────────────────────────
- * Delivery Status Notifications are the only first-party deliverability signal
- * available without a second mailbox: the receiving server tells us, in the
- * sender's own inbox, that a message was refused and why. Parsed here rather
- * than in the reply path because (a) DSNs would otherwise compete with genuine
- * replies for the 50-message poll window, and (b) fetching them deliberately
- * lets us read the structured RFC 3464 report instead of regexing localized
- * human-readable prose.
+ * DSNs are the only first-party deliverability signal without a second
+ * mailbox. Fetched separately from the reply path so they don't compete for
+ * the poll window and so we read the structured RFC 3464 report instead of
+ * regexing localized prose.
  */
 
 /** Matches an RFC 3463 enhanced status code ("5.1.1"). */
@@ -394,40 +376,33 @@ const ENHANCED_STATUS_RE = /\b([45]\.\d{1,3}\.\d{1,3})\b/;
 /** Matches a bare 3-digit SMTP reply code, for servers that omit the enhanced one. */
 const SMTP_CODE_RE = /\b([45]\d\d)\b/;
 /**
- * Diagnostics that mean "we refused this message" rather than "this address
- * doesn't exist". Catches servers that reject on policy with a plain 550 and
- * no 5.7.x enhanced code, which would otherwise be miscounted as a dead
- * address (and wrongly suppress a perfectly valid prospect).
+ * Diagnostics meaning "we refused this message", not "address doesn't exist" —
+ * a plain-550 policy reject would otherwise be miscounted as a dead address
+ * and wrongly suppress a valid prospect.
  */
 const POLICY_DIAGNOSTIC_RE =
   /\b(spam|blocked|blocklist|blacklist|policy|reputation|unsolicited|bulk|rejected due to|spamhaus|barracuda|greylist)/i;
 /**
- * Canonical DSN envelope senders. Used only as a fallback to the message's
- * actual From address — kept narrow deliberately: a broad pattern (no-reply@,
- * donotreply@…) would also discard a genuine failed recipient at one of those
- * addresses, and then the hard bounce would never be recorded or suppressed.
+ * Canonical DSN envelope senders — fallback only, kept narrow deliberately: a
+ * broad pattern (no-reply@…) would also discard a genuine failed recipient at
+ * one of those addresses.
  */
 const DAEMON_ADDRESS_RE = /^(mailer-daemon|postmaster)@/i;
 /**
- * Quantifiers are bounded to RFC 5321's limits (local-part 64, labels 63)
- * rather than left open. An unbounded `[...]+@` over a body that never contains
- * `@` backtracks from every start position — and DSN bodies are attacker-
- * influenced, since anyone can send mail with a mailer-daemon From. See also
- * PROSE_SCAN_LIMIT.
+ * Quantifiers bounded to RFC 5321's limits — an unbounded `[...]+@` over a
+ * body with no `@` backtracks from every start position, and DSN bodies are
+ * attacker-influenced. See also PROSE_SCAN_LIMIT.
  */
 const EMAIL_RE = /[\w.!#$%&'*+/=?^`{|}~-]{1,64}@[\w-]{1,63}(?:\.[\w-]{1,63}){1,8}/g;
 /**
- * Prose scanned by the fallback parser, in characters. A real DSN states the
- * failure in its first few lines; the rest is the quoted original message.
- * Capping bounds the regex work on hostile input.
+ * Prose cap (chars) for the fallback parser — a real DSN states the failure
+ * up front; the cap bounds regex work on hostile input.
  */
 const PROSE_SCAN_LIMIT = 8_000;
 
 /**
- * Severity for a delivery failure. `statusCode` is the enhanced RFC 3463 code
- * when the DSN provided one; `diagnostic` is the remote server's text. Policy
- * rejections are separated from address failures because only the latter
- * justifies suppressing the address — see BounceKind.
+ * Severity for a delivery failure. Policy rejections are separated from
+ * address failures because only the latter justifies suppressing the address.
  */
 export function classifyBounce(statusCode: string | null, diagnostic: string | null): BounceKind {
   const code = statusCode ?? diagnostic?.match(ENHANCED_STATUS_RE)?.[1] ?? null;
@@ -461,20 +436,12 @@ function findPart(
 }
 
 /**
- * The RFC 3464 field block of a `message/delivery-status` part.
- *
- * Two shapes occur in the wild. Exchange and most MTAs put the fields directly
- * on the part. Gmail's own NDRs make the part a container with an empty body
- * and nest the fields in a `text/plain` child. Reading only the direct body
- * therefore skipped every Gmail-generated DSN — the most common shape when the
- * sending identity is itself Gmail — so the structured branch never ran, the
- * prose fallback declined too, and a hard bounce recorded nothing and
- * suppressed nobody.
- *
- * Only the part's own body and its direct children are considered. Descending
- * further would reach the `message/rfc822` copy of the original outbound mail,
- * whose headers name the recipient we sent to and would parse as a failure
- * report for an address that never bounced.
+ * The RFC 3464 field block of a `message/delivery-status` part. Two shapes
+ * occur in the wild: fields directly on the part (Exchange, most MTAs) or
+ * nested in a `text/plain` child (Gmail's own NDRs). Only the part's own body
+ * and direct children are considered — descending further reaches the
+ * `message/rfc822` copy of the original mail, which would parse as a failure
+ * for an address that never bounced.
  */
 function decodeB64Url(data: string): string {
   return Buffer.from(data, "base64url").toString("utf8");
@@ -526,13 +493,10 @@ export interface ParsedBounce {
 }
 
 /**
- * Pull every failed recipient out of a DSN. Returns [] for ordinary mail, which
- * is what makes a deliberately broad Gmail query safe — the parser, not the
- * query, decides what counts as a bounce.
- *
- * Prefers the structured `message/delivery-status` report (locale-independent,
- * one block per recipient). Falls back to scraping the human-readable part for
- * senders that don't emit a conforming report.
+ * Pull every failed recipient out of a DSN. Returns [] for ordinary mail —
+ * the parser, not the query, decides what counts as a bounce. Prefers the
+ * structured `message/delivery-status` report; falls back to scraping the
+ * human-readable part.
  */
 export function parseBounce(msg: GmailMessageMeta): ParsedBounce[] {
   const text = dsnReportText(findPart(msg.payload, "message/delivery-status"));
@@ -569,11 +533,9 @@ export function parseBounce(msg: GmailMessageMeta): ParsedBounce[] {
     if (out.length > 0) return out;
   }
 
-  // Fallback: no conforming report. Gate it on the message actually being a
-  // delivery report first — prose-scraping is loose enough that an ordinary
-  // email mentioning "550 users" next to an address would otherwise parse as a
-  // hard bounce and suppress a live prospect. A structured report needs no such
-  // guard; its presence is proof on its own.
+  // Fallback: no conforming report. Gate on the message being a delivery
+  // report first — prose-scraping is loose enough that an ordinary email
+  // mentioning "550 users" would otherwise suppress a live prospect.
   const from = msg.payload?.headers?.find((h) => h.name.toLowerCase() === "from")?.value ?? "";
   const subject =
     msg.payload?.headers?.find((h) => h.name.toLowerCase() === "subject")?.value ?? "";
@@ -586,10 +548,9 @@ export function parseBounce(msg: GmailMessageMeta): ParsedBounce[] {
   if (!looksLikeDsn) return [];
 
   /**
-   * The DSN's own sender is never the address that failed. Matched by exact
-   * address first, falling back to the canonical daemon pattern — a broader
-   * pattern would discard a real failed recipient at, say,
-   * `no-reply@customer.example` and the bounce would go unrecorded.
+   * The DSN's own sender is never the address that failed. Exact address
+   * first, then the canonical daemon pattern — a broader pattern would
+   * discard a real failed recipient.
    */
   const isSender = (addr: string): boolean =>
     addr === senderAddress || DAEMON_ADDRESS_RE.test(addr);
@@ -600,12 +561,9 @@ export function parseBounce(msg: GmailMessageMeta): ParsedBounce[] {
   if (!statusCode && !SMTP_CODE_RE.test(body)) return [];
 
   /*
-   * A DSN's prose contains several addresses and only one of them failed.
-   * Picking the first non-sender match is wrong: a quoted `From:` header
-   * usually appears above the SMTP response, so a hard bounce would suppress
-   * the FOUNDER'S address rather than the target's. Score candidates by how
-   * strongly their line implies "this is the address that failed" and take the
-   * best, rather than the earliest.
+   * Several addresses appear in DSN prose and only one failed. First-match is
+   * wrong (a quoted `From:` header would suppress the FOUNDER'S address) —
+   * score candidates by how strongly their line implies failure, take best.
    */
   // Header lines naming the originator — never the failed recipient.
   const ORIGINATOR_LINE = /^\s*(from|sender|reply-to|return-path|x-original-from)\s*:/i;
@@ -657,16 +615,11 @@ export interface GmailBounce extends ParsedBounce {
 }
 
 /**
- * Delivery failures reported to this mailbox. The query is a coarse net (DSN
- * senders and subjects vary by MTA); `parseBounce` discards anything that isn't
- * actually a delivery report, so over-matching costs a wasted fetch, not a
- * false bounce. No `in:inbox` — a DSN the founder archived still counts — and
- * no `-from:me`, which would drop self-relayed reports.
- *
- * Paginated: a heavy sender can exceed one page of DSNs inside the window, and
- * stopping at the first page would leave those recipients unsuppressed while
- * reporting a falsely low bounce rate — a silent undercount, the worst failure
- * mode for a check whose whole job is to notice trouble.
+ * Delivery failures reported to this mailbox. The query is a coarse net —
+ * parseBounce discards non-reports, so over-matching costs a fetch, not a
+ * false bounce. No `in:inbox` (an archived DSN still counts) and no
+ * `-from:me` (would drop self-relayed reports). Paginated: stopping at the
+ * first page would silently undercount and leave recipients unsuppressed.
  */
 export async function listGmailBounces(
   opts?: { since?: string; limit?: number },
@@ -713,11 +666,9 @@ export async function listGmailBounces(
 }
 
 /* ── Inbox placement ─────────────────────────────────────────────────────────
- * What DSN harvesting structurally cannot tell you: a message can be accepted
- * without complaint and still be filtered into spam or buried in a tab. The
- * only way to know is to look in a real receiving mailbox — which requires a
- * SECOND authorized account, since a message you send to yourself is never
- * filtered.
+ * A message can be accepted and still be filtered into spam or a tab. Knowing
+ * requires a real receiving mailbox — a SECOND authorized account, since mail
+ * you send to yourself is never filtered.
  */
 
 /** All values for a header that may legitimately appear more than once. */
@@ -729,11 +680,10 @@ function headerValues(msg: GmailMessageMeta, name: string): string[] {
 }
 
 /**
- * Where Gmail filed the message, from its labelIds. Order matters: a message
- * in Promotions carries BOTH `INBOX` and `CATEGORY_PROMOTIONS`, so checking
- * `INBOX` first would report a tab-binned message as a clean inbox hit — the
- * exact failure this test exists to catch. SPAM is checked first because a
- * spammed message carries neither INBOX nor a category.
+ * Where Gmail filed the message, from its labelIds. Order matters: Promotions
+ * carries BOTH `INBOX` and `CATEGORY_PROMOTIONS`, so checking `INBOX` first
+ * would report a tab-binned message as a clean inbox hit; SPAM first because
+ * a spammed message carries neither.
  */
 export function classifyPlacement(labelIds: string[]): GmailPlacement {
   const labels = new Set(labelIds);
@@ -758,13 +708,8 @@ const VERDICTS: AuthVerdict[] = ["pass", "fail", "softfail", "neutral", "none"];
 
 /**
  * SPF/DKIM/DMARC as judged by the RECEIVING server, read off the delivered
- * message's `Authentication-Results` header. This is a verdict on the actual
- * message path — strictly better evidence than resolving DNS records ourselves,
- * and it needs no DNS tooling at all.
- *
- * Returns `unknown` per mechanism when the header is absent or silent on it,
- * which is normal for internal (same-Workspace) delivery that never crosses an
- * authenticating boundary.
+ * message's `Authentication-Results` header. Returns `unknown` per mechanism
+ * when the header is absent or silent — normal for same-Workspace delivery.
  */
 export function parseAuthResults(headers: string[]): AuthResults {
   const out: AuthResults = { spf: "unknown", dkim: "unknown", dmarc: "unknown" };
@@ -815,10 +760,8 @@ export interface PlacedMessage {
 
 /**
  * Find a message in this mailbox by Gmail search and report where it landed.
- *
- * `in:anywhere` is load-bearing: Gmail's default search EXCLUDES spam and
- * trash, so without it the one outcome this test exists to detect — the
- * message was filtered as spam — would read identically to "never arrived".
+ * `in:anywhere` is load-bearing: default search EXCLUDES spam/trash, so
+ * "filtered as spam" would read identically to "never arrived".
  */
 export async function findPlacedMessage(
   query: string,

--- a/packages/core/src/html-text.ts
+++ b/packages/core/src/html-text.ts
@@ -1,24 +1,13 @@
 /**
- * Dependency-free HTML → readable plain text, for email bodies.
- *
- * Exists because most reply clients mirror the format of the mail they answer,
- * and our outbound is HTML-only (`buildRawMessage` sends `text/html` with no
- * `multipart/alternative`) — so HTML-only replies are the NORMAL case for this
- * tool, and anything that renders or feeds an inbound body (the /inbox page,
- * reply drafting, triage) needs a text form. This is a preview-quality
- * conversion, not an HTML parser: good enough to read and to prompt an LLM
- * with, not a DOM.
+ * Dependency-free HTML → readable plain text for email bodies. Preview-quality
+ * conversion, not a DOM.
  *
  * Everything here is a single-pass left-to-right builder over indexOf, by
- * design and by hard-won lesson: three review rounds showed that EVERY
- * regex-with-a-middle over attacker-supplied HTML ends up polynomial
- * (`open[\s\S]*?close`, `</tag[^>]*>`, `<tag\b[^>]*>` — each fell to a
- * different `"prefix".repeat(n)` input), and iteration-capped replace loops
- * leak whatever lies past the cap. Builders are linear by construction and
- * handle any number of blocks in one pass; a small bounded fixpoint on top
- * handles reassembly (removing a span can butt `<scr` against `ipt>`), and a
- * truncation guard makes "an opener never survives" a hard invariant rather
- * than a hope.
+ * design: every regex-with-a-middle over attacker-supplied HTML goes
+ * polynomial, and iteration-capped replace loops leak whatever lies past the
+ * cap. A bounded fixpoint handles reassembly (removing a span can butt `<scr`
+ * against `ipt>`), and a truncation guard makes "an opener never survives" a
+ * hard invariant.
  */
 
 /** Named entities that actually occur in mail bodies; everything else numeric. */
@@ -68,10 +57,8 @@ function findToken(lower: string, token: string, from: number): number {
 
 /**
  * One left-to-right pass removing every `<tag …>…</tag …>` block, contents
- * included. Any number of blocks in one pass — no iteration cap to leak the
- * N+1th block. Unterminated opener or missing close tag drops to end-of-input:
- * per spec that content is still inside the element, and raw script/style text
- * must never leak into the "body".
+ * included — no iteration cap to leak the N+1th block. Unterminated opener or
+ * missing close drops to end-of-input: raw script/style text must never leak.
  */
 function stripBlocksOnce(s: string, tag: string): string {
   const lower = s.toLowerCase();
@@ -99,9 +86,8 @@ function stripBlocksOnce(s: string, tag: string): string {
 
 /**
  * stripBlocksOnce to a bounded fixpoint — excising a span can reassemble an
- * opener from the flanking pieces (`<scr<script>…</script>ipt>…`). Depth past
- * the bound doesn't leak: any surviving opener truncates the output there,
- * making "no <tag content in the result" an invariant, not a best effort.
+ * opener from the flanking pieces. Any opener surviving the bound truncates
+ * the output there: "no <tag content in the result" is an invariant.
  */
 function stripBlocks(s: string, tag: string): string {
   for (let pass = 0; pass < 10; pass++) {
@@ -148,12 +134,9 @@ const BREAK_CLOSERS = new Set([
 ]);
 
 /**
- * `\n` for structural tags, `""` for the rest. The check runs on one already-
- * isolated span, so it adds nothing to the pass's complexity — unlike the
- * `<br\b[^>]*>`-style replace regexes it displaced, which were quadratic on
- * `"<br ".repeat(n)` with no closing `>` (the same shape as every other
- * middle-scanning pattern this file has shed). Gmail's attribute-bearing
- * breaks (`<br class="gmail_default">`) still break the line.
+ * `\n` for structural tags, `""` for the rest. Runs on one already-isolated
+ * span so it adds nothing to the pass's complexity (a `<br\b[^>]*>` replace
+ * regex here is quadratic). Gmail's attribute-bearing breaks still break.
  */
 function tagReplacement(tagBody: string): string {
   const t = tagBody.toLowerCase();
@@ -163,11 +146,9 @@ function tagReplacement(tagBody: string): string {
 }
 
 /**
- * One pass dropping every TAG-SHAPED span: `<` followed by a letter, `!` or
- * `/`, through the next `>` — structural tags leave a newline behind. A bare
- * `<` in prose ("Revenue < $1m and growth > 20%") is comparison text and
- * passes through. An unterminated tag drops the rest — it's all inside the
- * tag per spec.
+ * One pass dropping every TAG-SHAPED span (`<` + letter/`!`/`/`, through the
+ * next `>`); structural tags leave a newline. A bare `<` in prose passes
+ * through; an unterminated tag drops the rest (inside the tag, per spec).
  */
 function stripTagsOnce(s: string): string {
   let out = "";

--- a/packages/core/src/identities.ts
+++ b/packages/core/src/identities.ts
@@ -36,12 +36,9 @@ function normalizeMailbox(raw: string | null | undefined): string {
 }
 
 /**
- * The active sender pool. `emailIdentities` set → returned verbatim.
- * Null → legacy single-identity mode: synthesize one identity from the
- * pre-rotation fields (emailProvider + sendingDomain / env refresh token) so
- * existing installs behave exactly as before rotation existed. Legacy
- * identities are uncapped — capping them would silently stall sends on
- * installs that never opted into rotation.
+ * The active sender pool. `emailIdentities` set → returned verbatim. Null =
+ * legacy single-identity mode: synthesize one identity from the pre-rotation
+ * fields. Legacy identities stay uncapped — capping would silently stall sends.
  */
 export function resolveIdentities(cfg: OneShotConfig): EmailIdentity[] {
   if (cfg.emailIdentities && cfg.emailIdentities.length > 0) return cfg.emailIdentities;
@@ -69,11 +66,9 @@ export function resolveIdentities(cfg: OneShotConfig): EmailIdentity[] {
 }
 
 /**
- * Persist a freshly authorized Gmail account: refresh token into the
- * chmod-600 store, identity into the rotation pool with warm-up defaults.
- * Legacy installs get their synthesized identity persisted first so existing
- * prospects keep their original From address. Re-auth of a known account
- * only refreshes the token — tuned caps are left alone.
+ * Persist a freshly authorized Gmail account (token → chmod-600 store,
+ * identity → pool). The legacy pool is materialized first so existing prospect
+ * pins survive; re-auth only refreshes the token, tuned caps are left alone.
  */
 export function registerGmailIdentity(input: { address: string; refreshToken: string }): {
   identityId: string;
@@ -98,13 +93,10 @@ export function registerGmailIdentity(input: { address: string; refreshToken: st
 }
 
 /**
- * Add a Smartlead-connected mailbox to the rotation pool. No credential is
- * stored per identity — sends resolve the workspace-wide SMARTLEAD_API_KEY and
- * pin the From by address. Default caps are the standard warm-up ramp, with
- * the DEFAULT ceiling clamped down to Smartlead's own `message_per_day` when
- * the caller passes it (an explicitly chosen `maxPerDay` — including null for
- * uncapped — is respected as-is, same trust model as OneShot caps).
- * Re-adding a known address is a no-op: tuned caps are left alone.
+ * Add a Smartlead-connected mailbox to the pool. No per-identity credential —
+ * sends use the workspace-wide SMARTLEAD_API_KEY and pin From by address.
+ * Default ramp is clamped to Smartlead's own `message_per_day` when given; an
+ * explicit `maxPerDay` (incl. null = uncapped) is respected as-is. Re-add = no-op.
  */
 export function registerSmartleadIdentity(input: {
   address: string;
@@ -148,10 +140,8 @@ export function registerSmartleadIdentity(input: {
 }
 
 /**
- * Founder-name-derived default local-part (first token, normalized) — the
- * mailbox used when an OneShot identity is added without an explicit one. Falls
- * back to "agent". Mirrors `fromLocalpart` in oneshot.ts but lives here to keep
- * identities.ts free of an import cycle with the send layer.
+ * Founder-name-derived default local-part, fallback "agent". Mirrors
+ * `fromLocalpart` in oneshot.ts; duplicated here to avoid an import cycle.
  */
 function defaultMailbox(founderName: string | null): string {
   const first = normalizeMailbox((founderName ?? "").trim().split(/\s+/)[0] ?? "");
@@ -159,24 +149,12 @@ function defaultMailbox(founderName: string | null): string {
 }
 
 /**
- * Add a OneShot sending identity (a wallet-owned domain + a mailbox local-part)
- * to the rotation pool. The OneShot analogue of `registerGmailIdentity`: there
- * was previously no way to put a second OneShot domain — or a second mailbox on
- * one domain — into the pool, only the single legacy `sendingDomain` config.
- *
- * Mirrors the Gmail path's invariants: the pool is materialized from legacy
- * config on first add (so existing prospect pins to the legacy sender survive),
- * and a duplicate id is a no-op. `sendingDomain` is NOT validated here against
- * the provisioned pool — callers (setup API / CLI) do that against
- * `listSendingDomains()` so this stays a pure persistence helper.
- *
- * Cap defaults, least-surprising:
- *  - neither field given → full cold-start ramp (10/day, +10/week, max 50).
- *  - `maxPerDay: <n>` → that hard ceiling, still ramping up to it (the ramp is
- *    kept unless the caller overrides `warmup`).
- *  - `maxPerDay: null` → truly uncapped — warmup is cleared too, since a ramp
- *    without a ceiling would itself re-impose one (warmupCap clamps to 50).
- *  - `warmup` always wins when explicitly provided.
+ * Add a OneShot sending identity (wallet-owned domain + mailbox local-part) to
+ * the pool. Same invariants as the Gmail path: legacy pool materialized on
+ * first add, duplicate id = no-op. `sendingDomain` is NOT validated here —
+ * callers check against `listSendingDomains()`. Caps: neither field → default
+ * ramp; `maxPerDay: n` → ceiling with ramp; `maxPerDay: null` → uncapped AND
+ * warmup cleared (a ramp would re-impose 50); explicit `warmup` always wins.
  */
 export function registerOneShotIdentity(input: {
   sendingDomain: string;
@@ -223,11 +201,9 @@ export function registerOneShotIdentity(input: {
 }
 
 /**
- * Drop an identity from the rotation pool. Materializes the pool from legacy
- * config first so a removal on a not-yet-persisted pool still takes effect.
- * Best-effort token cleanup for Gmail identities. Returns whether anything was
- * removed. NOTE: prospects already pinned to this id will refuse to send until
- * the id is restored — `resolveSenderIdentity` surfaces that loudly by design.
+ * Drop an identity from the pool (legacy pool materialized first). NOTE:
+ * prospects pinned to this id refuse to send until it's restored —
+ * `resolveSenderIdentity` surfaces that loudly by design.
  */
 export function removeIdentity(identityId: string): { removed: boolean } {
   const cfg = loadConfig();
@@ -244,12 +220,9 @@ export function removeIdentity(identityId: string): { removed: boolean } {
 }
 
 /**
- * Refresh token for a gmail identity. Identities created by `gmail auth` live
- * in the gmail-tokens.json store keyed by identity id. ONLY the legacy
- * synthetic identity may fall back to the single GMAIL_REFRESH_TOKEN secret —
- * letting any identity fall back would silently send from whatever account
- * the env token belongs to when a store entry goes missing, switching a
- * thread's From address mid-conversation.
+ * Refresh token for a gmail identity (gmail-tokens.json, keyed by id). ONLY
+ * the legacy synthetic identity may fall back to GMAIL_REFRESH_TOKEN — a
+ * general fallback could switch a thread's From address mid-conversation.
  */
 export function gmailAccountFor(
   identity: EmailIdentity,

--- a/packages/core/src/inflight.ts
+++ b/packages/core/src/inflight.ts
@@ -1,17 +1,9 @@
 /**
- * Process-wide in-flight SEND tracker, used to drain gracefully on shutdown.
- *
- * The risk this guards: a `kill`/Ctrl-C lands between "OneShot accepted the
- * send" and "we wrote the local `sequence_events` row". The dedup keys off that
- * row, so a send lost in that gap can be re-sent (a duplicate) on retry. The
- * server's shutdown handler waits for `activeSendCount()` to reach 0 before
- * exiting, so every in-flight send finishes recording first.
- *
- * In-memory by design: it complements the PERSISTED `send_started_at` /
- * `sending_started_at` markers (which survive a hard kill and are reconciled by
- * the cold-boot sweep). This counter only exists within a live process and only
- * matters for the graceful (signal) path. A hard SIGKILL skips it — the boot
- * sweep is the backstop there.
+ * Process-wide in-flight SEND tracker for graceful shutdown. A kill landing
+ * between "OneShot accepted the send" and "sequence_events row written" would
+ * dedup as unsent and re-send a duplicate — so shutdown waits for
+ * activeSendCount() to hit 0. In-memory by design: the persisted send markers
+ * + cold-boot sweep are the backstop for a hard SIGKILL.
  */
 
 let active = 0;
@@ -63,10 +55,9 @@ export function __resetInflight(): void {
 }
 
 /**
- * Poll until no sends are in-flight or `timeoutMs` elapses. Resolves
- * immediately when already idle. On timeout, returns `{ drained: false }` with
- * the count still outstanding so the caller can log it and exit anyway (the
- * boot sweep reconciles whatever was left).
+ * Poll until no sends are in-flight or `timeoutMs` elapses. On timeout returns
+ * `{ drained: false, remaining }` so the caller can log and exit anyway (the
+ * boot sweep reconciles what's left).
  */
 export async function waitForSendsToDrain(opts: {
   timeoutMs: number;

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -290,74 +290,44 @@ export class Ledger {
 
     // Lightweight migrations for installs that pre-date a column.
     this.addColumnIfMissing("prospects", "phone", "TEXT");
-    // v17 (2026-08): the profile URL the finder originally sourced this person
-    // from (GitHub / X / Luma). `linkedin_url` is polymorphic — profile-intro
-    // stores whichever social link it has there — so it can't double as a
-    // re-enrichment key. Keeping the source URL separately means a later
-    // LinkedIn lookup has a strong identifier instead of just a name.
+    // v17: source profile URL (GitHub / X / Luma) as a re-enrichment key —
+    // `linkedin_url` is polymorphic and can't serve that role.
     this.addColumnIfMissing("prospects", "source_profile_url", "TEXT");
-    // v18 (2026-08): job title at contact time, captured by the person-level
-    // ICP gate (packages/find/src/_qualify.ts). Persisted so (a) re-runs judge
-    // for free, and (b) the off-ICP audit can score history without re-buying
-    // enrichment. NULL on rows contacted before the gate existed.
+    // v18: job title at contact time (person-level ICP gate, _qualify.ts).
+    // NULL on rows contacted before the gate existed.
     this.addColumnIfMissing("prospects", "title", "TEXT");
-    // v18 (2026-08): person-level ICP verdict ('pass' | 'reject', NULL =
-    // unjudged) + the classifier's one-line reason. Written by the finder gate
-    // for new prospects and by the history audit for existing ones. The
-    // cadence step runner refuses to send follow-ups to 'reject' rows — the
-    // gate must be code-level, not prompt-level.
+    // v18: person-level ICP verdict ('pass' | 'reject', NULL = unjudged) +
+    // reason. The cadence step runner refuses follow-ups to 'reject' rows —
+    // the gate must be code-level, not prompt-level.
     this.addColumnIfMissing("prospects", "icp_verdict", "TEXT");
     this.addColumnIfMissing("prospects", "icp_verdict_reason", "TEXT");
-    // v5 (2026-04): persist trigger run-state so a server restart doesn't
-    // strand fire-and-forget runs as silent stale rows. See
-    // sweepStaleRunningTriggers + fireTriggerNow.
+    // v5: trigger run-state, so a restart doesn't strand fire-and-forget runs.
+    // See sweepStaleRunningTriggers + fireTriggerNow.
     this.addColumnIfMissing("triggers", "running_started_at", "TEXT");
-    // v6 (2026-05): persist drafts per target_queue row so the founder can
-    // review subject/body/flags after the SSE stream finishes (the /run
-    // page itself is ephemeral). See `setQueueDraft` + the persist hook in
-    // `apps/server/src/api/run.ts`.
+    // v6: persisted per-row drafts (the /run SSE stream is ephemeral).
     this.addColumnIfMissing("target_queue", "last_draft_json", "TEXT");
     this.addColumnIfMissing("target_queue", "last_drafted_at", "TEXT");
-    // v7 (2026-05): lease column for atomic drain claiming. Two concurrent
-    // /api/queue/drain calls used to see the same `approved` rows and both
-    // start sending; dequeueApproved now atomically flips this column inside
-    // a transaction so each drain sees a disjoint slice. Lease defaults to
-    // 15 min — long enough for a slow per-target SDK send, short enough that
-    // a crashed drain self-heals without a sweeper.
+    // v7: lease column — dequeueApproved flips it in a transaction so
+    // concurrent drains claim disjoint slices; 15-min lease self-heals a
+    // crashed drain.
     this.addColumnIfMissing("target_queue", "drain_claimed_at", "TEXT");
-    // v8 (2026-05): persist per-cadence next-step draft so /cadences can
-    // preview the 2nd/3rd email before firing (mirrors /queue's
-    // last_draft_json). JSON envelope = {subject, body, flags, payload,
-    // draftedAt}; cleared on cadence advance.
+    // v8: per-cadence next-step draft preview; cleared on cadence advance.
     this.addColumnIfMissing("cadence_state", "next_step_draft_json", "TEXT");
     this.addColumnIfMissing("cadence_state", "next_step_drafted_at", "TEXT");
-    // v9 (2026-06): persist "send in flight" marker so a fire-and-forget
-    // cadence-send survives a server restart. The in-memory `inFlightSends`
-    // Set was lost on every bun --watch reload, leaving the founder with no
-    // loading state AND no email delivered. Claimed via the atomic
-    // claimCadenceSendingMarker CAS update; cleared on success (inside
-    // advanceCadence) and on failure (catch). sweepStaleCadenceSends on cold
-    // boot treats every existing marker as stranded.
+    // v9: send-in-flight marker so a fire-and-forget cadence send survives a
+    // restart. CAS-claimed (claimCadenceSendingMarker); cleared on success and
+    // failure; sweepStaleCadenceSends treats cold-boot markers as stranded.
     this.addColumnIfMissing("cadence_state", "sending_started_at", "TEXT");
-    // v10 (2026-06): Mirror of v9 for the queue Send-draft path. Same bug
-    // shape — fire-and-forget background SDK send died on every server
-    // restart, leaving the founder with no UI feedback and no record. Wired
-    // via claimQueueSendingMarker + sweepStaleQueueSends; auto-cleared by
-    // setQueueStatus when the row flips to a terminal state.
+    // v10: mirror of v9 for the queue Send-draft path (claimQueueSendingMarker
+    // + sweepStaleQueueSends; cleared by setQueueStatus on terminal states).
     this.addColumnIfMissing("target_queue", "send_started_at", "TEXT");
-    // v11 (2026-06): sender rotation. `receipts.sender_identity` records which
-    // EmailIdentity (config emailIdentities[].id) sent each email.send — the
-    // per-identity daily counter + warm-up first-send date both derive from
-    // it. `sender_assignments` pins each prospect (canonical email) to the
-    // identity that sent their first touch so follow-ups never switch From
-    // address mid-thread. Keyed by email, NOT prospect_id: some sends happen
-    // before any prospect row exists (concierge prep email).
+    // v11: sender rotation. sender_identity feeds the per-identity daily
+    // counter + warm-up date; sender_assignments pins each prospect to their
+    // first-touch identity so follow-ups never switch From address mid-thread.
+    // Keyed by email, NOT prospect_id — some sends predate the prospect row.
     this.addColumnIfMissing("receipts", "sender_identity", "TEXT");
-    // v12 (2026-06): negative enrichment caching. NULL/"ok" = success row,
-    // "failed" = the enrich SDK job failed for this email — readers skip the
-    // retry within ENRICH_FAILURE_TTL_MS so drafts stop re-paying ~70s
-    // timeouts for known-bad emails (229 such failures on 2026-06-06..08
-    // left 154 queue rows re-enriching on every draft).
+    // v12: negative enrichment caching. NULL/"ok" = success, "failed" = skip
+    // retries within ENRICH_FAILURE_TTL_MS instead of re-paying ~70s timeouts.
     this.addColumnIfMissing("enrichment_cache", "status", "TEXT");
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS sender_assignments (
@@ -368,14 +338,9 @@ export class Ledger {
       CREATE INDEX IF NOT EXISTS idx_receipts_calltype_sender
         ON receipts(call_type, sender_identity, created_at);
     `);
-    // v13 (2026-06): persist inbox reply activity. The /inbox composer used to
-    // hold the draft + "replied" state only in React useState, so a refresh
-    // discarded the draft and reverted the row to a blank composer; the sent
-    // body was never stored anywhere (receipts hold metadata only). Keyed by
-    // thread_key = Gmail thread_id (else the email id) so follow-ups in a
-    // thread share one draft + sent history. `inbox_drafts` is the single
-    // mutable draft per thread (cleared on send); `inbox_sent` is the
-    // append-only history of replies actually sent (we allow replying again).
+    // v13: inbox reply persistence. thread_key = Gmail thread_id (else email
+    // id). inbox_drafts = single mutable draft per thread (cleared on send);
+    // inbox_sent = append-only history of replies actually sent.
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS inbox_drafts (
         thread_key       TEXT PRIMARY KEY,
@@ -399,21 +364,15 @@ export class Ledger {
       CREATE INDEX IF NOT EXISTS idx_inbox_sent_thread
         ON inbox_sent(thread_key, sent_at);
     `);
-    // v14 (2026-06): persist the last cadence send FAILURE so the /cadences row
-    // can show "send failed · retrying" instead of looking identical to a row
-    // that's merely waiting on the founder. A failed send doesn't advance the
-    // cadence, so without this the founder can't tell "blocked upstream" from
-    // "waiting on me". Set by recordCadenceSendError on a dispatch throw;
-    // cleared by advanceCadence / setCadenceStatus on any forward progress.
+    // v14: last cadence send FAILURE, so /cadences can distinguish "blocked
+    // upstream" from "waiting on the founder". Set by recordCadenceSendError;
+    // cleared on any forward progress.
     this.addColumnIfMissing("cadence_state", "last_send_error", "TEXT");
     this.addColumnIfMissing("cadence_state", "last_send_error_at", "TEXT");
-    // v15 (2026-06): persist candidates whose paid contact-resolution failed on
-    // a TRANSIENT platform error (the OneShot outage), so a finder doesn't lose
-    // them — re-scannable finders self-heal, but time-windowed ones (luma,
-    // show-hn) can't re-discover an expired source. `raw_json` holds whatever
-    // the finder's registered handler needs to re-resolve + enqueue. The
-    // scheduler retry pass drains this once the platform recovers; the
-    // (play_name, dedupe_key) PK also serves as the de-dup key against re-scan.
+    // v15: candidates whose contact-resolution failed on a TRANSIENT platform
+    // error. Time-windowed finders (luma, show-hn) can't re-discover an expired
+    // source, so the scheduler retry pass drains this; the (play_name,
+    // dedupe_key) PK doubles as the de-dup key against re-scan.
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS pending_resolution (
         play_name       TEXT NOT NULL,
@@ -428,15 +387,11 @@ export class Ledger {
       CREATE INDEX IF NOT EXISTS idx_pending_resolution_seen
         ON pending_resolution(first_seen_at);
     `);
-    // v16 (2026-06): receipt annotation. memo + decision_context mirror the
-    // audit fields already sent to OneShot at call time (buildAuditOpts), stored
-    // locally so the /receipts UI can show "why" without re-fetching the signed
-    // receipt. value_tag (+ value_tagged_at) hold the RoCS outcome value set by
-    // tagOutcomeValue once a reply/deal lands (also PATCHed to OneShot via
-    // tagReceiptValue). sequence_events.receipt_id links a sent step back to its
-    // send receipt so an outcome knows which receipts to tag — SDK 0.21's
-    // tagReceiptValue({requestId}) then resolves each via the stored request_id,
-    // so no platform receipt-id backfill is needed.
+    // v16: receipt annotation. memo + decision_context mirror the audit fields
+    // sent to OneShot at call time; value_tag(_at) hold the outcome value set
+    // by tagOutcomeValue. sequence_events.receipt_id links a sent step to its
+    // send receipt so outcomes know which receipts to tag (resolved upstream
+    // via request_id — no platform receipt-id backfill needed).
     this.addColumnIfMissing("receipts", "memo", "TEXT");
     this.addColumnIfMissing("receipts", "decision_context", "TEXT");
     this.addColumnIfMissing("receipts", "value_tag", "TEXT");
@@ -447,23 +402,16 @@ export class Ledger {
       CREATE INDEX IF NOT EXISTS idx_receipts_value_tag
         ON receipts(value_tag, created_at) WHERE value_tag IS NOT NULL;
     `);
-    // v17 (2026-06): goal-level value attribution (SDK 0.22). goal_id mirrors the
-    // cadence correlation key sent as decisionContext.goalId, so an outcome tags
-    // every receipt in the cadence at once (setReceiptValueTagByGoal) instead of
-    // walking sequence_events.receipt_id per receipt.
+    // v17: goal-level value attribution — goal_id mirrors decisionContext.goalId
+    // so an outcome tags every receipt in the cadence at once.
     this.addColumnIfMissing("receipts", "goal_id", "TEXT");
     this.db.exec(`
       CREATE INDEX IF NOT EXISTS idx_receipts_goal
         ON receipts(goal_id) WHERE goal_id IS NOT NULL;
     `);
-    // v18 (2026-08): delivery failures parsed from DSNs. Until now nothing ever
-    // wrote sequence_events.status='bounced' — the tool kept emailing addresses
-    // the receiving server had already refused, paying for each send and burning
-    // sending reputation, while the evidence sat unread in the mailbox.
-    // PK is (message_id, recipient): the DSN's own provider id makes a re-sweep
-    // idempotent (the sweep runs on every scheduler tick and re-sees the same
-    // 30-day window), and the recipient column keeps a multi-recipient report
-    // from collapsing into one row.
+    // v18: delivery failures parsed from DSNs. PK (message_id, recipient):
+    // the provider's message id makes the every-tick re-sweep idempotent, and
+    // recipient keeps multi-recipient reports from collapsing into one row.
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS bounces (
         message_id  TEXT NOT NULL,
@@ -482,11 +430,8 @@ export class Ledger {
       -- suppressionFor, on the send pre-flight path — must be an index seek.
       CREATE INDEX IF NOT EXISTS idx_bounces_recipient ON bounces(recipient, kind);
     `);
-    // v19 (2026-08): inbox-placement canary results. Bounces tell you a message
-    // was refused; nothing told you it was ACCEPTED and then filtered into spam
-    // or a tab, which for cold outreach is the same as never arriving. Each row
-    // is one manual A→B test. Append-only history so a reputation trend is
-    // visible rather than just the latest verdict.
+    // v19: inbox-placement canary results — one row per manual A→B test.
+    // Append-only so the reputation trend stays visible.
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS canary_results (
         id            INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -505,13 +450,9 @@ export class Ledger {
       );
       CREATE INDEX IF NOT EXISTS idx_canary_created ON canary_results(created_at DESC);
     `);
-    // v20 (2026-08): reply-poll watermark. The inbox poll used to fetch a bare
-    // newest-50 window across every mailbox with no memory of what it had
-    // already examined, so any reply that slipped out of that window between
-    // ticks (one noisy mailbox was enough) was never seen again. A persisted
-    // high-water mark turns the poll into "everything since last success" —
-    // survives restarts, and a failed tick simply leaves the mark where it was
-    // so the next good poll re-covers the gap.
+    // v20: reply-poll watermark — persisted high-water mark makes the inbox
+    // poll "everything since last success"; a failed tick leaves the mark in
+    // place so the next good poll re-covers the gap.
     this.db.exec(`
       CREATE TABLE IF NOT EXISTS poll_state (
         key        TEXT PRIMARY KEY,
@@ -522,17 +463,10 @@ export class Ledger {
   }
 
   /**
-   * CAS-claim a timestamp marker on a single row. Returns true when the row's
-   * marker was NULL (or older than `staleCutoffIso` when provided) and we set
-   * it to `startedAtIso`; false when another caller already holds the claim.
-   *
-   * Shared by every in-flight marker in the ledger: triggers.running_started_at,
-   * cadence_state.sending_started_at, target_queue.send_started_at. Each domain
-   * just supplies its own table + primary-key WHERE fragment.
-   *
-   * Identifier validation (table + column) mirrors `addColumnIfMissing` —
-   * SQLite has no parameter binding for table/column names, so we whitelist
-   * to bare ASCII to slam the door on any injection vector.
+   * CAS-claim a timestamp marker on a single row: true when the marker was
+   * NULL (or older than `staleCutoffIso`) and was set; false when another
+   * caller holds the claim. Shared by every in-flight marker in the ledger.
+   * Table/column names are whitelisted to bare ASCII (SQLite can't bind them).
    */
   private claimMarker(opts: {
     table: string;
@@ -910,16 +844,9 @@ export class Ledger {
   }
 
   /**
-   * Atomic claim of the sending marker. Returns `true` when the row had a
-   * NULL `sending_started_at` and the marker was set; `false` if another
-   * caller already holds the claim. Mirrors triggers' `markTriggerRunning`
-   * CAS pattern so two concurrent Send clicks can't double-fire.
-   *
-   * `staleCutoffIso` (optional): allows a fresh click to reclaim a marker
-   * whose `sending_started_at` is older than the cutoff — for the case where
-   * a previous send was stranded by a server restart and the cold-boot
-   * sweeper hasn't cleared it yet. Without this, the row would 409 every
-   * retry until the next boot sweep.
+   * Atomic CAS claim of the sending marker — two concurrent Send clicks can't
+   * double-fire. `staleCutoffIso` lets a fresh click reclaim a marker stranded
+   * by a restart before the cold-boot sweep (else the row 409s until reboot).
    */
   claimCadenceSendingMarker(input: {
     prospectId: number;
@@ -948,17 +875,11 @@ export class Ledger {
   }
 
   /**
-   * Sweep cadence rows whose `sending_started_at` is older than the cutoff
-   * (or any non-null value when `staleAgeMs` is 0 — cold-boot semantics).
-   * For each match, classify by whether a `sequence_events` row for the
-   * (prospect, play, current_step) already exists:
-   *   - event present → the send actually went out; clear the marker only.
-   *   - event absent  → the send was stranded (server died mid-call); clear
-   *     the marker but leave the draft so the founder can re-click Send.
-   * Returns the swept rows so the caller can log them.
-   *
-   * Pure-ish (takes `now` + `maxAgeMs` as args) — tests can drive both
-   * "fresh markers spared" and "stale markers swept" without faking the clock.
+   * Sweep stale `sending_started_at` markers (any non-null value when
+   * `staleAgeMs` is 0 — cold-boot semantics). A matching sequence_event means
+   * the send went out: clear the marker only; no event means it was stranded:
+   * clear the marker but keep the draft. Returns swept rows; takes `now` +
+   * `maxAgeMs` as args so tests don't fake the clock.
    */
   sweepStaleCadenceSends(input: { now: Date; maxAgeMs: number }): Array<{
     prospectId: number;
@@ -1048,12 +969,10 @@ export class Ledger {
   }
 
   /**
-   * Paid-lookup caches live in the cross-workspace SHARED DB (shared-db.ts):
-   * the same person researched for one product must not be bought again for
-   * another. These methods keep their original contracts and delegate, so the
-   * five call sites and their tests are untouched. On first use per ledger the
-   * legacy rows in THIS ledger's cache tables are copied across once; the
-   * local tables stay in place (unwritten) for rollback.
+   * Paid-lookup caches live in the cross-workspace SHARED DB (shared-db.ts) —
+   * the same person must never be bought twice across products. These methods
+   * keep their contracts and delegate; this ledger's legacy cache rows are
+   * copied across once on first use.
    */
   private shared(): ReturnType<typeof getSharedDb> {
     const shared = getSharedDb();
@@ -1217,12 +1136,9 @@ export class Ledger {
   }
 
   /**
-   * Record one delivery failure. INSERT OR IGNORE against the (message_id,
-   * recipient) PK: the sweep re-reads a 30-day window on every tick, so the
-   * same DSN is re-seen dozens of times and must only ever count once.
-   * Returns true when this was a NEW bounce — callers use that to decide
-   * whether to act on the cadence (stopping it repeatedly is harmless, but
-   * re-tagging receipts and logging on every tick is not).
+   * Record one delivery failure. INSERT OR IGNORE on (message_id, recipient):
+   * the sweep re-sees the same DSN every tick and it must count once. Returns
+   * true only for a NEW bounce — callers gate receipt-tagging/logging on that.
    */
   recordBounce(input: {
     messageId: string;
@@ -1356,17 +1272,10 @@ export class Ledger {
   ): { subject: string; body: string; playName: string } | null {
     const rows = this.db
       .query(
-        // All three statuses mean "this email was sent": a step is written as
-        // 'sent' and later UPDATEd in place to 'replied' by markLatestStepReplied
-        // (same convention as eventsByPlay). Matching only 'sent' would skip the
-        // copy of every prospect who answered — precisely the best-performing
-        // copy, and the canary would silently replay something older or nothing.
-        // Usability is filtered in SQL, not by scanning a fixed slice in JS.
-        // A slice can be exhausted by a run of pre-v8 / bodyless rows and then
-        // report "no copy" while perfectly good copy sits just past the cut —
-        // but dropping the bound entirely would load every send ever made to
-        // find one body. Letting SQLite discard the unusable rows means the
-        // small bound below only ever trims genuinely valid candidates.
+        // 'sent' rows are UPDATEd in place to 'replied', so all three statuses
+        // mean "sent" — matching only 'sent' would skip every prospect who
+        // answered. Usability is filtered in SQL (not a JS slice) so the small
+        // bound below only ever trims genuinely valid candidates.
         `SELECT play_name, metadata_json FROM sequence_events
          WHERE status IN ('sent', 'delivered', 'replied')
            AND channel = 'email' AND metadata_json IS NOT NULL
@@ -1451,18 +1360,10 @@ export class Ledger {
   }
 
   /**
-   * Fill in identity fields that are currently NULL on an existing prospect.
-   *
-   * `upsertProspect` is insert-or-return-existing: once a row exists it never
-   * writes again, so a prospect created without a LinkedIn URL could never
-   * acquire one. This is the only path that backfills those columns.
-   *
-   * COALESCE semantics on purpose — a backfill must never clobber a URL a
-   * finder already resolved from an authoritative source (a real Luma handle
-   * beats a fuzzy web-search hit). Passing `undefined`/`null` leaves the column
-   * untouched.
-   *
-   * Returns true when at least one column actually changed.
+   * Backfill identity columns that are NULL on an existing prospect — the only
+   * such path (`upsertProspect` never writes twice). COALESCE on purpose: a
+   * backfill must never clobber a URL a finder already resolved, and
+   * `undefined`/`null` leaves the column untouched. True when a column changed.
    */
   updateProspectIdentity(
     id: number,
@@ -1512,15 +1413,9 @@ export class Ledger {
   }
 
   /**
-   * Prospects that could take a LinkedIn URL but don't have one.
-   *
-   * Only rows whose `linkedin_url` is genuinely empty are returned. A row
-   * already holding a GitHub/X URL (profile-intro writes those into the same
-   * column) is deliberately skipped: `updateProspectIdentity` won't overwrite
-   * it, so including them would just report phantom candidates.
-   *
-   * A name is required — the lookup searches by name, so a nameless row has
-   * nothing to go on.
+   * Prospects that could take a LinkedIn URL but don't have one. Rows already
+   * holding a GitHub/X URL in `linkedin_url` are skipped (updateProspectIdentity
+   * won't overwrite them); a name is required — the lookup searches by name.
    */
   listProspectsMissingLinkedIn(opts: { limit?: number; play?: string } = {}): Array<{
     id: number;
@@ -1754,12 +1649,10 @@ export class Ledger {
   }
 
   /**
-   * True when a (prospect, play, step) already has a terminal-sent sequence_event
-   * — i.e. that step's email/SMS/voice already went out. Used by the cadence
-   * engine as a pre-dispatch guard so a crash between `recordSequenceEvent` and
-   * `advanceCadence` (which leaves `current_step` lagging the sent step) can't
-   * cause a re-send on the next due tick. Same status predicate as the stale-send
-   * sweep below.
+   * True when a (prospect, play, step) already has a terminal-sent
+   * sequence_event. Pre-dispatch guard: a crash between recordSequenceEvent
+   * and advanceCadence leaves current_step lagging the sent step — this stops
+   * the re-send on the next due tick.
    */
   hasSentSequenceEvent(prospectId: number, playName: string, stepIndex: number): boolean {
     return (
@@ -1775,16 +1668,10 @@ export class Ledger {
   }
 
   /**
-   * Mark a prospect's latest sent step `replied` (the reply-rate signal behind
-   * the home dashboard + measure/CAC, which all read `status='replied'` from
-   * sequence_events — nothing else writes it). A reply is modelled as a state
-   * transition of an existing sent step, NOT a new event, so `sent` counts that
-   * read `status IN ('sent','delivered','replied')` stay correct.
-   *
-   * Idempotent and safe to call on every poll: the `NOT EXISTS` guard means once
-   * any step for this (prospect, play) is `replied`, further calls are no-ops —
-   * so it never walks backwards marking earlier steps too. Returns true on the
-   * one call that flips a row.
+   * Mark the latest sent step `replied` — a state transition of the existing
+   * step, NOT a new event, so `sent` counts stay correct. Idempotent per
+   * (prospect, play) via the NOT EXISTS guard; returns true on the one call
+   * that flips a row.
    */
   markLatestStepReplied(input: { prospectId: number; playName: string }): boolean {
     const result = this.db
@@ -1806,28 +1693,15 @@ export class Ledger {
   }
 
   /**
-   * Single source of truth for "a prospect replied to a cadence". Atomically
-   * writes BOTH planes so they can't drift:
-   *  - control plane: `cadence_state.status='replied'` (stops further sends), and
-   *  - analytics plane: the latest sent step → `replied` in sequence_events
-   *    (the event log behind every reply metric — home, CAC, weekly review).
-   * The two surfaces read different tables on purpose (a lifetime status snapshot
-   * vs a 7-day count), but a reply now updates them together in one transaction.
-   *
-   * The two planes are gated SEPARATELY, because they answer different questions.
-   * Control plane is conservative: only a live cadence (`active`, or `paused` —
-   * a pause that resumes must not email someone who already answered) flips to
-   * `replied`, so a terminal `breakup`/`completed` sequence is never resurrected
-   * and a stopped cadence stays stopped. Analytics plane is unconditional: a reply is a fact
-   * about the outbound whatever the sequence did afterwards, so the event is
-   * recorded for ANY status. Gating them together is what made 424 of 457
-   * cadences invisible to reply metrics — a reply arriving after a sequence
-   * finished (the common case, since most cadences complete) was silently dropped.
-   *
-   * Returns both signals: `newlyReplied` marks the active→replied control
-   * transition, `eventRecorded` marks the one call that flipped a sequence_event
-   * row. Count replies on `eventRecorded` — `markLatestStepReplied` is idempotent
-   * per (prospect, play), so it is true exactly once no matter how often we poll.
+   * Single source of truth for "a prospect replied to a cadence" — writes both
+   * planes in one transaction so they can't drift. Control plane
+   * (`cadence_state.status='replied'`) is conservative: only a live cadence
+   * (`active`/`paused`) flips, so a terminal sequence is never resurrected.
+   * Analytics plane (sequence_events) is unconditional: the event is recorded
+   * for ANY status — gating the two together silently drops replies that
+   * arrive after a sequence finishes. Count replies on `eventRecorded` (true
+   * exactly once per (prospect, play)); `newlyReplied` marks the control
+   * transition.
    */
   recordCadenceReply(input: { prospectId: number; playName: string }): {
     newlyReplied: boolean;
@@ -1852,17 +1726,11 @@ export class Ledger {
   }
 
   /**
-   * Record a reply from a prospect. The inbox poll matches on from-address,
-   * which says nothing about plays, so this is the one place that decides what
-   * a reply means — and the two planes want different answers:
-   *  - control: EVERY live cadence for the prospect stops. Whatever they replied
-   *    to, nobody should keep getting follow-ups after answering.
-   *  - analytics: the reply is credited to ONE play — the one whose sent subject
-   *    the reply threads on (`Re: …`), else the most recent play that emailed
-   *    them. Crediting every play would count one reply several times in the
-   *    per-play rate; crediting none (the old behaviour for one-touch plays like
-   *    luma-events, which never enroll a cadence) dropped it on the floor.
-   * Returns one entry per play touched, so callers can count and tag.
+   * Record a reply. Control: EVERY live cadence for the prospect stops —
+   * nobody keeps getting follow-ups after answering. Analytics: the reply is
+   * credited to exactly ONE play — the one whose sent subject it threads on
+   * (`Re: …`), else the most recent play that emailed them. Returns one entry
+   * per play touched.
    */
   recordProspectReply(
     prospectId: number,
@@ -1955,14 +1823,9 @@ export class Ledger {
   }
 
   /**
-   * Bulk variant of listSequenceEventsForProspectPlay: one SQL round-trip for
-   * many (prospect_id, play_name) pairs. Returns a Map keyed by
-   * `${prospect_id}|${play_name}` so callers can index in O(1). The
-   * per-key arrays preserve the same (step_index ASC, id ASC) ordering the
-   * single-row method returns. Empty input → empty map (no query).
-   *
-   * Index-served by idx_sequence_events_prospect_play; the OR-chain is
-   * expanded into per-pair index seeks by the query planner.
+   * Bulk variant of listSequenceEventsForProspectPlay: one round-trip, Map
+   * keyed `${prospect_id}|${play_name}`, same (step_index ASC, id ASC)
+   * ordering. Index-served by idx_sequence_events_prospect_play.
    */
   listSequenceEventsForCadences(
     pairs: ReadonlyArray<{ prospectId: number; playName: string }>,
@@ -2218,12 +2081,9 @@ export class Ledger {
   }
 
   /**
-   * Cross-play dedup (finder side): is this email already sitting in a
-   * non-terminal queue row under ANY play? Catches the window where the same
-   * person is queued under two plays before either has sent (so no prospect row
-   * exists yet for findProspectByEmail to catch). Terminal rows
-   * (sent/rejected/expired) are excluded so they never block future work.
-   * Matches both `email` (most plays) and `founderEmail` (show-hn-style).
+   * Cross-play dedup (finder side): is this email in a non-terminal queue row
+   * under ANY play? Catches the window before either play has sent (no
+   * prospect row exists yet). Matches both `email` and `founderEmail`.
    */
   isEmailPendingInQueue(email: string): boolean {
     // Case-insensitive to match findProspectByEmail/upsertProspect, which store
@@ -2431,12 +2291,9 @@ export class Ledger {
   }
 
   /**
-   * Atomic claim-and-return. SELECTs approved rows whose lease has expired
-   * (or was never set) and UPDATEs their `drain_claimed_at` inside a single
-   * transaction so two concurrent drains can't return overlapping row sets.
-   * Default lease: 15 min — a crashed drain's claims self-heal after that
-   * without any sweeper. Held/error rows naturally back off for the lease
-   * duration (no LLM-burn loops on stuck-flagged content).
+   * Atomic claim-and-return: SELECT + `drain_claimed_at` UPDATE in one
+   * transaction so concurrent drains can't overlap. 15-min lease self-heals a
+   * crashed drain; held/error rows back off for the lease duration.
    */
   dequeueApproved(opts: { playName: string; limit?: number; leaseSeconds?: number }): QueueRow[] {
     const leaseSeconds = opts.leaseSeconds ?? 900;
@@ -2513,14 +2370,9 @@ export class Ledger {
   }
 
   // ── runs (per-/run-page dispatch records) ──────────────────────────────────
-  //
-  // Each click of the /run page's Execute CTA creates one `runs` row. The SSE
-  // endpoint persists every draft / send / error event to the row's
-  // `events_json` and updates counters atomically. The UI reads this row to
-  // rebuild progress on nav-back, and inspects `status` to decide whether to
-  // poll (running) or stop (done / interrupted). Cold-boot sweep flips any
-  // stranded `running` rows to `interrupted` so the founder sees the truth
-  // instead of an eternal spinner.
+  // One row per /run Execute click; the SSE endpoint persists events/counters,
+  // the UI rebuilds progress from the row, and the cold-boot sweep flips
+  // stranded `running` rows to `interrupted`.
 
   createRun(input: { playName: string; dryRun: boolean; targets: unknown[] }): {
     runId: number;
@@ -2785,24 +2637,11 @@ export class Ledger {
   }
 
   /**
-   * Atomic claim: marks a trigger as in-flight ONLY if it's not already
-   * running. Returns true when the claim succeeded (caller may proceed to
-   * fire), false when another caller already holds the slot.
-   *
-   * The conditional UPDATE closes the TOCTOU race that would otherwise let
-   * two concurrent `fireTriggerNow` calls both pass an `isTriggerRunning()`
-   * check, both write, both fire — burning real $ on duplicate API spend.
-   * SQLite serializes writes per process, so the second UPDATE's `changes`
-   * count is 0.
-   *
-   * `staleCutoffIso` (optional): when provided, the claim ALSO succeeds if
-   * the existing `running_started_at` is older than the cutoff — a stale
-   * marker (process killed, never cleared, freshness gate already says "not
-   * running"). Without this, a 4h-stale row would 409 every retry until
-   * the next cold-boot sweep, leaving the founder stuck.
-   *
-   * Cleared by `updateTriggerLastPoll` on completion or by
-   * `sweepStaleRunningTriggers` on the next cold boot.
+   * Atomic claim: marks a trigger in-flight only if not already running — the
+   * conditional UPDATE closes the TOCTOU race where two fireTriggerNow calls
+   * both fire and double-spend. `staleCutoffIso` also lets the claim succeed
+   * over a stale marker so a dead row doesn't 409 until the next cold boot.
+   * Cleared by updateTriggerLastPoll or sweepStaleRunningTriggers.
    */
   markTriggerRunning(name: string, startedAtIso: string, staleCutoffIso?: string): boolean {
     return this.claimMarker({
@@ -2816,14 +2655,9 @@ export class Ledger {
   }
 
   /**
-   * Sweep trigger rows whose `running_started_at` is older than `maxAgeMs`.
-   * For each match, write a `last_run_summary = { error: "killed_by_restart",
-   * at }` and clear the in-flight flag. Returns the swept rows so the caller
-   * can log them.
-   *
-   * Pure-ish (takes `now` + `maxAgeMs` as args) so tests can drive both
-   * "fresh entries are spared" and "stale entries are swept" without
-   * faking the system clock.
+   * Sweep stale `running_started_at` rows: write `{error:"killed_by_restart"}`
+   * and clear the in-flight flag; returns swept rows. Takes `now` + `maxAgeMs`
+   * as args so tests don't fake the clock.
    */
   sweepStaleRunningTriggers(input: {
     now: Date;
@@ -2890,15 +2724,9 @@ export class Ledger {
   }
 
   /**
-   * Persist the most-recent draft generated for this queue row. Called by
-   * the SSE /run endpoint after the play returns drafted output, so the
-   * founder can review subject/body/flags on /queue at any later time
-   * (the /run page itself is ephemeral).
-   *
-   * Most-recent-wins — re-runs overwrite without history. `last_drafted_at`
-   * is stored as ISO so it sorts/compares cleanly with the rest of the
-   * timestamp columns; the JSON envelope also embeds `draftedAt` for
-   * callers that already have the row payload.
+   * Persist the most-recent draft for this queue row (the /run page is
+   * ephemeral; /queue reviews from here). Most-recent-wins — re-runs
+   * overwrite without history.
    */
   setQueueDraft(input: {
     id: number;
@@ -2920,12 +2748,9 @@ export class Ledger {
   }
 
   /**
-   * Overwrite a queue row's `payload_json` (the per-target JSON the play
-   * drafts from). Used by the manual add-prospect flow: the row is enqueued
-   * immediately as a placeholder, then — once the async dossier research
-   * completes — its payload is rewritten to the full ProfileIntroTarget
-   * (identity + dossier + angle) so `/queue` regenerate re-drafts from the
-   * researched dossier instead of paying for research again.
+   * Overwrite a queue row's `payload_json`. Manual add-prospect flow: the row
+   * is enqueued as a placeholder, then rewritten with the researched dossier
+   * so regenerate re-drafts without paying for research again.
    */
   updateQueuePayload(input: { id: number; payload: unknown }): void {
     this.db

--- a/packages/core/src/oneshot.ts
+++ b/packages/core/src/oneshot.ts
@@ -162,15 +162,10 @@ async function getAgent(): Promise<OneShot> {
 }
 
 /**
- * The wallet's provisioned sending-domain pool (SDK 0.19+ `listDomains`), used
- * to validate a `sendingDomain` is wallet-owned BEFORE a live send 403s with
- * `domain_not_owned`, and to populate the domain picker in setup.
- *
- * Transient-tolerant by design: a brief OneShot/transport outage returns `[]`
- * ("couldn't enumerate") so it never blocks the founder from saving an identity
- * — callers must treat an empty list as "unknown", not "no domains owned".
- * Genuine auth failures (bad/absent wallet creds) DO propagate, since those are
- * a real config error the founder needs to see.
+ * The wallet's provisioned sending-domain pool — validates a `sendingDomain`
+ * is wallet-owned before a live send 403s. Transient outages return `[]`:
+ * callers must treat an empty list as "unknown", not "no domains owned".
+ * Genuine auth failures DO propagate (a real config error).
  */
 export async function listSendingDomains(): Promise<DomainPoolEntry[]> {
   // Demo mode: read-only fixture, before any agent construction (see demo.ts).
@@ -228,12 +223,10 @@ export function fromLocalpart(name: string | null): string {
 }
 
 /**
- * Stable Idempotency-Key for a OneShot email send (SDK 0.19+, honored by
- * email.send with a 24h replay window). Derived from the send's content so a
- * retry of the SAME logical email — a double-click, or a client retry after
- * the platform hung but actually sent — returns the original job instead of
- * charging + sending twice. A genuinely different body/subject hashes
- * differently, so it gets its own key (the server 422s same-key-different-body).
+ * Stable Idempotency-Key for a OneShot email send (24h replay window),
+ * derived from content: a retry of the SAME logical email returns the
+ * original job instead of charging + sending twice; a different body/subject
+ * hashes to its own key (the server 422s same-key-different-body).
  */
 function emailIdempotencyKey(parts: Array<string>): string {
   // NUL separator: it can't appear in an email address, identity id, subject,
@@ -313,12 +306,9 @@ async function sendEmailViaGmail(input: SendEmailInput, ctx: CallContext, identi
 }
 
 /**
- * Smartlead-path send. Same return contract as the Gmail path: cost 0 (the
- * Smartlead subscription is out-of-band), Smartlead's message id as request
- * id (which also dedupes receipt re-records). Smartlead documents no
- * idempotency mechanism, so — like Gmail — a timeout-then-retry can
- * double-send; the OneShot path is the only transport with a true
- * idempotency key.
+ * Smartlead-path send. Same contract as Gmail: cost 0, Smartlead's message id
+ * as request id. No idempotency mechanism — a timeout-then-retry can
+ * double-send; OneShot is the only transport with a true idempotency key.
  */
 async function sendEmailViaSmartlead(
   input: SendEmailInput,
@@ -437,16 +427,11 @@ async function dispatchEmail(input: SendEmailInput, ctx: CallContext) {
 }
 
 /**
- * Every outbound email funnels through here (plays, cadence, queue, concierge,
- * pmf-survey). Order matters:
- *   1. hard-bounce suppression (in dispatchEmail) — permanent, never overridable;
- *   2. the cross-workspace claim — ATOMIC check-and-reserve in the shared DB,
- *      before any routing or network, so two workspaces can't both pass;
- *   3. dispatch; then the reservation is confirmed (success) or released
- *      (any failure), so a failed send never counts as a touch and a crash
- *      mid-send expires on its own.
- * `replyEmail` is deliberately not gated — a reply goes to someone who just
- * wrote to us — it only records its touch.
+ * Every outbound email funnels through here. Order matters: 1. hard-bounce
+ * suppression (permanent, never overridable); 2. the ATOMIC cross-workspace
+ * claim, before any routing or network; 3. dispatch, then confirm (success)
+ * or release (failure) — a failed send never counts as a touch. `replyEmail`
+ * is deliberately not gated; it only records its touch.
  */
 export async function sendEmail(input: SendEmailInput, ctx: CallContext) {
   const claim = claimContactTouch({
@@ -493,15 +478,12 @@ export function replySubject(subject: string): string {
 }
 
 /**
- * Reply to an inbound email from the identity whose mailbox received it.
- * Deliberately NOT routed through sender rotation (resolveSenderIdentity): a
- * reply must keep the thread's From address, and replies to engaged humans
- * shouldn't be deferred by warmup caps. Receipts use callType "email.reply",
- * which also keeps them out of per-identity cap counting (email.send only).
- * Both transports thread for real: Gmail via threadId + In-Reply-To/References
- * on the raw message; OneShot via `reply_to_email_id` (SDK 0.19+ — the
- * platform resolves the threading headers + thread_id server-side). The
- * OneShot send also carries an idempotency key so a retry can't double-send.
+ * Reply to an inbound email from the identity whose mailbox received it —
+ * deliberately NOT sender-rotated: a reply must keep the thread's From
+ * address and must not be deferred by warmup caps (callType "email.reply"
+ * stays out of per-identity cap counting). Both transports thread for real
+ * (Gmail: threadId + In-Reply-To/References; OneShot: reply_to_email_id),
+ * and the OneShot send carries an idempotency key.
  */
 export async function replyEmail(input: ReplyEmailInput, ctx: CallContext) {
   const cfg = loadConfig();
@@ -800,11 +782,8 @@ export interface AnnotatedInboxListResult extends InboxListResult {
 
 /**
  * Ensure an inbound email has a readable `body`, falling back to a de-tagged
- * `body_html`. The OneShot inbox returns both fields, and an HTML-only mail
- * (the normal shape for replies to our HTML-only sends) has an empty `body` —
- * nothing in the pipeline read `body_html`, so /inbox rendered "(no body)" and
- * triage prompted the LLM with nothing. Applied in the annotate funnel so
- * EVERY consumer of listInbox benefits, not just the dashboard route.
+ * `body_html` (HTML-only mail is the normal shape for replies to our sends).
+ * Applied in the annotate funnel so EVERY listInbox consumer benefits.
  * Exported for tests.
  */
 export function fillInboxBody(e: InboxEmail): InboxEmail {
@@ -822,13 +801,10 @@ function annotateInboxResult(r: InboxListResult, identityId: string): AnnotatedI
 }
 
 /**
- * Replies across the WHOLE sender pool: the OneShot inbox (once, if any
- * oneshot identity exists) merged with every authorized Gmail account.
- * Stop-on-reply must see a reply no matter which identity sent the thread.
- * With multiple sources each is fetched under its own try/catch — one
- * revoked Gmail token must not blind reply detection for everything else.
- * A single source keeps legacy throw semantics (the /inbox route maps a
- * throw to its "couldn't reach the inbox" state).
+ * Replies across the WHOLE sender pool (OneShot inbox + every Gmail account):
+ * stop-on-reply must see a reply whichever identity sent the thread. Each
+ * source has its own try/catch — one revoked token must not blind the rest —
+ * but a single source keeps legacy throw semantics for the /inbox route.
  */
 export async function listInbox(opts?: {
   since?: string;
@@ -955,18 +931,12 @@ export interface IdentityBounce extends GmailBounce {
 }
 
 /**
- * Delivery failures across the whole sender pool. Gmail identities only: a DSN
- * comes back to the envelope sender, and for OneShot sends that return path
- * belongs to the platform, not to us — nothing surfaces in its inbox API.
- *
- * Attribution is free and exact: the mailbox that RECEIVED the bounce is the
- * mailbox that sent the message, so no join back through sender_assignments is
- * needed to know whose reputation this counts against.
- *
- * Per-source try/catch like listInbox — one revoked Gmail token must not blind
- * bounce detection for every other identity. Unlike listInbox this NEVER throws
- * on total failure: it runs on a background sweep where the only sane response
- * to "no sources answered" is to report nothing and retry next tick.
+ * Delivery failures across the sender pool. Gmail identities only — a DSN
+ * returns to the envelope sender, and OneShot's return path belongs to the
+ * platform. The receiving mailbox IS the sending mailbox, so attribution
+ * needs no join. Per-source try/catch, and unlike listInbox this NEVER
+ * throws on total failure — it runs on a background sweep; report nothing
+ * and retry next tick.
  */
 export async function listBounces(opts?: {
   since?: string;
@@ -1289,16 +1259,11 @@ export async function cadenceRocs(opts: { periodDays?: number } = {}): Promise<C
 }
 
 /**
- * Tag a cadence's value once its outcome (reply / meeting / deal) is known.
- * Resolves the cadence correlation key from (prospect, play), records the value
- * to OneShot in ONE call via `tagReceiptValue({goalId})` (SDK 0.22 fans it out
- * across the goal's receipts, recorded once so it can't double-count), and
- * mirrors the tag onto the local receipts for the /receipts UI. Best-effort —
- * any failure is logged and swallowed so it never breaks the triggering flow.
- *
- * A precedence/dedup guard skips an identical re-tag (avoids a duplicate platform
- * outcome) and never downgrades a higher-value tag (e.g. a reply detected AFTER a
- * deal is logged must not overwrite `revenue` with `engagement`).
+ * Tag a cadence's value once its outcome is known: one `tagReceiptValue({goalId})`
+ * call fans out across the goal's receipts, mirrored locally for /receipts.
+ * Best-effort — failures are logged and swallowed. The precedence/dedup guard
+ * skips identical re-tags and never downgrades a higher-value tag (a late
+ * reply must not overwrite `revenue` with `engagement`).
  */
 export async function tagOutcomeValue(input: {
   prospectId: number;

--- a/packages/core/src/parallel.ts
+++ b/packages/core/src/parallel.ts
@@ -1,21 +1,12 @@
 /**
- * Run `fn` over `items` with at most `concurrency` Promises in flight at once.
- * Preserves input order in the result array. Errors propagate via Promise.all
- * — caller is expected to catch per-item internally if partial success matters.
- *
- * Worker-pool implementation: spawn `concurrency` workers that pull from a
- * shared cursor. Cheaper than a chunked Promise.all (which stalls on the
- * slowest item per chunk) and avoids the dependency surface of p-limit.
- *
- * Lives in core so both `find` (candidate pipelines) and `plays` (batch send
- * loops) can share it without a cross-package dependency.
+ * Concurrency helpers shared by `find` and `plays`. `parallelMap` runs `fn`
+ * over `items` with at most `concurrency` in flight, preserving input order;
+ * errors propagate via Promise.all — catch per-item if partial success matters.
  */
 /**
- * Bound a promise to `ms`. On deadline: rejects with `<label> deadline
- * exceeded` — the underlying promise keeps running (callers that care attach
- * their own late-settle handlers; an abandoned SDK job is harmless). Guards
- * against platform endpoints that hang instead of failing (observed on both
- * the inbox and enrichment tools 2026-06).
+ * Bound a promise to `ms`. On deadline rejects with `<label> deadline
+ * exceeded` while the underlying promise keeps running. Guards against
+ * endpoints that hang instead of failing.
  */
 export function withDeadline<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
   return new Promise<T>((resolve, reject) => {
@@ -41,17 +32,9 @@ export async function parallelMap<T, R>(
   concurrency: number,
   fn: (item: T, index: number) => Promise<R>,
   /**
-   * Optional per-completion hook. Fires once per item AFTER `fn(item, i)`
-   * resolves, with the (item, result, index). Used by /api/run's SSE handler
-   * to emit `draft` + `send` frames as each target finishes — instead of
-   * batching them all at the end when the whole `Promise.all` resolves.
-   *
-   * Order: callbacks fire in COMPLETION order across workers, not input
-   * order. Consumers that care about index (the SSE event already does)
-   * key by the `index` argument.
-   *
-   * Throws inside the callback propagate as if `fn` threw — keep handlers
-   * defensive.
+   * Optional per-completion hook, fired after each `fn(item, i)` resolves.
+   * Fires in COMPLETION order across workers, not input order — key by
+   * `index`. A throw inside the callback propagates as if `fn` threw.
    */
   onItem?: (item: T, result: R, index: number) => void,
 ): Promise<R[]> {

--- a/packages/core/src/send-routing.ts
+++ b/packages/core/src/send-routing.ts
@@ -23,10 +23,9 @@ export function isSendDeferred(err: unknown): boolean {
 }
 
 /**
- * Thrown by sendEmail (pre-flight, before any network or LLM spend) when the
- * recipient has previously HARD bounced. Unlike SendDeferredError this is
- * permanent — callers must not leave the work queued for a retry, because no
- * retry can ever succeed. Name-based for the same cross-module reason.
+ * Thrown by sendEmail (pre-flight) when the recipient has previously HARD
+ * bounced. Permanent — callers must not re-queue, no retry can succeed.
+ * Name-based for the same cross-module reason.
  */
 export class SuppressedRecipientError extends Error {
   constructor(message: string) {
@@ -57,16 +56,11 @@ export function isRecentlyContacted(err: unknown): boolean {
 }
 
 /**
- * True when an error is a TRANSIENT platform/transport failure (the OneShot
- * backend or the network briefly broke) rather than a genuine negative result
- * (email not found, undeliverable, no enrichment data). Callers must NOT treat
- * a transient failure as a durable verdict about the candidate: don't drop it,
- * don't negative-cache it, defer/retry instead. Matches the failure shapes seen
- * in the 2026-06 worker outage. Message-based so it works across the SDK's
- * thrown errors, the `withDeadline` rejection, and serialized boundaries.
- *
- * Genuine negatives ("not found", "undeliverable", "no profile data") return
- * false — those ARE durable verdicts and should drop/negative-cache as before.
+ * True when an error is a TRANSIENT platform/transport failure rather than a
+ * genuine negative ("not found", "undeliverable" → false). Callers must NOT
+ * treat transient as a durable verdict: don't drop, don't negative-cache —
+ * defer/retry. Message-based so it works across the SDK's thrown errors, the
+ * `withDeadline` rejection, and serialized boundaries.
  */
 export function isTransientToolError(err: unknown): boolean {
   const msg = (err instanceof Error ? err.message : String(err ?? "")).toLowerCase();
@@ -139,15 +133,10 @@ export function warmupCap(
 }
 
 /**
- * The unit that shares one daily ceiling + warm-up ramp. OneShot reputation and
- * the daily send limit are PER-DOMAIN (every mailbox on a domain pools the same
- * reputation), so all oneshot identities with the same sendingDomain share a
- * budget. Gmail accounts are independent — Google warms per-account — so each
- * Gmail identity is its own group keyed by id (this also keeps two Gmail
- * accounts on one Workspace domain from sharing a cap, matching prior behavior).
- * Smartlead mailboxes are likewise per-account (Smartlead's own
- * message_per_day is per-mailbox), so each is its own group keyed by id;
- * grouping them by From-domain is a possible follow-up.
+ * The unit that shares one daily ceiling + warm-up ramp. OneShot reputation is
+ * PER-DOMAIN, so oneshot identities with the same sendingDomain share a budget.
+ * Gmail and Smartlead warm per-account, so each of those is its own group
+ * keyed by id.
  */
 export function capGroupKey(identity: EmailIdentity): string {
   if (identity.provider === "oneshot") {
@@ -171,15 +160,10 @@ interface PoolCapacity {
 }
 
 /**
- * Aggregate today's capacity for every cap-group in the pool:
- *  - ceiling = MAX member warm-up cap (the domain ramps as one; any uncapped
- *    member ⟹ uncapped group / overflow absorber),
- *  - warm-up anchor = EARLIEST member first-send,
- *  - used = SUM of member sends today.
- * A group with an uncapped member short-circuits to Infinity with NO ledger
- * read on the routing path, so legacy single-identity installs still pay
- * nothing to learn "∞". Display callers pass `countUncapped` to get the real
- * per-identity counts even for uncapped groups.
+ * Today's capacity per cap-group: ceiling = MAX member warm-up cap, anchor =
+ * EARLIEST member first-send, used = SUM of member sends. An uncapped member
+ * short-circuits the group to Infinity with NO ledger read on the routing
+ * path; display callers pass `countUncapped` for real counts anyway.
  */
 function computeCapacities(
   identities: EmailIdentity[],
@@ -288,18 +272,12 @@ export function identityCapacities(now = new Date()): Map<string, IdentityCapaci
 
 /**
  * Which identity sends to this address. Resolution order:
- *  1. Existing sender_assignments pin → that identity (config error if the
- *     id was removed from the pool — never silently re-route a live thread).
- *  2. No pin but the address was emailed pre-rotation → lazy-pin to the
- *     legacy identity (keeps in-flight cadences on their original From).
- *  3. Fresh prospect → CAPPED groups first: most remaining capacity today (the
- *     budget is per cap-group, so all mailboxes on one OneShot domain share it),
- *     tie → fewer sends by that mailbox (spreads traffic across mailboxes in a
- *     domain), then pool order. Uncapped groups are the overflow absorber, used
- *     only when every capped one is full — otherwise an uncapped OneShot domain
- *     would always win on remaining capacity (∞) and the warming Gmail accounts
- *     would never receive traffic. Pinned immediately so retries and follow-ups
- *     are deterministic.
+ *  1. Existing pin → that identity (error if removed from the pool — never
+ *     silently re-route a live thread).
+ *  2. Emailed pre-rotation → lazy-pin to the legacy identity.
+ *  3. Fresh prospect → capped groups by most remaining, tie → fewer own sends;
+ *     uncapped groups are the overflow absorber ONLY (else ∞ always wins and
+ *     warming accounts never get traffic). Pinned immediately for determinism.
  *  4. Nothing has capacity → SendDeferredError (callers leave work queued).
  */
 export function resolveSenderIdentity(to: string, now = new Date()): EmailIdentity {

--- a/packages/core/src/shared-db.ts
+++ b/packages/core/src/shared-db.ts
@@ -6,30 +6,20 @@ import { demoMode } from "./demo.ts";
 import { logEvent } from "./events.ts";
 
 /**
- * The one SQLite file shared ACROSS workspaces.
- *
- * A workspace (one ONESHOT_GTM_HOME) owns its founder voice, ICP, ledger and
- * sender identities — two products must never mix those. But some data is
- * rightly global to the operator, not the product:
- *
- * - the paid lookup caches (enrichment, LinkedIn): the same person researched
- *   for product A must not be bought again for product B;
- * - contact touches: which workspace emailed whom, when — so two motions
- *   don't pile into the same founder's inbox in the same week.
- *
- * Lives at `$ONESHOT_GTM_SHARED/shared.sqlite` (default `~/.oneshot-gtm-shared`).
- * Tests and demo mode point the env at a throwaway dir, for the same reason
- * ONESHOT_GTM_HOME exists. Many processes (one server per workspace) open this
- * file concurrently, hence WAL and a generous busy_timeout.
+ * The one SQLite file shared ACROSS workspaces: paid lookup caches (never
+ * re-buy a person researched for another product) and contact touches (two
+ * motions must not pile into one founder's inbox the same week). Everything
+ * else stays per-workspace. Lives at `$ONESHOT_GTM_SHARED/shared.sqlite`
+ * (default `~/.oneshot-gtm-shared`). Opened concurrently by every workspace's
+ * server + CLI, hence WAL and a generous busy_timeout.
  */
 
 /** How long a touch by another workspace holds a new first-touch for review. */
 export const CONTACT_TOUCH_WINDOW_MS = 7 * 24 * 3600 * 1000;
 /**
- * A pre-send reservation that was never confirmed or released (process died
- * mid-send) stops counting as a touch after this long — long enough to cover a
- * slow SDK send (~90s worst case seen), short enough not to hold a real first
- * touch hostage to a crash.
+ * An orphaned pre-send reservation (process died mid-send) stops counting as
+ * a touch after this long — covers a slow SDK send without holding a real
+ * first touch hostage to a crash.
  */
 export const RESERVATION_TTL_MS = 10 * 60 * 1000;
 
@@ -251,12 +241,10 @@ export class SharedDb {
   }
 
   /**
-   * Atomic check-and-reserve, the fix for the check→dispatch→record race:
-   * under BEGIN IMMEDIATE (the write lock serializes every workspace's server)
-   * either another workspace already holds this address — return it — or a
-   * 'reserved' row is inserted for us BEFORE any network call, so a concurrent
-   * claim from elsewhere sees it. Confirm on success, release on failure;
-   * a reservation orphaned by a crash expires after RESERVATION_TTL_MS.
+   * Atomic check-and-reserve (closes the check→dispatch→record race): under
+   * BEGIN IMMEDIATE either another workspace holds this address — return it —
+   * or a 'reserved' row lands BEFORE any network call. Confirm on success,
+   * release on failure; orphans expire after RESERVATION_TTL_MS.
    */
   claimTouch(input: {
     email: string;
@@ -328,10 +316,9 @@ export class SharedDb {
   // ── legacy import ──────────────────────────────────────────────────────────
 
   /**
-   * One-time copy of a per-workspace ledger's cache tables into the shared
-   * file (INSERT OR IGNORE — shared rows win). Keyed by ledger path so each
-   * workspace imports once; cheap no-op afterwards. The ledger's own tables
-   * are left in place, unwritten, for rollback.
+   * One-time copy of a ledger's cache tables into the shared file (INSERT OR
+   * IGNORE — shared rows win). Keyed by ledger path; the ledger's own tables
+   * are left in place for rollback.
    */
   ensureImported(ledgerDb: Database, ledgerPath: string): void {
     if (this.importedFrom.has(ledgerPath)) return;
@@ -416,10 +403,9 @@ export function getSharedDb(): SharedDb {
 }
 
 /**
- * Advisory read (draft time): was this address emailed by ANOTHER workspace
- * inside the hold window? The authoritative gate is `claimContactTouch` at
- * send time. Fail-open: a shared-DB hiccup must not block a send — this is
- * reputation hygiene, not a hard-bounce suppression.
+ * Advisory read (draft time); the authoritative gate is `claimContactTouch`
+ * at send time. Fail-open: a shared-DB hiccup must not block a send — this is
+ * reputation hygiene, not hard-bounce suppression.
  */
 export function recentTouchElsewhere(email: string): ContactTouch | null {
   try {
@@ -435,11 +421,10 @@ export function recentTouchElsewhere(email: string): ContactTouch | null {
 }
 
 /**
- * Send-time gate: atomically either learn that another workspace holds this
- * address, or reserve it for this send. Returns a `finish` callback the
- * caller invokes with the outcome — confirm on success, release on failure.
- * `override` reserves without checking (the manual send must still be visible
- * to other workspaces). Fail-open and a no-op in demo mode.
+ * Send-time gate: atomically learn another workspace holds this address, or
+ * reserve it. Caller invokes `finish(ok)` — confirm on success, release on
+ * failure. `override` reserves without checking (the manual send must still
+ * be visible to other workspaces). Fail-open; no-op in demo mode.
  */
 export function claimContactTouch(input: { email: string; playName: string; override: boolean }): {
   held: ContactTouch | null;

--- a/packages/core/src/telemetry.ts
+++ b/packages/core/src/telemetry.ts
@@ -2,28 +2,14 @@ import { loadConfigCached } from "./config.ts";
 import type { OneShotConfig } from "./types.ts";
 
 /**
- * Anonymous distribution telemetry — ONE summary event per CLI invocation.
+ * Anonymous distribution telemetry — ONE summary event per CLI invocation,
+ * separate from the local-only events.jsonl channel. TELEMETRY.md is the
+ * authoritative payload spec; the field set here must stay in lockstep.
  *
- * This is a separate channel from the verbose local `events.jsonl`
- * (see events.ts). That log is for the developer and never leaves the
- * machine; this is the opt-out, off-device signal documented in
- * TELEMETRY.md. The two share a privacy boundary (primitives, counters,
- * category labels — never user-typed values, prospect data, or content)
- * but emit different shapes to different sinks.
- *
- * TELEMETRY.md is the authoritative spec for the payload below. The field
- * set here must stay in lockstep with that file.
- *
- * ## Hard rules
- *
- * - `ONESHOT_GTM_TELEMETRY=0` / `false` is a kill switch checked BEFORE a
- *   payload is constructed (`shouldSendTelemetry`). No payload, no request.
- * - `cfg.telemetryEnabled === false` (the `config telemetry off` flag) does
- *   the same.
- * - Transmission never throws and never blocks process exit — a telemetry
- *   bug or an unreachable endpoint must be invisible to the user.
- * - No telemetry SDK: a plain `fetch` POST keeps the OSS client dependency
- *   free and transparent. The receiver is a first-party endpoint we operate.
+ * Hard rules: the env kill switch (ONESHOT_GTM_TELEMETRY=0) and
+ * `cfg.telemetryEnabled === false` are checked BEFORE any payload is built;
+ * transmission never throws and never blocks process exit; no telemetry SDK —
+ * a plain `fetch` POST to a first-party endpoint.
  */
 
 /** Outcome of a single CLI invocation. Mirrors the TELEMETRY.md `outcome` column. */
@@ -51,10 +37,8 @@ export interface TelemetryPayload {
 }
 
 /**
- * Default first-party ingest endpoint — a stable custom domain we own, so the
- * backend can move without re-shipping the client and no hosting details leak
- * into the OSS source. Operators can override per-run with
- * ONESHOT_GTM_TELEMETRY_URL; set it to "" to make telemetry a hard no-op.
+ * Default first-party ingest endpoint. Override per-run with
+ * ONESHOT_GTM_TELEMETRY_URL; set it to "" for a hard no-op.
  */
 export const DEFAULT_TELEMETRY_URL = "https://telemetry.oneshotagent.com/v1/cli";
 
@@ -66,11 +50,8 @@ export const DEFAULT_TELEMETRY_URL = "https://telemetry.oneshotagent.com/v1/cli"
 const TELEMETRY_TIMEOUT_MS = 1000;
 
 /**
- * Resolve the ingest URL. `ONESHOT_GTM_TELEMETRY_URL` overrides the default so
- * the receiver can be exercised locally / against staging. An *explicitly
- * empty* override (`ONESHOT_GTM_TELEMETRY_URL=""`) resolves to `""` — a hard
- * no-op (see reportCommand's `if (!url) return`) — honoring the documented kill
- * path. Only an absent var falls back to the default endpoint.
+ * Resolve the ingest URL. An *explicitly empty* ONESHOT_GTM_TELEMETRY_URL=""
+ * resolves to "" — a hard no-op; only an absent var falls back to the default.
  */
 export function telemetryUrl(env: NodeJS.ProcessEnv = process.env): string {
   const raw = env["ONESHOT_GTM_TELEMETRY_URL"];
@@ -79,10 +60,8 @@ export function telemetryUrl(env: NodeJS.ProcessEnv = process.env): string {
 }
 
 /**
- * Pure gate. Returns false — meaning "construct nothing, send nothing" — when
- * either the persisted flag is off or the env kill switch is set. Env wins so
- * a single shell-session export reliably silences telemetry regardless of
- * what's on disk.
+ * Pure gate: false = construct nothing, send nothing. The env kill switch
+ * wins over the persisted flag.
  */
 export function shouldSendTelemetry(
   cfg: Pick<OneShotConfig, "telemetryEnabled">,
@@ -106,10 +85,8 @@ export interface TelemetryInputs {
 }
 
 /**
- * Pure builder — no I/O, no clock, no globals. The caller supplies every
- * value so tests can pin them (mirrors `buildEventLine`). Strips nothing:
- * the field set IS the whitelist, so anything not listed simply can't be
- * carried.
+ * Pure builder — no I/O, no clock, no globals. The field set IS the
+ * whitelist, so anything not listed can't be carried.
  */
 export function buildTelemetryPayload(input: TelemetryInputs): TelemetryPayload {
   return {
@@ -165,10 +142,7 @@ export interface TelemetryEventInput {
 
 /**
  * The single send path shared by every emitter (CLI dispatch, server
- * executions). Resolves the endpoint + opt-out gate, reads the anonymous
- * install id / provider from config, stamps host fields (os, bun), and fires.
- * Best-effort: never throws, never blocks the caller. Centralizing this keeps
- * the CLI and server channels from drifting as the payload evolves.
+ * executions). Best-effort: never throws, never blocks the caller.
  */
 export async function reportTelemetryEvent(
   input: TelemetryEventInput,
@@ -197,15 +171,9 @@ export async function reportTelemetryEvent(
   }
 }
 
-// ---------------------------------------------------------------------------
-// Per-invocation outcome marker.
-//
-// Most commands map cleanly: a thrown error => "error", a clean return =>
-// "ok". But the anti-slop path prints "Not sent — fix lint flags" and returns
-// normally (printDrafts in motion.ts), so "lint-blocked" can't be inferred
-// from control flow. A command signals it explicitly via markTelemetryOutcome;
-// the dispatch wrapper reads it back with takeMarkedOutcome.
-// ---------------------------------------------------------------------------
+// Per-invocation outcome marker. "lint-blocked" can't be inferred from
+// control flow (the anti-slop path returns normally), so a command signals it
+// via markTelemetryOutcome; the dispatch wrapper reads takeMarkedOutcome.
 
 let markedOutcome: TelemetryOutcome | null = null;
 

--- a/packages/core/src/workspaces.ts
+++ b/packages/core/src/workspaces.ts
@@ -1,17 +1,9 @@
 /**
  * Named workspaces — fully isolated installs (one ONESHOT_GTM_HOME each).
- *
- * This module imports ONLY node builtins, on purpose: the CLI's bootstrap
- * shim must resolve `--workspace <name>` to a home dir BEFORE core's config.ts
- * is evaluated (it captures ONESHOT_GTM_HOME at module load), so anything
- * this file imported from core would defeat the whole point. It is exposed as
- * the `@oneshot-gtm/core/workspaces` subpath for that reason.
- *
- * Layout:
- *   ~/.oneshot-gtm                        the `default` workspace (legacy home)
- *   ~/.oneshot-gtm-workspaces/registry.json
- *   ~/.oneshot-gtm-workspaces/<name>/     every named workspace
- *
+ * Imports ONLY node builtins, on purpose: the CLI shim must resolve
+ * `--workspace` to a home dir BEFORE core's config.ts is evaluated (it
+ * captures ONESHOT_GTM_HOME at module load). Layout: ~/.oneshot-gtm =
+ * `default` (legacy home); ~/.oneshot-gtm-workspaces/{registry.json,<name>/}.
  * `ONESHOT_GTM_WORKSPACES` relocates the container (tests, demos).
  */
 import {
@@ -114,16 +106,11 @@ function sleepSync(ms: number): void {
 }
 
 /**
- * Serialize read-modify-write of the registry across processes with an
- * exclusive lock file (O_EXCL create). Without it two `workspace create`s at
- * once read the same registry, pick the same free port and the later save
- * overwrites the earlier one — a lost workspace AND a port collision.
- *
- * The lock carries an owner token: release only unlinks OUR lock, so a
- * process that legitimately broke a stale lock can't have its replacement
- * yanked by the original owner's `finally`. Every retry checks the deadline
- * first, so a persistent filesystem error (EACCES on stat/unlink) surfaces as
- * a WorkspaceError instead of a full-CPU spin.
+ * Serialize registry read-modify-write across processes via an O_EXCL lock
+ * file (else concurrent creates lose a workspace and collide on ports). The
+ * lock carries an owner token — release only unlinks OUR lock, so breaking a
+ * stale lock can't be undone by the dead owner's `finally`; retries check the
+ * deadline first so filesystem errors surface instead of spinning.
  */
 export function withRegistryLock<T>(fn: () => T, opts: { waitMs?: number } = {}): T {
   const lock = `${registryPath()}.lock`;
@@ -278,10 +265,9 @@ export function workspaceNameForHome(
 }
 
 /**
- * Dashboard port for the install at `home`: the registered port when that
- * exact home is a workspace, else BASE_PORT. Keyed by home rather than by the
- * derived name, so an unregistered ONESHOT_GTM_HOME can never borrow a
- * registered workspace's port and collide with its running dashboard.
+ * Dashboard port for the install at `home` (registered port, else BASE_PORT).
+ * Keyed by home, not derived name — an unregistered ONESHOT_GTM_HOME must
+ * never borrow a registered workspace's port.
  */
 export function portForHome(home: string, reg: WorkspaceRegistry = loadRegistry()): number {
   const target = canonicalPath(home);
@@ -292,11 +278,9 @@ export function portForHome(home: string, reg: WorkspaceRegistry = loadRegistry(
 }
 
 /**
- * What the bootstrap shim does: decide the home for this process from
- * `--workspace` (already stripped from argv by the caller), the env, or the
- * registry default. An explicit ONESHOT_GTM_HOME wins outright — it is the
- * lower-level escape hatch — and combining it with --workspace is an error,
- * since they would disagree about where the install is.
+ * Decide this process's home from `--workspace`, the env, or the registry
+ * default. An explicit ONESHOT_GTM_HOME wins outright; combining it with
+ * --workspace is an error (they'd disagree about where the install is).
  */
 export function resolveWorkspaceSelection(input: {
   flag: string | null;

--- a/packages/find/src/_breaker.ts
+++ b/packages/find/src/_breaker.ts
@@ -2,26 +2,12 @@ import { logEvent } from "@oneshot-gtm/core";
 
 /**
  * Process-wide circuit breaker for OneShot paid contact-resolution calls
- * (findEmail/verifyEmail). During a backend outage EVERY candidate's resolution
- * throws; without this, a run burns ~70s + spend per candidate draining all of
- * them through doomed calls (and drops each as if it were a bad candidate).
- *
- * State machine (closed → open → half-open → closed/open):
- * - CLOSED: calls flow normally. `isCircuitOpen()` → false.
- * - OPEN: trips after N consecutive platform errors. `isCircuitOpen()` → true,
- *   so `resolveAndVerifyContact` short-circuits (no spend) for COOLDOWN_MS.
- * - HALF-OPEN: once the cooldown elapses, `isCircuitOpen()` → false again so the
- *   next resolution issues a real probe call. That call's outcome either CLOSES
- *   the breaker (success) or RE-ARMS the cooldown (failure) — so a sustained
- *   outage keeps short-circuiting between probes instead of hammering, and a
- *   recovered backend closes the breaker on the first probe. Without the
- *   cooldown the breaker would latch open forever (nothing calls
- *   recordResolutionOutcome while open), permanently breaking finders until a
- *   process restart.
- *
- * The counter is process-wide and only platform errors (`status:"error"` from
- * the safe wrappers) count toward tripping; any genuine outcome resets it, so a
- * run of legitimately-unresolvable candidates never opens it.
+ * (findEmail/verifyEmail), so a backend outage doesn't drain a whole run
+ * through doomed paid calls. Trips OPEN after THRESHOLD consecutive platform
+ * errors; after COOLDOWN_MS the next call probes (half-open) — success closes
+ * the breaker, failure re-arms the cooldown (without which it would latch open
+ * forever). Only platform errors count toward tripping; any genuine outcome
+ * resets the counter, so legitimately-unresolvable candidates never open it.
  */
 const THRESHOLD = 5;
 export const COOLDOWN_MS = 60_000;

--- a/packages/find/src/_findemail-prescreen.ts
+++ b/packages/find/src/_findemail-prescreen.ts
@@ -1,29 +1,14 @@
 /**
- * Pre-flight guard for `findEmail` SDK calls.
- *
- * The OneShot `findEmail` SDK receives only `company_domain` + `full_name` and
- * guesses email patterns from those. Two structural causes of dud lookups we
- * can catch BEFORE spending the ~$0.05 per call:
- *
- *   1. `company_domain` points at a host where no company hosts email —
- *      free-tier app subdomains (vercel.app, github.io, …), social platforms,
- *      personal email providers, code hosts, link aggregators.
- *   2. `full_name` is a single-token handle (`samaralihussain`) not a real
- *      person name (`Sam Jones`). Pattern-based email guessing can't
- *      disambiguate a username.
- *
- * Callers do `shouldSkipFindEmail(...)` ahead of the SDK call; when it
- * returns `{ok:false}`, increment `result.droppedEnrichment` and emit a
- * `finder.skipped_findemail` event for telemetry, then move to the next
- * candidate. No new wire-protocol surface.
+ * Pre-flight guard for paid `findEmail` SDK calls: skip when `company_domain`
+ * is a host where no company hosts email (free-tier subdomains, social
+ * platforms, personal providers, …) or `full_name` is a single-token handle
+ * pattern-guessing can't use. Callers treat `{ok:false}` as droppedEnrichment
+ * and emit `finder.skipped_findemail`.
  */
 
 /**
- * Hosts where `findEmail` virtually never finds a deliverable company
- * address. Match is exact on the bare host or any subdomain of one of
- * these entries — `foo.vercel.app` and `bar.foo.vercel.app` both qualify.
- *
- * Curated, static. Adaptive/learned variants are out of scope.
+ * Hosts where `findEmail` virtually never finds a deliverable company address.
+ * Matched on the bare host or any subdomain. Curated, static.
  */
 const DUD_DOMAINS: ReadonlySet<string> = new Set([
   // Free-tier app / preview subdomains.
@@ -50,8 +35,7 @@ const DUD_DOMAINS: ReadonlySet<string> = new Set([
   "webflow.io",
   "wixsite.com",
   "googleusercontent.com",
-  // Personal / free email providers — the founder isn't reachable via the
-  // generic free-tier handle even if findEmail returns something.
+  // Personal / free email providers.
   "gmail.com",
   "yahoo.com",
   "outlook.com",
@@ -83,16 +67,14 @@ const DUD_DOMAINS: ReadonlySet<string> = new Set([
   "discord.gg",
   "slack.com",
   "news.ycombinator.com",
-  // Investor / startup-data aggregators — every result here is a profile
-  // page about a company, not the company's own domain.
+  // Investor / startup-data aggregators (profile pages, not company domains).
   "crunchbase.com",
   "producthunt.com",
   "wellfound.com",
   "pitchbook.com",
   "cbinsights.com",
   "tracxn.com",
-  // Code hosts (when this is the ONLY domain signal — caller already
-  // failed to find a company website).
+  // Code hosts (only ever the domain signal when no company website was found).
   "github.com",
   "gitlab.com",
   "bitbucket.org",
@@ -104,21 +86,10 @@ const DUD_DOMAINS: ReadonlySet<string> = new Set([
 ]);
 
 /**
- * True when the given domain is in the dud blocklist, either as an exact
- * match or as a subdomain (so `foo.vercel.app` is dud). `null`/empty
- * counts as dud — caller has no usable signal.
- *
- * Defensive normalization before matching:
- *   - lowercase + trim whitespace
- *   - strip `http://` / `https://` scheme
- *   - strip everything from the first `/` onward (paths/queries)
- *   - strip leading `www.` and trailing `.`
- *
- * Callers should pass bare hostnames (via `urlDomain` from `_dedupe.ts`),
- * but the normalization keeps an accidental full URL or trailing-dot DNS
- * form from silently slipping past the suffix match.
- *
- * Does no DNS lookup — purely suffix-based.
+ * True when the domain is in the dud blocklist, exact or as a subdomain.
+ * `null`/empty counts as dud (no usable signal). Defensively normalizes
+ * scheme/path/www/trailing-dot so an accidental full URL can't slip past the
+ * suffix match. Purely suffix-based — no DNS lookup.
  */
 export function isDudDomain(domain: string | null | undefined): boolean {
   if (!domain) return true;
@@ -138,17 +109,9 @@ export function isDudDomain(domain: string | null | undefined): boolean {
 }
 
 /**
- * True when the input looks like a single-token username/handle rather
- * than a real person name. Heuristics, in order:
- *
- *   - Empty / null → handle (no signal).
- *   - Contains whitespace → looks like a name. `"Sam Jones"`.
- *   - Contains a period → looks like a name. `"Sam J. Jones"`.
- *   - Single token of `[a-z0-9_-]` (case-insensitive) → handle.
- *
- * False-positive accepted: a real single-name like `Madonna` reads as a
- * handle. That's a fine tradeoff vs the volume of HN-style usernames we
- * filter out (90%+ of Show HN authors).
+ * True when the input looks like a single-token username/handle rather than a
+ * real person name (whitespace or a period reads as a name). Accepted
+ * false-positive: a real mononym like `Madonna` reads as a handle.
  */
 export function looksLikeUserHandle(name: string | null | undefined): boolean {
   if (name == null) return true;
@@ -160,14 +123,9 @@ export function looksLikeUserHandle(name: string | null | undefined): boolean {
 }
 
 /**
- * Pre-flight guard. Returns `{ok:true}` to proceed with the SDK call, or
- * `{ok:false, reason}` to skip. The reason is human-readable and stable
- * across releases — safe to log via `finder.skipped_findemail` for later
- * blocklist tuning.
- *
- * Check order matters: a missing/dud domain dominates a handle check (no
- * point flagging "handle-not-name" when the domain alone would have
- * disqualified the row).
+ * Pre-flight guard. `{ok:false, reason}` skips the SDK call; reasons are
+ * stable across releases (logged for blocklist tuning). Check order matters:
+ * a missing/dud domain dominates the handle check.
  */
 export function shouldSkipFindEmail(input: {
   fullName?: string | null;

--- a/packages/find/src/_linkedin.ts
+++ b/packages/find/src/_linkedin.ts
@@ -9,13 +9,9 @@ import {
 import { isCircuitOpen, recordResolutionOutcome } from "./_breaker.ts";
 
 /**
- * Shared LinkedIn / phone capture helpers used across all finders. Centralises:
- * - `findLinkedInUrl`: webSearch-based LinkedIn-URL discovery (active lookup)
- * - `extractFirstPhone`: passive read of phone fields from enrichment SDK results
- *
- * Both feed the same goal — populate `target.linkedinUrl` and `target.phone` so
- * the founder sees these signals in /queue review and the prospect row carries
- * them after drain.
+ * Shared LinkedIn / phone capture helpers used across all finders:
+ * webSearch-based LinkedIn-URL discovery and passive phone extraction from
+ * enrichment SDK results.
  */
 
 const PLAY_NAME = "linkedin-lookup";
@@ -46,31 +42,17 @@ function fold(s: string): string {
 }
 
 /**
- * Does this search result actually belong to the person we searched for?
- *
- * Checked against the result **title** — LinkedIn's own rendering of the
- * display name ("Elad Ben-Israel - Wing | LinkedIn"). Deliberately NOT the URL:
- * the slug is vanity text the member picks, so `/in/hackingonstuff` and
- * `/in/gtewari` are ordinary profiles and matching against it rejects ~1 in 4
- * correct hits.
- *
- * Rule: the surname must appear, plus at least one other name token. That
- * survives a middle name the profile omits ("Bradley Stuart Kirton" →
- * "Bradley Kirton") and an initial in place of a first name, while still
- * rejecting a same-first-name stranger.
- *
- * Returns true whenever the check can't reach a verdict — fewer than two
- * comparable tokens (a bare handle, a mononym, initials) or no title at all.
- * A guard that can neither confirm nor refute must not invent a rejection.
+ * Does this search result belong to the person we searched for? Checked
+ * against the result **title**, deliberately NOT the URL — the slug is vanity
+ * text and matching it rejects real hits. Rule: the surname must appear, plus
+ * at least one other name token. Returns true whenever the check can't reach
+ * a verdict — a guard that can neither confirm nor refute must not invent a
+ * rejection.
  */
 export function nameMatchesTitle(title: string, name: string): boolean {
-  // Whole-token comparison, never substring: "Ann Son" would otherwise match
-  // "Joanne Johnson" ("ann" inside "joanne", "son" inside "johnson") and write
-  // a stranger's profile.
-  //
-  // Short title tokens are kept, unlike the name side, so an initialised title
-  // ("J. Smith") can still confirm "John Smith". Dropping them would reject a
-  // correct profile AND cache that as a miss for LINKEDIN_MISS_TTL_MS.
+  // Whole-token comparison, never substring ("Ann Son" must not match "Joanne
+  // Johnson"). Short title tokens are kept, unlike the name side, so an
+  // initialised title ("J. Smith") can still confirm "John Smith".
   const titleTokens = fold(title)
     .split(" ")
     .filter((t) => t.length > 0);
@@ -116,12 +98,8 @@ const ORG_WORDS = new Set([
 ]);
 
 /**
- * True when a "name" is really an organisation ("ByteDance Inc.", "Baur
- * Software", "Atomic Bot").
- *
- * GitHub and Luma accounts are often orgs. Searching one as a person doesn't
- * miss — it finds *an* employee, and that lands outreach on someone with no
- * idea why. Cheaper and safer to not search at all.
+ * True when a "name" is really an organisation. Searching an org as a person
+ * doesn't miss — it finds *an* employee, landing outreach on the wrong human.
  */
 export function looksLikeOrgName(name: string | null | undefined): boolean {
   if (!name) return false;
@@ -131,10 +109,8 @@ export function looksLikeOrgName(name: string | null | undefined): boolean {
 }
 
 /**
- * Returns true when `url` looks like a LinkedIn profile URL (`linkedin.com/in/<slug>`).
- * Use to validate LLM-extracted `linkedinUrl` strings before persisting them —
- * the prompt instructs the LLM to emit only profile URLs but real outputs drift
- * (sometimes a `/posts/` URL, sometimes free-form prose).
+ * True when `url` looks like a LinkedIn profile URL. Validates LLM-extracted
+ * `linkedinUrl` strings before persisting — real LLM outputs drift.
  */
 export function isLinkedInProfileUrl(url: string | null | undefined): boolean {
   if (!url || typeof url !== "string") return false;
@@ -142,22 +118,11 @@ export function isLinkedInProfileUrl(url: string | null | undefined): boolean {
 }
 
 /**
- * Find a LinkedIn profile URL for a person via webSearch.
- *
- * Query shape: `"<fullName>" "<disambig1>" "<disambig2>" site:linkedin.com/in`.
- * The `site:` operator narrows results to actual profile pages (not company
- * pages or jobs). We iterate `webSearch` result URLs and return the first that
- * matches `linkedin.com/in/<slug>`. No regex over freeform text — webSearch
- * returns structured `{url, title, description}` results.
- *
- * Returns null on:
- *   - empty fullName
- *   - no result URL matches the LinkedIn-profile shape
- *   - webSearch throws (logged as `error.swallowed` so the caller's pipeline
- *     doesn't tear down)
- *
- * Cost: ~$0.01 per call (one webSearch). Cached per-run by
- * `(fullName, disambiguators)` so duplicate calls within a finder run are free.
+ * Find a LinkedIn profile URL for a person via webSearch
+ * (`"<name>" "<disambig>" site:linkedin.com/in`). Returns the first result
+ * matching the profile shape; null on empty name, no match, or a thrown
+ * webSearch (swallowed so the caller's pipeline doesn't tear down). Cached
+ * per-run and persistently by `(fullName, disambiguators)`.
  */
 export async function findLinkedInUrl(args: {
   fullName: string;
@@ -169,24 +134,15 @@ export async function findLinkedInUrl(args: {
   errKindPrefix: string;
   /**
    * Called once per result discarded by the name/title check. Reporting only —
-   * deliberately NOT a validation hook.
-   *
-   * There was a caller-supplied `accept` predicate here. It had a trap: both
-   * caches key on (fullName, disambiguators) and return before any result
-   * metadata exists, so a cache hit skipped the predicate and could hand back a
-   * URL that same predicate had rejected minutes earlier. The built-in check
-   * doesn't have that problem — it runs before a value is ever cached, so
-   * anything in the cache was verified against the same name. Rather than
-   * special-case the caches around an optional hook that no caller used, the
-   * verification lives in one place and is not overridable.
+   * deliberately NOT a validation hook: caches return before any result
+   * metadata exists, so verification must stay built-in and non-overridable.
    */
   onTitleMismatch?: (result: { url: string; title: string }) => void;
 }): Promise<string | null> {
   const fullName = args.fullName.trim();
   if (fullName.length === 0) return null;
 
-  // An org account can only resolve to some employee's profile, which is a
-  // wrong answer that costs money to get.
+  // An org account can only resolve to some employee's profile — a paid wrong answer.
   if (looksLikeOrgName(fullName)) {
     logEvent("linkedin.search.skipped_org", { full_name: fullName });
     return null;
@@ -201,18 +157,15 @@ export async function findLinkedInUrl(args: {
   ]);
   if (cache.has(cacheKey)) return cache.get(cacheKey) ?? null;
 
-  // Persistent cache. The in-process Map above only survives one run, so
-  // without this every scheduler restart re-pays ~$0.01 for the same misses —
-  // and this lookup now fires for every candidate, not just company-less ones.
+  // Persistent cache — the in-process Map only survives one run.
   const persisted = readPersistedLookup(cacheKey);
   if (persisted !== undefined) {
     cache.set(cacheKey, persisted);
     return persisted;
   }
 
-  // A webSearch outage would otherwise burn one call per candidate. The breaker
-  // is shared with email resolution, so a platform-wide failure trips it once
-  // and every subsequent candidate short-circuits for free.
+  // Breaker is shared with email resolution — a platform-wide failure trips it
+  // once and every subsequent candidate short-circuits for free.
   if (isCircuitOpen()) {
     logEvent("linkedin.search.skipped_breaker", { full_name: fullName });
     return null;
@@ -228,9 +181,8 @@ export async function findLinkedInUrl(args: {
       const url = typeof r.url === "string" ? r.url : "";
       if (LINKEDIN_PROFILE_RX.test(url)) {
         const title = typeof r.title === "string" ? r.title : "";
-        // Verify before accepting. A `site:linkedin.com/in` search for a common
-        // name happily returns a different person, and a wrong URL here isn't a
-        // blank field — it's outreach to a stranger.
+        // Verify before accepting — a wrong URL here isn't a blank field, it's
+        // outreach to a stranger.
         if (!nameMatchesTitle(title, fullName)) {
           args.onTitleMismatch?.({ url, title });
           logEvent("linkedin.search.title_mismatch", { full_name: fullName, url, title });
@@ -249,12 +201,10 @@ export async function findLinkedInUrl(args: {
   } catch (err) {
     const transient = isTransientToolError(err);
     recordResolutionOutcome(transient);
-    // Only persist a GENUINE miss. Caching a timeout/5xx would suppress this
-    // person's lookup for LINKEDIN_MISS_TTL_MS after the platform recovers —
-    // the same poisoning rule as _enrich.ts:130.
+    // Only persist a GENUINE miss — caching a timeout/5xx would suppress this
+    // person's lookup for LINKEDIN_MISS_TTL_MS after the platform recovers.
     if (!transient) writePersistedLookup(cacheKey, null);
-    // The in-process entry is still set either way: within a single run there's
-    // no point retrying a call that just failed.
+    // The in-process entry is set either way: no point retrying within one run.
     cache.set(cacheKey, null);
     logEvent(
       "error.swallowed",
@@ -296,17 +246,9 @@ function writePersistedLookup(cacheKey: string, url: string | null): void {
 }
 
 /**
- * Pull the first usable phone number out of either an enrichProfile or a
- * deepResearchPerson result shape. Both SDK results may surface a phone — this
- * is the single read site so finders don't have to know which shape they got.
- *
- * Shapes accepted:
- *   - deepResearchPerson: `enrichment.fullphone[0].fullphone` (array of objects)
- *   - enrichProfile: `profile.phone` (single string)
- *   - LLM extracts: `extract.phone` (single string)
- *
- * Returns the raw string from whichever source. No normalization — defer
- * E.164 formatting until a downstream consumer needs it.
+ * First usable phone from an enrichProfile (`profile.phone`), LLM extract
+ * (`extract.phone`), or deepResearchPerson (`enrichment.fullphone[]`) shape —
+ * the single read site for all three. Raw string, no E.164 normalization.
  */
 export function extractFirstPhone(source: unknown): string | null {
   if (!source || typeof source !== "object") return null;

--- a/packages/find/src/_luma-auth.ts
+++ b/packages/find/src/_luma-auth.ts
@@ -2,28 +2,12 @@ import { logEvent } from "@oneshot-gtm/core";
 import type { LumaPublicAttendee } from "./_types.ts";
 
 /**
- * Optional auth path for the luma-events finder. When the founder has pasted
- * their `luma.auth-session-key` cookie into `LUMA_SESSION_COOKIE`, this helper
- * tries to fetch the FULL guest list from Luma's internal API.
- *
- * KNOWN LIMIT (verified live, 2026-06): the guest-list endpoint is HOST-ONLY —
- * a valid cookie on someone else's event returns 403 "You don't have access to
- * this event", even when the host shows "Who's Coming". So this path only adds
- * coverage for events the FOUNDER hosts. (It also expects the `evt-` api_id
- * where the caller passes the URL slug, which 404s first — moot for cold
- * discovery given the 403.) Cold-discovery contact data comes from the public
- * `api.lu.ma/url` event JSON instead — see `fetchEventDetails` in
- * `_luma-discover.ts`.
- *
- * The endpoint is undocumented and may change. We try two URL shapes (the
- * `/admin/` and the bare variant) and fall back gracefully to null on any
- * 4xx / shape drift / network blip. The caller (luma.ts) treats null as
- * "stay in public-only mode for this event" — no crash.
- *
- * TOS posture: this is the founder's own cookie hitting pages they could
- * read in a browser. The cookie value is never logged (only its presence is)
- * and never persisted by this codebase beyond the `~/.oneshot-gtm/.env` file
- * the founder owns.
+ * Optional auth path for luma-events: with `LUMA_SESSION_COOKIE` set, fetch
+ * the full guest list from Luma's internal (undocumented) API. HOST-ONLY —
+ * a valid cookie on someone else's event 403s, so this only adds coverage for
+ * events the founder hosts; cold-discovery contacts come from the public event
+ * JSON (`_luma-discover.ts`). Null on any failure mode = caller stays in
+ * public-only mode. The cookie value is never logged or persisted.
  */
 
 const ENDPOINTS = [
@@ -135,9 +119,7 @@ export async function fetchAuthedGuestList(
         },
         "warn",
       );
-      // Network blip — try the next endpoint, but don't keep retrying
-      // forever. The next iteration's fetch will either work or this catch
-      // will fire again and exit the loop after the URL list is exhausted.
+      // Network blip — try the next endpoint.
       lastStatus = null;
       continue;
     }
@@ -188,13 +170,9 @@ export async function fetchAuthedGuestList(
 }
 
 /**
- * Merge public (LLM-extracted) attendees with auth'd attendees. Dedupe key is
- * the lowercased trimmed name; matches the per-event dedupe key used downstream.
- *
- * Per-field union: when both sides have an entry for the same name, the auth
- * value wins on conflict, but public values fill in any nulls. This handles
- * the realistic case where the auth API doesn't surface a field (`linkedinUrl`
- * = null) that the LLM caught from a visible attendee card.
+ * Merge public (LLM-extracted) + auth'd attendees. Dedupe key: lowercased
+ * trimmed name (matches the downstream per-event key). Per-field union — auth
+ * values win on conflict, public values fill nulls.
  */
 export function mergeAttendees(
   publicList: LumaPublicAttendee[],

--- a/packages/find/src/_qualify.ts
+++ b/packages/find/src/_qualify.ts
@@ -10,25 +10,11 @@ import { isCircuitOpen, recordResolutionOutcome } from "./_breaker.ts";
 import { type PersonCandidate, type PersonVerdict, hasRoleText, qualifyPerson } from "./_filter.ts";
 
 /**
- * Staged person-level ICP qualification.
- *
- * The problem this solves: 15% of everyone we emailed was off-ICP (a
- * snowboard-team coordinator, two investors, an Account Executive who was
- * pitching us) because nothing in the pipeline ever looked at a human's role.
- *
- * The gate runs in up to three stages, cheapest first, because role data
- * arrives at different points and at different prices:
- *
- *   A. pre-spend    $0      role text the finder already has (Luma attendeeBio,
- *                           extracted founderRole/guestRole/etc.)
- *   B. post-enrich  $0      `title` off the enrichProfile we ALREADY buy for
- *                           every verified email (see `_enrich.ts`)
- *   C. fill-the-gap ~$0.005 one extra enrichProfile keyed by LinkedIn URL
- *
- * `unclear` and "no role text" are the same thing to this module: both mean
- * we cannot decide, and both escalate. Guessing on ambiguity is what let the
- * bad prospects through, and guessing the other way would drop real founders
- * whose bio happens to be blank (31% of Luma candidates).
+ * Staged person-level ICP qualification — up to three stages, cheapest first:
+ * A pre-spend (free role text from the finder), B post-enrich (title off the
+ * enrichProfile already bought), C fill-the-gap (one extra enrichProfile keyed
+ * by LinkedIn URL). `unclear` and "no role text" both mean "cannot decide" and
+ * both escalate — guessing on ambiguity in either direction is wrong.
  */
 
 /** What the caller should do next. */
@@ -39,8 +25,7 @@ export type QualifyAction =
   | "reject"
   /**
    * Could not decide (classifier outage). Drop WITHOUT persisting — a
-   * persisted rejection burns the dedupeKey forever, so an LLM outage would
-   * permanently blacklist every candidate it touched.
+   * persisted rejection burns the dedupeKey forever.
    */
   | "defer";
 
@@ -67,28 +52,22 @@ function outcome(
 }
 
 /**
- * Stage A — before any spend.
- *
- * Only a `reject` is actionable here; that is the free win, and it fires
- * before findEmail + verify + enrich are paid for. An `unclear` deliberately
- * returns "proceed": stage B is free, so paying at A would burn ~$0.005 on
- * candidates whose email fails verification anyway.
+ * Stage A — before any spend. Only a `reject` is actionable here; `unclear`
+ * deliberately proceeds because stage B is free.
  */
 export async function qualifyPreSpend(input: {
   icp: string | null;
   person: PersonCandidate;
 }): Promise<QualifyOutcome> {
-  // Nothing to judge yet — that is normal for repo-interest and
-  // stack-consolidation, which carry no role at discovery. Defer to stage B.
+  // No role at discovery is normal for the repo finders — defer to stage B.
   if (!hasRoleText(input.person)) {
     return outcome("unclear", "no role text at discovery; deferred to enrichment", null);
   }
   const res = await qualifyPerson(input);
   const roleText = input.person.roleText ?? null;
 
-  // A transient classifier failure pre-spend is NOT a reason to drop the
-  // candidate: stage B gets another look for free. Downgrade to proceed so an
-  // LLM blip costs us nothing but a second opinion.
+  // A transient classifier failure pre-spend downgrades to proceed — stage B
+  // gets another look for free.
   if (res.verdict === "transient") {
     return outcome("unclear", "classifier unavailable pre-spend; deferred", roleText);
   }
@@ -114,9 +93,8 @@ export async function qualifyPostEnrich(input: {
   /** Per-finder switch for stage C spend. */
   fillGaps: boolean;
   /**
-   * Set when the caller ALREADY ran enrichProfile keyed by this same LinkedIn
-   * URL and it produced no title. Stage C would repeat that exact call, so it
-   * is skipped — buying the same miss twice is pure waste.
+   * Set when the caller already ran enrichProfile on this same LinkedIn URL
+   * with no title — stage C would repeat that exact call, so it is skipped.
    */
   alreadyEnrichedByLinkedin?: boolean;
   playName: string;
@@ -124,9 +102,8 @@ export async function qualifyPostEnrich(input: {
 }): Promise<QualifyOutcome> {
   const icp = input.icp;
 
-  // Best role text available for free: the enriched title beats a discovery
-  // headline (it is the current employer's record, not self-written), and the
-  // summary is a fallback when the title is absent.
+  // Enriched title beats a discovery headline (employer record, not
+  // self-written); summary is the fallback.
   const freeRole =
     firstNonEmpty(input.enrichedTitle, input.person.roleText, input.enrichedSummary) ?? null;
 
@@ -139,7 +116,7 @@ export async function qualifyPostEnrich(input: {
     return outcome("transient", stageB.reason, freeRole);
   }
 
-  // ---- Stage C: unclear or still no role text, so go buy a real title. ----
+  // Stage C: unclear or still no role text — buy a real title.
   if (!input.fillGaps) {
     return outcome("unclear", "unclear; fill-the-gap lookup disabled for this finder", freeRole);
   }
@@ -202,12 +179,8 @@ export async function qualifyPostEnrich(input: {
     return outcome("transient", stageC.reason, boughtTitle, costUsd, receiptId);
   }
   if (stageC.verdict === "unclear") {
-    // Softened 2026-08-25 (founder: "we might be too strict"): a bought title
-    // that STILL does not settle it is a genuine coin-flip, and the product is
-    // self-serve pay-per-use — the cost of a false send is one email, the cost
-    // of a false drop is a prospect gone forever. Proceed, log distinctly so
-    // the coin-flip volume stays visible, and let the reply (or silence)
-    // decide. Only a positive `reject` ever drops a candidate.
+    // A bought title that still doesn't settle it is a coin-flip: proceed and
+    // log distinctly. Only a positive `reject` ever drops a candidate.
     logEvent("icp.person_unclear_after_enrich", {
       reason_120: stageC.reason.slice(0, 120),
       role_120: (boughtTitle ?? "").slice(0, 120),
@@ -248,12 +221,9 @@ function readTitle(profile: unknown): string | null {
 }
 
 /**
- * Persist an auditable rejected row for a person-level ICP miss.
- *
- * Mirrors the company-level ICP rejection pattern (`auto: ICP — …`) so both
- * kinds of auto-drop show up the same way in /queue and the founder can
- * override either. Best-effort: the drop already happened, and losing the
- * audit row must never take the run down.
+ * Persist an auditable rejected row for a person-level ICP miss, mirroring the
+ * company-level pattern so both show up the same way in /queue. Best-effort:
+ * losing the audit row must never take the run down.
  */
 export function persistRoleRejection(args: {
   playName: string;

--- a/packages/find/src/_repo-pipeline.ts
+++ b/packages/find/src/_repo-pipeline.ts
@@ -23,19 +23,10 @@ import { detectRepoStack } from "./_repo-stack.ts";
 import type { AgentBuilderExtract, FinderResult } from "./_types.ts";
 
 /**
- * Shared per-candidate pipeline for repo-style finders. Today it has one
- * caller (`github-topics`); kept as its own module because the per-candidate
- * body — snippet ICP → GitHub manifest scan + user fetch → minVendors gate →
- * resolveContact (3-tier: extract domain → GitHub user → deepResearchPerson) →
- * verifyEmail → enqueue — is large enough that inlining it back would obscure
- * the finder, and ctx-based parameterisation keeps the door open for future
- * repo finders without re-extracting later.
- *
- * Stack detection used to be a webRead + LLM extract on the README, which
- * (a) timed out ~44% of the time on JS-rendered GitHub pages and (b) read
- * marketing copy that didn't reflect actual code. We now pull the truth
- * directly from package.json / pyproject.toml / requirements.txt /
- * .env.example via the GitHub Contents API. Free, fast, deterministic.
+ * Shared per-candidate pipeline for repo-style finders: snippet ICP →
+ * manifest scan + GitHub user fetch → minVendors gate → contact resolution
+ * (3-tier) → verifyEmail → person gate → enqueue. Parameterised via ctx so
+ * future repo finders can reuse it.
  */
 const PLAY_NAME = "stack-consolidation";
 
@@ -67,10 +58,8 @@ export interface RepoPipelineCtx {
   /** Mutable accumulator. Workers mutate fields on this directly. */
   result: FinderResult;
   /**
-   * Boxed flag so workers share the same reference across the parallelMap
-   * pool. Soft halt: workers check at the top of each iteration but several
-   * may pass before any flips it — over-shoot up to (concurrency-1) is
-   * acceptable for the scales we operate at.
+   * Boxed flag shared across the parallelMap pool. Soft halt — over-shoot up
+   * to (concurrency-1) is acceptable.
    */
   halted: { value: boolean };
   limit: number;
@@ -125,9 +114,7 @@ export async function processRepoCandidate(
   };
   const errKindPrefix = ctx.sourceTag.replace(/^find:/, "");
 
-  // 1) ICP on the snippet — cheap pre-filter. Skips the manifest scan +
-  //    user-fetch + contact-resolution chain on candidates the classifier
-  //    rejects, which is most of them in practice.
+  // 1) ICP on the snippet — cheap pre-filter ahead of the paid chain.
   const snippetFilter = await icpFilter({
     icp: ctx.icp,
     candidate: {
@@ -137,9 +124,8 @@ export async function processRepoCandidate(
     },
   });
   if (snippetFilter.match === null) {
-    // Transient classifier failure (Anthropic 5xx, timeout, rate limit) —
-    // drop without persisting. A rejection would burn the dedupeKey for
-    // every future watch tick since isQueueDuplicate ignores status.
+    // Transient classifier failure — drop without persisting. A rejection
+    // would burn the dedupeKey forever (isQueueDuplicate ignores status).
     result.droppedEnrichment++;
     return;
   }
@@ -156,15 +142,8 @@ export async function processRepoCandidate(
     return;
   }
 
-  // 2) Stack detection — deterministic GitHub-API scan of manifest files
-  // (package.json, pyproject.toml, requirements.txt, .env.example) instead
-  // of webRead + LLM extract. Three reasons:
-  //   - webRead timed out on ~44% of GitHub repo pages (JS-rendered)
-  //   - READMEs are marketing copy that don't always match what code imports
-  //   - Manifest scanning is free (counts against GITHUB_TOKEN's 5k/hr) and
-  //     authoritative — if `openai` is in package.json the repo uses OpenAI
-  //
-  // Author / company come from the GitHub user profile (also free).
+  // 2) Stack detection — deterministic manifest scan via the GitHub Contents
+  // API (free, authoritative). Author/company come from the user profile.
   const owner = ownerFromRepoUrl(hit.url);
   const repoName = repoNameFromRepoUrl(hit.url);
   if (!owner || !repoName) {
@@ -191,27 +170,21 @@ export async function processRepoCandidate(
   const extract: AgentBuilderExtract = {
     repoUrl: hit.url,
     githubHandle: owner,
-    // Prefer the human-friendly name; many GitHub users leave it blank.
-    // findEmail downstream short-circuits gracefully when this is null.
+    // Often blank on GitHub; findEmail downstream short-circuits on null.
     authorFullName: ghUserInfo?.name ?? null,
     authorRole: null, // not derivable from GitHub user API
     companyName: ghUserInfo?.company ?? null,
-    // The GitHub blog field is a single bare hostname — we don't have enough
-    // signal to know if it's corporate or personal, so map it to companyDomain
-    // and leave personalDomain null. The resolveContact fallback chain reads
-    // both via `?? null`, so the choice doesn't change behavior.
+    // GitHub's blog field could be corporate or personal; mapped to
+    // companyDomain — resolveContact reads both, so the choice is behavior-neutral.
     companyDomain: ghUserInfo?.blogDomain ?? null,
     personalDomain: null,
     stackDetected: stack.detected,
     summary: null,
   };
 
-  // Route by direct-competitor match: a candidate whose detected stack
-  // includes one of the founder's head-on rivals gets the competitor-switch
-  // motion ("switch from X"); everything else is a stack-consolidation
-  // (vendor-sprawl) pitch. directCompetitors is empty by default → always
-  // stack-consolidation. The resolved play name is used for the rest of this
-  // candidate's pipeline (dedupe, receipt tags, enqueue).
+  // Route by direct-competitor match: head-on rival in the stack →
+  // competitor-switch, else stack-consolidation. The resolved play name is
+  // used for the rest of this candidate's pipeline (dedupe, receipts, enqueue).
   const directSet = new Set((ctx.directCompetitors ?? []).map((s) => s.toLowerCase()));
   const matchedCompetitor = extract.stackDetected.find((v) => directSet.has(v.toLowerCase()));
   const playName = matchedCompetitor ? "competitor-switch" : "stack-consolidation";
@@ -237,9 +210,8 @@ export async function processRepoCandidate(
     return;
   }
 
-  // verifyEmail can throw on transient SDK / network errors. Catch and drop
-  // the candidate rather than letting one bad call tear down the pool —
-  // identical reasoning to the findEmail wrap in resolveContact.tryFindEmail.
+  // verifyEmail can throw on transient errors — catch and drop the candidate
+  // rather than letting one bad call tear down the pool.
   let verified: Awaited<ReturnType<typeof verifyEmail>>;
   try {
     verified = await verifyEmail({ email: contact.email }, { playName });
@@ -261,9 +233,8 @@ export async function processRepoCandidate(
     return;
   }
 
-  // Always-on post-verify enrichment so phone + linkedin land on every
-  // queue row. Path B' may have already populated both — skip the call
-  // when so. ~$0.005 per call when fired (per OneShot pricing).
+  // Always-on post-verify enrichment so phone + linkedin land on every queue
+  // row; skipped when Path B' already populated them.
   if (!contact.phone || !contact.linkedinUrl || !contact.title) {
     const enr = await enrichVerifiedContact(contact.email, {
       playName,
@@ -276,9 +247,8 @@ export async function processRepoCandidate(
     contact.summary = contact.summary ?? enr.summary;
   }
 
-  // Person-level ICP gate. GitHub exposes no role (`extract.authorRole` is
-  // always null here), so the decision rests on the enriched title — which is
-  // free, since the call above already ran.
+  // Person-level ICP gate. GitHub exposes no role, so the decision rests on
+  // the (already-bought) enriched title.
   const gate = await qualifyPostEnrich({
     icp: ctx.icp,
     person: {
@@ -310,8 +280,7 @@ export async function processRepoCandidate(
     return;
   }
   if (gate.action === "defer") {
-    // Classifier/platform outage — not a verdict. Same handling as any other
-    // platform error so the candidate is retried rather than blacklisted.
+    // Classifier/platform outage — not a verdict; retried, never blacklisted.
     result.droppedEnrichment++;
     return;
   }
@@ -340,8 +309,7 @@ export async function processRepoCandidate(
         company,
         competitor: matchedCompetitor,
         evidenceUrl: hit.url,
-        // Honest, specific evidence — no fabricated "auth surfaces". Single
-        // vendor, so no rule-of-three risk. Setting evidenceText also makes
+        // Honest, specific evidence. Setting evidenceText also makes
         // competitor-switch skip its (expensive) browser scrape.
         evidenceText: `Their public repo uses ${matchedCompetitor} (found in ${stack.manifestsFound.join(", ")}).`,
         yourEdge: ctx.yourEdge,
@@ -402,25 +370,17 @@ interface ResolvedContact {
   /** Free-text bio/headline from post-verify enrichment. Secondary gate evidence. */
   summary: string | null;
   /**
-   * True when Path B' already ran enrichProfile against `linkedinUrl`. Lets the
-   * ICP gate skip a fill-the-gap lookup that would repeat that exact call.
+   * True when Path B' already ran enrichProfile against `linkedinUrl` — lets
+   * the ICP gate skip a duplicate fill-the-gap lookup.
    */
   enrichedByLinkedin: boolean;
 }
 
 /**
- * Resolve a deliverable contact for a repo candidate.
- *
- * Decision tree (cheapest path first; one paid call per tier):
- *   1. extract has a domain → findEmail($0.005). Done if found.
- *   2. GitHub user provides an email directly → use it (no findEmail spend).
- *   3. (opt-in) deepResearchPerson($0.05, 2-5 min async) with the repo URL +
- *      author name — recovers the bucket where nobody has a resolvable
- *      companyDomain anywhere.
- *
- * The pre-fetched `ghUser` is required from the pipeline (we already fetch
- * it for the extract construction); accepting it here avoids a duplicate
- * lookup. Pass null if the candidate isn't a GitHub repo.
+ * Resolve a deliverable contact for a repo candidate, cheapest path first:
+ * extract domain → findEmail; GitHub user email direct; then (opt-in)
+ * deepResearchPerson. `ghUser` is passed pre-fetched to avoid a duplicate
+ * lookup; null if the candidate isn't a GitHub repo.
  */
 export async function resolveContact(args: {
   extract: AgentBuilderExtract;
@@ -443,16 +403,9 @@ export async function resolveContact(args: {
   // ICP gate never buys the same lookup a second time.
   let didEnrichByLinkedin = false;
 
-  // LinkedIn capture runs for EVERY candidate, ahead of the email paths.
-  //
-  // This used to live inside the `!companyForGate` block below, whose job is
-  // recovering a *company* for the deep-research gate — LinkedIn was only a
-  // side effect. The consequence: candidates that already had a company (the
-  // best ones) skipped the lookup entirely, and since `discoveredLinkedinUrl`
-  // is read by all of this function's return paths, every one of them handed
-  // back null. That's why this pipeline produced 11 LinkedIn URLs out of 80.
-  //
-  // Cost: ~$0.01 webSearch per candidate. Cached per-run inside findLinkedInUrl.
+  // LinkedIn capture runs for EVERY candidate, ahead of the email paths — it
+  // is a first-class output read by all return paths, not a side effect of
+  // company recovery. Cached inside findLinkedInUrl.
   if (extract.authorFullName || extract.githubHandle) {
     const nameTokens = [extract.authorFullName, extract.githubHandle].filter((t): t is string =>
       Boolean(t),
@@ -497,17 +450,10 @@ export async function resolveContact(args: {
     };
   }
 
-  // Path B': enrichProfile off the LinkedIn URL found above, to recover
-  // company / company_domain / sometimes email. Bridges the common case where
-  // GitHub gives us a name but no company/blog — without this, deep-research
-  // (Path C) fails its required-identifier gate and the candidate drops.
-  //
-  // The webSearch itself now happens unconditionally further up (LinkedIn is a
-  // first-class output, not a side effect of company recovery). What stays
-  // gated is the paid enrichProfile: only worth $0.005 when we still lack a
-  // company to satisfy the deep-research gate.
-  //
-  // Cost when triggered: ~$0.005 enrichProfile (the webSearch is already spent).
+  // Path B': enrichProfile off the LinkedIn URL, to recover company /
+  // company_domain / sometimes email — without it, Path C fails its
+  // required-identifier gate. The paid enrichProfile only fires when a
+  // company is still missing.
   let companyForGate: string | null = extract.companyName ?? null;
   let domainForGate: string | null = extractDomain;
   if (!companyForGate && discoveredLinkedinUrl) {
@@ -517,16 +463,12 @@ export async function resolveContact(args: {
       didEnrichByLinkedin = true;
       accumCost(enriched.result.cost ?? 0);
       const profile = enriched.result.profile;
-      // PersonResult exposes phone (string) AND fullphone (array) — extractFirstPhone
-      // reads either. Capture once and reuse on every return path so we don't drop
-      // a phone the SDK already paid to retrieve.
+      // Captured once and reused on every return path.
       const enrichedPhone = extractFirstPhone(profile);
       // Cache the linkedin-keyed enrich by the SURFACED email so the later
-      // post-verify enrichVerifiedContact (by email) becomes a cache hit and
-      // skips its second SDK call. Only cache when profile.email is directly
-      // surfaced — for paths that derive the email via findEmail (different
-      // API), we can't guarantee the profile is for the same person, so
-      // skip the cache to avoid poisoning.
+      // by-email enrichVerifiedContact becomes a cache hit. Only when
+      // profile.email is directly surfaced — a findEmail-derived email may be
+      // a different person, and caching it would poison.
       if (profile?.email) {
         try {
           getLedger().setCachedEnrichment(
@@ -585,21 +527,15 @@ export async function resolveContact(args: {
     }
   }
 
-  // Path C: deep research as the last resort. The API needs strong identifiers
-  // to find a person — empirically, `socialMediaUrl: <github-repo-url>` alone
-  // is NOT enough (we burned $0.15 on three "Could not find data for this
-  // person" failures with just that). Require either:
-  //   (a) a known email, OR
-  //   (b) full name AND company  (company may have been populated by Path B')
-  // Anything weaker spends $0.05 on a near-guaranteed miss. The repoUrl is
-  // still passed as `socialMediaUrl` for bonus signal when present.
+  // Path C: deep research as the last resort. The API needs strong
+  // identifiers — a repo URL alone is empirically not enough, so require a
+  // known email OR full name AND company; the repoUrl still rides along as
+  // `socialMediaUrl` for bonus signal.
   if (!useDeepResearch) return null;
   const hasName = Boolean(extract.authorFullName && extract.authorFullName.length > 0);
   const hasCompany = Boolean(companyForGate && companyForGate.length > 0);
-  // We never have an email here by definition — Paths A/B both bail before
-  // setting one, and a contact found earlier short-circuits before this tier.
-  // Kept as a placeholder for future flexibility (e.g. a discovery layer that
-  // surfaces a tentative email).
+  // Never true here by definition (earlier paths short-circuit on a found
+  // contact); kept as a placeholder for a future tentative-email source.
   const hasEmail = false;
   if (!hasEmail && !(hasName && hasCompany)) return null;
   try {
@@ -647,12 +583,10 @@ export async function resolveContact(args: {
 }
 
 /**
- * Single findEmail attempt with consistent fault-handling. OneShot's
- * findEmail requires `full_name` (or first+last) — without one it throws
- * synchronously, and a throw here would tear down the parallelMap pool. We
- * short-circuit cleanly when there's no name, and catch the SDK throw on
- * transient network errors. Either failure mode returns null so the caller
- * falls through to the next contact-resolution tier.
+ * Single findEmail attempt with consistent fault-handling. findEmail throws
+ * synchronously without a `full_name`, and any throw here would tear down the
+ * parallelMap pool — both failure modes return null so the caller falls
+ * through to the next tier.
  */
 async function tryFindEmail(
   domain: string,
@@ -702,14 +636,9 @@ async function tryFindEmail(
 }
 
 /**
- * Compose the snippet-ICP `summary` from whichever signal we have. Topic-driven
- * candidates (github-topics) carry the repo's self-tagged GitHub topics. The
- * `vendors` branch is reserved for future finders that surface known vendor
- * names at discovery. If neither is present, return the bare description
- * rather than emitting an empty `topics: ` tail.
- *
- * Exported for direct unit testing — integration coverage of both branches
- * would require a discovery shape that doesn't exist yet.
+ * Compose the snippet-ICP `summary` from whichever signal is present
+ * (vendors, topics, or bare description — never an empty `topics:` tail).
+ * Exported for direct unit testing.
  */
 export function describeForIcp(hit: RepoCandidate): string {
   if (hit.vendors.length > 0) {

--- a/packages/find/src/_repo-stack.ts
+++ b/packages/find/src/_repo-stack.ts
@@ -2,28 +2,11 @@ import { logEvent } from "@oneshot-gtm/core";
 import { githubHeaders } from "./_github-search.ts";
 
 /**
- * Deterministic stack detection from a GitHub repo's manifest files. Replaces
- * the older webRead + LLM-extract path that was unreliable in two ways: (1)
- * webRead timed out on ~44% of GitHub README pages (JS-rendered), and (2)
- * READMEs are marketing copy that doesn't always match what the code
- * actually imports. Manifests are authoritative — if `openai` is in
- * `package.json`, the project uses OpenAI.
- *
- * Files we scan in priority order: package.json (npm), pyproject.toml +
- * requirements.txt (Python), .env.example (env-var leakage). Each fetch is
- * independent + best-effort; missing files just contribute nothing.
- *
- * The `vocab` argument is the founder-controlled vendor list. Each vocab
- * string is substring-matched (case-insensitive) against the union of all
- * extracted manifest tokens — `twilio` matches `twilio`, `twilio-node`,
- * `@twilio/voice-sdk`, AND `TWILIO_ACCOUNT_SID`. There is no hardcoded
- * vendor catalog; oneshot-gtm is a generic founder tool and competitive
- * vocabularies vary entirely by founder. The strategist proposes vocab
- * populations from the founder's product/ICP context (see
- * `packages/prompts/strategist-trigger.md`).
- *
- * Cost: ~3-4 GitHub API calls per candidate. With `GITHUB_TOKEN` set the
- * 5,000/hr quota is plenty for any practical run.
+ * Deterministic stack detection from a GitHub repo's manifest files
+ * (manifests are authoritative; READMEs aren't). `vocab` is the founder's
+ * vendor list — substring-matched (case-insensitive) against manifest deps
+ * and env-var keys; there is no hardcoded vendor catalog. Each manifest
+ * fetch is independent and best-effort.
  */
 
 export interface StackDetection {
@@ -63,11 +46,8 @@ export async function detectRepoStack(args: {
     }
   }
 
-  // Single transparent matching loop. Each vocab entry is a substring needle
-  // searched across every extracted token. Casing doesn't matter (tokens
-  // were lowercased on insertion). Substring is intentional: founder typing
-  // `twilio` matches `twilio-node`, `@twilio/voice-sdk`, and `TWILIO_*` env
-  // keys — three real signals from one vocab entry.
+  // Substring match is intentional: `twilio` matches `twilio-node`,
+  // `@twilio/voice-sdk`, and `TWILIO_*` env keys (tokens lowercased on insertion).
   const detected = new Set<string>();
   for (const v of vocab) {
     const needle = v.toLowerCase();
@@ -95,9 +75,7 @@ export async function detectRepoStack(args: {
 
 /**
  * Fetch a file from a repo's default branch via the GitHub Contents API.
- * Returns null on any non-2xx (including 404 — file just doesn't exist),
- * network error, or unexpected content type. Same fault-tolerance pattern
- * as `fetchGitHubUser`.
+ * Returns null on any non-2xx, network error, or unexpected content type.
  */
 async function fetchRepoFile(owner: string, repo: string, path: string): Promise<string | null> {
   const url = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${path}`;
@@ -106,9 +84,7 @@ async function fetchRepoFile(owner: string, repo: string, path: string): Promise
     const res = await fetch(url, { headers });
     if (!res.ok) return null;
     const text = await res.text();
-    // Defensive cap. Manifests are usually < 50KB; anything larger is either
-    // a spurious vendored file or a bug. We're only doing substring matches
-    // so trimming is safe.
+    // Defensive cap — only substring matching happens downstream, so trimming is safe.
     return text.length > 200_000 ? text.slice(0, 200_000) : text;
   } catch {
     return null;
@@ -150,10 +126,8 @@ function parsePackageJson(content: string): string[] {
 }
 
 /**
- * Pull dep names out of a pyproject.toml. We don't ship a TOML parser — a
- * regex over `name = "..."` patterns inside `[project.dependencies]` and
- * Poetry-style `[tool.poetry.dependencies]` sections covers the bulk of
- * real-world files. Fail-soft: missing matches just yield no names.
+ * Regex-based pyproject.toml dep extraction (Poetry + PEP 621 shapes) — no
+ * TOML parser shipped. Fail-soft: missing matches just yield no names.
  */
 function parsePyProject(content: string): string[] {
   const out: string[] = [];
@@ -176,10 +150,7 @@ function parsePyProject(content: string): string[] {
   return out;
 }
 
-/**
- * Reserved top-level keys in pyproject.toml that aren't dependencies. The
- * Poetry regex is loose enough to match these; this set filters them out.
- */
+/** Non-dependency pyproject keys the loose Poetry regex would otherwise match. */
 const RESERVED_PYPROJECT_KEYS = new Set([
   "name",
   "version",
@@ -221,10 +192,8 @@ function parseRequirementsTxt(content: string): string[] {
 }
 
 /**
- * Pull env-var keys out of a `.env.example` (or `.env.sample`). Vendor SDKs
- * conventionally name their keys after themselves (`OPENAI_API_KEY`,
- * `TWILIO_ACCOUNT_SID`, etc), so the keys themselves are great signal even
- * when the values are placeholder.
+ * Env-var keys from `.env.example` — vendor SDKs name keys after themselves
+ * (`OPENAI_API_KEY`), so keys are signal even with placeholder values.
  */
 function parseEnvKeys(content: string): string[] {
   const out: string[] = [];

--- a/packages/find/src/post-funding.ts
+++ b/packages/find/src/post-funding.ts
@@ -86,7 +86,6 @@ export async function runPostFundingFinder(opts: PostFundingFinderOpts): Promise
       continue;
     }
 
-    // Read the announcement.
     let extract: PostFundingExtract;
     try {
       const read = await webRead({ url }, { playName: PLAY_NAME });

--- a/packages/find/src/registry.ts
+++ b/packages/find/src/registry.ts
@@ -59,17 +59,12 @@ export function checkReadiness(spec: TriggerSpec, config: Record<string, unknown
 const ONE_HOUR = 3600 * 1000;
 
 /**
- * Default cohort sweep for the `accelerator-batch` trigger. Covers seven
- * incubators × {latest, previous-latest} cohorts as of 2026-05-20. Only the
- * yc-* entries hit the structured yc-oss/api directory; the other 12 route
- * to the websearch + LLM-extract adapter and will have spotty per-cohort
- * recall (Neo is invite-only, SPC publishes thin web footprint, etc.).
- * Per-cohort failures are isolated — the run only halts when EVERY cohort
- * comes back empty.
- *
- * ROTATION: this list goes stale within ~3 months as YC announces W27,
- * Techstars rolls Fall 2026, etc. Founders should edit `cohorts[]` via the
- * trigger config UI on /queue when new batches announce.
+ * Default cohort sweep for `accelerator-batch`. Only yc-* entries hit the
+ * structured yc-oss/api directory; the rest use the websearch + LLM-extract
+ * adapter with spotty recall. Per-cohort failures are isolated — the run only
+ * halts when EVERY cohort comes back empty.
+ * ROTATION: goes stale within ~3 months; founders edit `cohorts[]` in the
+ * /queue trigger config as new batches announce.
  */
 const DEFAULT_COHORTS: CohortEntry[] = [
   { cohort: "yc-w26", cohortLabel: "YC W26" },
@@ -108,10 +103,7 @@ export const TRIGGERS: TriggerSpec[] = [
     name: "accelerator-batch",
     defaultIntervalMs: 24 * ONE_HOUR,
     enabledByDefault: false,
-    // Default sweep: every known incubator × {latest, previous-latest} cohorts.
-    // Founders can trim or edit the list in /queue → trigger config; per-cohort
-    // failures don't halt the run, so spotty incubators (Neo, SPC) coexist
-    // with high-recall ones (YC, Techstars) in one trigger fire.
+    // Every known incubator × {latest, previous-latest}; editable in /queue.
     defaultConfig: {
       cohorts: DEFAULT_COHORTS,
       limit: 25,
@@ -285,12 +277,9 @@ export const TRIGGERS: TriggerSpec[] = [
       }),
   },
   {
-    // Luma upcoming-event hosts + featured guests. Discovery reads Luma's
-    // per-city pages (genuinely upcoming; webSearch fallback for unmapped
-    // cities); each event passes a keyword + LLM topic/ICP gate before any
-    // paid read; attendees come structured (with linkedin/website) from
-    // Luma's public event JSON. Contact via LinkedIn enrichProfile or
-    // website domain, then the standard findEmail chain.
+    // Luma upcoming-event hosts + featured guests: per-city page discovery
+    // (webSearch fallback), keyword + LLM topic/ICP gate before any paid read,
+    // attendees from Luma's public event JSON.
     name: "luma-events",
     defaultIntervalMs: 24 * ONE_HOUR,
     enabledByDefault: false,
@@ -343,13 +332,9 @@ export const TRIGGERS: TriggerSpec[] = [
       }),
   },
   {
-    // GitHub-Topic-driven repo finder. Discovers via the (free) GitHub Search
-    // API filtered by `topic:<slug>` — topic-tagged repos are pre-curated by
-    // maintainers self-tagging, much higher signal-per-fetch than the
-    // retired combo-search approach. Feeds stack-consolidation (vendor-
-    // sprawl pitch) by default, or competitor-switch when a detected vendor
-    // is on `directCompetitors`. Config-driven — the founder supplies topics
-    // + vendors + edge via /queue; ships empty so nothing fires until configured.
+    // GitHub-Topic-driven repo finder (free Search API, `topic:<slug>`).
+    // Routes to stack-consolidation, or competitor-switch on a
+    // `directCompetitors` match. Ships empty so nothing fires until configured.
     name: "github-topics",
     defaultIntervalMs: 12 * ONE_HOUR,
     enabledByDefault: false,
@@ -504,9 +489,7 @@ export const TRIGGERS: TriggerSpec[] = [
 
 /**
  * Resolve the active interval for a trigger: stored config_json may override
- * the registry's defaultIntervalMs via `intervalMs`. This keeps the JSON-config
- * editor in /queue meaningful — bumping it from 24h → 6h actually changes the
- * watch loop's cadence.
+ * the registry's defaultIntervalMs via `intervalMs`.
  */
 export function effectiveIntervalMs(
   spec: TriggerSpec,
@@ -524,9 +507,7 @@ export interface TriggerRunOutcome {
   fired: boolean;
   result?: FinderResult;
   error?: string;
-  /** Wall-clock of the run, present only when `fired`. Surfaced so callers
-   * (e.g. the dashboard scheduler's telemetry) can attribute duration without
-   * re-deriving it. */
+  /** Wall-clock of the run, present only when `fired`. */
   duration_ms?: number;
   /** ms until this trigger is next due */
   nextDueInMs: number;
@@ -534,38 +515,20 @@ export interface TriggerRunOutcome {
 
 /**
  * Maximum age before an in-flight `running_started_at` is considered a
- * killed-by-restart zombie and swept by `sweepStaleRunningTriggers`.
- *
- * Real finder runtimes are dominated by the per-candidate pipeline (icpFilter
- * LLM + findEmail + verifyEmail, occasionally + webRead + deepResearchPerson).
- * github-topics with concurrency=3 typically completes 25 candidates in
- * 5-15 min; the deepResearchPerson tier (2-5 min async per call) sets the
- * realistic upper bound when many candidates fall into the hard-recovery bucket.
- *
- * 4h is set with generous headroom so a genuinely-running finder is never
- * mistakenly classified as zombie. If a run actually exceeds this, the
- * sweep marks it killed and `markTriggerRunning` lets a follow-up click
- * re-claim — bounded duplicate spend is preferable to the permanently-
- * stuck 409 state.
+ * killed-by-restart zombie and swept. 4h leaves generous headroom over real
+ * finder runtimes; a run that exceeds it gets marked killed and re-claimable —
+ * bounded duplicate spend beats a permanently-stuck 409.
  */
 export const MAX_RUN_AGE_MS = 4 * 60 * 60 * 1000;
 
 /**
- * Truth of "is this trigger running" lives in the ledger
- * (`triggers.running_started_at`). Survives server restart so the UI shows
- * accurate state across `bun --watch` re-execs and OS reboots.
- *
- * The freshness gate (`< MAX_RUN_AGE_MS`) hides stale rows that the boot
- * sweep hasn't cleaned up yet — defense in depth so we never report "still
- * running" for a row that's older than any real run could be.
+ * Truth of "is this trigger running" lives in the ledger and survives server
+ * restart. The freshness gate hides stale rows the boot sweep hasn't cleaned
+ * up yet — never report "still running" for a row older than any real run.
  */
 /**
- * Pure helper extracted so the freshness gate is unit-testable without
- * mocking the ledger. Returns the parsed start-epoch when the iso
- * timestamp is valid AND fresh (within MAX_RUN_AGE_MS of `now`); null
- * otherwise.
- *
- * `nowMs` is injected so tests can drive time without faking Date.
+ * Pure helper (unit-testable without the ledger): parsed start-epoch when the
+ * timestamp is valid AND within MAX_RUN_AGE_MS of `nowMs`; null otherwise.
  */
 export function freshRunningStartedAtMs(
   iso: string | null | undefined,
@@ -587,10 +550,8 @@ export function getTriggerRunningSince(name: string): number | null {
 }
 
 /**
- * Stored config with corruption fallback. A bare JSON.parse here used to let
- * one corrupt config_json row throw out of runDueTriggers' loop and stall
- * every trigger until the row was fixed by hand; now the trigger runs on its
- * defaults with a warning instead.
+ * Stored config with corruption fallback — one corrupt config_json row must
+ * not stall every trigger, so it runs on defaults with a warning instead.
  */
 export function storedTriggerConfig(
   stored: TriggerRow | null,
@@ -606,19 +567,10 @@ export function storedTriggerConfig(
 }
 
 /**
- * Fire-and-forget wrapper around `runTriggerNow`: returns immediately after
- * marking the trigger as running in the ledger; the actual finder work runs
- * on the event loop. Throws synchronously if the trigger is unknown,
- * already running, or unready.
- *
- * Errors from the finder are swallowed here — `runTriggerNow` already
- * persists them to the ledger (`last_run_summary`) and emits a
- * `trigger.run.error` event, so there's nothing useful for the caller to do.
- *
- * If the process is killed mid-run (bun --watch re-exec, OS reboot), the
- * row's `running_started_at` stays set. The next cold boot's
- * `sweepStaleRunningTriggers` call writes a `killed_by_restart` summary so
- * the UI shows the truth instead of frozen-from-an-hour-ago state.
+ * Fire-and-forget wrapper around `runTriggerNow`. Throws synchronously if the
+ * trigger is unknown, already running, or unready; finder errors are already
+ * persisted by runTriggerNow. A process killed mid-run leaves
+ * `running_started_at` set — the cold-boot sweep writes `killed_by_restart`.
  */
 export function fireTriggerNow(name: string): void {
   const spec = TRIGGERS.find((t) => t.name === name);
@@ -643,28 +595,17 @@ export function fireTriggerNow(name: string): void {
       enabled: spec.enabledByDefault !== false,
     });
   }
-  // Atomic claim — no TOCTOU race. Two concurrent fires both calling
-  // markTriggerRunning will see exactly one `true` and one `false`, so
-  // only one finder run actually launches.
-  //
-  // The `staleCutoffIso` lets a fresh click reclaim a row whose previous
-  // `running_started_at` is older than `MAX_RUN_AGE_MS` — i.e. the freshness
-  // gate already says "not running" but the DB flag never got cleared
-  // (process killed, no cold-boot sweep yet). Without this the user would
-  // see Run-button-enabled, click, and get 409'd every retry.
+  // Atomic claim — no TOCTOU race: exactly one of two concurrent fires wins.
+  // `staleCutoffIso` lets a fresh click reclaim a row whose stale
+  // `running_started_at` never got cleared, instead of 409ing every retry.
   const nowIso = new Date().toISOString();
   const staleCutoffIso = new Date(Date.now() - MAX_RUN_AGE_MS).toISOString();
   const claimed = ledger.markTriggerRunning(name, nowIso, staleCutoffIso);
   if (!claimed) {
     throw new Error(`trigger '${name}' is already running`);
   }
-  // Explicit catch — `void` discards the promise without wiring rejection
-  // handling. If `runTriggerNow` throws synchronously OR rejects before its
-  // own try/catch (e.g. JSON.parse on a corrupted config_json, an import
-  // resolution issue under bun --hot, anything that would otherwise be a
-  // silent unhandled rejection), we surface the failure AND clear the
-  // stranded `running_started_at` so the row doesn't stay "running" until
-  // the next boot sweep.
+  // Explicit catch (not `void`): a rejection before runTriggerNow's own
+  // try/catch must surface AND clear the stranded `running_started_at`.
   runTriggerNow(name).catch((err) => {
     const message = (err as Error).message ?? "runTriggerNow rejected";
     logEvent("trigger.run.fire_failed", { name, message_120: message.slice(0, 120) }, "error");
@@ -674,17 +615,15 @@ export function fireTriggerNow(name: string): void {
         summary: { error: `fire_failed: ${message}`, at: new Date().toISOString() },
       });
     } catch {
-      // updateTriggerLastPoll itself failing is hopeless; the boot sweep
-      // is the safety net.
+      // The boot sweep is the safety net.
     }
   });
 }
 
 /**
- * Run a single trigger by name immediately, ignoring its scheduled dueAt
- * and the enabled flag. Useful for the /queue UI's "Run now" affordance:
- * the founder explicitly asked, so we bypass the scheduler. Persists
- * last_polled_at + last_run_summary so the watch loop respects the run.
+ * Run a single trigger immediately, ignoring dueAt and the enabled flag
+ * (the founder explicitly asked). Persists last_polled_at + last_run_summary
+ * so the watch loop respects the run.
  */
 export async function runTriggerNow(name: string): Promise<TriggerRunOutcome> {
   startRun();
@@ -764,7 +703,6 @@ export async function runDueTriggers(): Promise<TriggerRunOutcome[]> {
   for (const spec of TRIGGERS) {
     const stored = ledger.getTrigger(spec.name);
     const defaultEnabled = spec.enabledByDefault !== false;
-    // Initialize on first sight.
     if (!stored) {
       ledger.upsertTrigger({
         name: spec.name,
@@ -782,9 +720,8 @@ export async function runDueTriggers(): Promise<TriggerRunOutcome[]> {
       continue;
     }
 
-    // Readiness gate: skip without touching last_polled_at so the watch loop
-    // retries on the *next* tick once config is fixed, not on the next
-    // interval boundary.
+    // Readiness gate: skip without touching last_polled_at so a config fix is
+    // picked up on the next tick, not the next interval boundary.
     const readiness = checkReadiness(spec, config);
     if (!readiness.ready) {
       outcomes.push({ name: spec.name, fired: false, nextDueInMs: intervalMs });
@@ -803,13 +740,9 @@ export async function runDueTriggers(): Promise<TriggerRunOutcome[]> {
       continue;
     }
 
-    // Atomic claim — same pattern as fireTriggerNow (line 436-441) so the
-    // scheduled-fire path can't race with a manual click on the same trigger
-    // and double-spend. `staleCutoffIso` lets a fresh tick reclaim a row
-    // whose previous `running_started_at` is older than MAX_RUN_AGE_MS (the
-    // freshness gate already says "not running" but the marker never got
-    // cleared — process killed before updateTriggerLastPoll ran, no boot
-    // sweep yet). Cleared by updateTriggerLastPoll on success/error.
+    // Atomic claim — same pattern as fireTriggerNow, so the scheduled path
+    // can't race a manual click and double-spend; `staleCutoffIso` reclaims a
+    // stale marker. Cleared by updateTriggerLastPoll on success/error.
     const claimNowIso = new Date().toISOString();
     const staleCutoffIso = new Date(Date.now() - MAX_RUN_AGE_MS).toISOString();
     const claimed = ledger.markTriggerRunning(spec.name, claimNowIso, staleCutoffIso);

--- a/packages/plays/src/_cadence.ts
+++ b/packages/plays/src/_cadence.ts
@@ -68,23 +68,16 @@ export function registerSequence(seq: Sequence): void {
   playSequences.set(seq.playName, seq);
 }
 
-/**
- * "Does this label name a breakup step?" — single source of truth for the
- * label-substring check. Used by isBreakupStepAt for the cadence-final
- * semantic check AND by /plays for per-step rendering where each row is
- * already a step.
- */
+/** Single source of truth for the breakup-label substring check (isBreakupStepAt + /plays). */
 export function isBreakupLabel(label: string | null | undefined): boolean {
   return Boolean(label && label.toLowerCase().includes("breakup"));
 }
 
 /**
- * Centralized breakup-step detection for cadence-progress semantics. A
- * step is "the breakup" iff (a) it sits at the END of the sequence and
- * (b) its label is a breakup label. Both clauses matter: the
- * breakup-email PROMPT is also used as accelerator-batch's only
- * follow-up — at index 0 — and that one isn't semantically a breakup
- * for cadence UX purposes (no value follow-up preceded it).
+ * A step is "the breakup" iff it sits at the END of the sequence AND has a
+ * breakup label. Both clauses matter: the breakup-email prompt is reused as
+ * accelerator-batch's only follow-up at index 0, which isn't semantically a
+ * breakup.
  */
 export function isBreakupStepAt(seq: Sequence, stepEntryIndex: number): boolean {
   if (stepEntryIndex !== seq.steps.length - 1) return false;
@@ -102,20 +95,16 @@ export interface NextStepInfo {
 
 /**
  * Number of follow-up steps registered for this play (excludes day-0).
- * Always returns the registered total regardless of current_step — the UI
- * uses `playFollowupCount + 1` for the StepProgress dot count which should
- * be stable for completed cadences too.
+ * Always the registered total regardless of current_step, so the UI's dot
+ * count stays stable for completed cadences.
  */
 export function playFollowupCount(playName: string): number {
   return effectiveSequence(playName)?.steps.length ?? 0;
 }
 
 /**
- * Given a play + the cadence's current_step, describe the NEXT step
- * scheduled to fire. Returns null when the cadence is at or past the
- * last step (no more steps to send). Source of truth for both the
- * server's CadenceView and the /cadences UI — avoids hardcoded
- * play→step-count Records in the web layer.
+ * Describe the NEXT step scheduled to fire, or null at/past the last step.
+ * Source of truth for both the server's CadenceView and the /cadences UI.
  */
 export function nextStepInfo(playName: string, currentStep: number): NextStepInfo | null {
   const seq = effectiveSequence(playName);
@@ -141,12 +130,10 @@ export function defaultSequence(playName: string): Sequence | undefined {
 }
 
 /**
- * The registered (code) sequence with the founder's per-play timing overrides
- * applied. The code sequence defines the structure (which prompts fire, where
- * the breakup sits); a matching-length `cadenceOverrides[playName]` in config
- * replaces each step's RELATIVE dayOffset. A length mismatch (e.g. after a
- * later structural change) is ignored — the code default wins, never throws.
- * Read fresh each call so a /plays edit takes effect without a restart.
+ * The registered sequence with the founder's per-play timing overrides. Code
+ * defines the structure; a matching-length `cadenceOverrides[playName]`
+ * replaces each RELATIVE dayOffset. A length mismatch is ignored — code wins,
+ * never throws. Read fresh each call so a /plays edit applies without restart.
  */
 export function effectiveSequence(playName: string): Sequence | undefined {
   const base = playSequences.get(playName);
@@ -197,9 +184,8 @@ export interface ReplyPollResult {
   /** Inbox emails examined. */
   polled: number;
   /**
-   * Replies learned for the FIRST time this poll — one per (prospect, play)
-   * whose sequence_events row flipped to `replied`. This is the number the
-   * reply-rate metrics move by, whatever state the cadence was in.
+   * Replies learned for the FIRST time this poll — the number the reply-rate
+   * metrics move by, whatever state the cadence was in.
    */
   repliesDetected: number;
   /** Subset of the above that also stopped a still-active cadence. */
@@ -210,17 +196,14 @@ export interface ReplyPollResult {
 /** poll_state key for the reply poll's high-water mark (newest received_at seen on a clean poll). */
 const REPLY_WATERMARK_KEY = "inbox_replies";
 /**
- * poll_state key for an unfinished catch-up: JSON `{ since, until }` naming the
- * slice of the window a poll ran out of page budget before reaching. Consumed
- * by later polls, a few pages at a time, until it is exhausted — so a backlog
- * larger than one poll's budget is delayed, never skipped.
+ * poll_state key for an unfinished catch-up slice (JSON `{ since, until }`),
+ * drained by later polls — a backlog is delayed, never skipped.
  */
 const REPLY_BACKLOG_KEY = "inbox_replies_backlog";
 /**
- * Re-examine this much before the watermark on every poll. Gmail's `after:` is
- * second-granular and mailboxes don't deliver in strict order, so a little
- * overlap is the difference between "never misses" and "usually doesn't".
- * Recording is idempotent, so overlap costs fetches, not correctness.
+ * Re-examine this much before the watermark every poll: Gmail's `after:` is
+ * second-granular and delivery isn't strictly ordered. Recording is
+ * idempotent, so overlap costs fetches, not correctness.
  */
 const REPLY_WATERMARK_OVERLAP_MS = 60 * 60_000;
 /** What the sources fall back to when no `since` is given (Gmail: `newer_than:30d`). */
@@ -228,17 +211,13 @@ const REPLY_DEFAULT_WINDOW_MS = 30 * 24 * 60 * 60_000;
 /** Page size per fetch — the same window the /inbox route uses. */
 const REPLY_POLL_LIMIT = 200;
 /**
- * Pages walked per poll before the rest is parked as backlog. In steady state
- * (5-minute ticks) one page is never full; this only bites on the first poll
- * after install or after a long outage, where it bounds a single poll to
- * ~2,000 messages and leaves the remainder for the next ticks.
+ * Pages walked per poll before the rest is parked as backlog — bounds a single
+ * poll after an install or outage; steady-state polls never fill one page.
  */
 const REPLY_POLL_MAX_PAGES = 10;
 /**
- * The poll runs in the background and is not latency-sensitive the way the
- * /inbox route is, so it can afford a longer per-source deadline than the 15s
- * default — a page of 200 full-message Gmail fetches takes ~8s on a good day
- * and was the single biggest source of `inbox.source_failed`.
+ * Background poll isn't latency-sensitive like the /inbox route, so it affords
+ * a longer per-source deadline than the 15s default.
  */
 const REPLY_POLL_DEADLINE_MS = 60_000;
 
@@ -253,12 +232,11 @@ interface WalkResult {
 }
 
 /**
- * Examine one (since, until) slice of the inbox newest-first, page by page,
- * recording replies as they are matched. Each page's oldest message bounds the
- * next page; the bound is pushed one second LATER than that message so the
- * boundary second is fetched again rather than skipped (`before:`/`until` are
- * exclusive at second granularity and two mails can share a second), with
- * `seen` de-duplicating by id across pages so nothing is counted twice.
+ * Examine one (since, until) inbox slice newest-first, page by page, recording
+ * replies. Each next-page bound is pushed one second LATER than the page's
+ * oldest message so the boundary second is refetched, not skipped
+ * (`before:`/`until` are exclusive at second granularity); `seen` de-dupes by
+ * id across pages.
  */
 async function walkInboxWindow(
   ledger: ReturnType<typeof getLedger>,
@@ -326,23 +304,13 @@ async function walkInboxWindow(
 }
 
 /**
- * Poll the inbox and record a reply wherever an inbound email's from-address
- * matches a prospect we emailed. Read-only except for the reply writes — it
- * never drafts or sends, so it's safe to run on a background timer (the server
- * scheduler) as well as inside `advanceCadence`. Without a background caller,
- * replies are only noticed when the founder manually advances/sends a cadence,
- * so a reply can sit unrecognized for days and the sequence keeps emailing.
- *
- * Three things make this see the whole field rather than a sliver of it:
- *  - the window is "since the last clean poll" (persisted watermark + overlap),
- *    not a bare newest-N across every mailbox that a noisy inbox could fill;
- *  - a window bigger than one poll's page budget is parked as a backlog slice
- *    and drained by the following polls, so it is delayed, never dropped; and
- *  - the reply is recorded against the play that emailed the prospect,
- *    regardless of cadence state, via `recordProspectReply` — so a reply that
- *    arrives after a sequence completed (the common case) still counts.
- *
- * `opts` exist for tests and deliberate backfills; production callers pass none.
+ * Poll the inbox and record a reply wherever an inbound from-address matches a
+ * prospect we emailed. Never drafts or sends, so it's safe on a background
+ * timer as well as inside `advanceCadence`. Coverage guarantees: the window is
+ * "since the last clean poll" (watermark + overlap), overflow is parked as
+ * backlog (delayed, never dropped), and replies are recorded regardless of
+ * cadence state so post-completion replies still count. `opts` exist for tests
+ * and backfills; production callers pass none.
  */
 export async function pollInboxReplies(opts?: {
   pageSize?: number;
@@ -447,10 +415,6 @@ export interface BouncePollResult {
  * Poll the mailbox for DSNs and act on them. Sibling to pollInboxReplies:
  * read-only except for the bounce row and the resulting cadence stop, so it's
  * safe on a background timer as well as inside advanceCadence.
- *
- * Without a background caller the tool learns an address is dead only by
- * failing to get a reply — meanwhile the sequence keeps emailing it, paying
- * per send, and each refusal costs sending reputation.
  */
 export async function pollInboxBounces(): Promise<BouncePollResult> {
   const ledger = getLedger();
@@ -509,12 +473,9 @@ export async function pollInboxBounces(): Promise<BouncePollResult> {
           identityId: b.identityId,
         },
       });
-      // Only a HARD bounce stops the sequence. A 5.7.x block is a verdict on
-      // this message or our sending domain, not on the mailbox — the address
-      // may well accept mail tomorrow, so killing the cadence would throw away
-      // a live prospect over one spam-filter decision. Blocks surface through
-      // the doctor check instead. Only `active` rows flip: a `replied` cadence
-      // has already proved the human is there.
+      // Only a HARD bounce stops the sequence — a 5.7.x block judges the
+      // message/domain, not the mailbox (blocks surface via the doctor check).
+      // Only `active` rows flip: a `replied` cadence proved the human is there.
       if (b.kind === "hard" && cad.status === "active") {
         ledger.setCadenceStatus({
           prospectId: prospect.id,
@@ -606,9 +567,8 @@ export async function advanceCadence(
   }
 
   // 2. For each active cadence with next_due_at <= now, execute the next step.
-  // Parallelized (concurrency 3): each step is an LLM draft + send (~5-90s), and
-  // `due` rows are distinct (prospect, play) pairs, so there's no shared-write
-  // contention. Results are collected in input order before counting.
+  // Concurrency 3 is safe: `due` rows are distinct (prospect, play) pairs, so
+  // no shared-write contention. Results are collected in input order.
   const nowIso = new Date().toISOString();
   const due = ledger.listActiveCadences({ dueByIso: nowIso });
 
@@ -686,12 +646,10 @@ export interface RunCadenceStepResult {
 }
 
 /**
- * Per-prospect cadence step runner. Single source of truth for both the
- * batch `advanceCadence` (CLI) and the per-row /cadences UI (preview + send).
- * Caller decides dryRun (no send) or persistedPayload (send a previously
- * built draft verbatim). On a successful send, advances `current_step`
- * to `nextIndex` and sets `next_due_at` to the next step's offset; clears
- * any persisted preview draft via ledger.advanceCadence.
+ * Per-prospect cadence step runner — single source of truth for the batch
+ * `advanceCadence` and the per-row /cadences UI. On a successful send,
+ * advances `current_step`, sets `next_due_at`, and clears any persisted
+ * preview draft via ledger.advanceCadence.
  */
 export async function runCadenceStepForProspect(
   opts: RunCadenceStepOptions,
@@ -710,11 +668,9 @@ export async function runCadenceStepForProspect(
       note: `cadence is ${cadence.status}`,
     };
   }
-  // Suppression check ahead of drafting. sendEmail would refuse this anyway,
-  // but only after an LLM draft has been paid for, and the resulting throw
-  // would land in recordCadenceSendError as "send failed · retrying" — which
-  // misrepresents a permanent failure as a transient one. Both the batch pass
-  // and the /cadences UI route through here, so this covers both.
+  // Suppression check ahead of drafting: sendEmail would refuse anyway, but
+  // only after paying for a draft, and its throw would misreport a permanent
+  // failure as "send failed · retrying".
   if (cadence.prospect_email) {
     const suppression = ledger.suppressionFor(cadence.prospect_email);
     if (suppression) {
@@ -731,12 +687,9 @@ export async function runCadenceStepForProspect(
       };
     }
   }
-  // Person-level ICP gate. A prospect judged off-ICP (by the finder gate or
-  // the history audit) must not receive further follow-ups — the intro was the
-  // mistake; the cadence would compound it. Code-level on purpose: the same
-  // lesson as the frequency caps, a prompt can be talked out of a rule but a
-  // status change cannot. Terminal + distinct ("off-icp", not "completed") so
-  // reporting stays honest about WHY the sequence stopped.
+  // Person-level ICP gate: an off-ICP prospect must not receive follow-ups.
+  // Code-level on purpose — a prompt can be talked out of a rule, a status
+  // change cannot. Terminal + distinct ("off-icp") so reporting stays honest.
   {
     const prospect = ledger.getProspectById(opts.prospectId);
     if (prospect?.icp_verdict === "reject") {
@@ -790,18 +743,12 @@ export async function runCadenceStepForProspect(
   if (!step) return { action: "skipped", payload: null, receiptIds: [] };
 
   // Re-send guard. `current_step` advances only AFTER a successful send, so a
-  // crash between dispatch and `advanceCadence` (e.g. a `bun --watch` reload
-  // killing the fire-and-forget send batch) leaves a prospect that already
-  // received step `nextIndex` still sitting at the old `current_step`. Without
-  // this guard the next due tick re-dispatches that step — and the SDK
-  // idempotency key is content-keyed, not step-keyed, so a redraft drift would
-  // send a real duplicate. If the step already has a terminal-sent event,
-  // reconcile by moving the cadence forward WITHOUT re-sending — running the
-  // SAME terminal transition a successful send would (so a reconciled breakup
-  // step lands in `breakup`, not `completed`), but skipping both the dispatch
-  // and the builder (no LLM redraft). Skipped on dryRun — previews never record
-  // sequence_events, and we don't want a preview to silently advance a real
-  // cadence.
+  // crash between dispatch and `advanceCadence` can leave a sent step behind —
+  // and the SDK idempotency key is content-keyed, not step-keyed, so a redraft
+  // would send a real duplicate. If the step already has a sent event,
+  // reconcile forward WITHOUT re-sending, running the SAME terminal transition
+  // a successful send would. Skipped on dryRun so a preview never advances a
+  // real cadence.
   if (!opts.dryRun && ledger.hasSentSequenceEvent(opts.prospectId, opts.playName, nextIndex)) {
     logEvent(
       "cadence.step.reconciled_already_sent",
@@ -887,11 +834,9 @@ export async function runCadenceStepForProspect(
 
   const receiptIds: number[] = [];
   if (!opts.dryRun) {
-    // Single send convergence point for every path (advance / per-row / batch).
-    // On a hard send failure (e.g. the platform's "Tool execution failed"),
-    // persist it so /cadences can show "send failed · retrying" instead of an
-    // indistinguishable "overdue"; the existing caller catches still log/clear
-    // the in-flight marker. Cleared on the next successful advance.
+    // Single send convergence point for every path. A hard send failure is
+    // persisted so /cadences can show "send failed · retrying" instead of an
+    // indistinguishable "overdue"; cleared on the next successful advance.
     let channelOutcome: Awaited<ReturnType<typeof dispatchStep>>;
     try {
       channelOutcome = await dispatchStep({
@@ -904,9 +849,8 @@ export async function runCadenceStepForProspect(
         ...(step.label !== undefined ? { label: step.label } : {}),
       });
     } catch (err) {
-      // A daily-cap deferral isn't a failure — the step just stays due for
-      // tomorrow. Only record genuine send errors (e.g. platform "Tool
-      // execution failed"); deferrals propagate untouched as before.
+      // A daily-cap deferral isn't a failure — the step stays due for
+      // tomorrow. Only genuine send errors are recorded.
       if (!isSendDeferred(err)) {
         ledger.recordCadenceSendError({
           prospectId: opts.prospectId,
@@ -1034,10 +978,9 @@ export async function previewCadenceStep(input: {
 }
 
 /**
- * Send a previously-previewed cadence step verbatim. Reads the persisted
- * draft (or 409s if none), dispatches it through runCadenceStepForProspect,
- * and advances the cadence. The advance clears the persisted draft so a
- * subsequent Preview rebuilds against the new current_step.
+ * Send a previously-previewed cadence step verbatim (throws if none
+ * persisted). The advance clears the draft so a later Preview rebuilds
+ * against the new current_step.
  */
 export async function sendCadenceStep(input: {
   prospectId: number;
@@ -1077,12 +1020,9 @@ export interface BatchSendResult {
 }
 
 /**
- * Parallel preview of a list of cadence rows (concurrency 3). Each
- * per-prospect failure is captured in the result array — the batch never
- * throws. `parallelMap` preserves input order so the returned array matches
- * `items` 1:1. Concurrency mirrors `runEmailPlay` + `advanceCadence`; the
- * founder is waiting at the UI, so 3× speedup on a 10-row preview drops
- * wall-clock from ~100s to ~35s.
+ * Parallel preview of cadence rows (concurrency 3). Per-prospect failures are
+ * captured in the result array — the batch never throws. `parallelMap`
+ * preserves input order so the result matches `items` 1:1.
  */
 export async function previewCadenceStepBatch(items: BatchItem[]): Promise<BatchPreviewResult[]> {
   return parallelMap(items, 3, async (item) => {
@@ -1101,16 +1041,11 @@ export async function previewCadenceStepBatch(items: BatchItem[]): Promise<Batch
 }
 
 /**
- * Serial send of a list of previewed cadence rows. Each per-prospect failure
- * is captured; the batch never throws. Used by `POST /api/cadences/send-batch`
- * as a background promise — caller returns 202 immediately and the UI sees
- * progress via subsequent `/api/cadences` refetches (the existing
- * `advanceCadence` clears `next_step_draft_json` as each row completes).
- *
- * Sends stay serial (unlike previewCadenceStepBatch) for two reasons: the
- * `onItemSettled` callback drives the in-flight UI badge per row (parallel
- * would batch-flash all rows at once), and parallel SMTP to the same
- * domain risks soft-bounces.
+ * Serial send of previewed cadence rows; per-prospect failures are captured,
+ * the batch never throws. Run as a background promise by
+ * `POST /api/cadences/send-batch` (202 + refetch-driven progress). Sends stay
+ * serial: `onItemSettled` drives the per-row in-flight badge, and parallel
+ * SMTP to the same domain risks soft-bounces.
  */
 export async function sendCadenceStepBatch(
   items: BatchItem[],
@@ -1312,10 +1247,8 @@ export function buildFollowUpEmail(opts: {
     });
     const parsed = tryParseJsonObject<{ subject?: string; body?: string }>(res.content, {});
     if (!parsed.subject || !parsed.body) return null;
-    // Apply the deterministic autofixer (em-dash → ", ", curly quotes → ASCII,
-    // emoji strip, etc.) — same humanization the initial-send plays get via
-    // draftEmailFromPrompt. Without this, cadence follow-ups ship em-dashes
-    // raw even though lintEmail flags them.
+    // Same deterministic humanization the initial-send plays get via
+    // draftEmailFromPrompt — without it, follow-ups ship em-dashes raw.
     const cleaned = humanizeDraft({
       subject: parsed.subject.trim(),
       body: parsed.body.trim(),
@@ -1337,10 +1270,8 @@ export interface PriorStepRow {
 }
 
 /**
- * Parse a prospect's prior sends for a given play into clean per-step rows.
- * Source of truth shared by the LLM PRIOR-EMAILS injection (which filters
- * legacy rows) and the /api/cadences view (which surfaces them with a
- * "body not captured" placeholder).
+ * Parse a prospect's prior sends for a play into per-step rows. Shared by the
+ * LLM PRIOR-EMAILS injection and the /api/cadences view.
  */
 export function getPriorStepsForProspect(prospectId: number, playName: string): PriorStepRow[] {
   if (!prospectId) return [];
@@ -1384,11 +1315,9 @@ function rowToPriorStep(r: {
 }
 
 /**
- * Bulk variant of getPriorStepsForProspect: one SQL round-trip for many
- * (prospect_id, play_name) pairs. Returns a Map keyed by
- * `${prospectId}|${playName}` so /api/cadences's toView can index in O(1)
- * instead of issuing one query per row. Pairs the founder hasn't sent for
- * are absent from the map (callers should default to []).
+ * Bulk variant of getPriorStepsForProspect: one SQL round-trip, Map keyed by
+ * `${prospectId}|${playName}`. Never-sent pairs are absent (callers default
+ * to []).
  */
 export function getPriorStepsBulk(
   pairs: ReadonlyArray<{ prospectId: number; playName: string }>,

--- a/packages/plays/src/_lib.ts
+++ b/packages/plays/src/_lib.ts
@@ -20,12 +20,9 @@ import { complete, loadPrompt, tryParseJsonObject } from "@oneshot-gtm/intel";
 const FAILED_ENRICH = { status: "failed", profile: null, cost: 0 };
 
 /**
- * enrichProfile that (a) never throws and (b) caches by email. The dossier is a
- * nice-to-have for drafting, the SDK call is slow (~70s) and billed, and the
- * same person can recur across plays / repeated previews / re-sends — so we
- * cache the result by email (TTL) and reuse it. A cache hit returns receiptId 0
- * (no new SDK call, no spend). On failure: log a warn and return an empty
- * result so callers' `enr.result` / `enr.receiptId` usage keeps working.
+ * enrichProfile that never throws and caches by email (the SDK call is slow
+ * and billed). A cache hit returns receiptId 0 (no spend); on failure, returns
+ * an empty result so callers' `enr.result` / `enr.receiptId` usage keeps working.
  */
 export async function safeEnrich(
   input: Parameters<typeof enrichProfile>[0],
@@ -38,9 +35,7 @@ export async function safeEnrich(
     const cached = ledger.getCachedEnrichment(email);
     if (cached) {
       const ageMs = Date.now() - new Date(cached.fetched_at).getTime();
-      // Negative entry: the SDK job failed recently — don't burn another ~70s
-      // attempt; draft from payload context. Expired failures fall through
-      // and retry below.
+      // Negative entry: recent SDK failure — don't retry until the TTL expires.
       if (cached.status === "failed") {
         if (ageMs < ENRICH_FAILURE_TTL_MS) {
           return { result: FAILED_ENRICH, receiptId: 0 } as unknown as Awaited<
@@ -97,9 +92,8 @@ export async function safeEnrich(
     const message = (err as Error)?.message ?? "";
     logEvent("enrich.failed", { play: ctx.playName, message_120: message.slice(0, 120) }, "warn");
     // Only negative-cache a GENUINE failure (no data for this email). A
-    // transient platform/transport error (e.g. "Tool execution failed" during
-    // the 2026-06 outage) must NOT be cached, or every email it touched stays
-    // un-enrichable for ENRICH_FAILURE_TTL_MS even after the platform recovers.
+    // transient platform/transport error must NOT be cached, or the email stays
+    // un-enrichable for ENRICH_FAILURE_TTL_MS after the platform recovers.
     if (email && !isTransientToolError(err)) {
       try {
         ledger.setCachedEnrichmentFailure(email, message);
@@ -148,10 +142,9 @@ export const SLOP_PHRASES: Array<[RegExp, string]> = [
 ];
 
 /**
- * Trailing signature lines that the signatureDirective forces the LLM to
- * append (founder name, then product domain, then optional "Sent from my
- * iPhone"). Returned in last-line-first order so callers can peel from the
- * end. Empty when neither name nor domain is configured (no sig to strip).
+ * Trailing signature lines the signatureDirective forces the LLM to append,
+ * in last-line-first order so callers can peel from the end. Empty when
+ * neither name nor domain is configured.
  */
 function configuredSigLines(): string[] {
   const cfg = loadConfig();
@@ -165,21 +158,16 @@ function configuredSigLines(): string[] {
 }
 
 /**
- * Word count for body-too-long lint. Strips the trailing signature lines so
- * the LLM isn't penalized for the 2-3 deterministic words the
- * signatureDirective forces it to append. Otherwise a prompt that says "≤110
- * words" only really gives the LLM ~107 for content, and borderline drafts
- * trip body-too-long even when they're inside the contract.
- *
- * `sigLines` (last-line-first order) is exposed for tests so they don't have
- * to mock loadConfig — production passes nothing and reads config.
+ * Word count for body-too-long lint, minus the trailing signature lines the
+ * signatureDirective forces — so those deterministic words don't eat the
+ * prompt's word budget. `sigLines` (last-line-first) is exposed for tests;
+ * production passes nothing and reads config.
  */
 export function bodyWordsForLint(body: string, sigLines?: string[]): number {
   const lines = sigLines ?? configuredSigLines();
   let trimmed = body.replace(/\s+$/, "");
-  // Peel each sig line off the tail, but only if it matches the current
-  // last line — guarantees we never chop content that happens to contain
-  // the founder's name mid-paragraph.
+  // Peel each sig line off the tail only if it matches the current last line —
+  // never chop content that merely contains the founder's name mid-paragraph.
   for (const line of lines) {
     const i = trimmed.lastIndexOf("\n");
     const last = (i < 0 ? trimmed : trimmed.slice(i + 1)).trim();
@@ -214,11 +202,9 @@ export interface DraftedEmail {
 }
 
 /**
- * Stub drafted-row for a target whose per-target processing threw (LLM API
- * error, SDK JobTimeoutError, ledger write failure, etc.). Plays wrap their
- * per-target body in try/catch and push this on failure so the rest of the
- * batch can keep going. Same shape `drain.ts` synthesizes when its outer
- * `dispatchOneTarget` catches — one source of truth for the error envelope.
+ * Stub drafted-row for a target whose per-target processing threw, so the rest
+ * of the batch keeps going. Same shape `drain.ts` synthesizes — one source of
+ * truth for the error envelope.
  */
 interface ErrorDraft {
   subject: string;
@@ -239,26 +225,17 @@ export function errorDraft(message: string | null | undefined): ErrorDraft {
 }
 
 /**
- * Record WHY a single target failed, next to every `errorDraft` call site.
- *
- * What reaches the queue row (and the founder's screen) is errorDraft's 80-char
- * slice of `err.message` — for an SDK ToolError that's the generic "Tool
- * request failed", true and useless. The status code and response body carry
- * the actual reason (`403 domain_not_owned`, the last time one was captured).
- * Without this, a drain could fail every send and leave nothing in
- * events.jsonl to diagnose from.
- *
- * Mirrors the whole-run handler in apps/server/src/api/run.ts, which already
- * logs these fields; per-target failures were the gap.
+ * Record WHY a single target failed, next to every `errorDraft` call site: the
+ * queue row only carries an 80-char message slice, while the SDK error's status
+ * code and response body hold the actual reason. Without this a failed drain
+ * leaves nothing in events.jsonl to diagnose from.
  */
 export function logTargetError(input: {
   playName: string;
   /**
-   * Recipient address. Only its DOMAIN is logged — events.jsonl is a
-   * PII-free sink (see the `email_domain` precedent in core/send-routing.ts),
-   * and the domain is the diagnostic half anyway: it tells you whether one
-   * receiving domain is rejecting. Redaction lives here, not at the call
-   * sites, so no caller can leak the address by accident.
+   * Recipient address. Only its DOMAIN is logged — events.jsonl is a PII-free
+   * sink. Redaction lives here, not at call sites, so no caller can leak the
+   * address by accident.
    */
   to?: string | null;
   err: unknown;
@@ -268,17 +245,13 @@ export function logTargetError(input: {
     statusCode?: number;
     responseBody?: string;
   };
-  // Nothing here may throw. This runs INSIDE the per-target catch whose whole
-  // job is to stop one bad target from killing the batch — a TypeError raised
-  // while logging would escape that catch and abort the entire drain. A thrown
-  // value is `unknown`: `{ message: 500 }` is legal, so is a rejected string,
-  // and `.slice()` on either blows up. Coerce, don't assume.
+  // Nothing here may throw: this runs INSIDE the per-target catch, so a
+  // TypeError while logging would abort the entire drain. Thrown values are
+  // `unknown` — coerce, don't assume.
   try {
     logTargetErrorUnsafe(e, input);
   } catch {
-    // Belt and braces: a hostile shape (a throwing `message` getter, a
-    // String()-hostile object) must not turn a logged failure into a dead
-    // batch. Losing the diagnosis is bad; losing the run is worse.
+    // A hostile shape must not turn a logged failure into a dead batch.
   }
 }
 
@@ -313,10 +286,9 @@ function logTargetErrorUnsafe(
 }
 
 /**
- * Deterministic, semantics-preserving cleanups that the LLM occasionally
- * slips through despite the humanizer rules being in its system prompt.
- * Applied silently inside `draftEmailFromPrompt` so these four flags never
- * surface in the UI.
+ * Deterministic, semantics-preserving cleanups the LLM occasionally slips
+ * through. Applied silently inside `draftEmailFromPrompt` so these flags
+ * never surface in the UI.
  */
 export function humanizeDraft(input: DraftedEmail): DraftedEmail {
   return {
@@ -342,21 +314,16 @@ function applyAutofixes(s: string): string {
       // (e.g. `☀️` → `️`).
       .replace(/\u{FE0F}|\u{200D}/gu, "")
       .replace(/!\s*!+/g, "!")
-      // Strip trailing horizontal whitespace before a newline. Catches the
-      // `paragraph,_\n` artifact left by an em-dash at end-of-line, plus
-      // any stray trailing space from emoji removal.
+      // Strip trailing horizontal whitespace left by em-dash/emoji removal.
       .replace(/[ \t]+\n/g, "\n")
       .trim()
   );
 }
 
 /**
- * Binding sign-off directive appended to every email system prompt. Forces
- * the founder's product domain onto its own line beneath their name, even on
- * prompts that say "no links / no tagline" (a bare domain is a signature, not
- * a hyperlink). Returns "" when no domain is configured, so founders who
- * haven't set one keep the prior name-only sign-off. Loaded fresh each call
- * so a /setup change takes effect without a process restart.
+ * Binding sign-off directive appended to every email system prompt. Returns ""
+ * when no domain is configured (name-only sign-off). Loaded fresh each call so
+ * a /setup change takes effect without a process restart.
  */
 export function signatureDirective(): string {
   const cfg = loadConfig();
@@ -386,11 +353,9 @@ export function signatureDirective(): string {
 }
 
 /**
- * Build a SOCIAL PROOF input block from the founder's three optional config
- * fields. Returns null when none are set — callers skip the line entirely
- * so the prompt's "if SOCIAL PROOF is in the inputs" conditional kicks in.
- * Each prompt should weave AT MOST ONE beat (credentials OR built-with OR
- * partners) into the email, not stack them.
+ * SOCIAL PROOF input block from the founder's three optional config fields.
+ * Null when none are set, so the prompt's conditional skips the beat. At most
+ * ONE beat per email, never stacked.
  */
 export function socialProofBlock(): string | null {
   const cfg = loadConfig();
@@ -409,18 +374,11 @@ export function socialProofBlock(): string | null {
 }
 
 /**
- * ADMISSION line for the prompt's optional damaging-admission beat — a true
- * concession, surfaced only when the founder set one AND this prospect drew
- * the slot. The prompt is told to use ONLY what this line carries and to skip
- * the beat when it is absent, so the model can never invent a weakness (the
- * same lie as inventing a strength).
- *
- * The "roughly a third of emails" cap lives HERE, not in the prompt: a model
- * cannot hold a frequency across independent calls (given "at most 1 in 3" it
- * used the admission on 3 of 4 drafts, the same way the optional "Hey {name}"
- * opener runs at 4 of 4). Gating whether the material is supplied is the only
- * honest way to get the rate — and it is keyed on the prospect, so a
- * regenerate makes the same decision instead of flapping.
+ * ADMISSION line for the prompt's damaging-admission beat — surfaced only when
+ * the founder set one AND this prospect drew the slot, so the model can never
+ * invent a weakness. The roughly-1-in-3 cap lives HERE, not in the prompt: a
+ * model cannot hold a frequency across independent calls. Keyed on the
+ * prospect so a regenerate makes the same decision instead of flapping.
  */
 export function admissionBlock(prospectEmail: string): string | null {
   const admission = loadConfig().founderAdmission?.trim();
@@ -474,22 +432,17 @@ export interface SendDraftedOpts {
     phone?: string | null;
     source?: string | null;
     /** Profile URL the finder sourced this person from (GitHub / X / Luma).
-     *  Unlike `linkedin_url` this is never repurposed, so it survives as a
-     *  re-enrichment key when the LinkedIn lookup misses on the first pass. */
+     *  Never repurposed, so it survives as a re-enrichment key when the
+     *  LinkedIn lookup misses. */
     source_profile_url?: string | null;
-    /** Job title at contact time, from the person-level ICP gate. Persisting
-     *  it makes re-runs and the off-ICP audit free. (This field existing here
-     *  is what makes it persistable at all — `dossier_json` stayed dead schema
-     *  for months precisely because it was never added to this type.) */
+    /** Job title at contact time, from the person-level ICP gate. */
     title?: string | null;
   };
   metadata?: Record<string, unknown>;
   dryRun: boolean;
   /**
-   * Allow a first-touch even if the prospect was already touched by ANOTHER
-   * play. Off by default (we never first-touch the same person twice). Only
-   * breakup-revive sets this — deliberately re-contacting cold prospects is its
-   * whole job, mirroring how its finder bypasses isDuplicate.
+   * Allow a first-touch even if another play already touched the prospect.
+   * Off by default; only breakup-revive sets this.
    */
   allowRecontact?: boolean;
   /** Manual override of the cross-workspace `contacted-elsewhere` hold (queue send-draft only). */
@@ -510,10 +463,9 @@ export async function sendDraftedEmail(opts: SendDraftedOpts): Promise<SendDraft
   const receiptIds: number[] = [];
   let sent = false;
   if (!opts.dryRun && opts.flags.length === 0) {
-    // Pre-send dedupe: refuse to send step-0 a second time to the same
-    // (prospect, play). Catches double-fire from drain-after-drain, /run
-    // resubmits, two-tab races, etc. Residual race window is microseconds
-    // between this read and recordSequenceEvent; documented as acceptable.
+    // Pre-send dedupe: never send step-0 twice to the same (prospect, play).
+    // Residual microsecond race between this read and recordSequenceEvent is
+    // accepted.
     const existing = ledger.findProspectByEmail(opts.to);
     if (existing) {
       const prior = ledger.listSequenceEventsForProspectPlay(existing.id, opts.playName);
@@ -522,8 +474,7 @@ export async function sendDraftedEmail(opts: SendDraftedOpts): Promise<SendDraft
         return { receiptIds: [], sent: false };
       }
       // Cross-play guard: never first-touch someone a DIFFERENT play already
-      // first-touched. The authoritative dedup for the "same person queued
-      // under two plays before either sent" race. breakup-revive opts out.
+      // first-touched. breakup-revive opts out.
       if (!opts.allowRecontact && ledger.prospectHasFirstTouch(existing.id)) {
         opts.flags.push("already-contacted");
         return { receiptIds: [], sent: false };
@@ -676,16 +627,10 @@ const ORG_SUFFIX_RE = /(labs?|team|studios?|\.(dev|ai|io|com|app|xyz|net|org|co)
 
 /**
  * Best-effort first-name extraction from a prospect's `name` field. Returns
- * `null` when we shouldn't use a greeting at all: missing data, the placeholder
- * "(unknown)", a username-looking handle, a company name, a role or mailbox
- * word, an initial, or a non-capitalized opening token (which usually signals
- * a handle fragment rather than a real first name). A wrong greeting is worse
- * than none — "Hey CEO," and "Hey Bytedance," both shipped before this gate.
- *
- * Used to optionally surface `PROSPECT_FIRST_NAME` to the LLM input block so
- * prompts can occasionally open with `Hey {firstName},`. The LLM owns the
- * decision to actually greet — this helper just gates whether the field is
- * present.
+ * `null` whenever a greeting shouldn't be used (handle, company, role word,
+ * initial, non-capitalized token) — a wrong greeting is worse than none. The
+ * LLM owns the decision to actually greet; this helper only gates whether
+ * `PROSPECT_FIRST_NAME` is present in the input block.
  */
 export function firstNameFrom(name: string | null | undefined): string | null {
   if (!name) return null;
@@ -741,18 +686,11 @@ interface VerifyAndFilterResult<T> {
 }
 
 /**
- * Verify a batch of target emails BEFORE drafting + sending. Used by
- * direct-input entry points (CLI motion commands + dashboard /run) where
- * the founder pastes targets directly without going through a finder.
- * Drops undeliverable rows so the caller skips ~$0.005-0.02 of LLM
- * drafting cost per bad email AND avoids the send attempt itself.
- *
- * Skips on dryRun (no real spend during preview) and on empty input.
- * De-dupes the underlying verifyEmail calls so a duplicated email in
- * the input doesn't double-bill.
- *
- * Finder-sourced rows that flow through /queue → drain do NOT call this
- * — they were already verified at finder enqueue time.
+ * Verify a batch of target emails BEFORE drafting + sending, for direct-input
+ * entry points (CLI motion commands + dashboard /run). Skips on dryRun and
+ * empty input; de-dupes verifyEmail calls so duplicates don't double-bill.
+ * Finder-sourced rows through /queue → drain do NOT call this — they were
+ * verified at enqueue time.
  */
 export async function verifyAndFilterTargets<T>(
   targets: T[],
@@ -770,10 +708,8 @@ export async function verifyAndFilterTargets<T>(
   }
 
   const uniqueEmails = [...new Set(emailFor.values())];
-  // Catch SDK throws (transient network / rate-limit / invalid-format errors)
-  // and treat the affected target as dropped rather than aborting the whole
-  // run. Mirrors the per-candidate handling finders already do — one bad
-  // verify call shouldn't kill a 25-target batch.
+  // Catch SDK throws and drop the affected target rather than aborting the
+  // whole run — one bad verify call shouldn't kill the batch.
   const verifications = await Promise.all(
     uniqueEmails.map(async (email) => {
       try {

--- a/packages/plays/src/_metadata.ts
+++ b/packages/plays/src/_metadata.ts
@@ -1,25 +1,9 @@
 /**
- * Per-play step-0 metadata, addressable by play name.
- *
- * Why this exists: each play's `EmailPlayDef.metadata` stamps the evidence that
- * made someone a prospect (`repo`, `eventTitle`, `vendorStack`, …) onto the
- * step-0 `sequence_events` row. `runEmailPlay` applies it — but the /queue
- * "send this reviewed draft" route (`apps/server/src/api/queue.ts`) calls
- * `sendDraftedEmail` directly and used to pass no metadata at all. The result:
- * 178 of 351 repo-interest step-0 rows had no `repo` key, which silently
- * mis-routed 19 prospects into the wrong arm of the LinkedIn A/B experiment.
- *
- * These are the SAME functions the play defs reference (each play imports its
- * own), so the queue route and the play cannot drift apart — there is exactly
- * one definition of "what this play records".
- *
- * Contract: every function is a PURE map from the target/payload to the
- * metadata object. No run options, no config, no I/O. Functions take `object`
- * (not the play's target interface) so both a typed target and a raw queue
- * payload are accepted; fields are read defensively. `accelerator-batch` is
- * the one play whose def also mixes in a run option (`opts.senderCohort` as a
- * fallback) — its def layers that on top; queue sends have no run options, so
- * the payload field is used as-is.
+ * Per-play step-0 metadata, addressable by play name. The play defs and the
+ * /queue send route must share these exact functions so they can't drift.
+ * Contract: pure maps from target/payload to metadata — no run options, no
+ * config, no I/O; `object` params so typed targets and raw queue payloads both
+ * work, fields read defensively.
  */
 
 type Payload = Record<string, unknown>;

--- a/packages/plays/src/handoff.ts
+++ b/packages/plays/src/handoff.ts
@@ -198,7 +198,6 @@ export async function handoffFirstAe(input: FirstAeAnswers): Promise<FirstAeResu
 
 function parseHandoffJson<T extends { raw: string }>(content: string, fallback: T): T {
   const parsed = tryParseJsonObject<Record<string, unknown>>(content, {});
-  // Map snake_case JSON keys to camelCase result keys for both shapes.
   const obj: Record<string, unknown> = {
     verdict: parsed["verdict"],
     reasoning: parsed["reasoning"],


### PR DESCRIPTION
Repo-wide comment cleanup across packages/ and apps/ production TypeScript. The codebase's verbosity was essay-style rationale (incident postmortems with dates/stats, worked examples, history) with real invariants buried mid-paragraph — this condenses every ≥5-line block to 1-3 lines that keep the invariant and drop the narrative.

**What was kept, deliberately:**
- Every API quirk / ordering / race / TOCTOU / must-never constraint (in short form)
- Per-field JSDoc on wire types (shared-types) and config semantics (core/types.ts)
- Provenance trailers on magic strings, sentinel-constant tuning notes, lint-suppression justifications, ASCII output specs
- All comment-shaped runtime data untouched: configBrief strings, packages/prompts, LLM directive template literals, doctor/setup UI copy, ACTION wire markers, generated files

**Also:** ledger.ts migration narration reduced to one line per schema version; structural JSX labels ({/* Masthead */} etc.) and dataset.ts divider dressing removed; the handful of pure narration one-liners deleted.

One commit per package/app for granular review. ~1,300 net comment lines removed.

**Verification:** oxfmt clean, tsc --noEmit clean, vitest 1777/1777 passing. Diff audited to touch only comment lines.

https://claude.ai/code/session_01DV676i6x8Any5Czfq44Muh

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Condense verbose comments to load-bearing constraints across core, find, plays, server, web, and CLI
> - Rewrites and shortens documentation comments across roughly 40 source files in `packages/core`, `packages/find`, `packages/plays`, `apps/server`, `apps/web`, and `apps/cli`, plus a handful of web route components.
> - Removes redundant section-label JSX comments (e.g. `Masthead`, `KPI strip`) and horizontal separator lines, and tightens inline explanations of concurrency, scheduling, telemetry, and routing constraints.
> - No executable code, types, signatures, queries, or UI structure are changed; all edits are comment-only.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce2e32d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->