### PR TITLE
fix: issue #72: feat(cli): find watch --install-service — generate launchd plist and systemd unit

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,48 @@ Two ICP gates run per candidate, not one. The **topic gate** judges the source �
 
 The dashboard server runs an in-process scheduler, so enabling a trigger is enough — no separate daemon. `find watch` stays useful for cron and headless boxes. Approved rows ship via the **Drain** button or `find drain <play>`.
 
+### Background monitoring as a service
+
+`find watch --install-service` generates a service file that keeps the watch daemon running in the background — a launchd user agent on macOS, a systemd user unit on Linux. It prints to stdout (redirect-friendly); add `--write` to drop it at the platform-conventional path. Every path is embedded absolute at generation time — the bun binary, the CLI entry, and the active `ONESHOT_GTM_HOME` (so `--workspace acme find watch --install-service` pins the service to that workspace) — because service managers don't source your shell profile. Regenerate with `--write` after moving bun or the checkout.
+
+**macOS (launchd).** Logs go to `<home>/find-watch.log`; the agent restarts on crash and survives reboots.
+
+```bash
+oneshot-gtm find watch --install-service            # inspect the plist
+oneshot-gtm find watch --install-service --write    # → ~/Library/LaunchAgents/com.oneshot-gtm.find-watch.plist
+launchctl load ~/Library/LaunchAgents/com.oneshot-gtm.find-watch.plist
+
+# uninstall
+launchctl unload ~/Library/LaunchAgents/com.oneshot-gtm.find-watch.plist
+rm ~/Library/LaunchAgents/com.oneshot-gtm.find-watch.plist
+```
+
+**Linux (systemd user unit).** Logs go to the user journal: `journalctl --user -u oneshot-gtm-find-watch`.
+
+```bash
+oneshot-gtm find watch --install-service --write    # → ~/.config/systemd/user/oneshot-gtm-find-watch.service
+systemctl --user daemon-reload
+systemctl --user enable --now oneshot-gtm-find-watch
+
+# uninstall
+systemctl --user disable --now oneshot-gtm-find-watch
+rm ~/.config/systemd/user/oneshot-gtm-find-watch.service
+```
+
+On a headless box, also run `loginctl enable-linger $USER` once so the user unit starts at boot rather than at first login.
+
+**Windows (Task Scheduler).** There's no user-service template; schedule the cron-style `find watch --once` instead, which runs all due triggers and exits:
+
+```powershell
+schtasks /Create /TN "oneshot-gtm find watch" /SC MINUTE /MO 15 `
+  /TR "\"C:\Users\you\.bun\bin\bun.exe\" \"C:\path\to\oneshot-gtm\apps\cli\src\main.ts\" find watch --once --quiet"
+
+# uninstall
+schtasks /Delete /TN "oneshot-gtm find watch" /F
+```
+
+The classic cron route works the same way on any platform: `*/15 * * * * ONESHOT_GTM_HOME=$HOME/.oneshot-gtm /path/to/bun /path/to/apps/cli/src/main.ts find watch --once --quiet`.
+
 ### The plays
 
 Seventeen of them. Ten have a **Run** page in the dashboard and drain from the queue:

--- a/apps/cli/__tests__/__snapshots__/install-service.test.ts.snap
+++ b/apps/cli/__tests__/__snapshots__/install-service.test.ts.snap
@@ -1,0 +1,57 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`renderLaunchdPlist > matches the template snapshot 1`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.oneshot-gtm.find-watch</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/homebrew/bin/bun</string>
+    <string>/Users/jo/oneshot-gtm/apps/cli/src/main.ts</string>
+    <string>find</string>
+    <string>watch</string>
+    <string>--quiet</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>ONESHOT_GTM_HOME</key>
+    <string>/Users/jo/.oneshot-gtm</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/bin:/bin</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>/Users/jo/.oneshot-gtm/find-watch.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/jo/.oneshot-gtm/find-watch.log</string>
+</dict>
+</plist>
+"
+`;
+
+exports[`renderSystemdUnit > matches the template snapshot 1`] = `
+"[Unit]
+Description=oneshot-gtm find watch — poll registered triggers and enqueue candidates
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart="/opt/homebrew/bin/bun" "/Users/jo/oneshot-gtm/apps/cli/src/main.ts" find watch --quiet
+Environment="ONESHOT_GTM_HOME=/Users/jo/.oneshot-gtm"
+Environment="PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=default.target
+"
+`;

