### PR TITLE
fix: issue #77: fix(intel): retry and time-bound `complete()` LLM calls

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,7 +41,7 @@ The verify gate has holes an agent can close without touching product behaviour.
 
 ## Reliability
 
-- [ ] **Retry and time-bound LLM calls** · M — `complete()` in `packages/intel/src/client.ts` issues one `fetch` with no `AbortSignal` and no retry. A 429 or a 503 from OpenRouter partway through a 50-target drain throws and takes the batch with it.
+- [x] **Retry and time-bound LLM calls** · M — `complete()` in `packages/intel/src/client.ts` issues one `fetch` with no `AbortSignal` and no retry. A 429 or a 503 from OpenRouter partway through a 50-target drain throws and takes the batch with it.
       _Done when:_ 429/5xx/network errors retry with bounded exponential backoff and jitter, honouring `Retry-After` when present; a per-request timeout aborts and counts as retryable; retries and the final give-up are logged as `llm.retry` / `llm.error`; 4xx other than 429 never retries; all covered by fake-timer tests with no real network.
 - [ ] **Rotate `events.jsonl`** · S — `logEvent` in `packages/core/src/events.ts` calls `appendFileSync` with no size cap. A long-running install grows the file until the disk complains, and the README tells people to `tail -f` it.
       _Done when:_ the log rolls to `events.1.jsonl` past a configurable byte ceiling, keeps a bounded number of generations, and rotation failure still drops the event silently rather than throwing at the caller.

--- a/packages/intel/__tests__/retry.test.ts
+++ b/packages/intel/__tests__/retry.test.ts
@@ -493,4 +493,118 @@ describe("complete() retry integration", () => {
     expect(error.name).toBe("LlmError");
     expect(attemptCount).toBe(1);
   });
+
+  it("does NOT abort or retry slow calls when no explicit timeoutMs is provided", async () => {
+    const { complete } = await import("../src/client.ts");
+
+    // Regression fix: before the fix, a 90s default timeout applied to every
+    // call site, so a slow legitimate generation was aborted, retried, and failed.
+    // Now, no timeoutMs = no client-side abort = preserves existing behavior.
+    let attemptCount = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      attemptCount++;
+      // Simulate a slow response (e.g., strategist with maxTokens: 4096 on reasoning model)
+      // that completes after 100 seconds — longer than the old 90s default.
+      return new Promise((resolve) => {
+        setTimeout(() => {
+          resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                choices: [{ message: { content: "slow but valid" }, finish_reason: "stop" }],
+              }),
+          });
+        }, 100_000);
+      });
+    }) as any;
+
+    const promise = complete({
+      messages: [{ role: "user", content: "test" }],
+      maxAttempts: 3,
+      // No timeoutMs — should wait indefinitely
+    });
+
+    // Advance past the old 90s default that would have aborted
+    await vi.advanceTimersByTimeAsync(95_000);
+    expect(attemptCount).toBe(1); // Still waiting on first attempt
+
+    // Complete the slow response
+    await vi.advanceTimersByTimeAsync(10_000);
+    await vi.runAllTimersAsync();
+
+    const result = await promise;
+    expect(result.content).toBe("slow but valid");
+    expect(attemptCount).toBe(1); // Exactly one attempt, no retry
+  });
+
+  it("retries OpenRouter 200 + {error:{code:429}} and stops on non-numeric codes", async () => {
+    const { complete } = await import("../src/client.ts");
+
+    // Finding 2: OpenRouter returns 200 with an error envelope for upstream faults.
+    // Numeric codes (429, 5xx) should be retried; non-numeric/absent codes are terminal.
+    let attemptCount = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      attemptCount++;
+      if (attemptCount === 1) {
+        // First call: 200 + {error:{code:429}} — should retry
+        return Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              error: { code: 429, message: "rate limited" },
+            }),
+        });
+      }
+      // Second call: success
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            choices: [{ message: { content: "recovered" }, finish_reason: "stop" }],
+          }),
+      });
+    }) as any;
+
+    const promise = complete({
+      messages: [{ role: "user", content: "test" }],
+      maxAttempts: 3,
+    });
+
+    await vi.runAllTimersAsync();
+
+    const result = await promise;
+    expect(result.content).toBe("recovered");
+    expect(attemptCount).toBe(2); // Retried once
+  });
+
+  it("does NOT retry OpenRouter 200 + {error:{code:'INVALID_KEY'}} — non-numeric is terminal", async () => {
+    const { complete } = await import("../src/client.ts");
+
+    let attemptCount = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      attemptCount++;
+      // 200 + non-numeric error code — should NOT retry
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            error: { code: "INVALID_KEY", message: "authentication failed" },
+          }),
+      });
+    }) as any;
+
+    const promise = complete({
+      messages: [{ role: "user", content: "test" }],
+      maxAttempts: 3,
+    });
+    const rejection = promise.catch((err) => err);
+
+    await vi.runAllTimersAsync();
+
+    const error = await rejection;
+    expect(error.message).toContain("error envelope");
+    expect(error.message).toContain("INVALID_KEY");
+    expect(error.status).toBeUndefined(); // Non-numeric code = no status
+    expect(attemptCount).toBe(1); // No retry
+  });
 });

