### PR TITLE
feat(web): trim Today + move the doctor there as an expandable health line

### DIFF
--- a/apps/web/__tests__/doctorSummary.test.ts
+++ b/apps/web/__tests__/doctorSummary.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import type { DoctorCheck } from "@oneshot-gtm/shared-types";
+import { summarizeDoctor, worstOf } from "../src/lib/doctorSummary.ts";
+
+const check = (severity: DoctorCheck["severity"]): DoctorCheck => ({
+  name: "c",
+  severity,
+  message: "m",
+});
+
+describe("summarizeDoctor", () => {
+  it("all clear when every check is ok", () => {
+    expect(summarizeDoctor([check("ok"), check("ok")])).toEqual({
+      failing: 0,
+      warnings: 0,
+      text: "all clear",
+      tone: "receipt",
+    });
+  });
+
+  it("warnings only", () => {
+    expect(summarizeDoctor([check("ok"), check("warn")])).toMatchObject({
+      warnings: 1,
+      text: "1 warning",
+      tone: "spend",
+    });
+    expect(summarizeDoctor([check("warn"), check("warn")]).text).toBe("2 warnings");
+  });
+
+  it("failing wins the tone and names both counts", () => {
+    expect(summarizeDoctor([check("fail"), check("warn"), check("warn")])).toMatchObject({
+      failing: 1,
+      warnings: 2,
+      text: "1 failing · 2 warnings",
+      tone: "blocked",
+    });
+    expect(summarizeDoctor([check("fail")]).text).toBe("1 failing · 0 warnings");
+  });
+
+  it("undefined and empty inputs read as all clear (loading states render separately)", () => {
+    expect(summarizeDoctor(undefined).text).toBe("all clear");
+    expect(summarizeDoctor([]).text).toBe("all clear");
+  });
+});
+
+describe("worstOf", () => {
+  it("fail > warn > ok", () => {
+    expect(worstOf([check("ok"), check("warn"), check("fail")])).toBe("fail");
+    expect(worstOf([check("ok"), check("warn")])).toBe("warn");
+    expect(worstOf([check("ok")])).toBe("ok");
+    expect(worstOf([])).toBe("ok");
+  });
+});

--- a/apps/web/src/components/home/DoctorPanel.tsx
+++ b/apps/web/src/components/home/DoctorPanel.tsx
@@ -5,6 +5,7 @@ import { Badge } from "../primitives/Badge.tsx";
 import { EmptyNote } from "../primitives/EmptyNote.tsx";
 import { SkeletonRow } from "../primitives/Skeleton.tsx";
 import { cn } from "../../lib/cn.ts";
