### PR TITLE
docs: count in the X channel — 11 finders, 17 plays, x-reposters rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ The dashboard always knows where it is: a masthead chip names the workspace and 
 
 ## Where targets come from
 
-Ten **finders** discover prospects, ICP-filter them, and enqueue into `/queue` for one-click approve or reject. Each runs as a trigger with its own interval and spend cap.
+Eleven **finders** discover prospects, ICP-filter them, and enqueue into `/queue` for one-click approve or reject. Each runs as a trigger with its own interval and spend cap.
 
 | Finder              | Signal                                                                                                                                                             |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -182,6 +182,7 @@ Ten **finders** discover prospects, ICP-filter them, and enqueue into `/queue` f
 | `github-stars`      | recent stargazers of repos you watch; tag each repo `competitor` or `adjacent` to route the play — needs `GITHUB_TOKEN`                                            |
 | `luma-events`       | upcoming events from Luma's own city pages, gated per event by a topic + ICP check before any spend; pitches the hosts and featured guests Luma exposes publicly   |
 | `breakup-revive`    | your own ledger — prospects cold for 60–90 days. No LLM or OneShot spend                                                                                           |
+| `x-reposters`       | people who repost/quote X accounts you watch, in two lanes: builders who'd adopt (founder lane → email cadence) and dev accounts with reach who'd boost a launch (amplifier lane → one-touch email, or a hand-sent DM draft when no email is found) — needs X API OAuth1 keys, or `TWITTERAPI_IO_KEY` for the ~55x cheaper engine |
 
 Only `show-hn` and `post-funding-auto` are on by default; enable the rest from `/queue`. A trigger missing required config reads as **not ready** — the toggle and Run button disable with the reason, and the API returns `409`, so scripted callers can't bypass the gate either.
 
@@ -193,11 +194,11 @@ The dashboard server runs an in-process scheduler, so enabling a trigger is enou
 
 ### The plays
 
-Fourteen of them. Ten have a **Run** page in the dashboard and drain from the queue:
+Seventeen of them. Ten have a **Run** page in the dashboard and drain from the queue:
 
 `show-hn` · `job-change` · `post-funding` · `accelerator-batch` · `hiring-signal` · `podcast-guest` · `competitor-switch` · `stack-consolidation` · `repo-interest` · `luma-events`
 
-Two more drain from the queue without a Run form — `profile-intro` (what Add Prospect enqueues) and `breakup-revive`. The last two, `concierge` and `demo-no-show`, are CLI-only because they open with a voice call and an SMS respectively.
+Five more drain from the queue without a Run form — `profile-intro` (what Add Prospect enqueues), `breakup-revive`, and the three the `x-reposters` finder feeds: `x-repost-intro` (founder-lane email + cadence), `x-amplify` (one-touch launch-day repost ask), and `x-amplify-dm` — the one play that never auto-sends: it drafts X DM/reply text you copy and send by hand from the X app, then **Mark sent** records it as a channel-`x` touch. The last two, `concierge` and `demo-no-show`, are CLI-only because they open with a voice call and an SMS respectively.
 
 Most carry a cadence — a value follow-up, then a breakup, spread over roughly three to nine days and editable per play from `/plays`. Any reply stops the sequence — and is recorded whether the sequence is still running, already finished, or never existed (one-touch plays like `luma-events`), credited to the play whose subject it threads on.
 
@@ -257,8 +258,8 @@ apps/
 packages/
   core/       SDK wrapper, SQLite ledger, config + secrets, Gmail transport, JSONL events
   intel/      LLM client, advise, personalize, triage, weekly-review
-  plays/      14 outreach plays + handoff/icp/pmf modules + cadence engine
-  find/       10 finders + shared pipeline (manifest scan, dedupe, ICP filter, drain, registry)
+  plays/      17 outreach plays + handoff/icp/pmf modules + cadence engine
+  find/       11 finders + shared pipeline (manifest scan, dedupe, ICP filter, drain, registry)
   prompts/    Markdown prompts — humanizer canon, per-play, per-extract
   doctor/     Wallet, ledger, key and deliverability health checks
   shared-types/  Wire types shared across CLI / server / web

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,8 @@
 # Status
 