--- a/packages/intel/__tests__/retry.test.ts
+++ b/packages/intel/__tests__/retry.test.ts
@@ -2,9 +2,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { backoffDelayMs, isRetryableLlmError, parseRetryAfter } from "../src/client.ts";
 
 describe("isRetryableLlmError", () => {
-  it("retries generic Error (network/DNS failures)", () => {
-    expect(isRetryableLlmError(new Error("network error"))).toBe(true);
-    expect(isRetryableLlmError(new TypeError("fetch failed"))).toBe(true);
+  it("does NOT retry a bare Error — only the classified set is retryable", () => {
+    // A TypeError here is a property access on a malformed body, not a socket
+    // failure; postJson raises a classified error for the ones worth repeating.
+    expect(isRetryableLlmError(new Error("network error"))).toBe(false);
+    expect(isRetryableLlmError(new TypeError("Cannot read properties of undefined"))).toBe(false);
+  });
+
+  it("does NOT retry non-Error throws", () => {
+    expect(isRetryableLlmError("boom")).toBe(false);
+    expect(isRetryableLlmError(undefined)).toBe(false);
   });
 });
 
@@ -30,9 +37,12 @@ describe("parseRetryAfter", () => {
     expect(parseRetryAfter(null, NOW)).toBeUndefined();
   });
 
-  it("clamps past dates to zero", () => {
+  it("clamps past dates to zero, and the backoff floor keeps them paced", () => {
     const pastDate = "Fri, 29 Aug 2026 09:59:00 GMT";
-    expect(parseRetryAfter(pastDate, NOW)).toBe(0);
+    const parsed = parseRetryAfter(pastDate, NOW);
+    expect(parsed).toBe(0);
+    // Parsing yields 0, but the honoured delay is never 0 — see the floor test.
+    expect(backoffDelayMs(1, parsed, () => 0.5)).toBe(375);
   });
 });
 
@@ -40,6 +50,19 @@ describe("backoffDelayMs", () => {
   it("honors Retry-After when provided", () => {
     expect(backoffDelayMs(1, 5000)).toBe(5000);
     expect(backoffDelayMs(3, 10_000)).toBe(10_000);
+  });
+
+  it("floors Retry-After at the exponential backoff", () => {
+    const fixed = () => 0.5;
+
+    // Retry-After: 0 and a past HTTP-date both parse to 0. Honouring them
+    // literally would fire every attempt within milliseconds, unpaced.
+    expect(backoffDelayMs(1, 0, fixed)).toBe(375);
+    expect(backoffDelayMs(3, 0, fixed)).toBe(1500);
+
+    // A hint shorter than our own backoff is raised to it; a longer one wins.
+    expect(backoffDelayMs(3, 100, fixed)).toBe(1500);
+    expect(backoffDelayMs(3, 9000, fixed)).toBe(9000);
   });
 
   it("caps Retry-After at MAX_RETRY_AFTER_MS (60s)", () => {
@@ -89,8 +112,10 @@ describe("backoffDelayMs", () => {
 describe("complete() retry integration", () => {
   beforeEach(() => {
     vi.useFakeTimers();
+    // ONESHOT_GTM_HOME is not stubbed here: config.ts captures CONFIG_DIR at
+    // module load, so a stub set now would do nothing. vitest.setup.ts already
+    // points the whole suite at a temp data dir before any module loads.
     vi.stubEnv("OPENROUTER_API_KEY", "test-key");
-    vi.stubEnv("ONESHOT_GTM_HOME", "/tmp/test-home");
   });
 
   afterEach(() => {
@@ -294,5 +319,178 @@ describe("complete() retry integration", () => {
     const result = await promise;
     expect(result.content).toBe("success after timeout");
     expect(attemptCount).toBe(2);
+  });
+
+  it("does NOT retry a 200 whose message carries no text content", async () => {
+    const { complete } = await import("../src/client.ts");
+
+    // Finding 1: a refusal / tool-call-only message is an already-billed
+    // success. Reading .length off its null content used to throw INSIDE the
+    // retry try, so the paid-for response was discarded and the prompt re-sent.
+    let attemptCount = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      attemptCount++;
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            choices: [{ message: { content: null }, finish_reason: "tool_calls" }],
+          }),
+      });
+    }) as any;
+
+    const promise = complete({
+      messages: [{ role: "user", content: "test" }],
+      maxAttempts: 3,
+    });
+    const rejection = promise.catch((err) => err);
+
+    await vi.runAllTimersAsync();
+
+    const error = await rejection;
+    expect(error).toBeInstanceOf(Error);
+    expect(error.message).toContain("no text content");
+    // The provider signal is named, so the failure is diagnosable.
+    expect(error.message).toContain("tool_calls");
+    expect(attemptCount).toBe(1);
+  });
+
+  it("does NOT retry a 200 error envelope with no choices", async () => {
+    const { complete } = await import("../src/client.ts");
+
+    // OpenRouter reports upstream faults with 200 + an error envelope. Touching
+    // data.choices[0] on it throws a bare TypeError, which used to be retryable.
+    let attemptCount = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      attemptCount++;
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ error: { message: "upstream is unhappy", code: 502 } }),
+      });
+    }) as any;
+
+    const promise = complete({
+      messages: [{ role: "user", content: "test" }],
+      maxAttempts: 3,
+    });
+    const rejection = promise.catch((err) => err);
+
+    await vi.runAllTimersAsync();
+
+    const error = await rejection;
+    expect(error.message).toContain("upstream is unhappy");
+    expect(attemptCount).toBe(1);
+  });
+
+  it("does NOT retry a status-less truncation error", async () => {
+    const { complete } = await import("../src/client.ts");
+
+    // Finding 5: a truncated response reproduces exactly on a resend, so
+    // retrying it just triples the bill for the same unusable output.
+    let attemptCount = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      attemptCount++;
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            choices: [{ message: { content: "half a js" }, finish_reason: "length" }],
+          }),
+      });
+    }) as any;
+
+    const promise = complete({
+      messages: [{ role: "user", content: "test" }],
+      maxTokens: 16,
+      maxAttempts: 3,
+    });
+    const rejection = promise.catch((err) => err);
+
+    await vi.runAllTimersAsync();
+
+    const error = await rejection;
+    expect(error.message).toContain("truncated at max_tokens=16");
+    expect(error.status).toBeUndefined();
+    expect(attemptCount).toBe(1);
+  });
+
+  it("waits at least the exponential backoff when Retry-After is 0", async () => {
+    const { complete } = await import("../src/client.ts");
+
+    // Finding 2: Retry-After: 0 (and past HTTP-dates, which parse to 0) must not
+    // collapse the pacing — the honoured delay is floored at our own backoff.
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+    let attemptCount = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      attemptCount++;
+      if (attemptCount === 1) {
+        return Promise.resolve({
+          ok: false,
+          status: 429,
+          headers: new Headers({ "retry-after": "0" }),
+          text: () => Promise.resolve("rate limited"),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            choices: [{ message: { content: "paced" }, finish_reason: "stop" }],
+          }),
+      });
+    }) as any;
+
+    const promise = complete({
+      messages: [{ role: "user", content: "test" }],
+      maxAttempts: 3,
+    });
+
+    // Attempt 1's backoff is 500/2 + 0.5 * 250 = 375ms. One tick short of it,
+    // the retry must not have fired yet.
+    await vi.advanceTimersByTimeAsync(374);
+    expect(attemptCount).toBe(1);
+
+    await vi.runAllTimersAsync();
+
+    const result = await promise;
+    expect(result.content).toBe("paced");
+    expect(attemptCount).toBe(2);
+  });
+
+  it("keeps a 400 non-retryable when the timeout fires while reading its body", async () => {
+    const { complete } = await import("../src/client.ts");
+
+    // Finding 4: the status is already known, so it decides. Laundering this
+    // into a timeout would make a permanent bad request retry three times.
+    let attemptCount = 0;
+    global.fetch = vi.fn().mockImplementation((_url: string, options: any) => {
+      attemptCount++;
+      return Promise.resolve({
+        ok: false,
+        status: 400,
+        headers: new Headers(),
+        // The error body never arrives; the per-request abort fires mid-read.
+        text: () =>
+          new Promise((_resolve, reject) => {
+            options.signal?.addEventListener("abort", () => reject(new Error("aborted")));
+          }),
+      });
+    }) as any;
+
+    const promise = complete({
+      messages: [{ role: "user", content: "test" }],
+      timeoutMs: 1000,
+      maxAttempts: 3,
+    });
+    const rejection = promise.catch((err) => err);
+
+    await vi.advanceTimersByTimeAsync(1100);
+    await vi.runAllTimersAsync();
+
+    const error = await rejection;
+    expect(error).toMatchObject({ status: 400 });
+    expect(error.name).toBe("LlmError");
+    expect(attemptCount).toBe(1);
   });
 });

