### PR TITLE
fix(find): amplifier lane survives research failure → manual DM fallback

### DIFF
--- a/packages/find/__tests__/x-reposters.test.ts
+++ b/packages/find/__tests__/x-reposters.test.ts
@@ -34,6 +34,8 @@ let stageBVerdict: "pass" | "reject" | "unclear" | "transient" = "pass";
 let dupHandles = new Set<string>();
 /** handle → email deepResearchPerson finds; absent → no email in the dossier. */
 let emailsByHandle: Record<string, string> = {};
+/** handles whose deepResearchPerson call throws ("Could not find data…"). */
+let researchFailsFor = new Set<string>();
 
 function user(over: Partial<XUser> = {}): XUser {
   return {
@@ -165,6 +167,9 @@ vi.mock("@oneshot-gtm/core", async () => {
     deepResearchPerson: async (input: { socialMediaUrl?: string }) => {
       const handle = (input.socialMediaUrl ?? "").split("/").pop() ?? "";
       researchCalls.push(handle);
+      if (researchFailsFor.has(handle.toLowerCase())) {
+        throw new Error("Job failed: Could not find data for this person.");
+      }
       const email = emailsByHandle[handle.toLowerCase()];
       return {
         result: {
@@ -210,6 +215,7 @@ beforeEach(() => {
   stageBVerdict = "pass";
   dupHandles = new Set();
   emailsByHandle = {};
+  researchFailsFor = new Set();
 });
 afterEach(() => vi.clearAllMocks());
 
@@ -253,6 +259,26 @@ describe("runXRepostersFinder — lane → play routing", () => {
     expect(row.payload["engine"]).toBe("xapi");
     expect(row.payload["xUserId"]).toBe("u-noemail");
     expect(row.payload["launchDate"]).toBe("2026-09-23");
+  });
+
+  it("a research failure on an amplifier falls through to the manual DM draft", async () => {
+    // Observed on the first live run: deepResearchPerson "Could not find data
+    // for this person" killed the only pick. The DM path needs no email and no
+    // dossier — the repost is the hook — so the amplifier must survive.
+    harvestCandidates = [amplifierCandidate("ghost")];
+    researchFailsFor = new Set(["ghost"]);
+    const out = await runXRepostersFinder({ dryRun: false, seeds: SEEDS });
+    expect(out.enqueued).toBe(1);
+    expect(enqueued[0]!.playName).toBe("x-amplify-dm");
+    expect(out.droppedEnrichment).toBe(0);
+  });
+
+  it("a research failure on a founder still drops — that lane is email-only", async () => {
+    harvestCandidates = [founderCandidate("ghostf")];
+    researchFailsFor = new Set(["ghostf"]);
+    const out = await runXRepostersFinder({ dryRun: false, seeds: SEEDS });
+    expect(out.droppedEnrichment).toBe(1);
+    expect(enqueued).toHaveLength(0);
   });
 
   it("founder wins when someone qualifies for both lanes", async () => {

--- a/packages/find/src/_x-harvest.ts
+++ b/packages/find/src/_x-harvest.ts
@@ -73,7 +73,7 @@ export async function harvestReposters(
     } catch (e) {
       if (isStop(e)) {
         stoppedEarly = (e as Error).message;
-        log(`  ${stoppedEarly} — keeping what we have`);
+        log(`  ${stoppedEarly}`);
         break;
       }
       throw e;
@@ -102,7 +102,7 @@ export async function harvestReposters(
       } catch (e) {
         if (isStop(e)) {
           stoppedEarly = (e as Error).message;
-          log(`  ${stoppedEarly} — keeping what we have`);
+          log(`  ${stoppedEarly}`);
           break outer;
         }
         throw e;

--- a/packages/find/src/x-reposters.ts
+++ b/packages/find/src/x-reposters.ts
@@ -330,9 +330,12 @@ export async function runXRepostersFinder(opts: XRepostersFinderOpts): Promise<F
 
     // Research the person from their X profile. X gives no company domain
     // (and x.com is a dud domain for the findEmail prescreen), so
-    // deepResearchPerson is the contact path for BOTH lanes.
+    // deepResearchPerson is the contact path for BOTH lanes. A research
+    // failure is fatal only for founders (that lane is email-only); an
+    // amplifier falls through to the manual DM draft, which needs neither an
+    // email nor a dossier — the repost itself is the hook.
     const twitterUrl = `https://x.com/${c.user.username}`;
-    let research: Awaited<ReturnType<typeof deepResearchPerson>>;
+    let research: Awaited<ReturnType<typeof deepResearchPerson>> | null = null;
     try {
       research = await deepResearchPerson(
         { socialMediaUrl: twitterUrl, name: c.user.name },
@@ -343,16 +346,18 @@ export async function runXRepostersFinder(opts: XRepostersFinderOpts): Promise<F
         kind: `${PLAY_NAME}.research`,
         message: ((err as Error).message ?? "").slice(0, 120),
       });
-      result.droppedEnrichment++;
-      return;
+      if (pick.lane === "founder") {
+        result.droppedEnrichment++;
+        return;
+      }
     }
-    sdkCost += research.result?.cost ?? 0;
-    const enrichment = (research.result?.result?.enrichment ?? {}) as Record<string, unknown>;
-    const articles = research.result?.result?.articles;
+    sdkCost += research?.result?.cost ?? 0;
+    const enrichment = (research?.result?.result?.enrichment ?? {}) as Record<string, unknown>;
+    const articles = research?.result?.result?.articles;
     const hasSignal =
       Object.keys(enrichment).length > 0 || (Array.isArray(articles) && articles.length > 0);
     const dossier = hasSignal
-      ? JSON.stringify(research.result?.result ?? research.result, null, 2).slice(0, 6000)
+      ? JSON.stringify(research?.result?.result ?? research?.result, null, 2).slice(0, 6000)
       : "";
 
     // SDK-found emails, cheapest-to-extract order.


### PR DESCRIPTION
First live x-reposters run surfaced this: the single pick that cleared the lane gates was dropped because `deepResearchPerson` returned *Could not find data for this person*. For the amplifier lane that's wrong — the decision was email-first **with X-draft fallback**, and `x-amplify-dm` needs neither an email nor a dossier. Research failure now falls through to the DM draft; the founder lane (email-only by design) still drops. Plus a doubled '— keeping what we have' log suffix fix. Two regression tests; suite 1909/1909.

https://claude.ai/code/session_019SyPeo3U5zNxFaWHGF8ddp

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `runXRepostersFinder` to keep amplifier lane on `deepResearchPerson` failure
> - In `runXRepostersFinder`, `deepResearchPerson` failures no longer drop amplifier-lane candidates; they proceed without a dossier/email toward a manual DM path. Founder-lane candidates still drop on failure.
> - Research-derived fields (cost, enrichment, articles, dossier) are now accessed via optional chaining with a `null` guard.
> - Adds tests in [x-reposters.test.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/57/files#diff-b11490315b023f497f072697be86591b46aaf5eba0215da08ceb002ef92ede3a) that simulate per-handle `deepResearchPerson` failures and verify amplifier proceeds to `x-amplify-dm` while founder is dropped.
> - Removes the ` — keeping what we have` suffix from stop-condition log messages in [harvestReposters](https://github.com/oneshot-agent/oneshot-gtm/pull/57/files#diff-5ca1b0cfafb0fdcece839ec0a4be0f67e36f727cc72d03600ce9c766481ddc71).
> - Behavioral Change: amplifier candidates that previously incremented `droppedEnrichment` on research failure now bypass research and continue; reviewers should verify downstream `x-amplify-dm` logic tolerates missing dossier/email fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c6e16f1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->