-**Assume green unless it's listed below.** The 48 CLI commands, 14 plays, 10 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and, with the exceptions on this page, verified end to end against the live OneShot API.
+**Assume green unless it's listed below.** The 49 CLI commands, 17 plays, 11 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and, with the exceptions on this page, verified end to end against the live OneShot API.
 
-Last verified **2026-08-25** · Bun 1.3.13 · OneShot SDK 0.22.0 · 1777 tests / 137 files · typecheck + oxlint clean.
+Last verified **2026-08-27** · Bun 1.3.13 · OneShot SDK 0.22.0 · 1924 tests / 154 files · typecheck + oxlint clean.
 
 The person-level ICP gate (#45) was calibrated against 84 real LinkedIn titles (all 13 known off-ICP prospects caught, zero false rejects among 44 builders) and the history audit ran live `enrichProfile` for 111 titles. The workspace switcher's auto-start was live-verified in both directions (default ↔ gtm).
 
@@ -30,11 +30,11 @@ Every failure mode in the two deliverability paths is loud rather than silent �
 
 ## Off by default
 
-Only **`show-hn`** and **`post-funding-auto`** fire out of the box. The other eight finders are opt-in, enabled per trigger from `/queue`:
+Only **`show-hn`** and **`post-funding-auto`** fire out of the box. The other nine finders are opt-in, enabled per trigger from `/queue`:
 
-`accelerator-batch` · `job-change` · `hiring-signal` · `podcast-guest` · `luma-events` · `github-topics` · `github-stars` · `breakup-revive`
+`accelerator-batch` · `job-change` · `hiring-signal` · `podcast-guest` · `luma-events` · `github-topics` · `github-stars` · `breakup-revive` · `x-reposters`
 
-Five of those also stay **not ready** until you give them required config, and refuse to fire until you do (the API returns `409`):
+Six of those also stay **not ready** until you give them required config, and refuse to fire until you do (the API returns `409`):
 
 | Finder              | Needs                                 |
 | ------------------- | ------------------------------------- |
@@ -43,6 +43,7 @@ Five of those also stay **not ready** until you give them required config, and r
 | `github-topics`     | `topics[]` + `vendors[]` + `yourEdge` |
 | `github-stars`      | `repos[]` + `yourEdge`                |
 | `luma-events`       | `topics[]` + `cities[]` + `yourEdge`  |
+| `x-reposters`       | `seeds[]` + engine credentials        |
 
 Both GitHub finders need `GITHUB_TOKEN`. Unauthenticated, GitHub allows 60 requests/hour per IP **shared across the two** — one `github-stars` pass (each repo, up to 3 pages) can spend that alone, and the finder then halts on a `403` that reads like a dead endpoint rather than degrading to lower volume. A classic token with **no scopes** is enough for the public data both read, and lifts the ceiling to 5,000/hour. `doctor` warns when either finder is enabled without one. `luma-events` accepts an optional `LUMA_SESSION_COOKIE` to read authed guest lists. `x-reposters` needs the X credentials for whichever engine its config names (`xapi`: 4 OAuth1 keys, `twitterapiio`: 1 key) — settable from `/setup`'s X card or `config keys`, switchable with `config x-engine`.
 


### PR DESCRIPTION
README finder table + plays section gain x-reposters and its three plays
(incl. the manual x-amplify-dm hand-send flow); STATUS.md's verified header,
off-by-default lists and needs-config table catch up (49 CLI commands with
config x-engine; 1924 tests / 154 files as of 2026-08-27).

Claude-Session: https://claude.ai/code/session_019SyPeo3U5zNxFaWHGF8ddp


<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update docs to count 11 finders, 17 plays, and `x-reposters` rows
> - Bumps finder count from ten to eleven across [README.md](https://github.com/oneshot-agent/oneshot-gtm/pull/60/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5) and [STATUS.md](https://github.com/oneshot-agent/oneshot-gtm/pull/60/files#diff-6c33a39439907887e8de50ebb50d264136cb2a7c916dc8d4c184ee24fb5cec9e), adding the new `x-reposters` opt-in finder with its credential requirements.
> - Bumps plays count from fourteen to seventeen, documenting three new X-related plays: `x-repost-intro`, `x-amplify`, and `x-amplify-dm`.
> - Updates STATUS.md metrics: CLI commands to 49, tests to 1924 across 154 files, last verified date to 2026-08-27.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e331182.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->