--- a/packages/intel/__tests__/retry.test.ts
+++ b/packages/intel/__tests__/retry.test.ts
@@ -1,0 +1,297 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { backoffDelayMs, isRetryableLlmError, parseRetryAfter } from "../src/client.ts";
+
+describe("isRetryableLlmError", () => {
+  it("retries generic Error (network/DNS failures)", () => {
+    expect(isRetryableLlmError(new Error("network error"))).toBe(true);
+    expect(isRetryableLlmError(new TypeError("fetch failed"))).toBe(true);
+  });
+});
+
+describe("parseRetryAfter", () => {
+  const NOW = Date.parse("2026-08-29T10:00:00Z");
+
+  it("parses delta-seconds", () => {
+    expect(parseRetryAfter("30", NOW)).toBe(30_000);
+    expect(parseRetryAfter("  60  ", NOW)).toBe(60_000);
+  });
+
+  it("parses HTTP-date", () => {
+    const futureDate = "Fri, 29 Aug 2026 10:01:00 GMT";
+    expect(parseRetryAfter(futureDate, NOW)).toBe(60_000);
+  });
+
+  it("returns undefined for unparseable input", () => {
+    expect(parseRetryAfter("invalid", NOW)).toBeUndefined();
+    expect(parseRetryAfter("not-a-number", NOW)).toBeUndefined();
+  });
+
+  it("returns undefined for null", () => {
+    expect(parseRetryAfter(null, NOW)).toBeUndefined();
+  });
+
+  it("clamps past dates to zero", () => {
+    const pastDate = "Fri, 29 Aug 2026 09:59:00 GMT";
+    expect(parseRetryAfter(pastDate, NOW)).toBe(0);
+  });
+});
+
+describe("backoffDelayMs", () => {
+  it("honors Retry-After when provided", () => {
+    expect(backoffDelayMs(1, 5000)).toBe(5000);
+    expect(backoffDelayMs(3, 10_000)).toBe(10_000);
+  });
+
+  it("caps Retry-After at MAX_RETRY_AFTER_MS (60s)", () => {
+    expect(backoffDelayMs(1, 120_000)).toBe(60_000);
+    expect(backoffDelayMs(1, 900_000)).toBe(60_000);
+  });
+
+  it("uses exponential backoff without Retry-After", () => {
+    const fixed = () => 0.5;
+
+    // Attempt 1: 500 * 2^0 = 500, half fixed (250) + half jitter (250 * 0.5 = 125) = 375
+    expect(backoffDelayMs(1, undefined, fixed)).toBe(375);
+
+    // Attempt 2: 500 * 2^1 = 1000, 500 + 250 = 750
+    expect(backoffDelayMs(2, undefined, fixed)).toBe(750);
+
+    // Attempt 3: 500 * 2^2 = 2000, 1000 + 500 = 1500
+    expect(backoffDelayMs(3, undefined, fixed)).toBe(1500);
+  });
+
+  it("caps backoff at MAX_DELAY_MS (20s)", () => {
+    const fixed = () => 0.5;
+
+    // Attempt 10: 500 * 2^9 = 256000 > 20000, capped to 20000, 10000 + 5000 = 15000
+    expect(backoffDelayMs(10, undefined, fixed)).toBe(15_000);
+  });
+
+  it("adds jitter to prevent thundering herd", () => {
+    const delays = new Set<number>();
+    for (let i = 0; i < 20; i++) {
+      delays.add(backoffDelayMs(1));
+    }
+    // With random jitter, we should get different delays
+    expect(delays.size).toBeGreaterThan(1);
+  });
+
+  it("jitter is bounded correctly", () => {
+    // For attempt 1, base is 500, so delay should be [250, 500]
+    for (let i = 0; i < 50; i++) {
+      const delay = backoffDelayMs(1);
+      expect(delay).toBeGreaterThanOrEqual(250);
+      expect(delay).toBeLessThanOrEqual(500);
+    }
+  });
+});
+
+describe("complete() retry integration", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+    vi.stubEnv("ONESHOT_GTM_HOME", "/tmp/test-home");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
+
+  it("retries 429 with backoff and succeeds on second attempt", async () => {
+    const { complete } = await import("../src/client.ts");
+
+    let attemptCount = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      attemptCount++;
+      if (attemptCount === 1) {
+        return Promise.resolve({
+          ok: false,
+          status: 429,
+          headers: new Headers({ "retry-after": "2" }),
+          text: () => Promise.resolve("rate limited"),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            choices: [{ message: { content: "success" }, finish_reason: "stop" }],
+          }),
+      });
+    }) as any;
+
+    const promise = complete({
+      messages: [{ role: "user", content: "test" }],
+      maxAttempts: 3,
+    });
+
+    // Fast-forward through the retry delay
+    await vi.runAllTimersAsync();
+
+    const result = await promise;
+    expect(result.content).toBe("success");
+    expect(attemptCount).toBe(2);
+  });
+
+  it("retries 5xx errors and succeeds on third attempt", async () => {
+    const { complete } = await import("../src/client.ts");
+
+    let attemptCount = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      attemptCount++;
+      if (attemptCount <= 2) {
+        return Promise.resolve({
+          ok: false,
+          status: 503,
+          headers: new Headers(),
+          text: () => Promise.resolve("service unavailable"),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            choices: [{ message: { content: "recovered" }, finish_reason: "stop" }],
+          }),
+      });
+    }) as any;
+
+    const promise = complete({
+      messages: [{ role: "user", content: "test" }],
+      maxAttempts: 5,
+    });
+
+    await vi.runAllTimersAsync();
+
+    const result = await promise;
+    expect(result.content).toBe("recovered");
+    expect(attemptCount).toBe(3);
+  });
+
+  it("does NOT retry 400 bad request", async () => {
+    const { complete } = await import("../src/client.ts");
+
+    let attemptCount = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      attemptCount++;
+      return Promise.resolve({
+        ok: false,
+        status: 400,
+        headers: new Headers(),
+        text: () => Promise.resolve("bad request"),
+      });
+    }) as any;
+
+    await expect(
+      complete({
+        messages: [{ role: "user", content: "test" }],
+        maxAttempts: 3,
+      }),
+    ).rejects.toThrow("400");
+
+    expect(attemptCount).toBe(1);
+  });
+
+  it("gives up after maxAttempts retries", async () => {
+    const { complete } = await import("../src/client.ts");
+
+    let attemptCount = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      attemptCount++;
+      return Promise.resolve({
+        ok: false,
+        status: 429,
+        headers: new Headers(),
+        text: () => Promise.resolve("rate limited"),
+      });
+    }) as any;
+
+    const promise = complete({
+      messages: [{ role: "user", content: "test" }],
+      maxAttempts: 3,
+    });
+
+    await vi.runAllTimersAsync();
+
+    try {
+      await promise;
+      throw new Error("Should have thrown");
+    } catch (err) {
+      expect(err).toMatchObject({ status: 429 });
+    }
+    expect(attemptCount).toBe(3);
+  });
+
+  it("retries network errors (fetch throws)", async () => {
+    const { complete } = await import("../src/client.ts");
+
+    let attemptCount = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      attemptCount++;
+      if (attemptCount === 1) {
+        return Promise.reject(new TypeError("network error"));
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            choices: [{ message: { content: "recovered from network error" } }],
+          }),
+      });
+    }) as any;
+
+    const promise = complete({
+      messages: [{ role: "user", content: "test" }],
+      maxAttempts: 3,
+    });
+
+    await vi.runAllTimersAsync();
+
+    const result = await promise;
+    expect(result.content).toBe("recovered from network error");
+    expect(attemptCount).toBe(2);
+  });
+
+  it("aborts on timeout and retries", async () => {
+    const { complete } = await import("../src/client.ts");
+
+    let attemptCount = 0;
+    global.fetch = vi.fn().mockImplementation((_url: string, options: any) => {
+      attemptCount++;
+
+      if (attemptCount === 1) {
+        // Simulate a slow response that triggers timeout
+        return new Promise((resolve, reject) => {
+          options.signal?.addEventListener("abort", () => {
+            reject(new Error("aborted"));
+          });
+        });
+      }
+
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            choices: [{ message: { content: "success after timeout" } }],
+          }),
+      });
+    }) as any;
+
+    const promise = complete({
+      messages: [{ role: "user", content: "test" }],
+      timeoutMs: 1000,
+      maxAttempts: 3,
+    });
+
+    // Advance past the timeout
+    await vi.advanceTimersByTimeAsync(1100);
+    // Then advance through retry delay
+    await vi.runAllTimersAsync();
+
+    const result = await promise;
+    expect(result.content).toBe("success after timeout");
+    expect(attemptCount).toBe(2);
+  });
+});

