### PR TITLE
fix: issue #85: chore(repo): ignore .worktrees/ in git, oxlint and oxfmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,6 +88,11 @@ ehthumbs.db
 Thumbs.db
 Desktop.ini
 
+# ── Agent git worktrees ───────────────────────────────────────────────────────
+# Agents check out isolated copies of the repo under .worktrees/. They're
+# real checkouts, not build output — never commit them.
+.worktrees/
+
 # ── Runtime / temp ────────────────────────────────────────────────────────────
 .cache/
 tmp/

--- a/.oxfmtrc.json
+++ b/.oxfmtrc.json
@@ -3,6 +3,7 @@
   "ignorePatterns": [
     "dist",
     "node_modules",
+    ".worktrees",
     "bun.lock",
     "*.tsbuildinfo",
     "**/routeTree.gen.ts",

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,6 +1,13 @@
 {
   "$schema": "./node_modules/oxlint/configuration_schema.json",
-  "ignorePatterns": ["dist", "node_modules", "bun.lock", "*.tsbuildinfo", "**/routeTree.gen.ts"],
+  "ignorePatterns": [
+    "dist",
+    "node_modules",
+    ".worktrees",
+    "bun.lock",
+    "*.tsbuildinfo",
+    "**/routeTree.gen.ts"
+  ],
   "plugins": ["eslint", "oxc", "react", "unicorn", "typescript"],
   "categories": {
     "correctness": "warn",

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -79,7 +79,7 @@ The ICP filter currently judges each candidate cold — `icpFilter` in `packages
 
 ## Tech debt
 
-- [ ] **Ignore `.worktrees/` everywhere** · S — agent worktrees land in `.worktrees/` and the directory is in neither `.gitignore`, `.oxlintrc.json` nor `.oxfmtrc.json`. It shows up as untracked in `git status`, and `bun run lint` / `bun run fmt:check` walk a full duplicate of the tree per worktree.
+- [x] **Ignore `.worktrees/` everywhere** · S — agent worktrees land in `.worktrees/` and the directory is in neither `.gitignore`, `.oxlintrc.json` nor `.oxfmtrc.json`. It shows up as untracked in `git status`, and `bun run lint` / `bun run fmt:check` walk a full duplicate of the tree per worktree.
       _Done when:_ `.worktrees/` is gitignored and in both tool ignore lists; `git status` is clean with a worktree present, and lint/fmt file counts are unchanged by adding one.
 - [ ] **Surface the server's error body on GET** · S — `getJson` in `apps/web/src/api/client.ts` throws `${status} ${statusText}: ${path}` and discards the `{ error }` JSON the server sends; `postJson` right below it reads the body. A 409 from a not-ready trigger reaches the dashboard as "409 Conflict" with the reason thrown away.
       _Done when:_ `getJson` parses the error body the same way `postJson` does and falls back to the status line when the body isn't JSON; covered by a test with a mocked `fetch`.


### PR DESCRIPTION
Closes #85.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base fail (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ignore `.worktrees/` in git, oxlint, and oxfmt
> Adds `.worktrees/` to ignore patterns in [.gitignore](https://github.com/oneshot-agent/oneshot-gtm/pull/86/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947), [.oxfmtrc.json](https://github.com/oneshot-agent/oneshot-gtm/pull/86/files#diff-ba6bdb5315b18041509bd0925c6394aa9250917b715ab46ca0a36231c566c8e5), and [.oxlintrc.json](https://github.com/oneshot-agent/oneshot-gtm/pull/86/files#diff-2113aef2ff3d50c021fca1fb6ecf4d4553a0e3f5f51ded7302ad499e43bc2b1e) so agent-created git worktree checkouts are excluded from version control, formatting, and linting. Marks the corresponding tech debt item in [ROADMAP.md](https://github.com/oneshot-agent/oneshot-gtm/pull/86/files#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51) as completed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6c34cb1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->