### PR TITLE
fix(inbox): always surface known repliers + shorter reply drafts

### DIFF
--- a/apps/server/__tests__/inbox-route.test.ts
+++ b/apps/server/__tests__/inbox-route.test.ts
@@ -16,6 +16,7 @@ const ledger = {
   recordInboxSent: recordInboxSentMock,
   getInboxThreads: getInboxThreadsMock,
   listAllCadences: () => [],
+  listRepliedProspectEmails: () => [],
   getProspectByEmail: () => null,
   findProspectByEmail: () => knownProspect,
   recordProspectReply: recordProspectReplyMock,

--- a/apps/server/src/api/inbox.ts
+++ b/apps/server/src/api/inbox.ts
@@ -3,6 +3,7 @@ import {
   getLedger,
   isDraining,
   listInbox,
+  listRepliesFrom,
   loadConfig,
   logEvent,
   replyEmail,
@@ -60,6 +61,29 @@ export async function listInboxRoute(req: Request): Promise<Response> {
     // Truthful truncation signal — the page must never present a clamped
     // window as the entire mailbox.
     hasMore = result.has_more;
+    // Known repliers get a targeted all-time fetch on top of the window: the
+    // ledger knows who replied, and their mail must never be pushed out by
+    // noise or the broad query's 30d recency cutoff. Best-effort in its own
+    // try — a supplement failure must not take down the main list.
+    try {
+      const repliedEmails = ledger.listRepliedProspectEmails();
+      if (repliedEmails.length > 0) {
+        const targeted = await listRepliesFrom(repliedEmails);
+        const seen = new Set(emails.map((e) => e.id));
+        const extra = targeted.filter((e) => !seen.has(e.id));
+        if (extra.length > 0) {
+          emails = [...emails, ...extra].sort(
+            (a, b) => new Date(b.received_at).getTime() - new Date(a.received_at).getTime(),
+          );
+        }
+      }
+    } catch (err) {
+      logEvent(
+        "inbox.replies_from_failed",
+        { message_120: ((err as Error)?.message ?? "").slice(0, 120) },
+        "warn",
+      );
+    }
   } catch (err) {
     logEvent(
       "inbox.list_failed",

--- a/apps/web/src/routes/queue.tsx
+++ b/apps/web/src/routes/queue.tsx
@@ -640,6 +640,7 @@ function QueueRow({
   const email = emailFor(row.payload);
   const name = nameFor(row.payload);
   const company = companyFor(row.payload);
+  const title = titleFor(row.payload);
   const linkedinUrl = linkedinUrlFor(row.payload);
   const phone = phoneFor(row.payload);
   const eventTitle = eventTitleFor(row.payload);
@@ -689,6 +690,7 @@ function QueueRow({
           <div className="text-ink-cream">{name ? <Pii kind="name">{name}</Pii> : "(unknown)"}</div>
           <div className="font-mono text-[11px] text-ink-faint">
             {email ? <Pii kind="email">{email}</Pii> : "—"}
+            {title ? <span className="text-ink-cream-2">{` · ${title}`}</span> : null}
             {company ? (
               <>
                 {" · "}
@@ -1658,6 +1660,15 @@ function companyFor(payload: unknown): string | null {
   const p = payload as Record<string, unknown>;
   if (typeof p["company"] === "string") return p["company"] as string;
   return null;
+}
+
+// Stamped on the payload by the person-level ICP gate; absent on rows queued
+// before the gate existed.
+function titleFor(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const p = payload as Record<string, unknown>;
+  const v = p["title"];
+  return typeof v === "string" && v.trim().length > 0 ? v.trim() : null;
 }
 
 function linkedinUrlFor(payload: unknown): string | null {

--- a/packages/core/src/gmail.ts
+++ b/packages/core/src/gmail.ts
@@ -317,17 +317,26 @@ export async function listGmailReplies(
     /** Exclusive upper bound — lets a backfill page through months of mail in slices. */
     until?: string;
     limit?: number;
+    /**
+     * Targeted mode: only mail FROM one of these addresses, searched across
+     * all time (no `newer_than` default) — known-replier fetches must not be
+     * clipped by the recency window that keeps the broad poll cheap.
+     */
+    fromAnyOf?: string[];
   },
   account?: GmailAccount,
 ): Promise<InboxListResult> {
   const sinceClause = opts?.since
     ? `after:${Math.floor(new Date(opts.since).getTime() / 1000)}`
-    : "newer_than:30d";
+    : opts?.fromAnyOf?.length
+      ? ""
+      : "newer_than:30d";
   const untilClause = opts?.until
     ? ` before:${Math.floor(new Date(opts.until).getTime() / 1000)}`
     : "";
+  const fromClause = opts?.fromAnyOf?.length ? ` from:(${opts.fromAnyOf.join(" OR ")})` : "";
   const params = new URLSearchParams({
-    q: `-from:me -in:spam -in:trash ${sinceClause}${untilClause}`,
+    q: `-from:me -in:spam -in:trash ${sinceClause}${untilClause}${fromClause}`.trim(),
     maxResults: String(opts?.limit ?? 50),
   });
   const list = await gmailJson<{ messages?: Array<{ id: string }>; nextPageToken?: string }>(

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -961,6 +961,21 @@ export class Ledger {
     );
   }
 
+  /**
+   * Emails of every prospect with a recorded reply — the target list for the
+   * inbox's known-replier fetch, so a reply is never lost to the live window.
+   */
+  listRepliedProspectEmails(): string[] {
+    const rows = this.db
+      .query(
+        `SELECT DISTINCT p.email FROM sequence_events se
+         JOIN prospects p ON p.id = se.prospect_id
+         WHERE se.status = 'replied' AND p.email IS NOT NULL AND p.email != ''`,
+      )
+      .all() as Array<{ email: string }>;
+    return rows.map((r) => r.email);
+  }
+
   /** Full prospect record by id (PK seek). Avoids loading every prospect to find one. */
   getProspectById(id: number): ProspectRecord | null {
     return (

--- a/packages/core/src/oneshot.ts
+++ b/packages/core/src/oneshot.ts
@@ -907,21 +907,43 @@ export async function listInbox(opts?: {
  */
 export async function listRepliesFrom(
   addresses: string[],
-  opts?: { limitPerSource?: number; deadlineMs?: number },
+  opts?: { limitPerSource?: number; deadlineMs?: number; maxPagesPerSource?: number },
 ): Promise<AnnotatedInboxEmail[]> {
   if (addresses.length === 0 || demoMode()) return [];
   const deadlineMs = opts?.deadlineMs ?? INBOX_SOURCE_TIMEOUT_MS;
+  const limit = opts?.limitPerSource ?? 50;
+  const maxPages = opts?.maxPagesPerSource ?? 5;
   const identities = resolveIdentities(loadConfig()).filter((i) => i.provider === "gmail");
   const results = await parallelMap(identities, 3, async (identity) => {
     try {
       const account = gmailAccountFor(identity);
       if (!account) return null;
-      const r = await withDeadline(
-        listGmailReplies({ fromAnyOf: addresses, limit: opts?.limitPerSource ?? 30 }, account),
-        deadlineMs,
-        `replies-from source '${identity.id}'`,
-      );
-      return annotateInboxResult(r, identity.id);
+      // Page backwards by `until` so a busy known-replier set isn't clipped at
+      // one window (a from:() query is small; the page cap only bounds a
+      // pathological mailbox). `until` is nudged +1s past the oldest so a
+      // same-second sibling isn't skipped by Gmail's second-granularity
+      // `before:`; the seen-set makes the overlap a no-op.
+      const seen = new Set<string>();
+      const collected: AnnotatedInboxEmail[] = [];
+      let until: string | undefined;
+      for (let page = 0; page < maxPages; page++) {
+        const r = await withDeadline(
+          listGmailReplies({ fromAnyOf: addresses, limit, ...(until ? { until } : {}) }, account),
+          deadlineMs,
+          `replies-from source '${identity.id}'`,
+        );
+        const annotated = annotateInboxResult(r, identity.id);
+        const fresh = annotated.emails.filter((e) => !seen.has(e.id));
+        for (const e of fresh) seen.add(e.id);
+        collected.push(...fresh);
+        if (!r.has_more || fresh.length === 0) break;
+        const oldest = fresh.reduce(
+          (m, e) => (e.received_at < m ? e.received_at : m),
+          fresh[0]!.received_at,
+        );
+        until = new Date(new Date(oldest).getTime() + 1000).toISOString();
+      }
+      return collected;
     } catch (err) {
       logEvent(
         "inbox.replies_from_failed",
@@ -931,7 +953,7 @@ export async function listRepliesFrom(
       return null;
     }
   });
-  return results.filter((r): r is AnnotatedInboxListResult => r != null).flatMap((r) => r.emails);
+  return results.filter((r): r is AnnotatedInboxEmail[] => r != null).flat();
 }
 
 /**

--- a/packages/core/src/oneshot.ts
+++ b/packages/core/src/oneshot.ts
@@ -898,6 +898,43 @@ export async function listInbox(opts?: {
 }
 
 /**
+ * Targeted fetch of mail FROM the given addresses across every Gmail identity,
+ * searched all-time — so a known replier's mail surfaces even when the broad
+ * newest-N window is full of noise or the reply predates its recency cutoff.
+ * Best-effort: per-source failures are logged and skipped, and the OneShot
+ * inbox is not queried (it can't filter by sender; its small replies-only
+ * mailbox is already covered by the main window). Returns [] in demo mode.
+ */
+export async function listRepliesFrom(
+  addresses: string[],
+  opts?: { limitPerSource?: number; deadlineMs?: number },
+): Promise<AnnotatedInboxEmail[]> {
+  if (addresses.length === 0 || demoMode()) return [];
+  const deadlineMs = opts?.deadlineMs ?? INBOX_SOURCE_TIMEOUT_MS;
+  const identities = resolveIdentities(loadConfig()).filter((i) => i.provider === "gmail");
+  const results = await parallelMap(identities, 3, async (identity) => {
+    try {
+      const account = gmailAccountFor(identity);
+      if (!account) return null;
+      const r = await withDeadline(
+        listGmailReplies({ fromAnyOf: addresses, limit: opts?.limitPerSource ?? 30 }, account),
+        deadlineMs,
+        `replies-from source '${identity.id}'`,
+      );
+      return annotateInboxResult(r, identity.id);
+    } catch (err) {
+      logEvent(
+        "inbox.replies_from_failed",
+        { source: identity.id, message_120: ((err as Error).message ?? "").slice(0, 120) },
+        "warn",
+      );
+      return null;
+    }
+  });
+  return results.filter((r): r is AnnotatedInboxListResult => r != null).flatMap((r) => r.emails);
+}
+
+/**
  * Dedupe, sort newest-first and clamp source results to the requested window,
  * with `has_more` true whenever the window is not the whole story — either a
  * source said so itself, or the clamp dropped rows. Shared by BOTH listInbox

--- a/packages/prompts/reply-email.md
+++ b/packages/prompts/reply-email.md
@@ -23,7 +23,8 @@ You are the founder, personally answering an email a prospect wrote back to you.
 - If they're interested: propose ONE concrete next step (a short call, a link, an answer) — not a menu.
 - Match the sender's depth. If they made a technical claim, described their architecture, or asked how something works, engage with its SUBSTANCE using PRODUCT BRIEF and SENDER DOSSIER — one concrete, specific point (name the mechanism, the protocol, the tradeoff) beats three generic ones. Never answer a technical message with only curiosity questions.
 - Links: you may include at most ONE link, and only a URL that appears VERBATIM in PRODUCT BRIEF. Never construct, guess, or adapt a URL. No PRODUCT BRIEF = no links.
-- Length: 40-90 words for social replies; up to 130 when answering a substantive technical message. 1-3 short paragraphs. It's a reply, not a letter.
+- Length: MIRROR THEIRS. A one-line answer gets one or two sentences back (under 40 words) — acknowledging their answer and asking or offering ONE thing. 40-90 words only when they wrote substance; up to 130 only for a substantive technical message. 1-3 short paragraphs. It's a reply, not a letter.
+- A short answer to a question you asked is not an invitation to pitch. Take the answer, go one level deeper on THEIR pain, and stop. No "I built X to handle that" origin story mid-thread — mention the product only when they ask about it, in one sentence.
 - No capability lists, no feature dumps, no discounts or credits, no invented artifacts (decks, teardowns, case studies you don't have).
 - Forbidden phrases: "thanks for the feedback" as an opener, "I appreciate you taking the time", "circling back", "just to clarify", "hope this finds you well".
 - Do not re-introduce yourself or the product — they know who you are; PRIOR EMAILS already did that.


### PR DESCRIPTION
Two fixes from reviewing the live inbox:

**1. Replies were getting lost.** The inbox fetched only the newest 200 mails per window with a `newer_than:30d` Gmail query, so of 5 real replies in the ledger only 1 showed — June replies could never appear, and Aug ones drowned in ~200 no-match mails. Now the ledger's list of known repliers (`sequence_events.status='replied'`) drives a targeted, all-time `from:(...)` Gmail fetch that's merged into the window (deduped by message id, best-effort in its own try/catch so it can never break the main list). All 5 replies — 4 of them to the freebutter mailboxes — will now always render under **matched**.

**2. Reply drafts were too verbose.** A three-word prospect answer was getting a 100+-word reply with an "I built OneShot to…" pitch paragraph. The reply prompt now mirrors the sender's length (one-liner in → 1-2 sentences out) and explicitly bans mid-thread product re-introduction: take their answer, go one level deeper on their pain, stop.

fmt / tsc / 1777 tests green.

https://claude.ai/code/session_01DV676i6x8Any5Czfq44Muh

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Surface known repliers in inbox and shorten reply drafts
> - The inbox route now fetches replies from prospect addresses that previously replied (via `Ledger.listRepliedProspectEmails`), merging them into the primary inbox window and deduping by email id. The supplemental fetch is best-effort: failures are logged at warn level with event `inbox.replies_from_failed` and do not affect the main response.
> - New `oneshot.listRepliesFrom` paginates backward across all Gmail identities to find replies from specific senders, searching all time instead of the default 30-day window.
> - `gmail.listGmailReplies` gains a `fromAnyOf` option; when set, the 30-day `newer_than` clause is skipped and a `from:(addr1 OR addr2 ...)` clause is appended.
> - The reply-email prompt now instructs the model to mirror the prospect's message length, avoid pitching after a short answer, and only mention the product when asked.
> - The queue row UI displays the prospect's title from the payload when available.
> - Risk: `gmail.listGmailReplies` with `fromAnyOf` skips the 30-day recency cutoff, so targeted sender queries search all time — verify that `oneshot.listRepliesFrom` page limits and per-source deadlines in [oneshot.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/52/files#diff-a75653098eb1094047ae1458ce831158ed4abd7e08122279a6827b46c0c2e9db) bound the query scope adequately.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1962638.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->