### PR TITLE
feat(queue): show prospect title in the identity line

### DIFF
--- a/apps/web/src/routes/queue.tsx
+++ b/apps/web/src/routes/queue.tsx
@@ -640,6 +640,7 @@ function QueueRow({
   const email = emailFor(row.payload);
   const name = nameFor(row.payload);
   const company = companyFor(row.payload);
+  const title = titleFor(row.payload);
   const linkedinUrl = linkedinUrlFor(row.payload);
   const phone = phoneFor(row.payload);
   const eventTitle = eventTitleFor(row.payload);
@@ -689,6 +690,7 @@ function QueueRow({
           <div className="text-ink-cream">{name ? <Pii kind="name">{name}</Pii> : "(unknown)"}</div>
           <div className="font-mono text-[11px] text-ink-faint">
             {email ? <Pii kind="email">{email}</Pii> : "—"}
+            {title ? <span className="text-ink-cream-2">{` · ${title}`}</span> : null}
             {company ? (
               <>
                 {" · "}
@@ -1658,6 +1660,15 @@ function companyFor(payload: unknown): string | null {
   const p = payload as Record<string, unknown>;
   if (typeof p["company"] === "string") return p["company"] as string;
   return null;
+}
+
+// Stamped on the payload by the person-level ICP gate; absent on rows queued
+// before the gate existed.
+function titleFor(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const p = payload as Record<string, unknown>;
+  const v = p["title"];
+  return typeof v === "string" && v.trim().length > 0 ? v.trim() : null;
 }
 
 function linkedinUrlFor(payload: unknown): string | null {


### PR DESCRIPTION
Shows the prospect's role (e.g. "Principal", "Co-Founder and CEO") in the /queue row identity line — `email · title · company [in]` — for both the collapsed row and the expanded detail (same cell).

Source is `payload.title`, which the person-level ICP gate (#45) stamps on every new find; the server send path already persists the same key to `prospects.title`. Rows enqueued before the gate existed have no title and render exactly as before (verified: 2/86 live rows in the active workspace carry it today; all new finds will).

fmt / tsc / web tests green.

https://claude.ai/code/session_01DV676i6x8Any5Czfq44Muh

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add prospect title to contact column in `QueueRow`
> Adds a `titleFor(payload)` helper that returns a trimmed non-empty string from `payload['title']` or null otherwise. [queue.tsx](https://github.com/oneshot-agent/oneshot-gtm/pull/51/files#diff-ab2702847c8e5daaf53d7f5b91f4e059c734f2980e49449733dd4111103f308a) renders the title next to the email as a muted ` · ${title}` suffix when present. Missing, empty, or non-string values are treated as absent.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 96d72f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->