### PR TITLE
Ban the rhetorical moves that survive the word list

### DIFF
--- a/packages/prompts/_humanizer.md
+++ b/packages/prompts/_humanizer.md
@@ -204,6 +204,40 @@ These are chatbot artifacts pasted into output. Drop them.
 - Body length: aim for ≤80 words. Most plays cap at 80-100 words; longer drafts get flagged. PMF surveys are the exception (they cap at 200).
 - No Calendly URLs in body. The founder adds the scheduling link manually if relevant. Embedding it in a generated draft signals a bot.
 
+## Banned rhetorical moves (these survive a word ban)
+
+A model told not to write "delve" reaches for "here's the thing" instead. These are the
+tells that outlive a vocabulary list, and in a cold email each one reads as technique:
+
+- **False revelation.** "here's the thing", "what nobody tells you", "what's really going on".
+  You are promising a payoff in an 80-word email. There is no room to deliver it.
+- **Fake candour.** "let's be honest", "to be fair", "look,", "truth is". This repo already has
+  two real disarming moves — the anti-pitch open and the damaging admission — and both are
+  gated on being TRUE and sparing. A candour phrase with nothing behind it is the counterfeit
+  of those, and stacking it on either is the reader feeling handled.
+- **Shadowboxing.** "some might say", "you might be wondering", "I know what you're thinking".
+  The reader raised no objection. Answering one you invented makes the email about you.
+- **Announcing the point.** "let me explain why", "here's why that matters". Make the point.
+- **Formulaic sayings.** "at the end of the day", "make no mistake", "the bottom line is".
+- **Repeated sentence openings.** Three sentences starting on the same word reads as a template
+  filling itself in. Two is fine.
+- **Stacked dramatic fragments.** "Fast. Cheap. Done." One fragment lands. A run is a tic.
+- **Passive with no actor.** Name who did it. In outbound the actor is the whole point.
+- **Stacked qualifiers and hyphen chains.** "somewhat fairly consistently";
+  "community-governed on-chain multi-sig treasury-management layer".
+
+## What NOT to flag
+
+The linter runs post-generation, so a false positive costs a regenerate on copy that was fine.
+Do not treat any of these as a tell on its own:
+
+- One em dash, one short fragment, one "honestly" mid-sentence. The tell is the run, not the instance.
+- The deliberate lowercase subject line. That is the house register, not sloppiness.
+- The single planted typo from Proof-of-human. It is intentional; leave it.
+- A real concession from the `ADMISSION:` line. Fake candour is invented candour; a supplied
+  admission is a fact.
+- Short sentences generally. Terse is the voice.
+
 ## Voice rules
 
 - Have an opinion. Don't just neutrally report.


### PR DESCRIPTION
## What

`_humanizer.md` was built as a vocabulary ban. A model told not to write *delve* doesn't start writing plainly — it reaches for *here's the thing* instead. Those are the tells that now reach a prospect, and in an 80-word cold email each one reads as technique.

Adds nine constructions, tracking [blader/humanizer](https://github.com/blader/humanizer) v2.11.2:

| Move | Example |
|---|---|
| False revelation | "here's the thing", "what nobody tells you" |
| Fake candour | "let's be honest", "to be fair", "look," |
| Shadowboxing | "some might say", "you might be wondering" |
| Announcing the point | "let me explain why that matters" |
| Formulaic saying | "at the end of the day", "make no mistake" |
| Repeated sentence openings | three sentences starting on the same word |
| Stacked dramatic fragments | "Fast. Cheap. Done." |
| Actorless passive | name who did it |
| Stacked qualifiers / hyphen chains | "community-governed on-chain multi-sig treasury-management layer" |

## The one that needed care

Fake candour nearly collides with two moves this prompt already has. The **anti-pitch open** and the **damaging admission** are both real candour, both gated on being TRUE and sparing, and both earn their place. A candour phrase with nothing behind it is the counterfeit of those — so the ban names the counterfeit explicitly and points at the real ones rather than blanket-banning the register.

## New: "What NOT to flag"

`lintEmail()` runs post-generation, so a false positive costs a regenerate on copy that was fine. The new section exempts:

- one em dash, one short fragment, one mid-sentence "honestly" — the tell is the run, not the instance
- the deliberate lowercase subject line (house register, not sloppiness)
- the single planted typo from Proof-of-human
- any concession supplied by the `ADMISSION:` line
- short sentences generally — terse is the voice

## Test plan

- [x] `bun run test` — 1963 passed across 155 files
- [x] `packages/plays/__tests__/humanizer-coverage.test.ts` passes, so every lint rule still has its counterpart in the doc

## Deploy note

`packages/intel` caches the prompt in three module-level caches that are never invalidated (`humanizerPrologueCache`, `humanizerCache`, `promptCache`). CLI and cron runs exit per invocation and pick this up automatically; a long-lived `bun run ui` needs a restart to see it.

https://claude.ai/code/session_011Lkm62tX9xkTcttbd8QFoe

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add banned rhetorical moves and "What NOT to flag" sections to `_humanizer.md`
> Adds two guidance sections to the humanizer prompt: a list of rhetorical patterns that survive a word ban (false revelation, fake candour, shadowboxing, stacked fragments, passive with no actor, etc.) and a "What NOT to flag" list of acceptable single-instance patterns and house style items. Both sections include examples, rationale, and constraints for the post-generation linter.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3d9313a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->