### PR TITLE
fix(web): apps/web typechecks clean again

### DIFF
--- a/apps/web/src/routes/cadences.tsx
+++ b/apps/web/src/routes/cadences.tsx
@@ -94,7 +94,9 @@ function CadencesPage() {
   });
   const cadenceNavigate = Route.useNavigate();
   const clearSinceRun = (): void => {
-    void cadenceNavigate({ search: {} });
+    // validateSearch's return type makes `sinceRun` a required (if undefined)
+    // key, so `{}` doesn't typecheck — spell the cleared filter out.
+    void cadenceNavigate({ search: { sinceRun: undefined } });
   };
 
   const stop = useMutation({

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -10,7 +10,9 @@ export type CadenceStatus =
   | "completed"
   | "paused"
   /** Stopped by a hard bounce — the address is dead and is suppressed from further sends. */
-  | "bounced";
+  | "bounced"
+  /** Stopped by an explicit do-not-contact reply — the prospect is suppressed from further sends. */
+  | "unsubscribed";
 
 export interface CadenceNextStepDraft {
   subject: string;


### PR DESCRIPTION
Two errors were sitting in `cd apps/web && bunx tsc --noEmit` (outside root CI's tsconfig):

1. **Pre-existing**: `cadences.tsx` `clearSinceRun` passed `search: {}`, but `validateSearch`'s return type makes `sinceRun` a required-though-undefined key. Now passes `{ sinceRun: undefined }`.
2. **From #63**: the StepProgress tone compares `c.status === "unsubscribed"`, but shared-types `CadenceStatus` never gained the new status — added to the union.

`bunx tsc --noEmit` in apps/web is now completely clean; root typecheck/lint/fmt/tests all green (1963).

https://claude.ai/code/session_019SyPeo3U5zNxFaWHGF8ddp

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `apps/web` typechecking and add `"unsubscribed"` to `CadenceStatus`
> - In `CadencesPage.clearSinceRun`, the `navigate` call now passes `{ sinceRun: undefined }` instead of an empty search object to satisfy `validateSearch`'s typing requirement that the key exist even when cleared.
> - Adds `"unsubscribed"` as a new union member to the `CadenceStatus` type in [index.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/64/files#diff-8bfc1c4b53bda948594b3bcdeaead8e4c4130ad092154633bf858b7447c5d62f), representing an explicit do-not-contact reply that suppresses further sends.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ac206e3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->