+import { summarizeDoctor, worstOf, type DoctorTone as Tone } from "../../lib/doctorSummary.ts";
 
 const GROUP_ORDER: Array<{ key: DoctorGroup; label: string }> = [
   { key: "install", label: "install" },
@@ -13,17 +14,8 @@ const GROUP_ORDER: Array<{ key: DoctorGroup; label: string }> = [
   { key: "spend", label: "spend" },
 ];
 
-type Tone = "receipt" | "spend" | "blocked";
-
 function toneFor(severity: DoctorCheck["severity"]): Tone {
   return severity === "ok" ? "receipt" : severity === "warn" ? "spend" : "blocked";
-}
-
-/** Worst severity wins the group's accent: fail > warn > ok. */
-function worstOf(checks: DoctorCheck[]): DoctorCheck["severity"] {
-  if (checks.some((c) => c.severity === "fail")) return "fail";
-  if (checks.some((c) => c.severity === "warn")) return "warn";
-  return "ok";
 }
 
 /**
@@ -113,17 +105,7 @@ export function DoctorPanel({
     return <EmptyNote note="Couldn't run doctor — check the server log and refresh." />;
   }
 
-  const fails = checks.filter((c) => c.severity === "fail").length;
-  const warns = checks.filter((c) => c.severity === "warn").length;
-  const overall =
-    fails > 0
-      ? {
-          text: `${fails} failing · ${warns} warning${warns === 1 ? "" : "s"}`,
-          tone: "blocked" as Tone,
-        }
-      : warns > 0
-        ? { text: `${warns} warning${warns === 1 ? "" : "s"}`, tone: "spend" as Tone }
-        : { text: "all clear", tone: "receipt" as Tone };
+  const overall = summarizeDoctor(checks);
 
   return (
     <div className="rounded-[var(--radius-sm)] border border-ink-rule bg-ink-bg-deep">

--- a/apps/web/src/components/home/HealthCard.tsx
+++ b/apps/web/src/components/home/HealthCard.tsx
@@ -1,0 +1,68 @@
+import { useQuery } from "@tanstack/react-query";
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { useRef, useState } from "react";
+import { api } from "../../api/client.ts";
+import { cn } from "../../lib/cn.ts";
+import { summarizeDoctor, type DoctorTone } from "../../lib/doctorSummary.ts";
+import { DoctorPanel } from "./DoctorPanel.tsx";
+
+const TONE_CLASS: Record<DoctorTone, string> = {
+  receipt: "text-[color:var(--ink-receipt-2)]",
+  spend: "text-[color:var(--ink-spend-2)]",
+  blocked: "text-[color:var(--ink-blocked-2)]",
+};
+
+/**
+ * One-line install health on Today, expanding to the full grouped DoctorPanel.
+ * Reads the SAME ["doctor"] query the nav dot and StatusBar already poll at
+ * 60s, so this card costs zero extra requests. Auto-opens once when anything
+ * is failing or warning (seed-once ref — background refetches must not slam a
+ * toggle the founder set).
+ */
+export function HealthCard() {
+  const doctor = useQuery({ queryKey: ["doctor"], queryFn: api.doctor, staleTime: 30_000 });
+  const [open, setOpen] = useState(false);
+  const seeded = useRef(false);
+  const summary = summarizeDoctor(doctor.data?.checks);
+  if (!seeded.current && doctor.data) {
+    seeded.current = true;
+    if (summary.failing + summary.warnings > 0) setOpen(true);
+  }
+
+  return (
+    <section className="border-b border-ink-rule">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        aria-label={open ? "Collapse health detail" : "Expand health detail"}
+        className={cn(
+          "flex w-full items-center gap-2 px-6 py-2.5 text-left",
+          "transition-colors duration-[var(--dur-stamp)] hover:bg-ink-surface/60",
+        )}
+      >
+        <span className="text-ink-faint">
+          {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+        </span>
+        <span className="ln-eyebrow">Health</span>
+        <span className={cn("font-mono text-[11px]", TONE_CLASS[summary.tone])}>
+          {doctor.isLoading && !doctor.data
+            ? "checking…"
+            : doctor.isError
+              ? "unreachable"
+              : summary.text}
+        </span>
+        {!open && <span className="ml-auto font-mono text-[10px] text-ink-faint">see more</span>}
+      </button>
+      {open && (
+        <div className="px-6 pb-4">
+          <DoctorPanel
+            checks={doctor.data?.checks}
+            isLoading={doctor.isLoading}
+            error={doctor.isError ? "unreachable" : null}
+          />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/components/home/SchedulerStrip.tsx
+++ b/apps/web/src/components/home/SchedulerStrip.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { ArrowRight, ChevronDown, ChevronRight } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import type { TriggerView } from "@oneshot-gtm/shared-types";
 import { api } from "../../api/client.ts";
 import { cn, timeAgo } from "../../lib/cn.ts";
@@ -80,11 +80,34 @@ export function SchedulerStrip(): React.ReactElement {
 
   const enabledCount = rows.filter((r) => r.trigger.enabled).length;
   const overdueCount = rows.filter((r) => r.dueInMs != null && r.dueInMs < 0).length;
+  // Soonest upcoming tick, for the collapsed one-liner.
+  const nextDueMs = visible
+    .map((r) => r.dueInMs)
+    .filter((ms): ms is number => ms != null && ms >= 0)
+    .toSorted((a, b) => a - b)[0];
+
+  // Collapsed by default — the table duplicates /queue's trigger panel. Seed
+  // open ONCE when something is overdue; refetches never slam a manual toggle.
+  const [expanded, setExpanded] = useState(false);
+  const seeded = useRef(false);
+  if (!seeded.current && triggersQuery.data) {
+    seeded.current = true;
+    if (overdueCount > 0) setExpanded(true);
+  }
 
   return (
     <section className="flex flex-col border-b border-ink-rule">
-      <div className="flex items-baseline justify-between px-6 pb-2 pt-5">
-        <div className="flex items-baseline gap-3">
+      <div className="flex items-baseline justify-between pr-6">
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          aria-expanded={expanded}
+          aria-label={`${expanded ? "Collapse" : "Expand"} the scheduler table`}
+          className="flex flex-1 items-baseline gap-3 px-6 pb-2 pt-5 text-left transition-colors duration-[var(--dur-stamp)] hover:bg-ink-surface/40"
+        >
+          <span className="text-ink-faint">
+            {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+          </span>
           <div className="ln-eyebrow">Scheduler</div>
           <div className="font-mono text-[11px] text-ink-faint">
             {enabledCount} enabled
@@ -93,8 +116,12 @@ export function SchedulerStrip(): React.ReactElement {
                 · {overdueCount} overdue
               </span>
             )}
+            {!expanded && nextDueMs != null && (
+              <span className="ml-2">· next due in {humanInterval(nextDueMs)}</span>
+            )}
+            {!expanded && <span className="ml-2 text-ink-faint">· see more</span>}
           </div>
-        </div>
+        </button>
         <Link
           to="/queue"
           className="flex items-center gap-1 font-mono text-[11px] text-ink-muted transition-colors hover:text-ink-cream"
@@ -103,7 +130,7 @@ export function SchedulerStrip(): React.ReactElement {
         </Link>
       </div>
 
-      {triggersQuery.isLoading ? (
+      {!expanded ? null : triggersQuery.isLoading ? (
         <div>
           {Array.from({ length: 3 }, (_, i) => (
             <SkeletonRow key={i} />

--- a/apps/web/src/components/home/SignalFeed.tsx
+++ b/apps/web/src/components/home/SignalFeed.tsx
@@ -44,7 +44,17 @@ export function SignalFeed({
     <section className="flex flex-col border-b border-ink-rule">
       <div className="flex items-baseline justify-between px-6 pb-2 pt-5">
         <div className="ln-eyebrow">Signal feed</div>
-        <div className="font-mono text-[11px] text-ink-faint">newest first · refresh · 30s</div>
+        <div className="flex items-baseline gap-4">
+          <div className="hidden font-mono text-[11px] text-ink-faint sm:block">
+            newest first · refresh · 30s
+          </div>
+          <Link
+            to="/receipts"
+            className="flex items-center gap-1 font-mono text-[11px] text-ink-muted transition-colors hover:text-ink-cream"
+          >
+            all <ArrowRight size={10} />
+          </Link>
+        </div>
       </div>
       {loading ? (
         <div className="px-6 pb-5 font-mono text-[11.5px] text-ink-faint">…</div>

--- a/apps/web/src/lib/doctorSummary.ts
+++ b/apps/web/src/lib/doctorSummary.ts
@@ -1,0 +1,45 @@
+import type { DoctorCheck } from "@oneshot-gtm/shared-types";
+
+export type DoctorTone = "receipt" | "spend" | "blocked";
+
+export interface DoctorSummary {
+  failing: number;
+  warnings: number;
+  /** "all clear" · "2 warnings" · "1 failing · 2 warnings" */
+  text: string;
+  tone: DoctorTone;
+}
+
+/**
+ * Roll a doctor payload up to one line. Shared by the DoctorPanel header and
+ * the Today page's health card so the two can never disagree about what
+ * "healthy" means.
+ */
+export function summarizeDoctor(checks: DoctorCheck[] | undefined): DoctorSummary {
+  const failing = checks?.filter((c) => c.severity === "fail").length ?? 0;
+  const warnings = checks?.filter((c) => c.severity === "warn").length ?? 0;
+  if (failing > 0) {
+    return {
+      failing,
+      warnings,
+      text: `${failing} failing · ${warnings} warning${warnings === 1 ? "" : "s"}`,
+      tone: "blocked",
+    };
+  }
+  if (warnings > 0) {
+    return {
+      failing,
+      warnings,
+      text: `${warnings} warning${warnings === 1 ? "" : "s"}`,
+      tone: "spend",
+    };
+  }
+  return { failing: 0, warnings: 0, text: "all clear", tone: "receipt" };
+}
+
+/** Worst severity wins the accent: fail > warn > ok. */
+export function worstOf(checks: DoctorCheck[]): DoctorCheck["severity"] {
+  if (checks.some((c) => c.severity === "fail")) return "fail";
+  if (checks.some((c) => c.severity === "warn")) return "warn";
+  return "ok";
+}

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1,14 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
-import { createFileRoute, Link } from "@tanstack/react-router";
-import { ArrowRight } from "lucide-react";
+import { createFileRoute } from "@tanstack/react-router";
 import { api } from "../api/client.ts";
 import { CurrentRunsStrip } from "../components/home/CurrentRunsStrip.tsx";
+import { HealthCard } from "../components/home/HealthCard.tsx";
 import { NextStep } from "../components/home/NextStep.tsx";
 import { SchedulerStrip } from "../components/home/SchedulerStrip.tsx";
 import { SignalFeed } from "../components/home/SignalFeed.tsx";
-import { EmptyNote } from "../components/primitives/EmptyNote.tsx";
-import { SkeletonRow } from "../components/primitives/Skeleton.tsx";
-import { cn, formatUsd, timeAgo } from "../lib/cn.ts";
+import { formatUsd } from "../lib/cn.ts";
 
 export const Route = createFileRoute("/")({
   component: HomePage,
@@ -87,7 +85,7 @@ function HomePage() {
         <LedgerNumber
           label="Spend · 7d"
           value={d ? formatUsd(d.spendUsd7d) : undefined}
-          caption={d ? `${d.callsLast7d} agent calls` : undefined}
+          caption={d ? `${d.callsLast7d} agent calls · ${formatUsd(d.spendUsd30d)} 30d` : undefined}
           tone="spend"
         />
         <LedgerNumber
@@ -96,6 +94,9 @@ function HomePage() {
           caption="in flight, awaiting reply"
         />
       </section>
+
+      {/* Install health — one line, expandable to the full grouped doctor panel */}
+      <HealthCard />
 
       {/* In-flight /run dispatches — Resume link back to /run/<play>?runId=N */}
       <CurrentRunsStrip runs={home.data?.currentRuns ?? []} />
@@ -109,90 +110,6 @@ function HomePage() {
       />
 
       <SchedulerStrip />
-
-      <section className="flex flex-col border-b border-ink-rule">
-        <div className="flex items-baseline justify-between px-6 pb-2 pt-5">
-          <div className="ln-eyebrow">Recent receipts</div>
-          <Link
-            to="/receipts"
-            className="flex items-center gap-1 font-mono text-[11px] text-ink-muted transition-colors hover:text-ink-cream"
-          >
-            all <ArrowRight size={10} />
-          </Link>
-        </div>
-        {recent.isLoading ? (
-          <div>
-            {Array.from({ length: 5 }, (_, i) => (
-              <SkeletonRow key={i} />
-            ))}
-          </div>
-        ) : recent.data?.receipts.length === 0 ? (
-          <div className="px-6 pb-6">
-            <EmptyNote
-              note="No receipts yet. Every call the agent makes leaves one — a short ledger is an honest ledger."
-              cli="oneshot-gtm motion show-hn"
-            />
-          </div>
-        ) : (
-          <table className="w-full text-[13px]">
-            <thead>
-              <tr className="text-[10px] uppercase tracking-[0.14em] text-ink-faint">
-                <th className="px-6 py-2 text-left font-medium">id</th>
-                <th className="py-2 text-left font-medium">play</th>
-                <th className="py-2 text-left font-medium">type</th>
-                <th className="py-2 text-right font-medium">cost</th>
-                <th className="px-6 py-2 text-right font-medium">when</th>
-              </tr>
-            </thead>
-            <tbody>
-              {recent.data?.receipts.map((r, i) => (
-                <tr
-                  key={r.id}
-                  className={cn(
-                    "border-t border-ink-rule/60 transition-colors duration-[var(--dur-stamp)]",
-                    "hover:bg-ink-surface/50",
-                    i % 2 === 1 && "bg-ink-surface/20",
-                  )}
-                >
-                  <td className="px-6 py-2 font-mono text-[11px] text-ink-faint">#{r.id}</td>
-                  <td className="py-2 text-ink-cream">{r.playName}</td>
-                  <td className="py-2 font-mono text-[12px] text-ink-muted">{r.callType}</td>
-                  <td className="py-2 text-right font-mono text-ink-cream">
-                    {r.costUsd != null ? (
-                      formatUsd(r.costUsd)
-                    ) : (
-                      <span className="text-ink-faint">—</span>
-                    )}
-                  </td>
-                  <td className="px-6 py-2 text-right font-mono text-[12px] text-ink-faint">
-                    {timeAgo(r.createdAt)}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </section>
-
-      <section className="grid grid-cols-1 gap-8 px-6 py-8 lg:grid-cols-[1fr_280px]">
-        <div className="max-w-[58ch]">
-          <div className="ln-eyebrow">Editor's note</div>
-          <p className="ln-prose mt-2 max-w-[58ch] text-[14.5px] text-ink-cream-2">
-            Spend is the cost of proof. Every send came with a signed receipt; every receipt keeps
-            you honest with yourself. A short ledger is an honest ledger — one send always beats
-            zero.
-          </p>
-        </div>
-        <div className="border-l border-ink-rule pl-6">
-          <div className="ln-eyebrow">Spend · 30d</div>
-          <div className="mt-1 text-ink-cream ln-numeral" style={{ fontSize: 36, lineHeight: 1 }}>
-            {d ? formatUsd(d.spendUsd30d) : <span className="text-ink-faint">$—</span>}
-          </div>
-          <div className="mt-2 font-mono text-[11px] text-ink-muted">
-            {d ? `${d.callsLast7d} calls this week` : "…"}
-          </div>
-        </div>
-      </section>
     </div>
   );
 }

--- a/apps/web/src/routes/setup.tsx
+++ b/apps/web/src/routes/setup.tsx
@@ -11,7 +11,6 @@ import {
 } from "@oneshot-gtm/shared-types";
 import { api } from "../api/client.ts";
 import { Badge } from "../components/primitives/Badge.tsx";
-import { DoctorPanel } from "../components/setup/DoctorPanel.tsx";
 import { Button } from "../components/primitives/Button.tsx";
 import { Checkbox, Field, Input, Select, Textarea } from "../components/primitives/Field.tsx";
 
@@ -49,7 +48,6 @@ const X_OAUTH_KEYS = ["X_API_KEY", "X_API_SECRET", "X_ACCESS_TOKEN", "X_ACCESS_S
 function SetupPage() {
   const qc = useQueryClient();
   const status = useQuery({ queryKey: ["setup"], queryFn: api.setupStatus });
-  const doctor = useQuery({ queryKey: ["doctor"], queryFn: api.doctor });
   const triggers = useQuery({ queryKey: ["triggers"], queryFn: api.triggers });
 
   const [founderName, setFounderName] = useState("");
@@ -1280,17 +1278,6 @@ function SetupPage() {
           </Button>
         </div>
       </form>
-
-      <LedgerSection
-        eyebrow="— · Doctor"
-        lede="Health of the local install. Run `oneshot-gtm doctor` for the CLI view."
-      >
-        <DoctorPanel
-          checks={doctor.data?.checks}
-          isLoading={doctor.isLoading}
-          error={doctor.isError ? "unreachable" : null}
-        />
-      </LedgerSection>
     </div>
   );
 }


### PR DESCRIPTION
The Today page ran ~1,900px with three duplications (receipts table vs signal feed, spend footer vs KPI band, scheduler table vs /queue), and the doctor was buried at the bottom of /setup — warnings were invisible outside it. Per the founder: trim with progressive disclosure ('you can always add see more'), move the doctor to Today.

**Today after:** masthead → onboarding nudge (self-hides) → KPI band (Spend·7d caption now carries the 30d figure) → **Health line** → in-flight strip (self-hides) → signal feed (gains 'all →' to /receipts) → **collapsed scheduler line** (see-more expands the table; auto-opens when overdue). The receipts table and editor's-note/spend footer are removed. Default height ≈ 700–900px.

**HealthCard**: reads the same `["doctor"]` query the nav dot and StatusBar already poll at 60s — zero extra requests. One tone-colored line via a new shared `lib/doctorSummary.ts` (extracted from DoctorPanel's inline rollup, unit-tested), expanding to the full grouped DoctorPanel (file moved to `components/home/`). Auto-opens once when anything warns/fails; background refetches never slam a manual toggle (seed-once ref, the DoctorPanel idiom).

**/setup**: doctor section removed; the save-time `["doctor"]` invalidations stay (they feed the nav dot, StatusBar, and now Today).

Suite 1924/1924; root + apps/web typechecks clean.

https://claude.ai/code/session_019SyPeo3U5zNxFaWHGF8ddp

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add collapsible `HealthCard` to home page and make `SchedulerStrip` collapsible
> - Adds [HealthCard.tsx](https://github.com/oneshot-agent/oneshot-gtm/pull/59/files#diff-a6bf678dfe051e419ca79abfe91f9a2d56d9b302fd3fa781851afa9a1f203674): a collapsible card that queries the `['doctor']` endpoint, shows a one-line tone-colored summary, and auto-opens once if any checks fail or warn. Embeds the full `DoctorPanel` when expanded.
> - Extracts shared doctor summarization logic into [doctorSummary.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/59/files#diff-201b82c1936dab6e0b3fc99fbf4e9873fdcbf7b27015317b344f44ea7f27948f) (`summarizeDoctor`, `worstOf`), replacing the inline computation previously in `DoctorPanel`.
> - Makes [SchedulerStrip.tsx](https://github.com/oneshot-agent/oneshot-gtm/pull/59/files#diff-131094ae74799983f2b46baddd09d6e2cf9025a5590219eeccc406ca62a6a07e) collapsible by default with a condensed one-liner (enabled count, overdue count, next due interval) and auto-expands once when any trigger is overdue.
> - Removes the separate 'Recent receipts' table and 'Editor's note' from the home page ([index.tsx](https://github.com/oneshot-agent/oneshot-gtm/pull/59/files#diff-9a640a8d74a699e96d3eace06461dc8f8396f55a0813e916427bb0bb2f1a4597)); adds a 30d spend figure to the KPI caption and an 'all →' link to Receipts in [SignalFeed.tsx](https://github.com/oneshot-agent/oneshot-gtm/pull/59/files#diff-ea5f686a84de5a7ba571815818cc03d0cdadf46286ffb09eb2df79b4604cbec7).
> - Removes `DoctorPanel` rendering from the setup page ([setup.tsx](https://github.com/oneshot-agent/oneshot-gtm/pull/59/files#diff-8d426675a915adf798c40f7640497bf825ab5522167c3359604e391a1b54fcf3)) since doctor health now lives on the home page.
> - Behavioral Change: doctor health no longer appears on the setup page; it is surfaced only on the home page via the new `HealthCard`. `SchedulerStrip` now starts collapsed instead of always showing the full table.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9b3dd10.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->