### PR TITLE
feat(inbox): persist replies in the ledger + conversation threads

### DIFF
--- a/apps/server/__tests__/inbox-route.test.ts
+++ b/apps/server/__tests__/inbox-route.test.ts
@@ -8,6 +8,11 @@ const listInboxMock = vi.fn();
 const replyEmailMock = vi.fn();
 
 const recordProspectReplyMock = vi.fn(() => []);
+const listProspectIdsWithRepliesMock = vi.fn((): number[] => []);
+const listInboxRepliesForProspectMock = vi.fn((): unknown[] => []);
+const listSequenceEventsForProspectMock = vi.fn((): unknown[] => []);
+const recordInboxReplyMock = vi.fn(() => true);
+const getProspectByIdMock = vi.fn((): unknown => null);
 let knownProspect: { id: number } | null = null;
 
 const ledger = {
@@ -17,6 +22,13 @@ const ledger = {
   getInboxThreads: getInboxThreadsMock,
   listAllCadences: () => [],
   listRepliedProspectEmails: () => [],
+  // v21 conversation machinery — empty by default; tests override with
+  // mockReturnValueOnce (one-shot, so nothing leaks across tests).
+  listProspectIdsWithReplies: listProspectIdsWithRepliesMock,
+  listInboxRepliesForProspect: listInboxRepliesForProspectMock,
+  listSequenceEventsForProspect: listSequenceEventsForProspectMock,
+  recordInboxReply: recordInboxReplyMock,
+  getProspectById: getProspectByIdMock,
   getProspectByEmail: () => null,
   findProspectByEmail: () => knownProspect,
   recordProspectReply: recordProspectReplyMock,
@@ -94,6 +106,71 @@ describe("inbox route — persisted drafts & sent replies", () => {
     expect(out.replies).toHaveLength(1);
     expect(out.replies[0]!.thread?.draftBody).toBe("saved draft");
     expect(out.replies[0]!.thread?.sent.map((s) => s.body)).toEqual(["sent1"]);
+  });
+
+  it("assembles conversations: outreach + inbound replies + manual sends, in time order", async () => {
+    listInboxMock.mockResolvedValue({ emails: [] });
+    getInboxThreadsMock.mockReturnValue(
+      new Map([
+        [
+          "t1",
+          { draftBody: "wip", sent: [{ body: "my answer", sentAt: "2026-08-25T23:00:00.000Z" }] },
+        ],
+      ]),
+    );
+    listProspectIdsWithRepliesMock.mockReturnValueOnce([7]);
+    getProspectByIdMock.mockReturnValueOnce({
+      id: 7,
+      name: "Coder",
+      email: "coder@x.example",
+      company: "OGs",
+      source: "stack-consolidation",
+    });
+    listInboxRepliesForProspectMock.mockReturnValueOnce([
+      {
+        id: "m1",
+        thread_key: "t1",
+        prospect_id: 7,
+        play_name: "stack-consolidation",
+        from_email: "coder@x.example",
+        subject: "Re: stack thing",
+        body: "It's sdk maintenance",
+        received_at: "2026-08-25T22:38:09.000Z",
+        source_identity_id: "gmail:me@x.com",
+        thread_id: "t1",
+        message_id: "<m1@mail>",
+      },
+    ]);
+    listSequenceEventsForProspectMock.mockReturnValueOnce([
+      {
+        prospect_id: 7,
+        play_name: "stack-consolidation",
+        step_index: 0,
+        channel: "email",
+        status: "replied",
+        metadata_json: JSON.stringify({ subject: "stack thing", body: "outreach body" }),
+        created_at: "2026-08-24 10:00:00",
+      },
+    ]);
+
+    const res = await listInboxRoute(new Request("http://localhost/api/inbox"));
+    const out = (await res.json()) as {
+      conversations: Array<{
+        prospectId: number;
+        draftBody: string | null;
+        items: Array<{ kind: string; at: string; body: string | null }>;
+      }>;
+    };
+    expect(out.conversations).toHaveLength(1);
+    const conv = out.conversations[0]!;
+    expect(conv.prospectId).toBe(7);
+    // Saved composer draft rides along for the newest inbound's thread.
+    expect(conv.draftBody).toBe("wip");
+    // Timeline order: outreach (SQLite timestamp, normalized) → their reply → our manual answer.
+    expect(conv.items.map((i) => i.kind)).toEqual(["outreach", "reply", "sent"]);
+    expect(conv.items[0]!.body).toBe("outreach body");
+    expect(conv.items[1]!.body).toBe("It's sdk maintenance");
+    expect(conv.items[2]!.body).toBe("my answer");
   });
 
   it("saveDraftRoute persists the draft via upsertInboxDraft", async () => {
@@ -282,6 +359,7 @@ describe("inbox route — research-grounded drafting", () => {
       fromEmail: "aladdin@aliyev.site",
       prospectId: null,
       threadKey: "t1",
+      excludeId: "e1",
     });
     expect(draftInboxReplyMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/server/__tests__/reply-research.test.ts
+++ b/apps/server/__tests__/reply-research.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const ledger = {
   getProspectById: vi.fn(),
   getInboxThreads: vi.fn(() => new Map()),
+  listInboxRepliesForProspect: vi.fn(() => []),
   getCachedEnrichment: vi.fn(() => null),
   setCachedEnrichment: vi.fn(),
   setCachedEnrichmentFailure: vi.fn(),

--- a/apps/server/src/api/_reply-research.ts
+++ b/apps/server/src/api/_reply-research.ts
@@ -21,6 +21,8 @@ export interface ReplyContext {
   dossier: string | null;
   /** Replies the founder already sent in this thread (oldest first). */
   threadSent: Array<{ body: string; sentAt: string }>;
+  /** The prospect's earlier inbound messages (persisted replies, oldest first) — the other half of the exchange. */
+  priorInbound: Array<{ body: string; subject: string | null; receivedAt: string }>;
   /** Paid spend this call actually incurred (cache hits are $0). */
   costUsd: number;
   /** True when a paid research call ran (vs. free/cached context only). */
@@ -37,12 +39,24 @@ export async function gatherReplyContext(input: {
   fromEmail: string;
   prospectId: number | null;
   threadKey: string | null;
+  /** Provider id of the email being answered — excluded from priorInbound (it IS the inbound). */
+  excludeId?: string | null;
 }): Promise<ReplyContext> {
   const ledger = getLedger();
 
   const threadSent = input.threadKey
     ? (ledger.getInboxThreads().get(input.threadKey)?.sent ?? [])
     : [];
+
+  // Tier 0 (free): the prospect's earlier inbound messages from the ledger —
+  // the drafter should see the whole exchange, not just the newest email.
+  const priorInbound =
+    input.prospectId != null
+      ? ledger
+          .listInboxRepliesForProspect(input.prospectId)
+          .filter((r) => r.id !== input.excludeId)
+          .map((r) => ({ body: r.body, subject: r.subject, receivedAt: r.received_at }))
+      : [];
 
   const parts: string[] = [];
   let costUsd = 0;
@@ -99,6 +113,7 @@ export async function gatherReplyContext(input: {
   return {
     dossier: parts.length > 0 ? parts.join("\n\n---\n\n") : null,
     threadSent,
+    priorInbound,
     costUsd,
     researched,
   };

--- a/apps/server/src/api/inbox.ts
+++ b/apps/server/src/api/inbox.ts
@@ -12,6 +12,8 @@ import {
 } from "@oneshot-gtm/core";
 import { draftInboxReply } from "@oneshot-gtm/plays";
 import {
+  type ConversationItem,
+  type ConversationView,
   type InboxDraftReplyRequest,
   type InboxDraftReplyResult,
   type InboxReplyView,
@@ -90,30 +92,24 @@ export async function listInboxRoute(req: Request): Promise<Response> {
       { message_120: ((err as Error)?.message ?? "").slice(0, 120) },
       "warn",
     );
-    const out: InboxResult = { replies: [], hasMore: false, error: "couldn't reach the inbox" };
+    // The live window is gone, but the ledger isn't: conversations still
+    // render so a mailbox outage never empties the matched view.
+    let conversations: ConversationView[] = [];
+    try {
+      conversations = buildConversations(ledger, cadenceIndex(ledger), ledger.getInboxThreads());
+    } catch {
+      // degraded twice over — return the error state alone.
+    }
+    const out: InboxResult = {
+      replies: [],
+      conversations,
+      hasMore: false,
+      error: "couldn't reach the inbox",
+    };
     return jsonResponse(out, 200, req);
   }
 
-  // Index cadence-backed prospects by normalized email; prefer a
-  // `replied`/`active` cadence when a prospect has several.
-  const byEmail = new Map<
-    string,
-    { name: string | null; company: string | null; playName: string; status: string }
-  >();
-  for (const c of ledger.listAllCadences()) {
-    if (!c.prospect_email) continue;
-    const key = c.prospect_email.trim().toLowerCase();
-    const existing = byEmail.get(key);
-    const better = !existing || cadenceRank(c.status) > cadenceRank(existing.status);
-    if (better) {
-      byEmail.set(key, {
-        name: c.prospect_name,
-        company: c.prospect_company,
-        playName: c.play_name,
-        status: c.status,
-      });
-    }
-  }
+  const byEmail = cadenceIndex(ledger);
 
   // Provider per identity — the UI shows whether a reply threads (gmail) or
   // is a best-effort OneShot send.
@@ -182,8 +178,166 @@ export async function listInboxRoute(req: Request): Promise<Response> {
     .filter((r) => !selfAddresses.has(r.fromEmail))
     .toSorted((a, b) => (a.receivedAt < b.receivedAt ? 1 : a.receivedAt > b.receivedAt ? -1 : 0));
 
-  const out: InboxResult = { replies: visible, hasMore };
+  // Opportunistic capture: any matched live mail not yet persisted goes into
+  // inbox_replies now (INSERT OR IGNORE — re-sees are no-ops). This is also
+  // how pre-v21 history backfills itself: the targeted known-replier fetch
+  // above flows through here on first load. Best-effort.
+  try {
+    for (const r of visible) {
+      if (!r.matched) continue;
+      const p = ledger.findProspectByEmail(r.fromEmail);
+      if (!p) continue;
+      ledger.recordInboxReply({
+        id: r.id,
+        threadKey: inboxThreadKey({ threadId: r.threadId, id: r.id }),
+        prospectId: p.id,
+        playName: r.matched.playName,
+        fromEmail: r.fromEmail,
+        subject: r.subject,
+        body: r.body,
+        receivedAt: r.receivedAt,
+        sourceIdentityId: r.sourceIdentityId,
+        threadId: r.threadId,
+        messageId: r.messageId,
+      });
+    }
+  } catch (err) {
+    logEvent(
+      "inbox.reply_capture_failed",
+      { message_120: ((err as Error)?.message ?? "").slice(0, 120) },
+      "warn",
+    );
+  }
+
+  // Threaded matched view, built from the ledger (complete regardless of the
+  // live window): outreach steps + persisted inbound replies + manual replies
+  // sent from /inbox, merged per prospect and sorted oldest-first.
+  let conversations: ConversationView[] = [];
+  try {
+    conversations = buildConversations(ledger, byEmail, threads);
+  } catch (err) {
+    logEvent(
+      "inbox.conversations_failed",
+      { message_120: ((err as Error)?.message ?? "").slice(0, 120) },
+      "warn",
+    );
+  }
+
+  const out: InboxResult = { replies: visible, conversations, hasMore };
   return jsonResponse(out, 200, req);
+}
+
+/**
+ * Index cadence-backed prospects by normalized email; prefer a
+ * `replied`/`active` cadence when a prospect has several.
+ */
+function cadenceIndex(
+  ledger: ReturnType<typeof getLedger>,
+): Map<string, { name: string | null; company: string | null; playName: string; status: string }> {
+  const byEmail = new Map<
+    string,
+    { name: string | null; company: string | null; playName: string; status: string }
+  >();
+  for (const c of ledger.listAllCadences()) {
+    if (!c.prospect_email) continue;
+    const key = c.prospect_email.trim().toLowerCase();
+    const existing = byEmail.get(key);
+    const better = !existing || cadenceRank(c.status) > cadenceRank(existing.status);
+    if (better) {
+      byEmail.set(key, {
+        name: c.prospect_name,
+        company: c.prospect_company,
+        playName: c.play_name,
+        status: c.status,
+      });
+    }
+  }
+  return byEmail;
+}
+
+/** Assemble one ConversationView per prospect with at least one persisted reply. */
+function buildConversations(
+  ledger: ReturnType<typeof getLedger>,
+  byEmail: Map<
+    string,
+    { name: string | null; company: string | null; playName: string; status: string }
+  >,
+  threads: ReturnType<ReturnType<typeof getLedger>["getInboxThreads"]>,
+): ConversationView[] {
+  const out: ConversationView[] = [];
+  for (const prospectId of ledger.listProspectIdsWithReplies()) {
+    const prospect = ledger.getProspectById(prospectId);
+    if (!prospect?.email) continue;
+    const inbound = ledger.listInboxRepliesForProspect(prospectId);
+    if (inbound.length === 0) continue;
+
+    const items: ConversationItem[] = [];
+    for (const ev of ledger.listSequenceEventsForProspect(prospectId)) {
+      if (ev.channel !== "email") continue;
+      let subject: string | null = null;
+      let body: string | null = null;
+      try {
+        const meta = JSON.parse(ev.metadata_json ?? "{}") as Record<string, unknown>;
+        if (typeof meta["subject"] === "string") subject = meta["subject"];
+        if (typeof meta["body"] === "string") body = meta["body"];
+      } catch {
+        // pre-v8 / malformed metadata — render the step with no body.
+      }
+      items.push({
+        kind: "outreach",
+        at: sqliteToIso(ev.created_at),
+        subject,
+        body,
+        stepIndex: ev.step_index,
+        playName: ev.play_name,
+      });
+    }
+    const threadKeys = new Set<string>();
+    for (const r of inbound) {
+      threadKeys.add(r.thread_key);
+      items.push({
+        kind: "reply",
+        at: r.received_at,
+        subject: r.subject,
+        body: r.body,
+        id: r.id,
+        threadKey: r.thread_key,
+        sourceIdentityId: r.source_identity_id,
+        threadId: r.thread_id,
+        messageId: r.message_id,
+      });
+    }
+    for (const key of threadKeys) {
+      for (const s of threads.get(key)?.sent ?? []) {
+        items.push({ kind: "sent", at: s.sentAt, subject: null, body: s.body });
+      }
+    }
+    items.sort((a, b) => (a.at < b.at ? -1 : a.at > b.at ? 1 : 0));
+
+    const cadence = byEmail.get(prospect.email.trim().toLowerCase());
+    out.push({
+      prospectId,
+      name: prospect.name,
+      company: prospect.company,
+      email: prospect.email,
+      playName: cadence?.playName ?? inbound.at(-1)?.play_name ?? prospect.source,
+      cadenceStatus: cadence?.status ?? null,
+      lastActivityAt: items.at(-1)?.at ?? inbound.at(-1)!.received_at,
+      draftBody: threads.get(inbound.at(-1)!.thread_key)?.draftBody ?? null,
+      items,
+    });
+  }
+  // Most recent activity first — the row order of the matched tab.
+  return out.toSorted((a, b) => (a.lastActivityAt < b.lastActivityAt ? 1 : -1));
+}
+
+/**
+ * sequence_events.created_at is SQLite datetime('now') format ("YYYY-MM-DD
+ * HH:MM:SS", UTC, no 'T'/'Z'); inbox timestamps are ISO. Normalize so the
+ * merged timeline's string sort is chronological.
+ */
+function sqliteToIso(ts: string): string {
+  return ts.includes("T") ? ts : `${ts.replace(" ", "T")}Z`;
 }
 
 /**
@@ -232,6 +386,7 @@ export async function draftReplyRoute(req: Request): Promise<Response> {
   let context: Awaited<ReturnType<typeof gatherReplyContext>> = {
     dossier: null,
     threadSent: [],
+    priorInbound: [],
     costUsd: 0,
     researched: false,
   };
@@ -243,6 +398,7 @@ export async function draftReplyRoute(req: Request): Promise<Response> {
         typeof body.id === "string" && body.id.length > 0
           ? inboxThreadKey({ threadId: body.threadId ?? null, id: body.id })
           : null,
+      excludeId: typeof body.id === "string" ? body.id : null,
     });
   } catch (err) {
     logEvent(
@@ -260,6 +416,7 @@ export async function draftReplyRoute(req: Request): Promise<Response> {
       matched,
       dossier: context.dossier,
       threadSent: context.threadSent,
+      priorInbound: context.priorInbound,
     });
     const out: InboxDraftReplyResult = {
       body: draft.body,

--- a/apps/web/src/routes/inbox.tsx
+++ b/apps/web/src/routes/inbox.tsx
@@ -3,7 +3,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { ChevronDown, ChevronRight, Loader2, RefreshCw, Send, Sparkles } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
-import type { InboxReplyView } from "@oneshot-gtm/shared-types";
+import type { ConversationView, InboxReplyView } from "@oneshot-gtm/shared-types";
 import { inboxThreadKey } from "@oneshot-gtm/shared-types";
 import { api } from "../api/client.ts";
 import { Badge } from "../components/primitives/Badge.tsx";
@@ -55,18 +55,20 @@ function InboxPage() {
   });
 
   const replies = inbox.data?.replies ?? [];
+  // Ledger-backed threaded view — complete regardless of the live window.
+  const conversations = inbox.data?.conversations ?? [];
   const error = inbox.data?.error;
   // The server fetches a clamped window (newest 200 across all identities).
-  // When listInbox says there was more, every total gets a "+" so the page
-  // never presents the window as the whole mailbox.
+  // When listInbox says there was more, all/no-match totals get a "+" so the
+  // page never presents the window as the whole mailbox. `matched` is exact —
+  // it comes from the ledger, not the window.
   const windowSuffix = inbox.data?.hasMore ? "+" : "";
-  // Filter is purely client-side over the already-fetched list (the endpoint
-  // takes no params). Counts are off the full list so the buttons show the split.
-  const matchedCount = replies.filter((r) => r.matched != null).length;
-  const noMatchCount = replies.length - matchedCount;
+  const noMatchCount = replies.filter((r) => r.matched == null).length;
   const countFor = (key: ReplyMatchFilter): number =>
-    key === "matched" ? matchedCount : key === "no-match" ? noMatchCount : replies.length;
+    key === "matched" ? conversations.length : key === "no-match" ? noMatchCount : replies.length;
+  const suffixFor = (key: ReplyMatchFilter): string => (key === "matched" ? "" : windowSuffix);
   const visible = replies.filter((r) => matchesReplyFilter(r, matchFilter));
+  const showConversations = matchFilter === "matched";
 
   return (
     <div className="-mx-6 -my-6 flex flex-col">
@@ -90,9 +92,11 @@ function InboxPage() {
           <span className="font-mono text-[11px] text-ink-faint">
             {!inbox.data
               ? "…"
-              : matchFilter === "all"
-                ? `${replies.length}${windowSuffix} repl${replies.length === 1 && !windowSuffix ? "y" : "ies"}`
-                : `${visible.length} of ${replies.length}${windowSuffix}`}
+              : showConversations
+                ? `${conversations.length} conversation${conversations.length === 1 ? "" : "s"}`
+                : matchFilter === "all"
+                  ? `${replies.length}${windowSuffix} repl${replies.length === 1 && !windowSuffix ? "y" : "ies"}`
+                  : `${visible.length} of ${replies.length}${windowSuffix}`}
           </span>
           <Button
             variant="ghost"
@@ -131,9 +135,10 @@ function InboxPage() {
             {/* opacity, not a fixed faint color, so the count stays legible on any button fill. */}
             {inbox.data && (
               <span className="ml-1 font-mono opacity-60">
-                {/* Counts are computed over the truncated window — lower bounds when hasMore. */}
+                {/* all/no-match counts come from the truncated window (lower bounds when
+                    hasMore); matched is ledger-truth, so it's exact. */}
                 {countFor(f.key)}
-                {windowSuffix}
+                {suffixFor(f.key)}
               </span>
             )}
           </Button>
@@ -148,19 +153,33 @@ function InboxPage() {
 
       {inbox.isLoading ? (
         Array.from({ length: 5 }, (_, i) => <SkeletonRow key={i} />)
+      ) : showConversations ? (
+        conversations.length === 0 ? (
+          <div className="p-5">
+            <EmptyNote note="No conversations yet. When a prospect writes back, the whole exchange shows here." />
+          </div>
+        ) : (
+          <div>
+            {conversations.map((c, i) => (
+              <ConversationRow
+                key={c.prospectId}
+                conversation={c}
+                zebra={i % 2 === 1}
+                expanded={expanded === `c:${c.prospectId}`}
+                onToggle={() =>
+                  setExpanded(expanded === `c:${c.prospectId}` ? null : `c:${c.prospectId}`)
+                }
+              />
+            ))}
+          </div>
+        )
       ) : replies.length === 0 ? (
         <div className="p-5">
           <EmptyNote note="No replies yet. When a prospect writes back, it shows here." />
         </div>
       ) : visible.length === 0 ? (
         <div className="p-5">
-          <EmptyNote
-            note={
-              matchFilter === "matched"
-                ? "No matched replies — none of the mail here maps to a known prospect yet."
-                : "No unmatched replies — every reply here matches a prospect."
-            }
-          />
+          <EmptyNote note="No unmatched replies — every reply here matches a prospect." />
         </div>
       ) : (
         <div>
@@ -174,6 +193,155 @@ function InboxPage() {
             />
           ))}
         </div>
+      )}
+    </div>
+  );
+}
+
+/** Best-effort provider from an identity id — for ledger-backed rows the live window didn't attribute. */
+function providerFromIdentity(id: string | null): "gmail" | "oneshot" | "smartlead" | null {
+  if (!id) return null;
+  if (id.startsWith("gmail:") || id === "legacy-gmail") return "gmail";
+  if (id.startsWith("smartlead:")) return "smartlead";
+  return "oneshot";
+}
+
+function ConversationRow({
+  conversation,
+  zebra,
+  expanded,
+  onToggle,
+}: {
+  conversation: ConversationView;
+  zebra: boolean;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const c = conversation;
+  const who = c.name ?? c.email;
+  const replyCount = c.items.filter((i) => i.kind === "reply").length;
+  const newest = [...c.items].reverse().find((i) => i.kind === "reply");
+  // The composer answers the newest inbound; sent history renders in the
+  // timeline, so the composer's own history is deliberately empty.
+  const composerReply: InboxReplyView | null = newest
+    ? {
+        id: newest.id,
+        fromEmail: c.email,
+        fromRaw: c.email,
+        subject: newest.subject ?? "",
+        receivedAt: newest.at,
+        body: newest.body,
+        sourceIdentityId: newest.sourceIdentityId,
+        sourceProvider: providerFromIdentity(newest.sourceIdentityId),
+        threadId: newest.threadId,
+        messageId: newest.messageId,
+        matched: {
+          name: c.name,
+          company: c.company,
+          playName: c.playName,
+          cadenceStatus: c.cadenceStatus,
+        },
+        thread: { draftBody: c.draftBody, sent: [] },
+      }
+    : null;
+  return (
+    <>
+      <button
+        type="button"
+        onClick={onToggle}
+        className={cn(
+          "group flex w-full items-center gap-3 border-b border-ink-rule/60 px-6 py-3 text-left",
+          "transition-colors duration-[var(--dur-stamp)] hover:bg-ink-surface/60",
+          zebra && "bg-ink-surface/20",
+        )}
+      >
+        <span className="text-ink-faint">
+          {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="flex items-center gap-2">
+            <span className="truncate text-[13px] text-ink-cream">
+              <Pii kind="auto">{who}</Pii>
+            </span>
+            {c.company ? (
+              <span className="truncate font-mono text-[11px] text-ink-faint">
+                · <Pii kind="company">{c.company}</Pii>
+              </span>
+            ) : null}
+          </span>
+          <span className="block truncate text-[12px] text-ink-muted">
+            {newest?.subject || `${c.items.length} messages`}
+          </span>
+        </span>
+        <span className="shrink-0 font-mono text-[11px] text-ink-faint">
+          {replyCount} repl{replyCount === 1 ? "y" : "ies"}
+        </span>
+        <Badge tone={statusTone(c.cadenceStatus)}>
+          {c.playName ?? "prospect"}
+          {c.cadenceStatus ? ` · ${c.cadenceStatus}` : ""}
+        </Badge>
+        <span className="shrink-0 font-mono text-[12px] text-ink-muted">
+          {timeAgo(c.lastActivityAt)}
+        </span>
+      </button>
+      {expanded && (
+        <div className="border-b border-ink-rule/60 bg-ink-bg-deep/50 px-6 py-3">
+          <div className="flex flex-col gap-2">
+            {c.items.map((item, i) => (
+              <ConversationItemBlock key={i} item={item} />
+            ))}
+          </div>
+          {composerReply ? (
+            <ReplyComposer reply={composerReply} />
+          ) : (
+            <div className="mt-3 border-t border-ink-rule/60 pt-3 font-mono text-[11px] text-ink-faint">
+              nothing inbound to answer yet
+            </div>
+          )}
+        </div>
+      )}
+    </>
+  );
+}
+
+function ConversationItemBlock({ item }: { item: ConversationView["items"][number] }) {
+  if (item.kind === "reply") {
+    return (
+      <div className="rounded-sm border border-[color:var(--ink-signal)]/40 bg-ink-surface/40 px-3 py-2">
+        <div className="mb-1 font-mono text-[10px] uppercase tracking-wide text-ink-faint">
+          them · {timeAgo(item.at)}
+          {item.subject ? ` · ${item.subject}` : ""}
+        </div>
+        <pre className="max-h-[280px] overflow-auto whitespace-pre-wrap font-mono text-[12px] leading-[1.6] text-ink-cream">
+          {item.body || "(no body)"}
+        </pre>
+      </div>
+    );
+  }
+  if (item.kind === "sent") {
+    return (
+      <div className="rounded-sm border border-ink-rule/60 bg-ink-surface/30 px-3 py-2">
+        <div className="mb-1 font-mono text-[10px] uppercase tracking-wide text-ink-faint">
+          you replied · {timeAgo(item.at)}
+        </div>
+        <pre className="max-h-[240px] overflow-auto whitespace-pre-wrap font-mono text-[12px] leading-[1.6] text-ink-cream-2">
+          {item.body}
+        </pre>
+      </div>
+    );
+  }
+  return (
+    <div className="rounded-sm border border-ink-rule/40 px-3 py-2 opacity-80">
+      <div className="mb-1 font-mono text-[10px] uppercase tracking-wide text-ink-faint">
+        you · step {item.stepIndex} · {item.playName} · {timeAgo(item.at)}
+        {item.subject ? ` · ${item.subject}` : ""}
+      </div>
+      {item.body ? (
+        <pre className="max-h-[200px] overflow-auto whitespace-pre-wrap font-mono text-[12px] leading-[1.6] text-ink-muted">
+          {item.body}
+        </pre>
+      ) : (
+        <div className="font-mono text-[11px] text-ink-faint">(body not recorded)</div>
       )}
     </div>
   );

--- a/packages/core/__tests__/inbox-replies.test.ts
+++ b/packages/core/__tests__/inbox-replies.test.ts
@@ -1,0 +1,94 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { Ledger } from "../src/ledger.ts";
+
+let dbPath: string;
+let ledger: Ledger;
+
+beforeEach(() => {
+  dbPath = join(
+    tmpdir(),
+    `oneshot-gtm-inbox-replies-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`,
+  );
+  ledger = new Ledger(dbPath);
+});
+
+afterEach(() => {
+  ledger.close();
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      rmSync(`${dbPath}${suffix}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+function record(over: Partial<Parameters<Ledger["recordInboxReply"]>[0]> = {}): boolean {
+  return ledger.recordInboxReply({
+    id: "msg-1",
+    threadKey: "thread-1",
+    prospectId: 1,
+    playName: "stack-consolidation",
+    fromEmail: "Jane@Prospect.example",
+    subject: "Re: stack thing",
+    body: "It's sdk maintenance",
+    receivedAt: "2026-08-25T22:00:00.000Z",
+    sourceIdentityId: "gmail:me@corp.example",
+    threadId: "thread-1",
+    messageId: "<abc@mail.example>",
+    ...over,
+  });
+}
+
+describe("inbox_replies (v21)", () => {
+  it("stores a reply and is idempotent on the provider id", () => {
+    expect(record()).toBe(true);
+    // Re-sweep sees the same mail — must be a no-op, not a duplicate row.
+    expect(record({ body: "different body, same id" })).toBe(false);
+    const rows = ledger.listInboxRepliesForProspect(1);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.body).toBe("It's sdk maintenance");
+    // Sender address stored canonical, like every other prospect-email column.
+    expect(rows[0]!.from_email).toBe("jane@prospect.example");
+  });
+
+  it("keeps every reply on a thread, not just the first", () => {
+    record();
+    record({ id: "msg-2", body: "second reply", receivedAt: "2026-08-26T09:00:00.000Z" });
+    const rows = ledger.listInboxRepliesForProspect(1);
+    expect(rows.map((r) => r.body)).toEqual(["It's sdk maintenance", "second reply"]);
+  });
+
+  it("lists prospects with replies, most recent activity first", () => {
+    record();
+    record({ id: "msg-9", prospectId: 2, receivedAt: "2026-08-26T12:00:00.000Z" });
+    expect(ledger.listProspectIdsWithReplies()).toEqual([2, 1]);
+  });
+
+  it("listSequenceEventsForProspect returns sent steps across plays, oldest first", () => {
+    ledger.recordSequenceEvent({
+      prospectId: 1,
+      playName: "stack-consolidation",
+      stepIndex: 0,
+      channel: "email",
+      status: "sent",
+      metadata: { subject: "stack thing", body: "hey" },
+    });
+    ledger.recordSequenceEvent({
+      prospectId: 1,
+      playName: "luma-events",
+      stepIndex: 0,
+      channel: "email",
+      status: "sent",
+      metadata: { subject: "event", body: "yo" },
+    });
+    const events = ledger.listSequenceEventsForProspect(1);
+    expect(events).toHaveLength(2);
+    expect(new Set(events.map((e) => e.play_name))).toEqual(
+      new Set(["stack-consolidation", "luma-events"]),
+    );
+  });
+});

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -9,6 +9,7 @@ import type {
   BounceRecord,
   CanaryResultRecord,
   GmailPlacement,
+  InboxReplyRecord,
   InterviewRecord,
   ProspectRecord,
   QueueRow,
@@ -459,6 +460,31 @@ export class Ledger {
         value      TEXT NOT NULL,
         updated_at TEXT NOT NULL DEFAULT (datetime('now'))
       );
+    `);
+    // v21: inbound replies persisted at detection (body included) — the ledger,
+    // not the mailbox, is the store; a reply must never depend on a live fetch
+    // window. PK is the provider email id so the poll's overlap re-sweeps and
+    // the /inbox route's opportunistic captures are idempotent (mirrors
+    // bounces). Only prospect-matched mail is stored.
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS inbox_replies (
+        id                 TEXT PRIMARY KEY,
+        thread_key         TEXT NOT NULL,
+        prospect_id        INTEGER NOT NULL,
+        play_name          TEXT,
+        from_email         TEXT NOT NULL,
+        subject            TEXT,
+        body               TEXT NOT NULL,
+        received_at        TEXT NOT NULL,
+        source_identity_id TEXT,
+        thread_id          TEXT,
+        message_id         TEXT,
+        created_at         TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      CREATE INDEX IF NOT EXISTS idx_inbox_replies_prospect
+        ON inbox_replies(prospect_id, received_at);
+      CREATE INDEX IF NOT EXISTS idx_inbox_replies_thread
+        ON inbox_replies(thread_key, received_at);
     `);
   }
 
@@ -974,6 +1000,71 @@ export class Ledger {
       )
       .all() as Array<{ email: string }>;
     return rows.map((r) => r.email);
+  }
+
+  /**
+   * Persist one inbound reply (full body) keyed by provider email id.
+   * INSERT OR IGNORE — re-sweeps and double captures are no-ops. Returns true
+   * when this call stored a NEW reply.
+   */
+  recordInboxReply(row: {
+    id: string;
+    threadKey: string;
+    prospectId: number;
+    playName?: string | null;
+    fromEmail: string;
+    subject?: string | null;
+    body: string;
+    receivedAt: string;
+    sourceIdentityId?: string | null;
+    threadId?: string | null;
+    messageId?: string | null;
+  }): boolean {
+    const res = this.db
+      .query(
+        `INSERT OR IGNORE INTO inbox_replies
+           (id, thread_key, prospect_id, play_name, from_email, subject, body,
+            received_at, source_identity_id, thread_id, message_id)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        row.id,
+        row.threadKey,
+        row.prospectId,
+        row.playName ?? null,
+        canonEmail(row.fromEmail),
+        row.subject ?? null,
+        row.body,
+        row.receivedAt,
+        row.sourceIdentityId ?? null,
+        row.threadId ?? null,
+        row.messageId ?? null,
+      );
+    return res.changes > 0;
+  }
+
+  /** All persisted inbound replies for one prospect, oldest first. */
+  listInboxRepliesForProspect(prospectId: number): InboxReplyRecord[] {
+    return this.db
+      .query(`SELECT * FROM inbox_replies WHERE prospect_id = ? ORDER BY received_at ASC, id ASC`)
+      .all(prospectId) as InboxReplyRecord[];
+  }
+
+  /** Provider ids of every persisted reply — dedupe set for capture passes. */
+  listInboxReplyIds(): Set<string> {
+    const rows = this.db.query(`SELECT id FROM inbox_replies`).all() as Array<{ id: string }>;
+    return new Set(rows.map((r) => r.id));
+  }
+
+  /** Prospects that have at least one persisted reply, most recent activity first. */
+  listProspectIdsWithReplies(): number[] {
+    const rows = this.db
+      .query(
+        `SELECT prospect_id, MAX(received_at) AS last FROM inbox_replies
+         GROUP BY prospect_id ORDER BY last DESC`,
+      )
+      .all() as Array<{ prospect_id: number }>;
+    return rows.map((r) => r.prospect_id);
   }
 
   /** Full prospect record by id (PK seek). Avoids loading every prospect to find one. */
@@ -1835,6 +1926,18 @@ export class Ledger {
          ORDER BY step_index ASC, id ASC`,
       )
       .all(prospectId, playName) as SequenceEventRecord[];
+  }
+
+  /** Every sent step for a prospect across ALL plays — the outreach half of a conversation timeline. */
+  listSequenceEventsForProspect(prospectId: number): SequenceEventRecord[] {
+    return this.db
+      .query(
+        `SELECT * FROM sequence_events
+         WHERE prospect_id = ?
+           AND status IN ('sent','delivered','replied')
+         ORDER BY created_at ASC, id ASC`,
+      )
+      .all(prospectId) as SequenceEventRecord[];
   }
 
   /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -48,6 +48,24 @@ export interface EmailIdentity {
   warmup: { startPerDay: number; incrementPerWeek: number } | null;
 }
 
+/** One persisted inbound reply (inbox_replies, v21) — column-shaped row. */
+export interface InboxReplyRecord {
+  /** Provider email id (Gmail message id / OneShot id) — the idempotency key. */
+  id: string;
+  /** Same key as inbox_drafts / inbox_sent (thread_id, else email id). */
+  thread_key: string;
+  prospect_id: number;
+  play_name: string | null;
+  from_email: string;
+  subject: string | null;
+  body: string;
+  received_at: string;
+  source_identity_id: string | null;
+  thread_id: string | null;
+  message_id: string | null;
+  created_at: string;
+}
+
 export interface ProspectRecord {
   id: number;
   name: string | null;

--- a/packages/plays/__tests__/cadence-reply.test.ts
+++ b/packages/plays/__tests__/cadence-reply.test.ts
@@ -14,6 +14,8 @@ let failedSources: string[] = [];
 let repliedSteps: Array<{ prospectId: number; playName: string }> = [];
 // The play behind the prospect's latest sent step — the no-cadence-row fallback.
 let latestSentPlay: string | null = null;
+// v21 inbox_replies rows captured by the poll (id-keyed, INSERT OR IGNORE semantics).
+let persistedReplies: Array<{ id: string }> = [];
 // Persisted poll_state rows (watermark + backlog), as the real ledger holds them.
 let pollState: Record<string, string> = {};
 const watermarkOf = () => pollState["inbox_replies"] ?? null;
@@ -75,6 +77,15 @@ vi.mock("@oneshot-gtm/core", async () => {
         lookupArgs.push(canon);
         return canon === STORED_EMAIL ? { id: 1 } : null;
       },
+      // v21 reply persistence: the poll stores every matched inbound before
+      // recording the reply transition. Attribution mirrors the real
+      // latestSentPlayForProspect via the test's `latestSentPlay` knob.
+      latestSentPlayForProspect: () => latestSentPlay,
+      recordInboxReply: (row: { id: string }) => {
+        const isNew = !persistedReplies.some((r) => r.id === row.id);
+        if (isNew) persistedReplies.push(row as (typeof persistedReplies)[number]);
+        return isNew;
+      },
       setCadenceStatus: ({
         prospectId,
         playName,
@@ -131,6 +142,7 @@ beforeEach(() => {
   lookupArgs = [];
   inboxEmails = [];
   repliedSteps = [];
+  persistedReplies = [];
   // The fixture cadence is also the latest play that emailed the prospect.
   latestSentPlay = "stack-consolidation";
   pollState = {};
@@ -206,6 +218,31 @@ describe("pollInboxReplies — standalone background detection (no sends)", () =
     // The reply metric (home/CAC) is fed via markLatestStepReplied.
     expect(repliedSteps).toEqual([{ prospectId: 1, playName: "stack-consolidation" }]);
     expect(calls.sendEmail).toBe(0);
+  });
+
+  it("persists every matched inbound (body included) into inbox_replies", async () => {
+    inboxEmails = [
+      { id: "m1", from: "Sophia <sophia@agenticarchitect.ai>", subject: "re: stack" },
+      { id: "m2", from: "Someone Else <nobody@elsewhere.com>", subject: "spam" },
+    ];
+
+    await pollInboxReplies();
+    // Matched mail is stored; unmatched noise is not.
+    expect(persistedReplies.map((r) => r.id)).toEqual(["m1"]);
+    expect(persistedReplies[0]).toMatchObject({
+      prospectId: 1,
+      fromEmail: STORED_EMAIL,
+      playName: "stack-consolidation",
+    });
+
+    // A later reply on the same (already-replied) thread is stored too — the
+    // per-(prospect, play) reply transition being idempotent must not stop
+    // the message capture.
+    inboxEmails = [
+      { id: "m3", from: "Sophia <sophia@agenticarchitect.ai>", subject: "re: re: stack" },
+    ];
+    await pollInboxReplies();
+    expect(persistedReplies.map((r) => r.id)).toEqual(["m1", "m3"]);
   });
 
   it("backfills the reply event for an already-replied cadence; no cadence is stopped", async () => {

--- a/packages/plays/src/_cadence.ts
+++ b/packages/plays/src/_cadence.ts
@@ -276,6 +276,23 @@ async function walkInboxWindow(
       const from = normalizeEmail(e.from);
       const prospect = ledger.findProspectByEmail(from);
       if (!prospect) continue;
+      // Persist the full inbound (body included) — the ledger, not the mailbox,
+      // is the reply store. Every matched email, not just the first reply per
+      // (prospect, play): later replies on a live thread must be kept too.
+      // Same thread key convention as inboxThreadKey (thread_id, else id).
+      ledger.recordInboxReply({
+        id: e.id,
+        threadKey: e.thread_id ?? e.id,
+        prospectId: prospect.id,
+        playName: ledger.latestSentPlayForProspect(prospect.id, e.subject),
+        fromEmail: from,
+        subject: e.subject,
+        body: e.body ?? "",
+        receivedAt: e.received_at,
+        sourceIdentityId: e.source_identity_id ?? null,
+        threadId: e.thread_id ?? null,
+        messageId: e.message_id ?? null,
+      });
       for (const r of ledger.recordProspectReply(prospect.id, { subject: e.subject })) {
         if (r.newlyReplied) out.cadencesStopped++;
         if (!r.eventRecorded) continue;

--- a/packages/plays/src/reply.ts
+++ b/packages/plays/src/reply.ts
@@ -48,6 +48,8 @@ export interface DraftInboxReplyInput {
   dossier?: string | null;
   /** Replies the founder already sent in this thread (oldest first) — round 2+ must not repeat round 1. */
   threadSent?: Array<{ body: string; sentAt: string }>;
+  /** The prospect's earlier inbound messages (oldest first) — the other half of the exchange. */
+  priorInbound?: Array<{ body: string; subject: string | null; receivedAt: string }>;
 }
 
 /**
@@ -89,6 +91,19 @@ export async function draftInboxReply(input: DraftInboxReplyInput): Promise<{ bo
         ].join("\n")
       : null;
 
+  // The other half of the exchange: what THEY said before this message, so the
+  // draft carries the conversation instead of treating each email as the first.
+  const priorInboundBlock =
+    input.priorInbound && input.priorInbound.length > 0
+      ? [
+          "THEIR EARLIER MESSAGES (what the prospect already told you — don't re-ask any of it):",
+          ...input.priorInbound.flatMap((m) => [
+            `--- received ${m.receivedAt}${m.subject ? ` · ${m.subject}` : ""} ---`,
+            stripQuotedChain(m.body).slice(0, 1000),
+          ]),
+        ].join("\n")
+      : null;
+
   const proofBlock = socialProofBlock();
   const firstName = firstNameFrom(input.matched?.name ?? null);
   const user = [
@@ -106,6 +121,7 @@ export async function draftInboxReply(input: DraftInboxReplyInput): Promise<{ bo
       ? ["", `SENDER DOSSIER (research about who wrote this):\n${input.dossier.trim()}`]
       : []),
     ...(priorBlock ? ["", priorBlock] : []),
+    ...(priorInboundBlock ? ["", priorInboundBlock] : []),
     ...(threadBlock ? ["", threadBlock] : []),
     "",
     "INBOUND EMAIL (the message you are answering):",

--- a/packages/prompts/luma-events-email.md
+++ b/packages/prompts/luma-events-email.md
@@ -28,6 +28,7 @@ You write a founder-to-founder cold email triggered by the prospect appearing on
   - Sign-off: founder name.
 - Forbidden: never promise a doc you don't have — no "want the teardown / comparison / writeup / playbook" framing (see _humanizer.md → Banned: invented artifacts); "I noticed you're going", "I came across your name", "great to see you'll be at", "as a fellow founder", "would love to chat", "are you going to {event}?" (don't ask — say you saw they're going / went).
 - EVENT ABOUT is background for YOU to grasp the topic — never quote, paraphrase, or recap it as if you read the page or attended; it's the event's own marketing copy, not your observation. Draw the TOPIC from it, then write in your own peer voice.
+- EVENT TITLE + EVENT ABOUT are the ONLY authority on what kind of gathering this is. Call it what they call it (a meetup, a dinner, a demo night, a conference) — never "hackathon", "demo weekend" or any other format word that doesn't appear there. ICP and YOUR EDGE describe your BUYER and your ANGLE; their vocabulary (e.g. "hackathon builders") must never leak into how you refer to THIS event or its attendees.
 - Forbidden when PAST: any future-tense reference to the event — "this {weekday}", "before the meetup", "ahead of the meetup", "see you there", or anything implying the event is still coming up. The event is over; write as if it already happened.
 
 ## Voice

--- a/packages/prompts/reply-email.md
+++ b/packages/prompts/reply-email.md
@@ -9,6 +9,7 @@ You are the founder, personally answering an email a prospect wrote back to you.
 - PRODUCT BRIEF (optional): real facts about the product — architecture, pricing model — and the ONLY links you are allowed to cite
 - SENDER DOSSIER (optional): research about who wrote this — their company, what they've built, what their site says
 - PRIOR EMAILS: what you already sent them (subject + body) — so you know what they're reacting to
+- THEIR EARLIER MESSAGES (optional): what the prospect already told you in this exchange — never re-ask any of it
 - THREAD — REPLIES YOU ALREADY SENT (optional): your earlier answers in this same conversation
 - INBOUND EMAIL: the message they just sent you (subject + body). THIS is what you're answering.
 - Optional SOCIAL PROOF block

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -551,8 +551,55 @@ export function inboxThreadKey(v: { threadId: string | null; id: string }): stri
   return v.threadId ?? v.id;
 }
 
+/** One item on a conversation timeline, oldest first. */
+export type ConversationItem =
+  | {
+      /** An outreach step this tool sent (sequence_events, email channel). */
+      kind: "outreach";
+      at: string;
+      subject: string | null;
+      body: string | null;
+      stepIndex: number;
+      playName: string;
+    }
+  | {
+      /** An inbound reply from the prospect (ledger-persisted, or live mail not yet captured). */
+      kind: "reply";
+      at: string;
+      subject: string | null;
+      body: string;
+      id: string;
+      threadKey: string;
+      sourceIdentityId: string | null;
+      threadId: string | null;
+      messageId: string | null;
+    }
+  | {
+      /** A manual reply the founder sent from /inbox (inbox_sent). */
+      kind: "sent";
+      at: string;
+      subject: string | null;
+      body: string;
+    };
+
+/** The full exchange with one prospect — ledger-backed, complete forever. */
+export interface ConversationView {
+  prospectId: number;
+  name: string | null;
+  company: string | null;
+  email: string;
+  playName: string | null;
+  cadenceStatus: string | null;
+  lastActivityAt: string;
+  /** Saved (auto-saved) composer draft for the newest inbound's thread, if any. */
+  draftBody: string | null;
+  items: ConversationItem[];
+}
+
 export interface InboxResult {
   replies: InboxReplyView[];
+  /** Threaded matched view: one entry per prospect with a recorded reply. */
+  conversations?: ConversationView[];
   hasMore: boolean;
   /** Present when the inbox fetch failed; replies will be empty. */
   error?: string;


### PR DESCRIPTION
Reply management v2, per the approved plan (stacked on #52 — merge that first).

**Persist replies.** New `inbox_replies` table (schema v21): every prospect-matched inbound email is stored with its full body at detection time — by the 5-minute poll and by the /inbox route (which is also how history backfills: the #52 targeted fetch flows through it, and all 5 historical replies are now permanently in the ledger, verified live). Keyed by provider message id with INSERT OR IGNORE, so overlap re-sweeps are no-ops, and a second reply on an already-replied thread is captured instead of dropped.

**Conversation threads.** `GET /api/inbox` returns `conversations`: one per replied prospect — outreach steps (from sequence_events metadata) + their replies + your manual replies, merged in time order. The matched tab renders these as expandable exchange timelines with the existing composer on the newest inbound; the matched count is now exact (ledger-truth, no "+"). Conversations render even when the live mailbox fetch fails — an outage no longer empties the view.

**Drafting.** The reply drafter now receives THEIR EARLIER MESSAGES (prior persisted inbound), so it sees the whole exchange and never re-asks what the prospect already said.

**Verified live** on the sdk workspace: all 5 conversations render (incl. the June ones that were unreachable before), bodies persisted in `inbox_replies`, draft carry-through works. fmt / tsc / 1783 tests green (6 new).

https://claude.ai/code/session_01DV676i6x8Any5Czfq44Muh

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist inbound replies in `inbox_replies` and build `ConversationView` timelines
> - Adds the `inbox_replies` ledger table and `recordInboxReply` for idempotent storage of matched inbound emails.
> - `inbox.buildConversations` merges persisted replies with `ledger.listSequenceEventsForProspect` outreach events into chronological `ConversationView` timelines.
> - The inbox web UI renders these timelines using the new `ConversationRow` and `ConversationItemBlock` components.
> - `reply.draftInboxReply` receives `priorInbound` from `gatherReplyContext` to include earlier prospect messages in the LLM prompt.
> - Risk: `inbox.listInboxRoute` returns ledger-backed conversations even if the live inbox fetch fails, which may show stale data if the live inbox is unavailable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7125a28.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->