--- a/apps/cli/__tests__/install-service.test.ts
+++ b/apps/cli/__tests__/install-service.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import {
+  activationHint,
+  LAUNCHD_LABEL,
+  renderLaunchdPlist,
+  renderSystemdUnit,
+  resolveServicePaths,
+  serviceWritePath,
+  SYSTEMD_UNIT,
+} from "../src/commands/install-service.ts";
+
+// Fixed fake paths: snapshots must not depend on the machine running the
+// suite. These tests only render strings — they NEVER touch launchctl,
+// systemctl, or any real service path.
+const PATHS = {
+  bunBin: "/opt/homebrew/bin/bun",
+  cliEntry: "/Users/jo/oneshot-gtm/apps/cli/src/main.ts",
+  home: "/Users/jo/.oneshot-gtm",
+};
+
+describe("renderLaunchdPlist", () => {
+  it("matches the template snapshot", () => {
+    expect(renderLaunchdPlist(PATHS)).toMatchSnapshot();
+  });
+
+  it("embeds every path absolute and unquoted (launchd execs the argv vector, no shell)", () => {
+    const plist = renderLaunchdPlist(PATHS);
+    expect(plist).toContain("<string>/opt/homebrew/bin/bun</string>");
+    expect(plist).toContain("<string>/Users/jo/oneshot-gtm/apps/cli/src/main.ts</string>");
+    expect(plist).toContain("<string>/Users/jo/.oneshot-gtm</string>");
+    // PATH must carry bun's own dir — launchd doesn't source a login shell.
+    expect(plist).toContain("<string>/opt/homebrew/bin:/usr/bin:/bin</string>");
+  });
+
+  it("XML-escapes paths so a checkout named e.g. `a&b` still yields a valid plist", () => {
+    const plist = renderLaunchdPlist({ ...PATHS, home: "/Users/jo/a&b/<gtm>" });
+    expect(plist).toContain("<string>/Users/jo/a&amp;b/&lt;gtm&gt;</string>");
+    expect(plist).not.toContain("<gtm>");
+  });
+});
+
+describe("renderSystemdUnit", () => {
+  it("matches the template snapshot", () => {
+    expect(renderSystemdUnit(PATHS)).toMatchSnapshot();
+  });
+
+  it("quotes ExecStart arguments and the environment so paths with spaces survive", () => {
+    const unit = renderSystemdUnit({
+      ...PATHS,
+      bunBin: "/home/jo/my tools/bun",
+      home: "/home/jo/gtm home",
+    });
+    expect(unit).toContain(
+      'ExecStart="/home/jo/my tools/bun" "/Users/jo/oneshot-gtm/apps/cli/src/main.ts" find watch --quiet',
+    );
+    expect(unit).toContain('Environment="ONESHOT_GTM_HOME=/home/jo/gtm home"');
+  });
+});
+
+describe("serviceWritePath", () => {
+  it("targets ~/Library/LaunchAgents on macOS and ~/.config/systemd/user on Linux", () => {
+    expect(serviceWritePath("darwin", "/Users/jo")).toBe(
+      `/Users/jo/Library/LaunchAgents/${LAUNCHD_LABEL}.plist`,
+    );
+    expect(serviceWritePath("linux", "/home/jo")).toBe(
+      `/home/jo/.config/systemd/user/${SYSTEMD_UNIT}`,
+    );
+  });
+
+  it("has no target on Windows (Task Scheduler route is docs-only)", () => {
+    expect(serviceWritePath("win32", "C:\\Users\\jo")).toBeNull();
+  });
+});
+
+describe("activationHint", () => {
+  it("covers install and uninstall on both platforms", () => {
+    const mac = activationHint("darwin", "/Users/jo/Library/LaunchAgents/x.plist").join("\n");
+    expect(mac).toContain("launchctl load");
+    expect(mac).toContain("launchctl unload");
+    const linux = activationHint("linux", `/home/jo/.config/systemd/user/${SYSTEMD_UNIT}`).join(
+      "\n",
+    );
+    expect(linux).toContain("systemctl --user enable --now");
+    expect(linux).toContain("systemctl --user disable --now");
+  });
+});
+
+describe("resolveServicePaths", () => {
+  it("resolves absolute paths for bun, the CLI entry, and the home", () => {
+    const p = resolveServicePaths();
+    expect(p.bunBin.startsWith("/")).toBe(true);
+    expect(p.cliEntry.endsWith("/apps/cli/src/main.ts")).toBe(true);
+    expect(p.cliEntry.startsWith("/")).toBe(true);
+    // Under vitest this is the throwaway temp home from vitest.setup.ts —
+    // the point is that it's absolute and flows into the template verbatim.
+    expect(p.home.startsWith("/")).toBe(true);
+    expect(typeof p.home).toBe("string");
+  });
+});

