### PR TITLE
feat(doctor): grouped health panel

### DIFF
--- a/apps/server/src/api/doctor.ts
+++ b/apps/server/src/api/doctor.ts
@@ -5,7 +5,12 @@ import { jsonResponse } from "../server.ts";
 export async function doctor(req: Request): Promise<Response> {
   const results = await runDoctor();
   const checks: DoctorCheck[] = results.map((r) => {
-    const out: DoctorCheck = { name: r.name, severity: r.severity, message: r.message };
+    const out: DoctorCheck = {
+      name: r.name,
+      group: r.group,
+      severity: r.severity,
+      message: r.message,
+    };
     if (r.hint) out.hint = r.hint;
     return out;
   });

--- a/apps/web/src/components/setup/DoctorPanel.tsx
+++ b/apps/web/src/components/setup/DoctorPanel.tsx
@@ -1,0 +1,200 @@
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { useRef, useState } from "react";
+import type { DoctorCheck, DoctorGroup } from "@oneshot-gtm/shared-types";
+import { Badge } from "../primitives/Badge.tsx";
+import { EmptyNote } from "../primitives/EmptyNote.tsx";
+import { SkeletonRow } from "../primitives/Skeleton.tsx";
+import { cn } from "../../lib/cn.ts";
+
+const GROUP_ORDER: Array<{ key: DoctorGroup; label: string }> = [
+  { key: "install", label: "install" },
+  { key: "senders", label: "senders" },
+  { key: "deliverability", label: "deliverability" },
+  { key: "spend", label: "spend" },
+];
+
+type Tone = "receipt" | "spend" | "blocked";
+
+function toneFor(severity: DoctorCheck["severity"]): Tone {
+  return severity === "ok" ? "receipt" : severity === "warn" ? "spend" : "blocked";
+}
+
+/** Worst severity wins the group's accent: fail > warn > ok. */
+function worstOf(checks: DoctorCheck[]): DoctorCheck["severity"] {
+  if (checks.some((c) => c.severity === "fail")) return "fail";
+  if (checks.some((c) => c.severity === "warn")) return "warn";
+  return "ok";
+}
+
+/**
+ * Sum the `today N/cap` usage suffixes off sender messages — tolerant, like
+ * StatusBar's shortValue: rows that don't parse are just left out of the sum.
+ */
+function senderUsage(checks: DoctorCheck[]): string | null {
+  let sent = 0;
+  let cap = 0;
+  let any = false;
+  for (const c of checks) {
+    const m = /today (\d+)\/(\d+)/.exec(c.message);
+    if (!m) continue;
+    any = true;
+    sent += Number(m[1]);
+    cap += Number(m[2]);
+  }
+  return any ? `${sent}/${cap} sent today` : null;
+}
+
+function groupSummary(key: DoctorGroup, checks: DoctorCheck[]): { text: string; tone: Tone } {
+  const fails = checks.filter((c) => c.severity === "fail").length;
+  const warns = checks.filter((c) => c.severity === "warn").length;
+  if (fails > 0) return { text: `${fails} failing`, tone: "blocked" };
+  if (warns > 0) return { text: `${warns} warning${warns === 1 ? "" : "s"}`, tone: "spend" };
+  if (key === "senders") {
+    const identities = checks.filter((c) => c.name.startsWith("sender ")).length;
+    const usage = senderUsage(checks);
+    return {
+      text: `${identities} identit${identities === 1 ? "y" : "ies"}${usage ? ` · ${usage}` : ""} · ok`,
+      tone: "receipt",
+    };
+  }
+  return { text: `all ${checks.length} ok`, tone: "receipt" };
+}
+
+/**
+ * Group headers carry it, so rows drop redundant label text: "sender " rows
+ * show just the identity, and the repeated bare "deliverability" label
+ * disappears entirely (its message names the mailbox).
+ */
+function rowLabel(group: DoctorGroup, name: string): string | null {
+  if (group === "senders" && name.startsWith("sender ")) return name.slice("sender ".length);
+  if (group === "deliverability" && name === "deliverability") return null;
+  return name;
+}
+
+const SUMMARY_TONE_CLASS: Record<Tone, string> = {
+  receipt: "text-ink-faint",
+  spend: "text-[color:var(--ink-spend-2)]",
+  blocked: "text-[color:var(--ink-blocked-2)]",
+};
+
+export function DoctorPanel({
+  checks,
+  isLoading,
+  error,
+}: {
+  checks: DoctorCheck[] | undefined;
+  isLoading: boolean;
+  error?: string | null;
+}) {
+  // Seed expansion once from the first loaded data: unhealthy groups open,
+  // healthy groups collapsed. A background refetch must not slam a group the
+  // founder opened (or close one they're reading), hence the seed-once ref.
+  const [open, setOpen] = useState<Partial<Record<DoctorGroup, boolean>>>({});
+  const seeded = useRef(false);
+  if (!seeded.current && checks && checks.length > 0) {
+    seeded.current = true;
+    const initial: Partial<Record<DoctorGroup, boolean>> = {};
+    for (const { key } of GROUP_ORDER) {
+      initial[key] = worstOf(checks.filter((c) => (c.group ?? "install") === key)) !== "ok";
+    }
+    setOpen(initial);
+  }
+
+  if (isLoading && !checks) {
+    return (
+      <div>
+        {Array.from({ length: 3 }, (_, i) => (
+          <SkeletonRow key={i} />
+        ))}
+      </div>
+    );
+  }
+  if (error || !checks) {
+    return <EmptyNote note="Couldn't run doctor — check the server log and refresh." />;
+  }
+
+  const fails = checks.filter((c) => c.severity === "fail").length;
+  const warns = checks.filter((c) => c.severity === "warn").length;
+  const overall =
+    fails > 0
+      ? {
+          text: `${fails} failing · ${warns} warning${warns === 1 ? "" : "s"}`,
+          tone: "blocked" as Tone,
+        }
+      : warns > 0
+        ? { text: `${warns} warning${warns === 1 ? "" : "s"}`, tone: "spend" as Tone }
+        : { text: "all clear", tone: "receipt" as Tone };
+
+  return (
+    <div className="rounded-[var(--radius-sm)] border border-ink-rule bg-ink-bg-deep">
+      <div className="flex items-center justify-between border-b border-ink-rule/60 px-4 py-2">
+        <span className="ln-eyebrow">health</span>
+        <span className={cn("font-mono text-[11px]", SUMMARY_TONE_CLASS[overall.tone])}>
+          {overall.text}
+        </span>
+      </div>
+      {GROUP_ORDER.map(({ key, label }) => {
+        const rows = checks.filter((c) => (c.group ?? "install") === key);
+        if (rows.length === 0) return null;
+        const summary = groupSummary(key, rows);
+        const expanded = open[key] ?? false;
+        return (
+          <div key={key}>
+            <button
+              type="button"
+              onClick={() => setOpen((o) => ({ ...o, [key]: !expanded }))}
+              className={cn(
+                "flex w-full items-center gap-2 border-b border-ink-rule/60 px-4 py-2.5 text-left",
+                "transition-colors duration-[var(--dur-stamp)] hover:bg-ink-surface/60",
+              )}
+            >
+              <span className="text-ink-faint">
+                {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+              </span>
+              <span className="ln-eyebrow flex-1">{label}</span>
+              <span className={cn("font-mono text-[11px]", SUMMARY_TONE_CLASS[summary.tone])}>
+                {summary.text}
+              </span>
+            </button>
+            {expanded &&
+              rows.map((c, i) => {
+                const name = rowLabel(key, c.name);
+                return (
+                  <div
+                    key={`${key}:${c.name}:${i}`}
+                    className="ln-row"
+                    data-tone={toneFor(c.severity)}
+                  >
+                    <Badge
+                      tone={
+                        c.severity === "ok"
+                          ? "receipt"
+                          : c.severity === "warn"
+                            ? "spend"
+                            : "blocked"
+                      }
+                    >
+                      {c.severity}
+                    </Badge>
+                    <div className="min-w-0 flex-1 py-1">
+                      <div className="text-[13px] leading-snug">
+                        {name ? (
+                          <span className="mr-2 font-mono text-[11px] text-ink-muted">{name}</span>
+                        ) : null}
+                        <span className="text-ink-cream">{c.message}</span>
+                      </div>
+                      {c.hint ? (
+                        <div className="ln-note mt-0.5 text-[11.5px] text-ink-muted">
+                          → {c.hint}
+                        </div>
+                      ) : null}
+                    </div>
+                  </div>
+                );
+              })}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/routes/setup.tsx
+++ b/apps/web/src/routes/setup.tsx
@@ -6,6 +6,7 @@ import { toast } from "sonner";
 import type { SetupRequest, SmartleadAccountView } from "@oneshot-gtm/shared-types";
 import { api } from "../api/client.ts";
 import { Badge } from "../components/primitives/Badge.tsx";
+import { DoctorPanel } from "../components/setup/DoctorPanel.tsx";
 import { Button } from "../components/primitives/Button.tsx";
 import { Checkbox, Field, Input, Select, Textarea } from "../components/primitives/Field.tsx";
 
@@ -1182,18 +1183,11 @@ function SetupPage() {
         eyebrow="— · Doctor"
         lede="Health of the local install. Run `oneshot-gtm doctor` for the CLI view."
       >
-        <div className="flex flex-col gap-1.5">
-          {doctor.data?.checks.map((c) => (
-            <div key={c.name} className="flex items-center gap-2 text-[13px]">
-              {c.severity === "ok" && <Badge tone="receipt">ok</Badge>}
-              {c.severity === "warn" && <Badge tone="spend">warn</Badge>}
-              {c.severity === "fail" && <Badge tone="blocked">fail</Badge>}
-              <span className="text-ink-muted">{c.name}</span>
-              <span className="text-ink-cream">{c.message}</span>
-              {c.hint && <span className="ln-note text-ink-muted">→ {c.hint}</span>}
-            </div>
-          ))}
-        </div>
+        <DoctorPanel
+          checks={doctor.data?.checks}
+          isLoading={doctor.isLoading}
+          error={doctor.isError ? "unreachable" : null}
+        />
       </LedgerSection>
     </div>
   );

--- a/packages/doctor/__tests__/workspace-checks.test.ts
+++ b/packages/doctor/__tests__/workspace-checks.test.ts
@@ -46,6 +46,14 @@ describe("doctor workspace checks", () => {
     expect(checks[0]?.message.startsWith("gtm · ")).toBe(true);
   });
 
+  it("every check carries a valid group (the dashboard panel keys sections off it)", async () => {
+    const checks = await runDoctor();
+    const valid = new Set(["install", "senders", "deliverability", "spend"]);
+    for (const c of checks) {
+      expect(valid.has(c.group), `check '${c.name}' has group '${c.group}'`).toBe(true);
+    }
+  });
+
   it("warns when another workspace uses the same sending domain", async () => {
     cfgOverride = {
       emailIdentities: [

--- a/packages/doctor/src/check.ts
+++ b/packages/doctor/src/check.ts
@@ -27,8 +27,12 @@ import {
 
 type CheckSeverity = "ok" | "warn" | "fail";
 
+/** Section a check renders under in the dashboard's grouped Doctor panel. */
+type CheckGroup = "install" | "senders" | "deliverability" | "spend";
+
 interface CheckResult {
   name: string;
+  group: CheckGroup;
   severity: CheckSeverity;
   message: string;
   hint?: string;
@@ -85,6 +89,7 @@ function deliverabilityChecks(): CheckResult[] {
       const providers = [...new Set(blind.map((i) => i.provider))].join(", ");
       results.push({
         name: "deliverability",
+        group: "deliverability",
         severity: "warn",
         message: `${blind.length} identit${blind.length === 1 ? "y" : "ies"} not covered (${providers}) — bounce detection reads DSNs from Gmail mailboxes only`,
       });
@@ -96,6 +101,7 @@ function deliverabilityChecks(): CheckResult[] {
       const gmailCount = identities.length - blind.length;
       results.push({
         name: "deliverability",
+        group: "deliverability",
         severity: "ok",
         message:
           gmailCount === 0
@@ -119,6 +125,7 @@ function deliverabilityChecks(): CheckResult[] {
       if (!s) {
         results.push({
           name: "deliverability",
+          group: "deliverability",
           severity: "ok",
           message:
             sent === 0
@@ -135,6 +142,7 @@ function deliverabilityChecks(): CheckResult[] {
       if (sent < MIN_SENDS_TO_JUDGE) {
         results.push({
           name: "deliverability",
+          group: "deliverability",
           severity: s.block > 0 ? "warn" : "ok",
           message: `${label} ${s.hard} hard / ${s.block} blocked of ${sent} sent (${BOUNCE_WINDOW_DAYS}d) — too few sends to rate${blockNote}`,
         });
@@ -147,6 +155,7 @@ function deliverabilityChecks(): CheckResult[] {
         rate > HARD_FAIL_RATE ? "fail" : rate > HARD_WARN_RATE || s.block > 0 ? "warn" : "ok";
       results.push({
         name: "deliverability",
+        group: "deliverability",
         severity,
         message: `${label} ${pct} bounced (${s.hard}/${sent}, ${BOUNCE_WINDOW_DAYS}d)${blockNote}`,
         ...(severity === "ok"
@@ -162,6 +171,7 @@ function deliverabilityChecks(): CheckResult[] {
   } catch (err) {
     results.push({
       name: "deliverability",
+      group: "deliverability",
       severity: "warn",
       message: `could not evaluate: ${(err as Error).message}`,
     });
@@ -184,6 +194,7 @@ function placementCheck(): CheckResult {
     if (!last) {
       return {
         name: "inbox placement",
+        group: "deliverability",
         severity: "ok",
         message: "never tested",
         hint: "run: bun run cli -- gmail placement (needs a second authorized Gmail account)",
@@ -209,6 +220,7 @@ function placementCheck(): CheckResult {
           : "ok";
     return {
       name: "inbox placement",
+      group: "deliverability",
       severity,
       message: `${last.placement} (${age}) · ${auth}${caveat}`,
       ...(ageDays > CANARY_STALE_DAYS
@@ -218,6 +230,7 @@ function placementCheck(): CheckResult {
   } catch (err) {
     return {
       name: "inbox placement",
+      group: "deliverability",
       severity: "warn",
       message: `could not evaluate: ${(err as Error).message}`,
     };
@@ -241,6 +254,7 @@ function workspaceChecks(cfg: ReturnType<typeof loadConfig>): CheckResult[] {
   } catch (err) {
     out.push({
       name: "workspace",
+      group: "install",
       severity: "warn",
       message: `${name} · ${configDir()}`,
       hint: `workspace registry unreadable: ${(err as Error).message}`,
@@ -250,6 +264,7 @@ function workspaceChecks(cfg: ReturnType<typeof loadConfig>): CheckResult[] {
   const mine = all.find(([n]) => n === name)?.[1];
   out.push({
     name: "workspace",
+    group: "install",
     severity: "ok",
     message: `${name} · ${configDir()}${mine ? ` · port ${mine.port}` : ""}`,
   });
@@ -282,6 +297,7 @@ function workspaceChecks(cfg: ReturnType<typeof loadConfig>): CheckResult[] {
     if (entry.port && portsSeen.has(entry.port)) {
       out.push({
         name: `workspace port ${entry.port}`,
+        group: "install",
         severity: "warn",
         message: `'${other}' and '${portsSeen.get(entry.port)}' both default to :${entry.port}`,
         hint: "run one with --port, or recreate the workspace",
@@ -328,6 +344,7 @@ function workspaceChecks(cfg: ReturnType<typeof loadConfig>): CheckResult[] {
       if (theirDomains.has(d)) {
         out.push({
           name: `sending domain ${d}`,
+          group: "senders",
           severity: "warn",
           message: `also used by workspace '${other}' — caps are per-workspace, so the domain's real daily budget is doubled`,
           hint: "give each workspace its own sending domain (oneshot-gtm identities add)",
@@ -338,6 +355,7 @@ function workspaceChecks(cfg: ReturnType<typeof loadConfig>): CheckResult[] {
       if (theirGmail.has(a)) {
         out.push({
           name: `gmail ${a}`,
+          group: "senders",
           severity: "warn",
           message: `also authorized in workspace '${other}' — both inbox pollers will see both products' replies`,
           hint: "use a separate Gmail account per workspace",
@@ -354,6 +372,7 @@ function workspaceChecks(cfg: ReturnType<typeof loadConfig>): CheckResult[] {
       if (theirSmartlead.has(a)) {
         out.push({
           name: `smartlead ${a}`,
+          group: "senders",
           severity: "warn",
           message: `also registered in workspace '${other}' — caps are per-workspace, so the mailbox's real daily budget is doubled`,
           hint: "register each Smartlead mailbox in only one workspace",
@@ -381,6 +400,7 @@ export async function runDoctor(): Promise<CheckResult[]> {
 
   results.push({
     name: "config dir",
+    group: "install",
     severity: existsSync(configDir()) ? "ok" : "warn",
     message: existsSync(configDir()) ? configDir() : `missing: ${configDir()}`,
     ...(existsSync(configDir()) ? {} : { hint: "run: oneshot-gtm init" }),
@@ -388,6 +408,7 @@ export async function runDoctor(): Promise<CheckResult[]> {
 
   results.push({
     name: "founder profile",
+    group: "install",
     severity: cfg.founderName && cfg.productOneLiner ? "ok" : "warn",
     message:
       cfg.founderName && cfg.productOneLiner
@@ -405,6 +426,7 @@ export async function runDoctor(): Promise<CheckResult[]> {
   const llmSrc = secretSource(llmEnv as never);
   results.push({
     name: `llm key (${cfg.llmProvider})`,
+    group: "install",
     severity: llmApiKey(cfg.llmProvider) ? "ok" : "fail",
     message: llmApiKey(cfg.llmProvider) ? `set (${llmSrc ?? "?"})` : `${llmEnv} not set`,
     ...(llmApiKey(cfg.llmProvider) ? {} : { hint: `oneshot-gtm config keys` }),
@@ -415,6 +437,7 @@ export async function runDoctor(): Promise<CheckResult[]> {
   const walletSrc = process.env.AGENT_PRIVATE_KEY ? pkSrc : cdpSrc;
   results.push({
     name: "wallet env",
+    group: "install",
     severity: oneshotEnvReady() ? "ok" : "fail",
     message: oneshotEnvReady()
       ? `${process.env.AGENT_PRIVATE_KEY ? "AGENT_PRIVATE_KEY" : "CDP wallet"} set (${walletSrc ?? "?"})`
@@ -427,12 +450,14 @@ export async function runDoctor(): Promise<CheckResult[]> {
     const sample = ledger.listReceipts({ limit: 1 });
     results.push({
       name: "ledger",
+      group: "install",
       severity: "ok",
       message: `ok, ${sample.length === 0 ? "empty" : "has receipts"} (${join(configDir(), "ledger.sqlite")})`,
     });
   } catch (err) {
     results.push({
       name: "ledger",
+      group: "install",
       severity: "fail",
       message: `error opening ledger: ${(err as Error).message}`,
     });
@@ -487,6 +512,7 @@ export async function runDoctor(): Promise<CheckResult[]> {
       } catch (err) {
         results.push({
           name: "smartlead",
+          group: "senders",
           severity: "warn",
           message: `could not verify Smartlead accounts: ${(err as Error).message}`,
         });
@@ -509,6 +535,7 @@ export async function runDoctor(): Promise<CheckResult[]> {
         if (missing.length > 0 || !account) {
           results.push({
             name,
+            group: "senders",
             severity: "fail",
             message:
               missing.length > 0 ? `missing: ${missing.join(", ")}` : "no refresh token stored",
@@ -518,10 +545,16 @@ export async function runDoctor(): Promise<CheckResult[]> {
         }
         try {
           const { emailAddress } = await getGmailProfile(account);
-          results.push({ name, severity: "ok", message: `sending as ${emailAddress} · ${usage}` });
+          results.push({
+            name,
+            group: "senders",
+            severity: "ok",
+            message: `sending as ${emailAddress} · ${usage}`,
+          });
         } catch (err) {
           results.push({
             name,
+            group: "senders",
             severity: "fail",
             message: `auth check failed: ${(err as Error).message}`,
             hint: GMAIL_AUTH_HINT,
@@ -533,6 +566,7 @@ export async function runDoctor(): Promise<CheckResult[]> {
         if (!smartleadApiKey()) {
           results.push({
             name,
+            group: "senders",
             severity: "fail",
             message: "SMARTLEAD_API_KEY not set — sends from this identity will fail",
             hint: "Store it with: bun run cli -- smartlead connect",
@@ -540,6 +574,7 @@ export async function runDoctor(): Promise<CheckResult[]> {
         } else if (smartleadByAddress && !account) {
           results.push({
             name,
+            group: "senders",
             severity: "fail",
             message: `${address || identity.id} is no longer connected in Smartlead`,
             hint: "Reconnect the mailbox in Smartlead, or remove the identity from the pool.",
@@ -547,12 +582,14 @@ export async function runDoctor(): Promise<CheckResult[]> {
         } else if (account && !account.isSmtpSuccess) {
           results.push({
             name,
+            group: "senders",
             severity: "fail",
             message: `${address} SMTP connection broken in Smartlead — reconnect it there · ${usage}`,
           });
         } else if (account && account.warmupStatus && account.warmupStatus !== "ACTIVE") {
           results.push({
             name,
+            group: "senders",
             severity: "warn",
             message: `sending as ${address} · warmup ${account.warmupStatus.toLowerCase()} in Smartlead · ${usage}`,
           });
@@ -561,12 +598,14 @@ export async function runDoctor(): Promise<CheckResult[]> {
           const warm = account.warmupStatus ? ` · warmup active${rep}` : "";
           results.push({
             name,
+            group: "senders",
             severity: "ok",
             message: `sending as ${address}${warm} · ${usage}`,
           });
         } else {
           results.push({
             name,
+            group: "senders",
             severity: "warn",
             message: `sending as ${address || identity.id} · unverified (Smartlead API unreachable) · ${usage}`,
           });
@@ -578,6 +617,7 @@ export async function runDoctor(): Promise<CheckResult[]> {
         if (!domain) {
           results.push({
             name,
+            group: "senders",
             severity: "warn",
             message: `no sendingDomain — SDK default domain · ${usage}`,
           });
@@ -586,6 +626,7 @@ export async function runDoctor(): Promise<CheckResult[]> {
           // send) but it'll go out cold with no server warmup — lean on the cap.
           results.push({
             name,
+            group: "senders",
             severity: "warn",
             message: `${localpart}${domain} not yet provisioned — auto-provisions on first send and bypasses server warm-up; client cap is the only throttle · ${usage}`,
             hint: "Confirm you control this domain, or pick a warmed one (oneshot-gtm identities list).",
@@ -593,6 +634,7 @@ export async function runDoctor(): Promise<CheckResult[]> {
         } else if (entry && (entry.status === "paused" || entry.status === "removed")) {
           results.push({
             name,
+            group: "senders",
             severity: "warn",
             message: `${localpart}${domain} is ${entry.status} in the pool · ${usage}`,
             hint: `Resume it on /setup (Sender → Provisioned domains) or run: oneshot-gtm domains resume ${domain}`,
@@ -604,6 +646,7 @@ export async function runDoctor(): Promise<CheckResult[]> {
               : "";
           results.push({
             name,
+            group: "senders",
             severity: "ok",
             message: `sending from ${localpart}${domain} · ${usage}${warmth}`,
           });
@@ -613,6 +656,7 @@ export async function runDoctor(): Promise<CheckResult[]> {
   } catch (err) {
     results.push({
       name: "sender identities",
+      group: "senders",
       severity: "warn",
       message: `could not evaluate: ${(err as Error).message}`,
     });
@@ -630,12 +674,14 @@ export async function runDoctor(): Promise<CheckResult[]> {
       const bal = await getBalance();
       results.push({
         name: "wallet balance",
+        group: "spend",
         severity: "ok",
         message: `${bal.balance}`,
       });
     } catch (err) {
       results.push({
         name: "wallet balance",
+        group: "spend",
         severity: "warn",
         message: `could not fetch: ${(err as Error).message}`,
       });

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -209,8 +209,13 @@ export type LlmProvider = "openrouter" | "openai" | "anthropic";
 export type WalletMode = "cdp" | "private-key";
 export type KeySource = "env" | "file" | null;
 
+/** Section a doctor check renders under in the dashboard's grouped panel. */
+export type DoctorGroup = "install" | "senders" | "deliverability" | "spend";
+
 export interface DoctorCheck {
   name: string;
+  /** Optional so stale clients tolerate its absence; the engine always sets it. */
+  group?: DoctorGroup;
   severity: "ok" | "warn" | "fail";
   message: string;
   hint?: string;


### PR DESCRIPTION
Cleans up the Doctor section on /setup per the approved plan: every check now carries a `group` (install / senders / deliverability / spend), and a new `DoctorPanel` renders group headers as ledger-style subtotal rows — healthy groups collapse to a summary line (senders shows aggregate `X/Y sent today`), warn/fail groups start expanded with the severity accent bar (`.ln-row`) and the fix hint on its own line. Also fixes the React key collision on repeated 'deliverability' rows.

Verified live against the sdk workspace: install 6 ok (collapsed), senders 5 ok + usage (collapsed), deliverability 3 ok / 2 warn (expanded), spend 1 ok; no ungrouped rows. fmt / tsc / 1778 tests green (1 new: every emitted check carries a valid group).

https://claude.ai/code/session_01DV676i6x8Any5Czfq44Muh

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add grouped health panel to `DoctorPanel` and classify checks by group
> - Introduces `CheckGroup` type (`install` | `senders` | `deliverability` | `spend`) and adds a required `group` field to every `CheckResult` in [check.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/55/files#diff-d2c91f825714de9a0d3059003c50a802666e81ce6d17545bd384de76cbae66ff)
> - Backend `/api/doctor` handler in [doctor.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/55/files#diff-cd06614714cd874133c77abc659e946939a9bb01597f17e2fb3020840a346873) now forwards the `group` field; shared types in [index.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/55/files#diff-8bfc1c4b53bda948594b3bcdeaead8e4c4130ad092154633bf858b7447c5d62f) add an optional `group?: DoctorGroup` to `DoctorCheck`
> - New `DoctorPanel` component in [DoctorPanel.tsx](https://github.com/oneshot-agent/oneshot-gtm/pull/55/files#diff-27d2ed34062c37eb79d012d3a6ca4a2e34f9de7d49af3b2e15074e59509061b0) replaces the flat check list on the setup page with collapsible group sections, per-group summaries, loading skeletons, and error fallback
> - Group summaries aggregate severity (`worstOf`), sender usage from message text, and elide redundant row labels within groups
> - Behavioral Change: `CheckResult` now requires `group`; any out-of-tree or custom checks that do not set `group` will fail to compile. `DoctorCheck.group` remains optional for backward compatibility.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4ea5a40. 5 files reviewed, 2 issues evaluated, 2 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/web/src/components/setup/DoctorPanel.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 38](https://github.com/oneshot-agent/oneshot-gtm/blob/4ea5a40cd89bd8be70bd54c85c116c2970c6c2c6/apps/web/src/components/setup/DoctorPanel.tsx#L38): `senderUsage` only matches `today N/cap`, but sender checks that share a domain are emitted as `today N · domain N/cap shared`. Consequently, as soon as two mailboxes share a domain, their collapsed senders header omits the `X/Y sent today` aggregate even though the per-row data is present. <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>apps/web/src/routes/setup.tsx — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 38](https://github.com/oneshot-agent/oneshot-gtm/blob/4ea5a40cd89bd8be70bd54c85c116c2970c6c2c6/apps/web/src/routes/setup.tsx#L38): `senderUsage` only matches `today N/cap`, but every sender sharing a OneShot domain emits `today <identity> · domain <total>/<cap> shared`. Thus a pool with two mailboxes on the same domain has no `X/Y sent today` total in its collapsed sender header (and a mixed pool reports only the unshared mailboxes), even though the actual shared-domain usage is available in each check message. <b>[ Skipped comment generation ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->