### PR TITLE
feat(inbox): classify auto-replies — OOO, dead mailboxes, unsubscribes are not replies

### DIFF
--- a/apps/server/__tests__/inbox-route.test.ts
+++ b/apps/server/__tests__/inbox-route.test.ts
@@ -360,6 +360,7 @@ describe("inbox route — research-grounded drafting", () => {
       prospectId: null,
       threadKey: "t1",
       excludeId: "e1",
+      skipPaid: false, // a human reply — the paid tier stays available
     });
     expect(draftInboxReplyMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/apps/server/src/api/_reply-research.ts
+++ b/apps/server/src/api/_reply-research.ts
@@ -41,6 +41,8 @@ export async function gatherReplyContext(input: {
   threadKey: string | null;
   /** Provider id of the email being answered — excluded from priorInbound (it IS the inbound). */
   excludeId?: string | null;
+  /** Skip the paid tier entirely (enrich + site read) — set for non-human inbound (OOO/unsubscribe). */
+  skipPaid?: boolean;
 }): Promise<ReplyContext> {
   const ledger = getLedger();
 
@@ -70,7 +72,7 @@ export async function gatherReplyContext(input: {
   } else {
     // Tier 2: paid research, bounded and gated.
     const domain = emailDomain(input.fromEmail)?.toLowerCase() ?? null;
-    if (!isDudDomain(domain)) {
+    if (!input.skipPaid && !isDudDomain(domain)) {
       try {
         const enr = await safeEnrich(
           { email: input.fromEmail },

--- a/apps/server/src/api/inbox.ts
+++ b/apps/server/src/api/inbox.ts
@@ -1,4 +1,5 @@
 import {
+  classifyReply,
   getGmailProfile,
   getLedger,
   isDraining,
@@ -9,6 +10,7 @@ import {
   replyEmail,
   resolveIdentities,
   trackSend,
+  type ReplyKind,
 } from "@oneshot-gtm/core";
 import { draftInboxReply } from "@oneshot-gtm/plays";
 import {
@@ -145,6 +147,7 @@ export async function listInboxRoute(req: Request): Promise<Response> {
       subject: e.subject,
       receivedAt: e.received_at,
       body: e.body ?? "",
+      kind: classifyReply({ subject: e.subject, body: e.body, autoSubmitted: e.auto_submitted }),
       sourceIdentityId: e.source_identity_id ?? null,
       sourceProvider: e.source_identity_id
         ? (providerById.get(e.source_identity_id) ?? null)
@@ -199,6 +202,7 @@ export async function listInboxRoute(req: Request): Promise<Response> {
         sourceIdentityId: r.sourceIdentityId,
         threadId: r.threadId,
         messageId: r.messageId,
+        kind: r.kind,
       });
     }
   } catch (err) {
@@ -305,6 +309,7 @@ function buildConversations(
         sourceIdentityId: r.source_identity_id,
         threadId: r.thread_id,
         messageId: r.message_id,
+        replyKind: (r.kind as ReplyKind | null) ?? "human",
       });
     }
     for (const key of threadKeys) {
@@ -399,6 +404,9 @@ export async function draftReplyRoute(req: Request): Promise<Response> {
           ? inboxThreadKey({ threadId: body.threadId ?? null, id: body.id })
           : null,
       excludeId: typeof body.id === "string" ? body.id : null,
+      // Never pay to research an autoresponder or an unsubscribe — there is
+      // no human on the other end to ground a draft in.
+      skipPaid: classifyReply({ subject, body: inboundBody }) !== "human",
     });
   } catch (err) {
     logEvent(

--- a/apps/server/src/api/inbox.ts
+++ b/apps/server/src/api/inbox.ts
@@ -29,6 +29,24 @@ import {
 import { jsonResponse } from "../server.ts";
 import { gatherReplyContext } from "./_reply-research.ts";
 
+/**
+ * Classification of the inbound being answered: the persisted kind when the
+ * email was captured (header-aware), else re-classified from its text.
+ */
+function inboundReplyKind(
+  ledger: ReturnType<typeof getLedger>,
+  prospectId: number | null,
+  body: Partial<InboxDraftReplyRequest>,
+  subject: string,
+  inboundBody: string,
+): ReplyKind {
+  if (prospectId != null && typeof body.id === "string") {
+    const stored = ledger.listInboxRepliesForProspect(prospectId).find((r) => r.id === body.id);
+    if (stored?.kind) return stored.kind as ReplyKind;
+  }
+  return classifyReply({ subject, body: inboundBody });
+}
+
 /** "Jane Doe <jane@x.com>" → "jane@x.com"; bare addresses pass through. */
 function normalizeFrom(raw: string): string {
   const m = raw.match(/<([^>]+)>/);
@@ -405,8 +423,12 @@ export async function draftReplyRoute(req: Request): Promise<Response> {
           : null,
       excludeId: typeof body.id === "string" ? body.id : null,
       // Never pay to research an autoresponder or an unsubscribe — there is
-      // no human on the other end to ground a draft in.
-      skipPaid: classifyReply({ subject, body: inboundBody }) !== "human",
+      // no human on the other end to ground a draft in. Prefer the persisted
+      // classification (it saw the Gmail headers at capture time); the text
+      // fallback covers mail that was never captured.
+      skipPaid:
+        inboundReplyKind(ledger, matched?.prospectId ?? null, body, subject, inboundBody) !==
+        "human",
     });
   } catch (err) {
     logEvent(

--- a/apps/server/src/scheduler.ts
+++ b/apps/server/src/scheduler.ts
@@ -71,8 +71,11 @@ export function startScheduler(): SchedulerHandle {
       // Reply detection is isolated: an inbox outage must not skip trigger
       // scheduling (or vice-versa), and it never sends, so it can't double-spend.
       let repliesDetected = 0;
+      let autoRepliesSkipped = 0;
       try {
-        repliesDetected = (await pollInboxReplies()).repliesDetected;
+        const replyPoll = await pollInboxReplies();
+        repliesDetected = replyPoll.repliesDetected;
+        autoRepliesSkipped = replyPoll.autoRepliesSkipped;
       } catch (err) {
         logEvent(
           "scheduler.reply_poll.failed",
@@ -111,6 +114,7 @@ export function startScheduler(): SchedulerHandle {
       logEvent("scheduler.tick.done", {
         fired,
         repliesDetected,
+        autoRepliesSkipped,
         bouncesRecorded,
         source: "server",
       });

--- a/apps/web/src/routes/cadences.tsx
+++ b/apps/web/src/routes/cadences.tsx
@@ -604,7 +604,7 @@ function CadencesPage() {
                                 ? "signal"
                                 : c.status === "breakup"
                                   ? "spend"
-                                  : c.status === "bounced"
+                                  : c.status === "bounced" || c.status === "unsubscribed"
                                     ? "blocked"
                                     : "receipt"
                             }

--- a/apps/web/src/routes/cadences.tsx
+++ b/apps/web/src/routes/cadences.tsx
@@ -63,6 +63,8 @@ function statusTone(status: string): "receipt" | "signal" | "spend" | "blocked" 
       return "blocked";
     case "off-icp":
       return "blocked";
+    case "unsubscribed":
+      return "blocked";
     default:
       return "neutral";
   }

--- a/apps/web/src/routes/inbox.tsx
+++ b/apps/web/src/routes/inbox.tsx
@@ -226,6 +226,7 @@ function ConversationRow({
   const composerReply: InboxReplyView | null = newest
     ? {
         id: newest.id,
+        kind: newest.replyKind,
         fromEmail: c.email,
         fromRaw: c.email,
         subject: newest.subject ?? "",
@@ -308,6 +309,22 @@ function ConversationRow({
   );
 }
 
+/** Badge copy + tone for a non-human inbound. Null for human (no badge). */
+function replyKindBadge(
+  kind: string | null | undefined,
+): { label: string; tone: "neutral" | "blocked" } | null {
+  switch (kind) {
+    case "auto":
+      return { label: "auto-reply", tone: "neutral" };
+    case "auto_permanent":
+      return { label: "dead mailbox", tone: "blocked" };
+    case "unsubscribe":
+      return { label: "unsubscribe", tone: "blocked" };
+    default:
+      return null;
+  }
+}
+
 function ConversationItemBlock({ item }: { item: ConversationView["items"][number] }) {
   if (item.kind === "reply") {
     return (
@@ -315,6 +332,7 @@ function ConversationItemBlock({ item }: { item: ConversationView["items"][numbe
         <div className="mb-1 font-mono text-[10px] uppercase tracking-wide text-ink-faint">
           them · {timeAgo(item.at)}
           {item.subject ? ` · ${item.subject}` : ""}
+          {replyKindBadge(item.replyKind) ? ` · ${replyKindBadge(item.replyKind)!.label}` : ""}
         </div>
         <pre className="max-h-[280px] overflow-auto whitespace-pre-wrap font-mono text-[12px] leading-[1.6] text-ink-cream">
           {item.body || "(no body)"}
@@ -399,6 +417,10 @@ function ReplyRow({
         ) : (
           <Badge tone="neutral">no match</Badge>
         )}
+        {(() => {
+          const kb = replyKindBadge(reply.kind);
+          return kb ? <Badge tone={kb.tone}>{kb.label}</Badge> : null;
+        })()}
         <span className="shrink-0 font-mono text-[12px] text-ink-muted">
           {timeAgo(reply.receivedAt)}
         </span>

--- a/packages/core/__tests__/inbox-replies.test.ts
+++ b/packages/core/__tests__/inbox-replies.test.ts
@@ -92,3 +92,49 @@ describe("inbox_replies (v21)", () => {
     );
   });
 });
+
+describe("inbox_replies.kind (v23)", () => {
+  it("stores the classification and reads it back", () => {
+    record({ kind: "auto" });
+    expect(ledger.listInboxRepliesForProspect(1)[0]!.kind).toBe("auto");
+  });
+
+  it("defaults to NULL (pre-classifier rows read as human via coalesce)", () => {
+    record();
+    expect(ledger.listInboxRepliesForProspect(1)[0]!.kind).toBeNull();
+  });
+
+  it("migrates the column onto a pre-v23 ledger without losing rows", () => {
+    // Simulate a pre-v23 install: rebuild inbox_replies without `kind`, insert
+    // a legacy row, then re-run migrations by reopening the ledger.
+    const db = (ledger as unknown as { db: { exec(s: string): void } }).db;
+    db.exec("DROP TABLE inbox_replies");
+    db.exec(`
+      CREATE TABLE inbox_replies (
+        id                 TEXT PRIMARY KEY,
+        thread_key         TEXT NOT NULL,
+        prospect_id        INTEGER NOT NULL,
+        play_name          TEXT,
+        from_email         TEXT NOT NULL,
+        subject            TEXT,
+        body               TEXT NOT NULL,
+        received_at        TEXT NOT NULL,
+        source_identity_id TEXT,
+        thread_id          TEXT,
+        message_id         TEXT,
+        created_at         TEXT NOT NULL DEFAULT (datetime('now'))
+      )`);
+    db.exec(`
+      INSERT INTO inbox_replies (id, thread_key, prospect_id, from_email, body, received_at)
+      VALUES ('legacy-1', 't1', 7, 'old@prospect.example', 'hi', '2026-06-01T00:00:00.000Z')`);
+    ledger.close();
+
+    ledger = new Ledger(dbPath); // migrate() adds the column
+    const rows = ledger.listInboxRepliesForProspect(7);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.kind).toBeNull();
+    // And new writes can set it.
+    record({ id: "msg-new", kind: "unsubscribe" });
+    expect(ledger.listInboxRepliesForProspect(1)[0]!.kind).toBe("unsubscribe");
+  });
+});

--- a/packages/core/__tests__/inbox-replies.test.ts
+++ b/packages/core/__tests__/inbox-replies.test.ts
@@ -138,3 +138,25 @@ describe("inbox_replies.kind (v23)", () => {
     expect(ledger.listInboxRepliesForProspect(1)[0]!.kind).toBe("unsubscribe");
   });
 });
+
+describe("contactSuppressionFor", () => {
+  it("returns the newest unsubscribe / dead-mailbox verdict for an address", () => {
+    record({ kind: "auto" }); // temporary OOO never suppresses
+    expect(ledger.contactSuppressionFor("jane@prospect.example")).toBeNull();
+
+    record({ id: "msg-2", kind: "unsubscribe", receivedAt: "2026-08-26T10:00:00.000Z" });
+    const hit = ledger.contactSuppressionFor("Jane@Prospect.example"); // canonicalized lookup
+    expect(hit).toMatchObject({ kind: "unsubscribe", received_at: "2026-08-26T10:00:00.000Z" });
+  });
+
+  it("treats a dead-mailbox autoresponder as a do-not-send", () => {
+    record({ kind: "auto_permanent" });
+    expect(ledger.contactSuppressionFor("jane@prospect.example")?.kind).toBe("auto_permanent");
+  });
+
+  it("human replies never suppress", () => {
+    record({ kind: "human" });
+    record({ id: "msg-2" }); // NULL kind (legacy) — also human
+    expect(ledger.contactSuppressionFor("jane@prospect.example")).toBeNull();
+  });
+});

--- a/packages/core/__tests__/oneshot-gmail-dispatch.test.ts
+++ b/packages/core/__tests__/oneshot-gmail-dispatch.test.ts
@@ -33,6 +33,7 @@ vi.mock("../src/ledger.ts", async () => {
     getLedger: () => ({
       // No prior hard bounce: these tests exercise the normal send path.
       suppressionFor: () => null,
+      contactSuppressionFor: () => null,
       recordReceipt,
       // Rotation routing dependencies: fresh prospect, no pins, no history.
       getSenderAssignment: () => null,

--- a/packages/core/__tests__/oneshot-reply.test.ts
+++ b/packages/core/__tests__/oneshot-reply.test.ts
@@ -46,6 +46,7 @@ vi.mock("../src/ledger.ts", async () => {
     getLedger: () => ({
       // No prior hard bounce: these tests exercise the normal send path.
       suppressionFor: () => null,
+      contactSuppressionFor: () => null,
       recordReceipt,
       // Rotation dependencies for the sendEmail() path: fresh prospect, no pins.
       getSenderAssignment: () => null,

--- a/packages/core/__tests__/oneshot-smartlead-dispatch.test.ts
+++ b/packages/core/__tests__/oneshot-smartlead-dispatch.test.ts
@@ -28,6 +28,7 @@ vi.mock("../src/ledger.ts", async () => {
     ...actual,
     getLedger: () => ({
       suppressionFor: () => null,
+      contactSuppressionFor: () => null,
       recordReceipt,
       getSenderAssignment: () => null,
       hasPriorEmailSend: () => false,

--- a/packages/core/__tests__/reply-classify.test.ts
+++ b/packages/core/__tests__/reply-classify.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "vitest";
+import { classifyReply, stripQuotedChain } from "../src/reply-classify.ts";
+
+describe("classifyReply", () => {
+  test("plain human reply is human", () => {
+    expect(
+      classifyReply({
+        subject: "Re: trustclaw stack",
+        body: "It's too soon for me to grant payment access to an agent but thank you for the offer.",
+      }),
+    ).toBe("human");
+  });
+
+  // The real payload that inflated the reply metric on 2026-08-27: a Chinese
+  // vacation autoresponder ("自动回复:" = "Automatic reply:").
+  test("自动回复 subject prefix is auto", () => {
+    expect(
+      classifyReply({
+        subject: "自动回复: nanoclaw and egress holes",
+        body: "山东尚家具欢迎您\nwww.sjiaju.com",
+      }),
+    ).toBe("auto");
+  });
+
+  // The other real payload: OOO responder announcing the mailbox is dead.
+  test("out-of-office with a retirement notice is auto_permanent", () => {
+    expect(
+      classifyReply({
+        subject: "out of office Re: your puppeteer setup",
+        body: "Retired October 2025.  No longer using this email.",
+      }),
+    ).toBe("auto_permanent");
+  });
+
+  test("header verdict alone classifies as auto (subject/body give no hint)", () => {
+    expect(
+      classifyReply({
+        subject: "Re: your ses setup",
+        body: "Thanks for your message. I will respond when I return.",
+        autoSubmitted: true,
+      }),
+    ).toBe("auto");
+  });
+
+  test("header verdict plus permanence phrase escalates to auto_permanent", () => {
+    expect(
+      classifyReply({
+        subject: "Re: intro",
+        body: "Jane has left the company. Please contact support@example.com.",
+        autoSubmitted: true,
+      }),
+    ).toBe("auto_permanent");
+  });
+
+  test("multilingual subject prefixes are auto", () => {
+    for (const subject of [
+      "Automatic reply: your millrace runtime",
+      "Auto-Reply: hi",
+      "Out of Office: hello",
+      "Abwesenheitsnotiz: Re: intro",
+      "Réponse automatique : votre message",
+      "Respuesta automática: hola",
+      "自動回覆: 您好",
+    ]) {
+      expect(classifyReply({ subject, body: "" })).toBe("auto");
+    }
+  });
+
+  test("OOO phrasing at the top of the body is auto", () => {
+    expect(
+      classifyReply({
+        subject: "Re: stack thing",
+        body: "I am out of the office until Sept 8 with limited access to email.",
+      }),
+    ).toBe("auto");
+  });
+
+  test("on-leave phrasing is auto", () => {
+    expect(
+      classifyReply({
+        subject: "Re: intro",
+        body: "I'm on parental leave until January and will reply after that.",
+      }),
+    ).toBe("auto");
+  });
+
+  test("mentioning a past vacation deep in a long reply stays human", () => {
+    const body =
+      "Hey, thanks for the nudge — this got buried. " +
+      "We shipped the migration last week and the numbers look right. " +
+      "Happy to do a call: what does your Thursday look like? " +
+      "Also apologies for the silence, " +
+      "x".repeat(400) +
+      " I was out of office for two weeks in July.";
+    expect(classifyReply({ subject: "Re: your ses setup", body })).toBe("human");
+  });
+
+  test("'out of ideas' is not out of office", () => {
+    expect(
+      classifyReply({
+        subject: "Re: intro",
+        body: "Honestly I'm out of ideas on the vendor sprawl front — curious what you'd do.",
+      }),
+    ).toBe("human");
+  });
+
+  test("quoting an OOO inside a human reply stays human", () => {
+    expect(
+      classifyReply({
+        subject: "Re: intro",
+        body: "Back now, let's talk.\n\nOn Wed, Aug 20, 2026 at 9:00 AM Jane <j@x.com> wrote:\n> I am out of the office until Monday.",
+      }),
+    ).toBe("human");
+  });
+
+  test("explicit removal requests are unsubscribe", () => {
+    for (const body of [
+      "Please remove me from your list.",
+      "unsubscribe",
+      "Do not contact me again.",
+      "Stop emailing me.",
+      "Take me off this list please",
+      "Not interested — please remove me.",
+    ]) {
+      expect(classifyReply({ subject: "Re: intro", body })).toBe("unsubscribe");
+    }
+  });
+
+  test("a bare soft no stays human", () => {
+    expect(
+      classifyReply({
+        subject: "Re: intro",
+        body: "Not interested right now, but ping me next quarter.",
+      }),
+    ).toBe("human");
+  });
+
+  test("our own footer in the quoted chain does not trigger unsubscribe", () => {
+    expect(
+      classifyReply({
+        subject: "Re: intro",
+        body: "Sounds interesting, tell me more.\n\nOn Tue, JN wrote:\n> ...\n> Reply unsubscribe to opt out.",
+      }),
+    ).toBe("human");
+  });
+
+  test("empty subject and body default to human", () => {
+    expect(classifyReply({})).toBe("human");
+  });
+});
+
+describe("stripQuotedChain (moved from plays/reply.ts)", () => {
+  test("cuts at the attribution line", () => {
+    expect(stripQuotedChain("New text.\nOn Mon, Jane wrote:\n> old")).toBe("New text.");
+  });
+  test("cuts at the first quoted run", () => {
+    expect(stripQuotedChain("New text.\n> old\n> older")).toBe("New text.");
+  });
+  test("passes plain bodies through", () => {
+    expect(stripQuotedChain("Just a reply.")).toBe("Just a reply.");
+  });
+});

--- a/packages/core/__tests__/reply-classify.test.ts
+++ b/packages/core/__tests__/reply-classify.test.ts
@@ -126,6 +126,40 @@ describe("classifyReply", () => {
     }
   });
 
+  test("a human apologizing for a PAST absence stays human", () => {
+    for (const body of [
+      "Sorry — I was out of the office last week, back now. Happy to talk.",
+      "Apologies, I've been on vacation. What did you have in mind?",
+      "I was away from my email for a few days. Still interested?",
+    ]) {
+      expect(classifyReply({ subject: "Re: your ses setup", body })).toBe("human");
+    }
+  });
+
+  test("a subject-only unsubscribe with an empty body is unsubscribe", () => {
+    expect(classifyReply({ subject: "Unsubscribe", body: "" })).toBe("unsubscribe");
+    expect(classifyReply({ subject: "Please remove me", body: "" })).toBe("unsubscribe");
+  });
+
+  test("an opt-out inside a vacation-style human note wins over the OOO phrasing", () => {
+    expect(
+      classifyReply({
+        subject: "Re: intro",
+        body: "Heading out on vacation — please remove me from your list.",
+      }),
+    ).toBe("unsubscribe");
+  });
+
+  test("header-verdict machine mail is never an unsubscribe, even with the word in it", () => {
+    expect(
+      classifyReply({
+        subject: "Re: intro",
+        body: "I am out of the office. To unsubscribe from these notifications click here.",
+        autoSubmitted: true,
+      }),
+    ).toBe("auto");
+  });
+
   test("a bare soft no stays human", () => {
     expect(
       classifyReply({

--- a/packages/core/__tests__/send-contacted-elsewhere.test.ts
+++ b/packages/core/__tests__/send-contacted-elsewhere.test.ts
@@ -28,6 +28,7 @@ vi.mock("../src/ledger.ts", async () => {
     ...actual,
     getLedger: () => ({
       suppressionFor: () => null,
+      contactSuppressionFor: () => null,
       getSenderAssignment: () => null,
       assignSender,
       recordReceipt: () => 1,

--- a/packages/core/__tests__/send-suppression.test.ts
+++ b/packages/core/__tests__/send-suppression.test.ts
@@ -10,6 +10,8 @@ const assignSender = vi.fn((_email: string, id: string) => id);
 const recordReceipt = vi.fn().mockReturnValue(1);
 /** Set per test: what suppressionFor returns for the recipient. */
 let suppression: { status_code: string | null; bounced_at: string } | null = null;
+/** Set per test: what contactSuppressionFor returns (unsubscribe / dead mailbox). */
+let contactSuppression: { kind: string; received_at: string } | null = null;
 
 vi.mock("../src/config.ts", async () => {
   const actual = await vi.importActual<typeof import("../src/config.ts")>("../src/config.ts");
@@ -31,6 +33,7 @@ vi.mock("../src/ledger.ts", async () => {
     ...actual,
     getLedger: () => ({
       suppressionFor: () => suppression,
+      contactSuppressionFor: () => contactSuppression,
       getSenderAssignment,
       assignSender,
       recordReceipt,
@@ -49,6 +52,7 @@ const INPUT = { to: "jane@dead.example", subject: "s", body: "b" };
 
 beforeEach(() => {
   suppression = null;
+  contactSuppression = null;
   getSenderAssignment.mockClear();
   assignSender.mockClear();
   recordReceipt.mockClear();
@@ -87,6 +91,23 @@ describe("sendEmail suppression backstop", () => {
   it("still tolerates a missing status code", async () => {
     suppression = { status_code: null, bounced_at: "2026-08-01T10:00:00.000Z" };
     await expect(sendEmail(INPUT, CTX)).rejects.toThrow(/not sending/);
+  });
+
+  it("refuses a recipient who unsubscribed — durable across plays and cadences", async () => {
+    contactSuppression = { kind: "unsubscribe", received_at: "2026-08-27T16:00:00.000Z" };
+    const err = (await sendEmail(INPUT, CTX).catch((e: unknown) => e)) as Error;
+    expect(isSuppressedRecipient(err)).toBe(true);
+    expect(err.message).toContain("asked not to be contacted");
+    expect(err.message).toContain("2026-08-27");
+    expect(getSenderAssignment).not.toHaveBeenCalled();
+    expect(recordReceipt).not.toHaveBeenCalled();
+  });
+
+  it("refuses a recipient whose autoresponder reported the mailbox dead", async () => {
+    contactSuppression = { kind: "auto_permanent", received_at: "2026-08-27T16:00:00.000Z" };
+    const err = (await sendEmail(INPUT, CTX).catch((e: unknown) => e)) as Error;
+    expect(isSuppressedRecipient(err)).toBe(true);
+    expect(err.message).toContain("mailbox reported dead");
   });
 
   it("lets an address with no bounce history through to routing", async () => {

--- a/packages/core/src/gmail.ts
+++ b/packages/core/src/gmail.ts
@@ -267,6 +267,18 @@ function header(msg: GmailMessageMeta, name: string): string {
   return h?.value ?? "";
 }
 
+/**
+ * Header-level autoresponder verdict (RFC 3834 and the de-facto vendor
+ * headers). The message is already fetched with format=full, so this costs
+ * nothing — and it catches OOO mail whose subject/body give no textual hint.
+ */
+function isAutoSubmitted(msg: GmailMessageMeta): boolean {
+  const auto = header(msg, "Auto-Submitted").trim().toLowerCase();
+  if (auto && auto !== "no") return true;
+  if (header(msg, "X-Autoreply") || header(msg, "X-Autorespond")) return true;
+  return header(msg, "Precedence").trim().toLowerCase() === "auto_reply";
+}
+
 /** DFS for the first part of `mimeType` that carries inline data, decoded. */
 function extractByMime(part: GmailPayloadPart | undefined, mimeType: string): string {
   if (!part) return "";
@@ -348,7 +360,7 @@ export async function listGmailReplies(
   const emails = await parallelMap(
     ids,
     4,
-    async (id): Promise<InboxEmail & { message_id?: string }> => {
+    async (id): Promise<InboxEmail & { message_id?: string; auto_submitted?: boolean }> => {
       const msg = await gmailJson<GmailMessageMeta>(
         `/messages/${id}?format=full`,
         undefined,
@@ -356,6 +368,7 @@ export async function listGmailReplies(
       );
       // RFC 2822 Message-ID — needed as In-Reply-To/References on a threaded reply.
       const messageId = header(msg, "Message-ID");
+      const autoSubmitted = isAutoSubmitted(msg);
       return {
         id: msg.id,
         from: header(msg, "From"),
@@ -364,6 +377,7 @@ export async function listGmailReplies(
         thread_id: msg.threadId,
         body: extractBody(msg),
         ...(messageId ? { message_id: messageId } : {}),
+        ...(autoSubmitted ? { auto_submitted: true } : {}),
       };
     },
   );

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,3 +17,4 @@ export * from "./identities.ts";
 export * from "./send-routing.ts";
 export * from "./parallel.ts";
 export * from "./types.ts";
+export * from "./reply-classify.ts";

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { configDir } from "./config.ts";
 import { getSharedDb } from "./shared-db.ts";
+import type { ReplyKind } from "./reply-classify.ts";
 import type {
   AuthVerdict,
   BounceKind,
@@ -486,6 +487,11 @@ export class Ledger {
       CREATE INDEX IF NOT EXISTS idx_inbox_replies_thread
         ON inbox_replies(thread_key, received_at);
     `);
+    // v23: reply classification ('human' | 'auto' | 'auto_permanent' |
+    // 'unsubscribe', see reply-classify.ts). NULL = row predates the
+    // classifier and reads as 'human' everywhere (coalesce). Must run after
+    // the CREATE TABLE above — ALTER on a fresh install needs the table.
+    this.addColumnIfMissing("inbox_replies", "kind", "TEXT");
     // v22: tweets the x-reposters finder already paid to harvest. Both X data
     // providers bill per resource RETURNED, and the finder's freshness window
     // (48h) is wider than its daily cadence — without this ledger every fresh
@@ -685,7 +691,7 @@ export class Ledger {
   setCadenceStatus(input: {
     prospectId: number;
     playName: string;
-    status: "active" | "replied" | "breakup" | "completed" | "bounced" | "off-icp";
+    status: "active" | "replied" | "breakup" | "completed" | "bounced" | "off-icp" | "unsubscribed";
   }): void {
     // Non-active terminal states clear the persisted draft AND any send
     // marker — a replied / breakup / completed / bounced cadence shouldn't have
@@ -1029,13 +1035,14 @@ export class Ledger {
     sourceIdentityId?: string | null;
     threadId?: string | null;
     messageId?: string | null;
+    kind?: ReplyKind | null;
   }): boolean {
     const res = this.db
       .query(
         `INSERT OR IGNORE INTO inbox_replies
            (id, thread_key, prospect_id, play_name, from_email, subject, body,
-            received_at, source_identity_id, thread_id, message_id)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+            received_at, source_identity_id, thread_id, message_id, kind)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         row.id,
@@ -1049,6 +1056,7 @@ export class Ledger {
         row.sourceIdentityId ?? null,
         row.threadId ?? null,
         row.messageId ?? null,
+        row.kind ?? null,
       );
     return res.changes > 0;
   }

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -492,6 +492,10 @@ export class Ledger {
     // classifier and reads as 'human' everywhere (coalesce). Must run after
     // the CREATE TABLE above — ALTER on a fresh install needs the table.
     this.addColumnIfMissing("inbox_replies", "kind", "TEXT");
+    // contactSuppressionFor, on the send pre-flight path — must be an index seek.
+    this.db.exec(
+      `CREATE INDEX IF NOT EXISTS idx_inbox_replies_from_kind ON inbox_replies(from_email, kind)`,
+    );
     // v22: tweets the x-reposters finder already paid to harvest. Both X data
     // providers bill per resource RETURNED, and the finder's freshness window
     // (48h) is wider than its daily cadence — without this ledger every fresh
@@ -1308,6 +1312,25 @@ export class Ledger {
            ORDER BY bounced_at DESC LIMIT 1`,
         )
         .get(canonEmail(email)) as BounceRecord) ?? null
+    );
+  }
+
+  /**
+   * A do-not-send verdict from the reply stream: the newest 'unsubscribe'
+   * (they asked to stop) or 'auto_permanent' (their responder says the
+   * mailbox is dead) captured from this address. Durable on purpose — it
+   * outlives any one cadence, so a later play can never re-enroll and email
+   * an unsubscribed or gone prospect. Sibling of suppressionFor (bounces).
+   */
+  contactSuppressionFor(email: string): { kind: string; received_at: string } | null {
+    return (
+      (this.db
+        .query(
+          `SELECT kind, received_at FROM inbox_replies
+           WHERE from_email = ? AND kind IN ('unsubscribe', 'auto_permanent')
+           ORDER BY received_at DESC LIMIT 1`,
+        )
+        .get(canonEmail(email)) as { kind: string; received_at: string }) ?? null
     );
   }
 

--- a/packages/core/src/oneshot.ts
+++ b/packages/core/src/oneshot.ts
@@ -368,6 +368,17 @@ async function dispatchEmail(input: SendEmailInput, ctx: CallContext) {
       `${input.to} hard-bounced${suppression.status_code ? ` (${suppression.status_code})` : ""} on ${suppression.bounced_at.slice(0, 10)} — not sending`,
     );
   }
+  // Same backstop for reply-stream verdicts: an unsubscribe or a dead-mailbox
+  // autoresponder is as final as a hard bounce, and stopping one cadence isn't
+  // enough — a later play could re-enroll the prospect and land here again.
+  const contactStop = getLedger().contactSuppressionFor(input.to);
+  if (contactStop) {
+    const why =
+      contactStop.kind === "unsubscribe" ? "asked not to be contacted" : "mailbox reported dead";
+    throw new SuppressedRecipientError(
+      `${input.to} ${why} (${contactStop.kind} reply on ${contactStop.received_at.slice(0, 10)}) — not sending`,
+    );
+  }
   // Sender rotation: resolve the sticky per-prospect identity BEFORE any
   // network call. Throws SendDeferredError when every identity is at its
   // daily cap — callers leave the work queued for tomorrow.

--- a/packages/core/src/oneshot.ts
+++ b/packages/core/src/oneshot.ts
@@ -768,6 +768,8 @@ async function listOneShotInbox(opts?: {
 export type AnnotatedInboxEmail = InboxEmail & {
   message_id?: string;
   source_identity_id?: string;
+  /** Header-level autoresponder verdict (Gmail sources only — RFC 3834 et al.). */
+  auto_submitted?: boolean;
 };
 
 export interface AnnotatedInboxListResult extends InboxListResult {

--- a/packages/core/src/reply-classify.ts
+++ b/packages/core/src/reply-classify.ts
@@ -1,0 +1,146 @@
+/**
+ * Deterministic inbound-reply classifier. Every email from a prospect's
+ * address used to count as a reply; real inboxes answer with vacation
+ * autoresponders, "no longer at this company" notices, and "take me off your
+ * list" one-liners — each of which must steer the pipeline differently
+ * (see kind docs below). Heuristic on purpose: this runs inside the 5-minute
+ * scheduler tick, so no LLM call, no network, no nondeterminism.
+ */
+
+/**
+ * What an inbound email from a prospect actually is:
+ * - `human`          — a person wrote back. The only kind that counts as a
+ *                      reply (metric, cadence stop, RoCS tag, friends push).
+ * - `auto`           — temporary autoresponder (OOO/vacation). Stored for the
+ *                      conversation history; changes nothing else — follow-ups
+ *                      continue as scheduled.
+ * - `auto_permanent` — autoresponder saying the mailbox is dead ("retired",
+ *                      "no longer with the company"). A human-layer hard
+ *                      bounce: stops active cadences, never counts as a reply.
+ * - `unsubscribe`    — a human wrote "remove me / do not contact". Stops ALL
+ *                      cadences and excludes the prospect from every campaign.
+ */
+export type ReplyKind = "human" | "auto" | "auto_permanent" | "unsubscribe";
+
+/**
+ * Drop the quoted prior-thread chain mail clients top-post beneath the new
+ * reply. Without this, a blind head-truncation can keep 2000 chars of OUR
+ * own quoted email and cut off the prospect's actual new text below it. Cuts
+ * at the first attribution line ("On <date>, <name> wrote:") or the first run
+ * of `>`-quoted lines — whichever comes first. Falls back to the full body
+ * when no quote marker is found (plain replies, or clients we don't match).
+ */
+export function stripQuotedChain(body: string): string {
+  const lines = body.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!.trim();
+    // Gmail/Apple/Outlook attribution line that precedes the quoted block.
+    if (/^On\b.*\bwrote:$/.test(line)) return lines.slice(0, i).join("\n").trim();
+    // A quoted line with real content above it — the chain has started.
+    if (line.startsWith(">") && i > 0) return lines.slice(0, i).join("\n").trim();
+  }
+  return body.trim();
+}
+
+// Subject prefixes mail servers stamp on autoresponses, across the locales
+// that have actually shown up in the inbox plus the common European ones.
+// Anchored at the start: a human writing "out of office" mid-subject is rare,
+// an autoresponder putting it anywhere else is rarer.
+const AUTO_SUBJECT_RE = new RegExp(
+  "^\\s*(?:" +
+    [
+      "automatic reply",
+      "auto[- ]?reply",
+      "auto[- ]?response",
+      "autosvar",
+      "out of office",
+      "ooo[:\\s]",
+      "abwesenheit(?:snotiz)?",
+      "automatische antwort",
+      "r[ée]ponse automatique",
+      "respuesta autom[áa]tica",
+      "automatisch(?:e|) antwoord",
+      "自动回复",
+      "自動回覆",
+      "부재중",
+    ].join("|") +
+    ")",
+  "i",
+);
+
+// Body phrases an autoresponder opens with. Checked against the head of the
+// quote-stripped body only — deep in a long human reply these read as prose
+// ("I was out of office last week"), near the top they read as a bot.
+const AUTO_BODY_RE = new RegExp(
+  [
+    "\\bout of (?:the )?office\\b",
+    "\\bon (?:annual|parental|maternity|paternity|sick) leave\\b",
+    "\\baway from (?:my|the) (?:email|office|desk)\\b",
+    "\\bon (?:vacation|holiday)\\b",
+    "\\blimited access to (?:my )?e-?mail\\b",
+    "\\bauto-?generated (?:message|response|reply)\\b",
+    "\\bi(?:'m| am) currently (?:away|out|travell?ing)\\b",
+    "自动回复",
+    "自動回覆",
+  ].join("|"),
+  "i",
+);
+
+// Escalates an `auto` to `auto_permanent` — the responder says the mailbox or
+// the person is gone for good, not on leave. Only consulted once something
+// already classified as auto: "retired" alone in a human reply must not trip.
+const PERMANENT_RE = new RegExp(
+  [
+    "\\bno longer (?:with|at|using|working|employed)\\b",
+    "\\bhas left\\b",
+    "\\bretired\\b",
+    "\\bis not with .{0,40}\\banymore\\b",
+    "\\b(?:mailbox|email|address|account) (?:is )?(?:no longer|not) (?:monitored|active|in use)\\b",
+  ].join("|"),
+  "i",
+);
+
+// A human asking off the list. Deliberately tight — a bare "not interested"
+// is a soft no and stays human; these are explicit removal requests. Checked
+// on the quote-stripped body so OUR OWN footer in the quoted chain can't trip.
+const UNSUBSCRIBE_RE = new RegExp(
+  [
+    "\\bunsubscribe\\b",
+    "\\bremove me\\b",
+    "\\btake me off\\b",
+    "\\bstop (?:emailing|contacting|messaging)\\b",
+    "\\bdo not (?:contact|email) me\\b",
+    "\\bdon'?t (?:contact|email) me\\b",
+    "\\bopt me out\\b",
+    "\\bnot interested\\b.{0,80}\\b(?:stop|remove|unsubscribe|don'?t)\\b",
+  ].join("|"),
+  "i",
+);
+
+// Autoresponders front-load their message; humans might mention a vacation
+// anywhere. Only this many chars of the (quote-stripped) body vote.
+const BODY_HEAD_CHARS = 400;
+
+/**
+ * Classify one inbound email. `autoSubmitted` is the header-level verdict the
+ * Gmail source computes from Auto-Submitted / X-Autoreply / Precedence —
+ * authoritative when present (OneShot-sourced mail never has it and relies on
+ * the subject/body heuristics alone).
+ */
+export function classifyReply(input: {
+  subject?: string | null;
+  body?: string | null;
+  autoSubmitted?: boolean;
+}): ReplyKind {
+  const subject = input.subject ?? "";
+  const stripped = stripQuotedChain(input.body ?? "");
+  const head = stripped.slice(0, BODY_HEAD_CHARS);
+
+  const isAuto =
+    input.autoSubmitted === true || AUTO_SUBJECT_RE.test(subject) || AUTO_BODY_RE.test(head);
+  if (isAuto) {
+    return PERMANENT_RE.test(subject) || PERMANENT_RE.test(head) ? "auto_permanent" : "auto";
+  }
+  if (UNSUBSCRIBE_RE.test(head)) return "unsubscribe";
+  return "human";
+}

--- a/packages/core/src/reply-classify.ts
+++ b/packages/core/src/reply-classify.ts
@@ -70,13 +70,16 @@ const AUTO_SUBJECT_RE = new RegExp(
 
 // Body phrases an autoresponder opens with. Checked against the head of the
 // quote-stripped body only — deep in a long human reply these read as prose
-// ("I was out of office last week"), near the top they read as a bot.
+// ("I was out of office last week"), near the top they read as a bot. The
+// past-tense lookbehinds keep a human's "sorry, I was out of the office last
+// week" from reading as a live responder: machines announce in present/future
+// tense, humans apologize in past tense.
 const AUTO_BODY_RE = new RegExp(
   [
-    "\\bout of (?:the )?office\\b",
-    "\\bon (?:annual|parental|maternity|paternity|sick) leave\\b",
-    "\\baway from (?:my|the) (?:email|office|desk)\\b",
-    "\\bon (?:vacation|holiday)\\b",
+    "(?<!\\bwas )(?<!\\bbeen )\\bout of (?:the )?office\\b",
+    "(?<!\\bwas )(?<!\\bbeen )\\bon (?:annual|parental|maternity|paternity|sick) leave\\b",
+    "(?<!\\bwas )(?<!\\bbeen )\\baway from (?:my|the) (?:email|office|desk)\\b",
+    "(?<!\\bwas )(?<!\\bbeen )\\bon (?:vacation|holiday)\\b",
     "\\blimited access to (?:my )?e-?mail\\b",
     "\\bauto-?generated (?:message|response|reply)\\b",
     "\\bi(?:'m| am) currently (?:away|out|travell?ing)\\b",
@@ -135,12 +138,18 @@ export function classifyReply(input: {
   const subject = input.subject ?? "";
   const stripped = stripQuotedChain(input.body ?? "");
   const head = stripped.slice(0, BODY_HEAD_CHARS);
+  const permanent = PERMANENT_RE.test(subject) || PERMANENT_RE.test(head);
 
-  const isAuto =
-    input.autoSubmitted === true || AUTO_SUBJECT_RE.test(subject) || AUTO_BODY_RE.test(head);
-  if (isAuto) {
-    return PERMANENT_RE.test(subject) || PERMANENT_RE.test(head) ? "auto_permanent" : "auto";
+  // The header verdict is authoritative machine mail: no human wrote it, so
+  // it can never be an unsubscribe — even if the responder's boilerplate
+  // happens to contain the word.
+  if (input.autoSubmitted === true) return permanent ? "auto_permanent" : "auto";
+  // For text-classified mail an explicit removal request wins over OOO
+  // phrasing: "heading out on vacation — please remove me from your list" is
+  // a human opting out, not a responder.
+  if (UNSUBSCRIBE_RE.test(subject) || UNSUBSCRIBE_RE.test(head)) return "unsubscribe";
+  if (AUTO_SUBJECT_RE.test(subject) || AUTO_BODY_RE.test(head)) {
+    return permanent ? "auto_permanent" : "auto";
   }
-  if (UNSUBSCRIBE_RE.test(head)) return "unsubscribe";
   return "human";
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -63,6 +63,8 @@ export interface InboxReplyRecord {
   source_identity_id: string | null;
   thread_id: string | null;
   message_id: string | null;
+  /** Reply classification (reply-classify.ts). NULL = pre-classifier row, read as 'human'. */
+  kind: string | null;
   created_at: string;
 }
 
@@ -97,7 +99,7 @@ export interface SequenceEventRecord {
   play_name: string;
   step_index: number;
   channel: "email" | "sms" | "voice" | "linkedin" | "x";
-  status: "queued" | "sent" | "delivered" | "replied" | "bounced" | "failed";
+  status: "queued" | "sent" | "delivered" | "replied" | "bounced" | "failed" | "unsubscribed";
   metadata_json: string | null;
   created_at: string;
 }

--- a/packages/plays/__tests__/cadence-batch.test.ts
+++ b/packages/plays/__tests__/cadence-batch.test.ts
@@ -56,6 +56,7 @@ vi.mock("@oneshot-gtm/core", async () => {
       recordProspectReply: () => [],
       // No prior hard bounce: these tests exercise the normal send path.
       suppressionFor: () => null,
+      contactSuppressionFor: () => null,
       listAllCadences: () => cadenceRows,
       listActiveCadences: () => cadenceRows.filter((c) => c.status === "active"),
       listCadencesForProspect: (prospectId: number) =>

--- a/packages/plays/__tests__/cadence-deferral.test.ts
+++ b/packages/plays/__tests__/cadence-deferral.test.ts
@@ -65,6 +65,7 @@ vi.mock("@oneshot-gtm/core", async () => {
       recordProspectReply: () => [],
       // No prior hard bounce: these tests exercise the normal send path.
       suppressionFor: () => null,
+      contactSuppressionFor: () => null,
       listAllCadences: () => cadenceRows,
       listActiveCadences: () => cadenceRows.filter((c) => c.status === "active"),
       listCadencesForProspect: (prospectId: number) =>

--- a/packages/plays/__tests__/cadence-reply.test.ts
+++ b/packages/plays/__tests__/cadence-reply.test.ts
@@ -6,7 +6,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // emailing someone who already replied.
 
 const calls = { sendEmail: 0 };
-let inboxEmails: Array<{ id?: string; from: string; subject: string; received_at?: string }> = [];
+let inboxEmails: Array<{
+  id?: string;
+  from: string;
+  subject: string;
+  received_at?: string;
+  body?: string;
+  auto_submitted?: boolean;
+}> = [];
 let lookupArgs: string[] = [];
 let listInboxArgs: Array<Record<string, unknown>> = [];
 let failedSources: string[] = [];
@@ -15,7 +22,9 @@ let repliedSteps: Array<{ prospectId: number; playName: string }> = [];
 // The play behind the prospect's latest sent step — the no-cadence-row fallback.
 let latestSentPlay: string | null = null;
 // v21 inbox_replies rows captured by the poll (id-keyed, INSERT OR IGNORE semantics).
-let persistedReplies: Array<{ id: string }> = [];
+let persistedReplies: Array<{ id: string; kind?: string | null }> = [];
+// Audit-trail sequence events recorded outside recordProspectReply (bounced/unsubscribed).
+let seqEvents: Array<{ prospectId: number; playName: string; status: string }> = [];
 // Persisted poll_state rows (watermark + backlog), as the real ledger holds them.
 let pollState: Record<string, string> = {};
 const watermarkOf = () => pollState["inbox_replies"] ?? null;
@@ -86,6 +95,13 @@ vi.mock("@oneshot-gtm/core", async () => {
         if (isNew) persistedReplies.push(row as (typeof persistedReplies)[number]);
         return isNew;
       },
+      recordSequenceEvent: (input: { prospectId: number; playName: string; status: string }) => {
+        seqEvents.push({
+          prospectId: input.prospectId,
+          playName: input.playName,
+          status: input.status,
+        });
+      },
       setCadenceStatus: ({
         prospectId,
         playName,
@@ -143,6 +159,7 @@ beforeEach(() => {
   inboxEmails = [];
   repliedSteps = [];
   persistedReplies = [];
+  seqEvents = [];
   // The fixture cadence is also the latest play that emailed the prospect.
   latestSentPlay = "stack-consolidation";
   pollState = {};
@@ -394,5 +411,105 @@ describe("pollInboxReplies — watermark", () => {
     const second = await pollInboxReplies({ pageSize: 2, maxPages: 2 });
     expect(second.repliesDetected).toBe(1);
     expect(pollState["inbox_replies_backlog"]).toBe("");
+  });
+});
+
+describe("pollInboxReplies — auto-reply classification (v23)", () => {
+  it("an OOO autoresponder is stored but is NOT a reply: cadence stays active", async () => {
+    inboxEmails = [
+      {
+        from: "Sophia Stein <sophia@agenticarchitect.ai>",
+        subject: "Automatic reply: your agent stack",
+      },
+    ];
+
+    const result = await pollInboxReplies();
+
+    expect(result.repliesDetected).toBe(0);
+    expect(result.autoRepliesSkipped).toBe(1);
+    expect(result.cadencesStopped).toBe(0);
+    expect(rows[0]?.status).toBe("active"); // follow-ups continue
+    expect(repliedSteps).toHaveLength(0); // no sequence_events flip → metric untouched
+    expect(persistedReplies).toHaveLength(1); // conversation history stays complete
+    expect(persistedReplies[0]?.kind).toBe("auto");
+  });
+
+  it("a dead-mailbox autoresponder stops the cadence as bounced, not replied", async () => {
+    inboxEmails = [
+      {
+        from: "sophia@agenticarchitect.ai",
+        subject: "out of office Re: your agent stack",
+        // The real 2026-08-27 payload shape: retired, address dead.
+        body: "Retired October 2025. No longer using this email.",
+        received_at: "2026-08-27T16:07:46.000Z",
+      },
+    ];
+
+    const result = await pollInboxReplies();
+
+    expect(result.repliesDetected).toBe(0);
+    expect(result.autoRepliesSkipped).toBe(1);
+    expect(result.cadencesStopped).toBe(1);
+    expect(rows[0]?.status).toBe("bounced");
+    expect(repliedSteps).toHaveLength(0);
+    expect(seqEvents).toEqual([
+      { prospectId: 1, playName: "stack-consolidation", status: "bounced" },
+    ]);
+    expect(persistedReplies[0]?.kind).toBe("auto_permanent");
+  });
+
+  it("an unsubscribe request stops the cadence as unsubscribed", async () => {
+    inboxEmails = [
+      {
+        from: "sophia@agenticarchitect.ai",
+        subject: "Re: your agent stack",
+        body: "Please remove me from your list.",
+      },
+    ];
+
+    const result = await pollInboxReplies();
+
+    expect(result.repliesDetected).toBe(0);
+    expect(result.autoRepliesSkipped).toBe(1);
+    expect(result.cadencesStopped).toBe(1);
+    expect(rows[0]?.status).toBe("unsubscribed");
+    expect(seqEvents).toEqual([
+      { prospectId: 1, playName: "stack-consolidation", status: "unsubscribed" },
+    ]);
+    expect(persistedReplies[0]?.kind).toBe("unsubscribe");
+  });
+
+  it("a terminal cadence is not resurrected or re-stopped by a dead-mailbox notice", async () => {
+    rows[0]!.status = "completed";
+    inboxEmails = [
+      {
+        from: "sophia@agenticarchitect.ai",
+        subject: "Automatic reply: gone",
+        body: "I have retired and am no longer using this email.",
+      },
+    ];
+
+    const result = await pollInboxReplies();
+
+    expect(result.cadencesStopped).toBe(0);
+    expect(rows[0]?.status).toBe("completed");
+    expect(seqEvents).toHaveLength(0);
+  });
+
+  it("a Gmail header verdict (auto_submitted) suppresses the reply even with a human-looking body", async () => {
+    inboxEmails = [
+      {
+        from: "sophia@agenticarchitect.ai",
+        subject: "Re: your agent stack",
+        body: "Thanks for your email, I will get back to you.",
+        auto_submitted: true,
+      },
+    ];
+
+    const result = await pollInboxReplies();
+
+    expect(result.repliesDetected).toBe(0);
+    expect(result.autoRepliesSkipped).toBe(1);
+    expect(rows[0]?.status).toBe("active");
   });
 });

--- a/packages/plays/__tests__/cadence-step-runner.test.ts
+++ b/packages/plays/__tests__/cadence-step-runner.test.ts
@@ -47,6 +47,7 @@ let deferOnSend = false;
 let alreadySentNextStep = false;
 // Simulates a prior hard bounce for this cadence's prospect.
 let suppression: { status_code: string | null; bounced_at: string } | null = null;
+let contactSuppression: { kind: string; received_at: string } | null = null;
 let icpVerdict: { verdict: string; reason: string | null } | null = null;
 
 vi.mock("@oneshot-gtm/core", async () => {
@@ -98,6 +99,7 @@ vi.mock("@oneshot-gtm/core", async () => {
       recordProspectReply: () => [],
       // Null by default: most tests exercise the normal send path.
       suppressionFor: () => suppression,
+      contactSuppressionFor: () => contactSuppression,
       listAllCadences: () => cadenceRows,
       listActiveCadences: () => cadenceRows.filter((c) => c.status === "active"),
       listCadencesForProspect: (prospectId: number) =>
@@ -243,6 +245,7 @@ beforeEach(() => {
   deferOnSend = false;
   alreadySentNextStep = false;
   suppression = null;
+  contactSuppression = null;
   icpVerdict = null;
   seedActiveCadence();
 });
@@ -323,6 +326,39 @@ describe("sendCadenceStep", () => {
         stepIndex: 1,
       }),
     });
+  });
+});
+
+describe("runCadenceStepForProspect — reply-stream do-not-send gate", () => {
+  it("an unsubscribe skips before drafting and stops the cadence as unsubscribed", async () => {
+    contactSuppression = { kind: "unsubscribe", received_at: "2026-08-27T16:00:00.000Z" };
+    const result = await runCadenceStepForProspect({
+      prospectId: 1,
+      playName: "stack-consolidation",
+      dryRun: false,
+    });
+    expect(result.action).toBe("skipped");
+    expect(result.note).toMatch(/asked not to be contacted/);
+    expect(calls.llm).toBe(0);
+    expect(calls.sendEmail).toBe(0);
+    expect(statusCalls).toEqual([
+      { prospectId: 1, playName: "stack-consolidation", status: "unsubscribed" },
+    ]);
+  });
+
+  it("a dead-mailbox verdict stops the cadence as bounced", async () => {
+    contactSuppression = { kind: "auto_permanent", received_at: "2026-08-27T16:00:00.000Z" };
+    const result = await runCadenceStepForProspect({
+      prospectId: 1,
+      playName: "stack-consolidation",
+      dryRun: false,
+    });
+    expect(result.action).toBe("skipped");
+    expect(result.note).toMatch(/mailbox reported dead/);
+    expect(calls.sendEmail).toBe(0);
+    expect(statusCalls).toEqual([
+      { prospectId: 1, playName: "stack-consolidation", status: "bounced" },
+    ]);
   });
 });
 

--- a/packages/plays/src/_cadence.ts
+++ b/packages/plays/src/_cadence.ts
@@ -746,6 +746,20 @@ export async function runCadenceStepForProspect(
         note: `suppressed: hard-bounced${suppression.status_code ? ` ${suppression.status_code}` : ""}`,
       };
     }
+    // Reply-stream do-not-send (unsubscribe / dead-mailbox autoresponder):
+    // same shape as the bounce check — stop before paying for a draft, and
+    // record an honest terminal status instead of a send failure.
+    const contactStop = ledger.contactSuppressionFor(cadence.prospect_email);
+    if (contactStop) {
+      const status = contactStop.kind === "unsubscribe" ? "unsubscribed" : "bounced";
+      ledger.setCadenceStatus({ prospectId: opts.prospectId, playName: opts.playName, status });
+      return {
+        action: "skipped",
+        payload: null,
+        receiptIds: [],
+        note: `suppressed: ${contactStop.kind === "unsubscribe" ? "asked not to be contacted" : "mailbox reported dead"}`,
+      };
+    }
   }
   // Person-level ICP gate: an off-ICP prospect must not receive follow-ups.
   // Code-level on purpose — a prompt can be talked out of a rule, a status

--- a/packages/plays/src/_cadence.ts
+++ b/packages/plays/src/_cadence.ts
@@ -1,4 +1,5 @@
 import {
+  classifyReply,
   getLedger,
   hasAnySendCapacity,
   isSendDeferred,
@@ -190,6 +191,8 @@ export interface ReplyPollResult {
   repliesDetected: number;
   /** Subset of the above that also stopped a still-active cadence. */
   cadencesStopped: number;
+  /** Matched inbound mail classified as non-human (OOO / dead mailbox / unsubscribe) — stored, never counted as a reply. */
+  autoRepliesSkipped: number;
   details: Array<{ prospectEmail: string; playName: string; subject: string }>;
 }
 
@@ -276,6 +279,15 @@ async function walkInboxWindow(
       const from = normalizeEmail(e.from);
       const prospect = ledger.findProspectByEmail(from);
       if (!prospect) continue;
+      // Autoresponders (OOO, "no longer here") and unsubscribe requests are
+      // NOT replies: they must not stop cadences as engagement, move the reply
+      // metric, or tag RoCS. Classified here — the one choke point every
+      // detection path funnels through.
+      const kind = classifyReply({
+        subject: e.subject,
+        body: e.body,
+        autoSubmitted: e.auto_submitted,
+      });
       // Persist the full inbound (body included) — the ledger, not the mailbox,
       // is the reply store. Every matched email, not just the first reply per
       // (prospect, play): later replies on a live thread must be kept too.
@@ -292,7 +304,32 @@ async function walkInboxWindow(
         sourceIdentityId: e.source_identity_id ?? null,
         threadId: e.thread_id ?? null,
         messageId: e.message_id ?? null,
+        kind,
       });
+      if (kind !== "human") {
+        out.autoRepliesSkipped++;
+        // A dead mailbox ("retired", "no longer at company") is a human-layer
+        // hard bounce; an unsubscribe is a do-not-contact. Either way active
+        // cadences stop — but with an honest status, no replied event, and no
+        // bounces-table row (that would poison identity reputation stats).
+        if (kind === "auto_permanent" || kind === "unsubscribe") {
+          const status = kind === "unsubscribe" ? "unsubscribed" : "bounced";
+          for (const cad of ledger.listCadencesForProspect(prospect.id)) {
+            if (cad.status !== "active" && cad.status !== "paused") continue;
+            ledger.recordSequenceEvent({
+              prospectId: prospect.id,
+              playName: cad.play_name,
+              stepIndex: cad.current_step,
+              channel: "email",
+              status,
+              metadata: { reason: kind === "unsubscribe" ? "unsubscribe" : "auto-reply-permanent" },
+            });
+            ledger.setCadenceStatus({ prospectId: prospect.id, playName: cad.play_name, status });
+            out.cadencesStopped++;
+          }
+        }
+        continue;
+      }
       for (const r of ledger.recordProspectReply(prospect.id, { subject: e.subject })) {
         if (r.newlyReplied) out.cadencesStopped++;
         if (!r.eventRecorded) continue;
@@ -334,7 +371,13 @@ export async function pollInboxReplies(opts?: {
   maxPages?: number;
 }): Promise<ReplyPollResult> {
   const ledger = getLedger();
-  const out: ReplyPollResult = { polled: 0, repliesDetected: 0, cadencesStopped: 0, details: [] };
+  const out: ReplyPollResult = {
+    polled: 0,
+    repliesDetected: 0,
+    cadencesStopped: 0,
+    autoRepliesSkipped: 0,
+    details: [],
+  };
   const pageSize = opts?.pageSize ?? REPLY_POLL_LIMIT;
   const maxPages = opts?.maxPages ?? REPLY_POLL_MAX_PAGES;
   const seen = new Set<string>();

--- a/packages/plays/src/reply.ts
+++ b/packages/plays/src/reply.ts
@@ -1,30 +1,14 @@
-import { loadConfig } from "@oneshot-gtm/core";
+import { loadConfig, stripQuotedChain } from "@oneshot-gtm/core";
 import { complete, loadPrompt, tryParseJsonObject } from "@oneshot-gtm/intel";
 import { getPriorStepsForProspect, type PriorStepRow } from "./_cadence.ts";
 import { firstNameFrom, humanizeDraft, signatureDirective, socialProofBlock } from "./_lib.ts";
 
+// stripQuotedChain moved to core (reply-classify.ts) — the classifier needs it
+// too. Re-exported so existing imports of this module keep working.
+export { stripQuotedChain };
+
 /** Mirror triage.ts's truncation — inbound bodies can be huge (quoted chains). */
 const INBOUND_BODY_MAX = 2000;
-
-/**
- * Drop the quoted prior-thread chain mail clients top-post beneath the new
- * reply. Without this, a blind head-truncation can keep 2000 chars of OUR
- * own quoted email and cut off the prospect's actual new text below it. Cuts
- * at the first attribution line ("On <date>, <name> wrote:") or the first run
- * of `>`-quoted lines — whichever comes first. Falls back to the full body
- * when no quote marker is found (plain replies, or clients we don't match).
- */
-export function stripQuotedChain(body: string): string {
-  const lines = body.split("\n");
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i]!.trim();
-    // Gmail/Apple/Outlook attribution line that precedes the quoted block.
-    if (/^On\b.*\bwrote:$/.test(line)) return lines.slice(0, i).join("\n").trim();
-    // A quoted line with real content above it — the chain has started.
-    if (line.startsWith(">") && i > 0) return lines.slice(0, i).join("\n").trim();
-  }
-  return body.trim();
-}
 
 export interface DraftInboxReplyInput {
   /** Normalized sender address of the inbound email. */

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -553,9 +553,18 @@ export function withXEngine(
   return out;
 }
 
+/**
+ * Classification of an inbound email (mirrors core's reply-classify.ts):
+ * `human` is a real reply; `auto` a temporary autoresponder (OOO);
+ * `auto_permanent` a dead-mailbox notice; `unsubscribe` a removal request.
+ */
+export type InboundReplyKind = "human" | "auto" | "auto_permanent" | "unsubscribe";
+
 /** A single inbox email (reply to outreach), with prospect/play context when matched. */
 export interface InboxReplyView {
   id: string;
+  /** What this inbound actually is — only `human` counts as a reply anywhere. */
+  kind: InboundReplyKind;
   /** Normalized sender address (lowercased, display-name stripped). */
   fromEmail: string;
   /** Raw From header as received (may include a display name). */
@@ -621,6 +630,8 @@ export type ConversationItem =
       sourceIdentityId: string | null;
       threadId: string | null;
       messageId: string | null;
+      /** Classification of this inbound (NULL rows from before the classifier read as human). */
+      replyKind: InboundReplyKind;
     }
   | {
       /** A manual reply the founder sent from /inbox (inbox_sent). */


### PR DESCRIPTION
Yesterday's sends surfaced the failure mode: a `自动回复:` (automatic reply) vacation autoresponder and an "out of office … Retired October 2025. No longer using this email." notice were both recorded as real replies — inflating Replied·7d, permanently stopping their cadences as engagement, and enrolling machines into reply-driven downstream flows.

## What this does

**Deterministic classifier** (`packages/core/src/reply-classify.ts`, no LLM — it runs inside the 5-minute scheduler tick) sorts every matched inbound into four kinds:

| kind | detection | behavior |
|---|---|---|
| `human` | default | unchanged: replied flip, metric, RoCS tag |
| `auto` | RFC 3834 headers (Gmail `format=full`, already fetched — free), multilingual subject prefixes, OOO body openers | stored for conversation history; nothing else — follow-ups continue |
| `auto_permanent` | auto + "retired / no longer with / has left / mailbox not monitored" | stops active cadences as `bounced` (no bounces-table row — identity reputation stats stay clean) |
| `unsubscribe` | quote-stripped body: "remove me / stop emailing / do not contact" (a bare "not interested" stays human) | stops all cadences with the new `unsubscribed` status |

**Storage**: `inbox_replies.kind` (v23 column, `NULL` = pre-classifier row reads as human via coalesce). The choke point is `walkInboxWindow` — every detection path funnels through it, so the metric, cadence stop, RoCS tag, and downstream consumers are all gated at once. The /inbox opportunistic-capture path classifies identically; views carry the kind to the UI (auto-reply / dead mailbox / unsubscribe badges); the paid reply-research tier is code-gated off for non-human inbound.

## Tests

Classifier suite includes both real payloads verbatim, header-only detection, multilingual subjects, quoted-OOO-stays-human, and our-own-footer-can't-trigger-unsubscribe. Poll suite covers all four kinds + no-resurrection of terminal cadences. Migration test rebuilds a pre-v23 table and re-migrates. 1952 tests green.

## After merge

A one-off backfill (ops/, founder-local) reclassifies the 8 existing rows — validated against a copy of the live ledger: 6 human, the vacation responder → `auto` (cadence resumes, follow-up due 08-30), the retired notice → `auto_permanent` (cadence → bounced).

https://claude.ai/code/session_019SyPeo3U5zNxFaWHGF8ddp

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `classifyReply` and block sending to dead mailboxes and unsubscribes
> - Introduces `classifyReply` to identify human, auto, `auto_permanent`, and `unsubscribe` inbounds using subject/body and auto-submitted headers. Adds DB migration v23 to persist this `kind` in `inbox_replies`.
> - Adds `Ledger.contactSuppressionFor` to query for prior durable do-not-send verdicts. `dispatchEmail` and `runCadenceStepForProspect` now throw `SuppressedRecipientError` or stop cadences with 'unsubscribed' or 'bounced' statuses.
> - `gatherReplyContext` skips paid research tiers for non-human inbounds, and the inbox UI displays badges for these reply kinds.
> - Risk: `dispatchEmail` now refuses to send to addresses with stored unsubscribe or `auto_permanent` reply classifications, stopping cadences for existing contacts who previously sent these replies.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 4acaac3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->