--- a/apps/cli/src/commands/install-service.ts
+++ b/apps/cli/src/commands/install-service.ts
@@ -1,0 +1,167 @@
+/**
+ * `find watch --install-service` — emit a service file that keeps the watch
+ * daemon running in the background: a launchd user agent on macOS, a systemd
+ * user unit on Linux. Pure templating over paths resolved at generation time
+ * (bun binary, CLI entry, ONESHOT_GTM_HOME) — service managers don't inherit
+ * a shell, so nothing here may rely on $PATH or a login profile. Windows has
+ * no user-service equivalent; the README covers the schtasks + `--once` route.
+ */
+import { mkdirSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { configDir } from "@oneshot-gtm/core";
+import { bail, c, note, ok } from "../output.ts";
+
+export const LAUNCHD_LABEL = "com.oneshot-gtm.find-watch";
+export const SYSTEMD_UNIT = "oneshot-gtm-find-watch.service";
+
+/** Every absolute path a service file embeds. Explicit so tests can pin them. */
+export interface ServicePaths {
+  /** Absolute path to the bun binary that will run the daemon. */
+  bunBin: string;
+  /** Absolute path to the CLI entry (apps/cli/src/main.ts). */
+  cliEntry: string;
+  /** The workspace home the daemon is bound to (ONESHOT_GTM_HOME). */
+  home: string;
+}
+
+export function resolveServicePaths(): ServicePaths {
+  return {
+    bunBin: process.execPath,
+    cliEntry: fileURLToPath(new URL("../main.ts", import.meta.url)),
+    home: configDir(),
+  };
+}
+
+/**
+ * launchd runs the ProgramArguments vector directly (no shell), so every path
+ * is a separate <string> and needs XML escaping only — never shell quoting.
+ * KeepAlive.SuccessfulExit=false restarts crashes but respects a clean
+ * SIGTERM shutdown; logs land in the workspace home next to events.jsonl.
+ */
+export function renderLaunchdPlist(p: ServicePaths): string {
+  const log = join(p.home, "find-watch.log");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LAUNCHD_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${xml(p.bunBin)}</string>
+    <string>${xml(p.cliEntry)}</string>
+    <string>find</string>
+    <string>watch</string>
+    <string>--quiet</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>ONESHOT_GTM_HOME</key>
+    <string>${xml(p.home)}</string>
+    <key>PATH</key>
+    <string>${xml(dirname(p.bunBin))}:/usr/bin:/bin</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>${xml(log)}</string>
+  <key>StandardErrorPath</key>
+  <string>${xml(log)}</string>
+</dict>
+</plist>
+`;
+}
+
+/**
+ * systemd user unit. ExecStart arguments are double-quoted so a home or
+ * checkout path with spaces survives systemd's own word splitting; stdout and
+ * stderr go to the user journal (`journalctl --user -u oneshot-gtm-find-watch`).
+ */
+export function renderSystemdUnit(p: ServicePaths): string {
+  return `[Unit]
+Description=oneshot-gtm find watch — poll registered triggers and enqueue candidates
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart="${p.bunBin}" "${p.cliEntry}" find watch --quiet
+Environment="ONESHOT_GTM_HOME=${p.home}"
+Environment="PATH=${dirname(p.bunBin)}:/usr/local/bin:/usr/bin:/bin"
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=default.target
+`;
+}
+
+/** Platform-conventional install path for `--write`, per-user (no root). */
+export function serviceWritePath(platform: NodeJS.Platform, userHome: string): string | null {
+  if (platform === "darwin")
+    return join(userHome, "Library", "LaunchAgents", `${LAUNCHD_LABEL}.plist`);
+  if (platform === "linux") return join(userHome, ".config", "systemd", "user", SYSTEMD_UNIT);
+  return null;
+}
+
+/** Post-install commands, shown after `--write` (and in the README). */
+export function activationHint(platform: NodeJS.Platform, writePath: string): string[] {
+  if (platform === "darwin") {
+    return [
+      `launchctl load ${writePath}`,
+      `# uninstall: launchctl unload ${writePath} && rm ${writePath}`,
+    ];
+  }
+  return [
+    "systemctl --user daemon-reload",
+    `systemctl --user enable --now ${SYSTEMD_UNIT}`,
+    `# uninstall: systemctl --user disable --now ${SYSTEMD_UNIT} && rm ${writePath}`,
+  ];
+}
+
+export async function commandInstallService(opts: { write: boolean }): Promise<void> {
+  const platform = process.platform;
+  if (platform !== "darwin" && platform !== "linux") {
+    bail(
+      `no service template for platform "${platform}". On Windows, schedule \`find watch --once\` ` +
+        "with Task Scheduler — see README § Background monitoring as a service.",
+    );
+  }
+  const paths = resolveServicePaths();
+  const content = platform === "darwin" ? renderLaunchdPlist(paths) : renderSystemdUnit(paths);
+  const target = serviceWritePath(platform, homedir());
+  if (!target) bail(`no conventional service path for platform "${platform}"`);
+
+  if (!opts.write) {
+    // Template only on stdout so `> file` redirection stays clean; the
+    // human-facing hints go to stderr.
+    process.stdout.write(content);
+    process.stderr.write(
+      `\n${c.dim(`Write it to the conventional path with --write (${target}), then:`)}\n` +
+        activationHint(platform, target)
+          .map((l) => c.dim(`  ${l}`))
+          .join("\n") +
+        "\n",
+    );
+    return;
+  }
+
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, content, { mode: 0o644 });
+  ok(`wrote ${target}`);
+  note("Activate it with:");
+  for (const line of activationHint(platform, target)) note(`  ${line}`);
+  note(
+    "Paths are embedded absolute — re-run --install-service --write after moving bun or the checkout.",
+  );
+}
+
+function xml(s: string): string {
+  return s.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;");
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -6,7 +6,7 @@ import {
   takeMarkedOutcome,
   type TelemetryOutcome,
 } from "@oneshot-gtm/core";
-import { CommandExit, fail } from "./output.ts";
+import { bail, CommandExit, fail } from "./output.ts";
 import { extractInvocation, type Invocation } from "./dispatch.ts";
 import { runInit } from "./commands/init.ts";
 import {
@@ -63,6 +63,7 @@ import {
 } from "./commands/workspace.ts";
 import { commandEnrichLinkedIn } from "./commands/enrich-linkedin.ts";
 import { commandFindDrain, commandFindWatch } from "./commands/find.ts";
+import { commandInstallService } from "./commands/install-service.ts";
 import {
   commandMotionBreakupRevive,
   commandMotionCompetitorSwitch,
@@ -297,10 +298,24 @@ find
   .command("watch")
   .option("--once", "run all due triggers once and exit (cron-friendly)", false)
   .option("--quiet", "log summary only, not per-trigger details", false)
+  .option(
+    "--install-service",
+    "print a launchd plist (macOS) / systemd user unit (Linux) that runs this daemon; doesn't start watching",
+    false,
+  )
+  .option(
+    "--write",
+    "with --install-service: write the file to the platform-conventional path instead of stdout",
+    false,
+  )
   .description("Daemon: continuously poll registered triggers and enqueue new candidates")
   .action(
-    runOrFail((opts: { once: boolean; quiet: boolean }) =>
-      commandFindWatch({ once: opts.once, quiet: opts.quiet }),
+    runOrFail(
+      (opts: { once: boolean; quiet: boolean; installService: boolean; write: boolean }) => {
+        if (opts.installService) return commandInstallService({ write: opts.write });
+        if (opts.write) bail("--write only makes sense with --install-service");
+        return commandFindWatch({ once: opts.once, quiet: opts.quiet });
+      },
     ),
   );
 find


### PR DESCRIPTION
Closes #72.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base fail (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--install-service` flag to `find watch` for launchd plist and systemd unit generation
> - Adds `commandInstallService` in [install-service.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/80/files#diff-2c6340b0537d178d21d72bdf474adf181c51f04425c97afd6dd920091eaea2e3) which resolves absolute paths for `bunBin`, `cliEntry`, and `home`, then renders a macOS launchd plist via `renderLaunchdPlist` or a Linux systemd user unit via `renderSystemdUnit`.
> - Extends the `find watch` command in [index.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/80/files#diff-4565ec586fe8103913bc7f7abc9b548cb8f4d8403669752a5f10874118093bce) with `--install-service` and `--write` options; `--write` without `--install-service` bails with an error.
> - Without `--write`, prints the generated file to stdout and activation hints to stderr. With `--write`, writes the file (mode 0644) to `~/Library/LaunchAgents/` (macOS) or `~/.config/systemd/user/` (Linux) and prints activation/uninstall commands.
> - Unsupported platforms (e.g. Windows) bail with guidance to use `--once` via Task Scheduler.
> - Risk: generated files embed `process.execPath` and a resolved `main.ts` path; if the bun binary or CLI entry moves after install, the service definition breaks silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 5d337d1. 3 files reviewed, 6 issues evaluated, 0 issues filtered, 6 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->