--- a/packages/intel/__tests__/retry.test.ts
+++ b/packages/intel/__tests__/retry.test.ts
@@ -213,14 +213,15 @@ describe("complete() retry integration", () => {
       maxAttempts: 3,
     });
 
+    // Attach rejection handler immediately to prevent unhandled rejection
+    const rejection = promise.catch((err) => err);
+
+    // Advance timers to trigger all retry attempts
     await vi.runAllTimersAsync();
 
-    try {
-      await promise;
-      throw new Error("Should have thrown");
-    } catch (err) {
-      expect(err).toMatchObject({ status: 429 });
-    }
+    // Verify the error matches expectations
+    const error = await rejection;
+    expect(error).toMatchObject({ status: 429 });
     expect(attemptCount).toBe(3);
   });
 

--- a/packages/intel/__tests__/retry.test.ts
+++ b/packages/intel/__tests__/retry.test.ts
@@ -355,17 +355,18 @@ describe("complete() retry integration", () => {
     expect(attemptCount).toBe(1);
   });
 
-  it("does NOT retry a 200 error envelope with no choices", async () => {
+  it("does NOT retry a 200 error envelope with a non-retryable code", async () => {
     const { complete } = await import("../src/client.ts");
 
     // OpenRouter reports upstream faults with 200 + an error envelope. Touching
     // data.choices[0] on it throws a bare TypeError, which used to be retryable.
+    // Non-retryable numeric codes (e.g. 400) are terminal.
     let attemptCount = 0;
     global.fetch = vi.fn().mockImplementation(() => {
       attemptCount++;
       return Promise.resolve({
         ok: true,
-        json: () => Promise.resolve({ error: { message: "upstream is unhappy", code: 502 } }),
+        json: () => Promise.resolve({ error: { message: "bad request", code: 400 } }),
       });
     }) as any;
 
@@ -378,7 +379,7 @@ describe("complete() retry integration", () => {
     await vi.runAllTimersAsync();
 
     const error = await rejection;
-    expect(error.message).toContain("upstream is unhappy");
+    expect(error.message).toContain("bad request");
     expect(attemptCount).toBe(1);
   });
 

--- a/packages/intel/src/client.ts
+++ b/packages/intel/src/client.ts
@@ -27,7 +27,6 @@ export interface LlmCompleteInput {
   maxAttempts?: number;
 }
 
-const DEFAULT_TIMEOUT_MS = 90_000;
 const DEFAULT_MAX_ATTEMPTS = 3;
 const BASE_DELAY_MS = 500;
 const MAX_DELAY_MS = 20_000;
@@ -195,7 +194,7 @@ export async function complete(input: LlmCompleteInput): Promise<LlmCompleteOutp
 
   const expanded: LlmCompleteInput = { ...input, messages: injectHumanizer(input.messages) };
 
-  const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const timeoutMs = input.timeoutMs;
   const maxAttempts = Math.max(1, input.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
 
   const startedAt = Date.now();
@@ -205,7 +204,7 @@ export async function complete(input: LlmCompleteInput): Promise<LlmCompleteOutp
     message_count: expanded.messages.length,
     max_tokens: expanded.maxTokens ?? null,
     max_attempts: maxAttempts,
-    timeout_ms: timeoutMs,
+    timeout_ms: timeoutMs ?? null,
   });
 
   // Only the dispatch itself sits inside the retry try. Success-path logging
@@ -261,7 +260,7 @@ function dispatch(
   model: string,
   key: string,
   input: LlmCompleteInput,
-  timeoutMs: number,
+  timeoutMs: number | undefined,
 ): Promise<LlmCompleteOutput> {
   switch (provider) {
     case "openrouter":
@@ -302,10 +301,10 @@ async function postJson(args: {
   headers: Record<string, string>;
   body: unknown;
   provider: string;
-  timeoutMs: number;
+  timeoutMs: number | undefined;
 }): Promise<unknown> {
   const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), args.timeoutMs);
+  const timer = args.timeoutMs ? setTimeout(() => controller.abort(), args.timeoutMs) : undefined;
   const timedOut = () =>
     new LlmTimeoutError(`${args.provider} request timed out after ${args.timeoutMs}ms`);
   try {
@@ -352,7 +351,7 @@ async function postJson(args: {
       );
     }
   } finally {
-    clearTimeout(timer);
+    if (timer !== undefined) clearTimeout(timer);
   }
 }
 
@@ -362,7 +361,7 @@ interface OpenAIArgs {
   baseUrl: string;
   provider: string;
   input: LlmCompleteInput;
-  timeoutMs: number;
+  timeoutMs: number | undefined;
   extraHeaders?: Record<string, string>;
 }
 
@@ -393,8 +392,12 @@ async function openaiCompatibleComplete(args: OpenAIArgs): Promise<LlmCompleteOu
   // data.choices[0] on it would throw a bare TypeError, which reads as weather.
   if (data.error) {
     const code = data.error.code === undefined ? "" : ` (code ${data.error.code})`;
+    // Pass numeric codes through as status so retry logic can classify them (429/5xx).
+    // Non-numeric or absent codes stay terminal.
+    const status = typeof data.error.code === "number" ? data.error.code : undefined;
     throw new LlmError(
       `${args.provider} returned an error envelope${code}: ${data.error.message ?? "no message"}`,
+      status,
     );
   }
 
@@ -439,7 +442,7 @@ interface AnthropicArgs {
   key: string;
   model: string;
   input: LlmCompleteInput;
-  timeoutMs: number;
+  timeoutMs: number | undefined;
 }
 
 async function anthropicComplete(args: AnthropicArgs): Promise<LlmCompleteOutput> {

--- a/packages/intel/src/client.ts
+++ b/packages/intel/src/client.ts
@@ -63,19 +63,34 @@ class LlmTimeoutError extends LlmError {
 }
 
 /**
- * Retry only what a second attempt can plausibly fix: rate limits, provider-side
- * faults, timeouts, and transport-level rejections (fetch throws a TypeError on
- * DNS/socket failures, which is not an LlmError). Everything we raise ourselves
- * with a status — 400 bad request, 401 bad key, 404 unknown model — is
- * deterministic, and so is a truncation or no-choices LlmError with no status.
+ * A transport-level rejection — DNS, TLS, socket reset. Raised only where we
+ * know no HTTP response was obtained, so a second attempt can plausibly land.
+ * Classifying at the call site rather than by error type matters: fetch signals
+ * these with a bare TypeError, and so does every accidental property access on
+ * a malformed response body.
+ */
+class LlmNetworkError extends LlmError {
+  constructor(message: string) {
+    super(message);
+    this.name = "LlmNetworkError";
+  }
+}
+
+/**
+ * Retry only the explicitly retryable set: rate limits, provider-side faults,
+ * timeouts, and transport failures. Everything else is terminal — a 400 bad
+ * request, a 401 bad key and a 404 unknown model are deterministic, a
+ * truncation / no-choices / no-content LlmError carries no status and will
+ * reproduce exactly, and a stray TypeError from parsing a malformed body is a
+ * bug in us, not weather. Retrying any of those triples the bill for nothing.
  */
 export function isRetryableLlmError(err: unknown): boolean {
-  if (err instanceof LlmTimeoutError) return true;
+  if (err instanceof LlmTimeoutError || err instanceof LlmNetworkError) return true;
   if (err instanceof LlmError) {
     if (err.status === undefined) return false;
     return err.status === 429 || err.status >= 500;
   }
-  return err instanceof Error;
+  return false;
 }
 
 /**
@@ -101,9 +116,14 @@ export function backoffDelayMs(
   retryAfterMs?: number,
   rand: () => number = Math.random,
 ): number {
-  if (retryAfterMs !== undefined) return Math.min(retryAfterMs, MAX_RETRY_AFTER_MS);
   const capped = Math.min(BASE_DELAY_MS * 2 ** (attempt - 1), MAX_DELAY_MS);
-  return Math.round(capped / 2 + rand() * (capped / 2));
+  const backoff = Math.round(capped / 2 + rand() * (capped / 2));
+  if (retryAfterMs === undefined) return backoff;
+  // Retry-After raises the wait, it never lowers it. `Retry-After: 0` and an
+  // HTTP-date already in the past (clock skew, second-rounding) are both common
+  // and both parse to 0 — honouring them literally would fire every attempt
+  // within milliseconds, unpaced and unjittered.
+  return Math.max(Math.min(retryAfterMs, MAX_RETRY_AFTER_MS), backoff);
 }
 
 function sleep(ms: number): Promise<void> {
@@ -188,17 +208,18 @@ export async function complete(input: LlmCompleteInput): Promise<LlmCompleteOutp
     timeout_ms: timeoutMs,
   });
 
+  // Only the dispatch itself sits inside the retry try. Success-path logging
+  // used to live in here, and a throw from it (a null `content` field on an
+  // already-billed response) discarded the paid-for completion and re-sent the
+  // whole prompt — the retry loop must never be able to reject work we have.
+  let result: LlmCompleteOutput | undefined;
+  let attempts = 0;
+
   for (let attempt = 1; ; attempt++) {
     try {
-      const result = await dispatch(cfg.llmProvider, cfg.llmModel, key, expanded, timeoutMs);
-      logEvent("llm.done", {
-        provider: cfg.llmProvider,
-        model: cfg.llmModel,
-        duration_ms: Date.now() - startedAt,
-        response_chars: result.content.length,
-        attempts: attempt,
-      });
-      return result;
+      result = await dispatch(cfg.llmProvider, cfg.llmModel, key, expanded, timeoutMs);
+      attempts = attempt;
+      break;
     } catch (err) {
       const status = err instanceof LlmError ? (err.status ?? null) : null;
       const ctx = {
@@ -224,6 +245,15 @@ export async function complete(input: LlmCompleteInput): Promise<LlmCompleteOutp
       throw err;
     }
   }
+
+  logEvent("llm.done", {
+    provider: cfg.llmProvider,
+    model: cfg.llmModel,
+    duration_ms: Date.now() - startedAt,
+    response_chars: result.content.length,
+    attempts,
+  });
+  return result;
 }
 
 function dispatch(
@@ -276,27 +306,51 @@ async function postJson(args: {
 }): Promise<unknown> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), args.timeoutMs);
+  const timedOut = () =>
+    new LlmTimeoutError(`${args.provider} request timed out after ${args.timeoutMs}ms`);
   try {
-    const res = await fetch(args.url, {
-      method: "POST",
-      headers: { "Content-Type": "application/json", ...args.headers },
-      body: JSON.stringify(args.body),
-      signal: controller.signal,
-    });
+    let res: Response;
+    try {
+      res = await fetch(args.url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json", ...args.headers },
+        body: JSON.stringify(args.body),
+        signal: controller.signal,
+      });
+    } catch (err) {
+      // No response at all: either our own abort or a transport failure. These
+      // are the only two shapes a retry can fix.
+      if (controller.signal.aborted) throw timedOut();
+      throw new LlmNetworkError(`${args.provider} request failed: ${(err as Error).message}`);
+    }
+
     if (!res.ok) {
-      const text = await res.text();
+      // The status is known, so the status decides — a 401 that happens to time
+      // out while we read its body is still a 401, and retrying it three times
+      // just burns the budget on the same rejected key.
+      let text = "";
+      try {
+        text = await res.text();
+      } catch {
+        text = "<error body unreadable>";
+      }
       throw new LlmError(
         `${args.provider} ${res.status}: ${text.slice(0, 400)}`,
         res.status,
         parseRetryAfter(res.headers.get("retry-after"), Date.now()),
       );
     }
-    return await res.json();
-  } catch (err) {
-    if (controller.signal.aborted) {
-      throw new LlmTimeoutError(`${args.provider} request timed out after ${args.timeoutMs}ms`);
+
+    try {
+      return await res.json();
+    } catch (err) {
+      // A 2xx whose body never arrives or is not JSON leaves us with nothing
+      // usable, so this one genuinely is worth another attempt.
+      if (controller.signal.aborted) throw timedOut();
+      throw new LlmNetworkError(
+        `${args.provider} response body could not be read: ${(err as Error).message}`,
+      );
     }
-    throw err;
   } finally {
     clearTimeout(timer);
   }
@@ -325,7 +379,8 @@ async function openaiCompatibleComplete(args: OpenAIArgs): Promise<LlmCompleteOu
     provider: args.provider,
     timeoutMs: args.timeoutMs,
   })) as {
-    choices: Array<{ message: { content: string }; finish_reason?: string }>;
+    choices?: Array<{ message?: { content?: string | null }; finish_reason?: string }>;
+    error?: { message?: string; code?: number };
     usage?: {
       prompt_tokens?: number;
       completion_tokens?: number;
@@ -333,7 +388,17 @@ async function openaiCompatibleComplete(args: OpenAIArgs): Promise<LlmCompleteOu
     };
   };
 
-  const choice = data.choices[0];
+  // OpenRouter answers upstream faults with 200 and an error envelope instead of
+  // choices. Naming it here keeps the failure a terminal LlmError — reaching for
+  // data.choices[0] on it would throw a bare TypeError, which reads as weather.
+  if (data.error) {
+    const code = data.error.code === undefined ? "" : ` (code ${data.error.code})`;
+    throw new LlmError(
+      `${args.provider} returned an error envelope${code}: ${data.error.message ?? "no message"}`,
+    );
+  }
+
+  const choice = data.choices?.[0];
   if (!choice) throw new LlmError(`${args.provider} returned no choices`);
 
   // A response cut off at max_tokens is unusable: every caller parses JSON out
@@ -351,8 +416,18 @@ async function openaiCompatibleComplete(args: OpenAIArgs): Promise<LlmCompleteOu
     );
   }
 
+  // A refusal, or a tool-call/reasoning-only message, carries no text. That is a
+  // real answer from the provider, not a transport hiccup: repeating the prompt
+  // buys the same reply at twice the price, so name the signal and stop.
+  const content = choice.message?.content;
+  if (typeof content !== "string") {
+    throw new LlmError(
+      `${args.provider} returned a message with no text content (finish_reason=${choice.finish_reason ?? "none"})`,
+    );
+  }
+
   return {
-    content: choice.message.content,
+    content,
     provider: args.provider,
     model: args.model,
     inputTokens: data.usage?.prompt_tokens,
@@ -386,7 +461,7 @@ async function anthropicComplete(args: AnthropicArgs): Promise<LlmCompleteOutput
     provider: "anthropic",
     timeoutMs: args.timeoutMs,
   })) as {
-    content: Array<{ type: string; text?: string }>;
+    content?: Array<{ type: string; text?: string }>;
     stop_reason?: string;
     usage?: { input_tokens?: number; output_tokens?: number };
   };
@@ -399,6 +474,14 @@ async function anthropicComplete(args: AnthropicArgs): Promise<LlmCompleteOutput
         maxTokens: args.input.maxTokens ?? 1024,
         completionTokens: data.usage?.output_tokens,
       }),
+    );
+  }
+
+  // Same as the OpenAI path: an absent content array is a provider signal
+  // (refusal, filtered output), not something a second attempt recovers.
+  if (!Array.isArray(data.content)) {
+    throw new LlmError(
+      `anthropic returned no content blocks (stop_reason=${data.stop_reason ?? "none"})`,
     );
   }
 

--- a/packages/intel/src/client.ts
+++ b/packages/intel/src/client.ts
@@ -1,4 +1,4 @@
-import { llmApiKey, loadConfig, logEvent } from "@oneshot-gtm/core";
+import { llmApiKey, loadConfig, logEvent, type OneShotConfig } from "@oneshot-gtm/core";
 import { loadPrompt } from "./prompts.ts";
 
 export interface LlmMessage {
@@ -17,7 +17,22 @@ export interface LlmCompleteInput {
    * silently degrades to an empty object downstream.
    */
   allowTruncation?: boolean;
+  /**
+   * Per-request wall-clock budget. The request is aborted when it expires and
+   * the attempt counts as retryable — a hung socket is the failure mode that
+   * otherwise stalls a whole 50-target drain behind one target.
+   */
+  timeoutMs?: number;
+  /** Total attempts including the first. Clamped to >= 1. */
+  maxAttempts?: number;
 }
+
+const DEFAULT_TIMEOUT_MS = 90_000;
+const DEFAULT_MAX_ATTEMPTS = 3;
+const BASE_DELAY_MS = 500;
+const MAX_DELAY_MS = 20_000;
+/** Ceiling on a server-supplied Retry-After — a 15-minute hint is a give-up, not a wait. */
+const MAX_RETRY_AFTER_MS = 60_000;
 
 export interface LlmCompleteOutput {
   content: string;
@@ -31,10 +46,68 @@ class LlmError extends Error {
   constructor(
     message: string,
     public readonly status?: number,
+    /** Parsed Retry-After, when the provider sent one. */
+    public readonly retryAfterMs?: number,
   ) {
     super(message);
     this.name = "LlmError";
   }
+}
+
+/** A per-request timeout that aborted the fetch. Always retryable. */
+class LlmTimeoutError extends LlmError {
+  constructor(message: string) {
+    super(message);
+    this.name = "LlmTimeoutError";
+  }
+}
+
+/**
+ * Retry only what a second attempt can plausibly fix: rate limits, provider-side
+ * faults, timeouts, and transport-level rejections (fetch throws a TypeError on
+ * DNS/socket failures, which is not an LlmError). Everything we raise ourselves
+ * with a status — 400 bad request, 401 bad key, 404 unknown model — is
+ * deterministic, and so is a truncation or no-choices LlmError with no status.
+ */
+export function isRetryableLlmError(err: unknown): boolean {
+  if (err instanceof LlmTimeoutError) return true;
+  if (err instanceof LlmError) {
+    if (err.status === undefined) return false;
+    return err.status === 429 || err.status >= 500;
+  }
+  return err instanceof Error;
+}
+
+/**
+ * Delta-seconds or HTTP-date, per RFC 9110. Returns undefined for anything
+ * unparseable so the caller falls back to its own backoff.
+ */
+export function parseRetryAfter(header: string | null, now: number): number | undefined {
+  if (!header) return undefined;
+  const trimmed = header.trim();
+  if (/^\d+$/.test(trimmed)) return Number(trimmed) * 1000;
+  const at = Date.parse(trimmed);
+  if (Number.isNaN(at)) return undefined;
+  return Math.max(0, at - now);
+}
+
+/**
+ * Bounded exponential backoff with equal jitter — half the delay is fixed so
+ * attempts still spread out, half is random so a batch that hits the same 429
+ * doesn't march back in lockstep. `attempt` is 1-based (the delay AFTER it).
+ */
+export function backoffDelayMs(
+  attempt: number,
+  retryAfterMs?: number,
+  rand: () => number = Math.random,
+): number {
+  if (retryAfterMs !== undefined) return Math.min(retryAfterMs, MAX_RETRY_AFTER_MS);
+  const capped = Math.min(BASE_DELAY_MS * 2 ** (attempt - 1), MAX_DELAY_MS);
+  return Math.round(capped / 2 + rand() * (capped / 2));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 /**
@@ -102,62 +175,130 @@ export async function complete(input: LlmCompleteInput): Promise<LlmCompleteOutp
 
   const expanded: LlmCompleteInput = { ...input, messages: injectHumanizer(input.messages) };
 
+  const timeoutMs = input.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxAttempts = Math.max(1, input.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
+
   const startedAt = Date.now();
   logEvent("llm.start", {
     provider: cfg.llmProvider,
     model: cfg.llmModel,
     message_count: expanded.messages.length,
     max_tokens: expanded.maxTokens ?? null,
+    max_attempts: maxAttempts,
+    timeout_ms: timeoutMs,
   });
-  try {
-    let result: LlmCompleteOutput;
-    switch (cfg.llmProvider) {
-      case "openrouter":
-        result = await openaiCompatibleComplete({
-          key,
-          model: cfg.llmModel,
-          baseUrl: "https://openrouter.ai/api/v1",
-          provider: "openrouter",
-          input: expanded,
-          extraHeaders: {
-            "HTTP-Referer": "https://github.com/oneshot-agent/oneshot-gtm",
-            "X-Title": "oneshot-gtm",
-          },
-        });
-        break;
-      case "openai":
-        result = await openaiCompatibleComplete({
-          key,
-          model: cfg.llmModel,
-          baseUrl: "https://api.openai.com/v1",
-          provider: "openai",
-          input: expanded,
-        });
-        break;
-      case "anthropic":
-        result = await anthropicComplete({ key, model: cfg.llmModel, input: expanded });
-        break;
-    }
-    logEvent("llm.done", {
-      provider: cfg.llmProvider,
-      model: cfg.llmModel,
-      duration_ms: Date.now() - startedAt,
-      response_chars: result.content.length,
-    });
-    return result;
-  } catch (err) {
-    logEvent(
-      "llm.error",
-      {
+
+  for (let attempt = 1; ; attempt++) {
+    try {
+      const result = await dispatch(cfg.llmProvider, cfg.llmModel, key, expanded, timeoutMs);
+      logEvent("llm.done", {
+        provider: cfg.llmProvider,
+        model: cfg.llmModel,
+        duration_ms: Date.now() - startedAt,
+        response_chars: result.content.length,
+        attempts: attempt,
+      });
+      return result;
+    } catch (err) {
+      const status = err instanceof LlmError ? (err.status ?? null) : null;
+      const ctx = {
         provider: cfg.llmProvider,
         model: cfg.llmModel,
         duration_ms: Date.now() - startedAt,
         error_class: (err as Error).constructor.name,
         message_120: ((err as Error).message ?? "").slice(0, 120),
-      },
-      "error",
-    );
+        status,
+        attempt,
+        max_attempts: maxAttempts,
+      };
+      if (attempt < maxAttempts && isRetryableLlmError(err)) {
+        const delayMs = backoffDelayMs(
+          attempt,
+          err instanceof LlmError ? err.retryAfterMs : undefined,
+        );
+        logEvent("llm.retry", { ...ctx, delay_ms: delayMs }, "warn");
+        await sleep(delayMs);
+        continue;
+      }
+      logEvent("llm.error", ctx, "error");
+      throw err;
+    }
+  }
+}
+
+function dispatch(
+  provider: OneShotConfig["llmProvider"],
+  model: string,
+  key: string,
+  input: LlmCompleteInput,
+  timeoutMs: number,
+): Promise<LlmCompleteOutput> {
+  switch (provider) {
+    case "openrouter":
+      return openaiCompatibleComplete({
+        key,
+        model,
+        baseUrl: "https://openrouter.ai/api/v1",
+        provider: "openrouter",
+        input,
+        timeoutMs,
+        extraHeaders: {
+          "HTTP-Referer": "https://github.com/oneshot-agent/oneshot-gtm",
+          "X-Title": "oneshot-gtm",
+        },
+      });
+    case "openai":
+      return openaiCompatibleComplete({
+        key,
+        model,
+        baseUrl: "https://api.openai.com/v1",
+        provider: "openai",
+        input,
+        timeoutMs,
+      });
+    case "anthropic":
+      return anthropicComplete({ key, model, input, timeoutMs });
+  }
+}
+
+/**
+ * One POST under a single abort budget covering the body read too — a provider
+ * that accepts the connection and then stalls mid-stream is the same failure as
+ * one that never answers. Non-2xx becomes an LlmError carrying status and
+ * Retry-After so the retry loop can classify and pace it.
+ */
+async function postJson(args: {
+  url: string;
+  headers: Record<string, string>;
+  body: unknown;
+  provider: string;
+  timeoutMs: number;
+}): Promise<unknown> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), args.timeoutMs);
+  try {
+    const res = await fetch(args.url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...args.headers },
+      body: JSON.stringify(args.body),
+      signal: controller.signal,
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new LlmError(
+        `${args.provider} ${res.status}: ${text.slice(0, 400)}`,
+        res.status,
+        parseRetryAfter(res.headers.get("retry-after"), Date.now()),
+      );
+    }
+    return await res.json();
+  } catch (err) {
+    if (controller.signal.aborted) {
+      throw new LlmTimeoutError(`${args.provider} request timed out after ${args.timeoutMs}ms`);
+    }
     throw err;
+  } finally {
+    clearTimeout(timer);
   }
 }
 
@@ -167,31 +308,23 @@ interface OpenAIArgs {
   baseUrl: string;
   provider: string;
   input: LlmCompleteInput;
+  timeoutMs: number;
   extraHeaders?: Record<string, string>;
 }
 
 async function openaiCompatibleComplete(args: OpenAIArgs): Promise<LlmCompleteOutput> {
-  const res = await fetch(`${args.baseUrl}/chat/completions`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${args.key}`,
-      ...args.extraHeaders,
-    },
-    body: JSON.stringify({
+  const data = (await postJson({
+    url: `${args.baseUrl}/chat/completions`,
+    headers: { Authorization: `Bearer ${args.key}`, ...args.extraHeaders },
+    body: {
       model: args.model,
       messages: args.input.messages,
       temperature: args.input.temperature ?? 0.7,
       max_tokens: args.input.maxTokens ?? 1024,
-    }),
-  });
-
-  if (!res.ok) {
-    const body = await res.text();
-    throw new LlmError(`${args.provider} ${res.status}: ${body.slice(0, 400)}`, res.status);
-  }
-
-  const data = (await res.json()) as {
+    },
+    provider: args.provider,
+    timeoutMs: args.timeoutMs,
+  })) as {
     choices: Array<{ message: { content: string }; finish_reason?: string }>;
     usage?: {
       prompt_tokens?: number;
@@ -231,6 +364,7 @@ interface AnthropicArgs {
   key: string;
   model: string;
   input: LlmCompleteInput;
+  timeoutMs: number;
 }
 
 async function anthropicComplete(args: AnthropicArgs): Promise<LlmCompleteOutput> {
@@ -239,28 +373,19 @@ async function anthropicComplete(args: AnthropicArgs): Promise<LlmCompleteOutput
     .filter((m) => m.role !== "system")
     .map((m) => ({ role: m.role, content: m.content }));
 
-  const res = await fetch("https://api.anthropic.com/v1/messages", {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      "x-api-key": args.key,
-      "anthropic-version": "2023-06-01",
-    },
-    body: JSON.stringify({
+  const data = (await postJson({
+    url: "https://api.anthropic.com/v1/messages",
+    headers: { "x-api-key": args.key, "anthropic-version": "2023-06-01" },
+    body: {
       model: args.model,
       max_tokens: args.input.maxTokens ?? 1024,
       temperature: args.input.temperature ?? 0.7,
       ...(system ? { system } : {}),
       messages,
-    }),
-  });
-
-  if (!res.ok) {
-    const body = await res.text();
-    throw new LlmError(`anthropic ${res.status}: ${body.slice(0, 400)}`, res.status);
-  }
-
-  const data = (await res.json()) as {
+    },
+    provider: "anthropic",
+    timeoutMs: args.timeoutMs,
+  })) as {
     content: Array<{ type: string; text?: string }>;
     stop_reason?: string;
     usage?: { input_tokens?: number; output_tokens?: number };


### PR DESCRIPTION
Closes #77.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base fail (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add retry loop and per-request timeout to `complete()` in `intel` client
> - `complete()` now retries 429/5xx/network/timeout errors up to `DEFAULT_MAX_ATTEMPTS` (3) using bounded exponential backoff with jitter, honoring parsed `Retry-After` headers
> - Adds optional `timeoutMs` to `LlmCompleteInput`; when set, requests are aborted via `AbortController` and retried as `LlmTimeoutError`
> - Introduces `postJson` helper and `dispatch` wrapper to unify provider calls; `openaiCompatibleComplete` and `anthropicComplete` now classify transport failures as `LlmNetworkError` and treat missing content or error envelopes as terminal `LlmError`
> - Adds comprehensive test suite in [retry.test.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/83/files#diff-7e0ed22290e3c81bb82caccfc3fc680afaa35144cbc394999ead59f1125ddeaf)
> - Behavioral Change: non-retryable outcomes (400, null content, truncation, non-numeric error envelopes) now fail immediately without retry; `LlmError` carries `retryAfterMs` and `status`; `llm.retry` and `llm.done` log fields changed to include `delay_ms`, `attempts`, `max_attempts`, `timeout_ms`
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4840d8e. 1 file reviewed, 2 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->