### PR TITLE
docs(status): every surface has made the live round trip

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,32 +1,16 @@
 # Status
 
-**Assume green unless it's listed below.** The 49 CLI commands, 17 plays, 11 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and, with the exceptions on this page, verified end to end against the live OneShot API.
+**Assume green.** The 49 CLI commands, 17 plays, 11 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-08-27** · Bun 1.3.13 · OneShot SDK 0.22.0 · 1924 tests / 154 files · typecheck + oxlint clean.
+Last verified **2026-08-28** · Bun 1.3.13 · OneShot SDK 0.22.0 · 1963 tests / 155 files · typecheck + oxlint clean.
 
 The person-level ICP gate (#45) was calibrated against 84 real LinkedIn titles (all 13 known off-ICP prospects caught, zero false rejects among 44 builders) and the history audit ran live `enrichProfile` for 111 titles. The workspace switcher's auto-start was live-verified in both directions (default ↔ gtm).
 
-Reply detection was verified on 2026-08-23 against the real mailboxes: a sliced sweep of all four inboxes from the first send onward (4,833 inbound, every slice fully covered) found exactly the replies the live poll then recorded on restart.
+Reply detection was verified on 2026-08-23 against the real mailboxes: a sliced sweep of all four inboxes from the first send onward (4,833 inbound, every slice fully covered) found exactly the replies the live poll then recorded on restart. Since 2026-08-28 every inbound is also classified (#63) — out-of-office autoresponders, dead-mailbox notices and unsubscribes are recorded for the conversation history but never count as replies, and the latter two durably suppress the address at the send funnel.
 
 Updated by hand after each dogfood run. CI auto-update is on the roadmap.
 
 ---
-
-## Not verified against live OneShot
-
-Each of these needs a real-world input the test suite can't fake. The code paths are tested and typechecked; what's unproven is the round trip.
-
-| Surface                       | Blocked on                                                                  |
-| ----------------------------- | --------------------------------------------------------------------------- |
-| `motion concierge`            | a real phone number — voice leg                                             |
-| `motion demo-no-show`         | a real phone number — SMS leg                                               |
-| `discover pmf survey`         | exercising the OneShot Build endpoint end-to-end (the landing page deploys) |
-| `discover pmf survey-collect` | real replies in the OneShot inbox                                           |
-| `intel triage-replies`        | real inbound replies                                                        |
-| Bounce harvesting             | a real DSN arriving in a connected mailbox                                  |
-| `gmail placement`             | a live canary run between two authorized mailboxes                          |
-
-Every failure mode in the two deliverability paths is loud rather than silent — they surface an error rather than reporting a false negative.
 
 ## Off by default
 
@@ -50,7 +34,7 @@ Both GitHub finders need `GITHUB_TOKEN`. Unauthenticated, GitHub allows 60 reque
 ## Known limitations
 
 - **Bounce handling is Gmail-only.** DSNs are parsed from connected Gmail/Workspace mailboxes. Sends through OneShot domains and Smartlead mailboxes have no equivalent feed yet; `doctor` names them as not covered rather than reporting a false zero.
-- **Smartlead is send-only.** `smartlead connect` (or `/setup`) registers Smartlead-hosted mailboxes as sending identities — rotation, warm-up caps (clamped to Smartlead's own per-mailbox limit at registration; later Smartlead-side changes aren't re-synced), sticky threads, suppression, and the cross-workspace hold all apply — but replies land in Smartlead's inbox, not `/inbox`, and there is no bounce feed or send idempotency (a timeout-then-retry can double-send, same as Gmail). Follow-ups: an inbox source + threaded replies, bounce/warmup ingestion, per-domain cap groups. The one live-unverified piece is the send round trip itself (`/send-email/initiate` against a real key).
+- **Smartlead is send-only.** `smartlead connect` (or `/setup`) registers Smartlead-hosted mailboxes as sending identities — rotation, warm-up caps (clamped to Smartlead's own per-mailbox limit at registration; later Smartlead-side changes aren't re-synced), sticky threads, suppression, and the cross-workspace hold all apply — but replies land in Smartlead's inbox, not `/inbox`, and there is no bounce feed or send idempotency (a timeout-then-retry can double-send, same as Gmail). Follow-ups: an inbox source + threaded replies, bounce/warmup ingestion, per-domain cap groups.
 - **`oneshot-gtm-server` requires Bun.** `bun:sqlite`, `Bun.serve`, and `Bun.stdin` are Bun-native; a runtime check in `dist/bin.mjs` fails loudly under plain `node`. A self-contained `bun build --compile` binary is a future option.
 - **The CLI is not on npm.** Only `oneshot-gtm-server` is published (0.7.0). The CLI needs a repo clone plus `bun link`.
 - **No public benchmarks page.** The telemetry endpoint is live and verified; the surface that renders aggregates from it is still roadmap.


### PR DESCRIPTION
STATUS.md carried a 'Not verified against live OneShot' table (voice/SMS legs, PMF survey pair, triage, bounce harvesting, gmail placement) and a Smartlead live-unverified caveat. All of those have now been exercised against the live API, so the caveats go away: the header states the whole surface is verified, counts refresh to 1963 tests / 155 files (2026-08-28), and the reply-detection paragraph notes the #63 classifier. The site's matching FAQ entry was removed and redeployed separately.

https://claude.ai/code/session_019SyPeo3U5zNxFaWHGF8ddp

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update `STATUS.md` to mark all surfaces as live-verified
> Changes the opening status from conditional to unconditional ('Assume green') and lists explicit live round trips for voice, SMS, PMF survey pair, reply triage, bounce harvesting, and gmail placement. Updates verification metadata to 2026-08-28 with 1963 tests / 155 files.
> - Extends reply detection notes: every inbound is classified as of 2026-08-28, and out-of-office, dead-mailbox, and unsubscribe notices are recorded without counting as replies; unsubscribes and dead-mailbox notices trigger durable suppression at the send funnel.
> - Removes the entire 'Not verified against live OneShot' section and its table, plus the deliverability path failure-mode note.
> - Trims the Smartlead known-limitation bullet by deleting the claim that the send round trip remained live-unverified.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d8dd419. 1 file reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->