### PR TITLE
docs(status): re-measure against main after tonight's merges

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,13 +2,15 @@
 
 **Assume green.** The 49 CLI commands, 17 plays, 11 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-08-29** · Bun 1.3.13 · OneShot SDK 0.22.0 · 1963 tests / 155 files · typecheck + oxlint + oxfmt clean.
+Last verified **2026-08-29** · Bun 1.3.13 · OneShot SDK 0.22.0 · **1982 tests / 157 files** · typecheck + oxlint + oxfmt clean, all measured on `main`.
 
-**What the gate does and doesn't cover.** `bun run typecheck` uses the root `tsconfig.json`, which
-excludes `apps/web` and includes only `packages/*/__tests__` — so the dashboard source and every
-app test file sit outside it. Closing both holes is the first item under Gates and coverage in
-`ROADMAP.md`. Coverage is also thin in two packages: `packages/doctor` has one test file against
-799 lines of `check.ts`, and `packages/intel` has two against the whole package.
+**What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
+type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. The
+remaining hole is `apps/*/__tests__`, which the root `tsconfig.json` still excludes, so app test
+files are compiled by vitest and by nothing else; that item is open under Gates and coverage in
+`ROADMAP.md`. Coverage is thin in two packages: `packages/doctor` has one test file against 799
+lines of `check.ts`, and `packages/intel` is now covered for the retry path but not for
+`triage`, `synthesize`, `advise` or `weekly-review`.
 
 **Dependency pins.** The root `package.json` carries `overrides` for `seroval`, `seroval-plugins`
 (CVE-2026-59940) and `ws`. Forks inherit these.

--- a/STATUS.md
+++ b/STATUS.md
@@ -9,8 +9,8 @@ type-checked in CI, and a deliberate error under `apps/web/src` fails the root s
 remaining hole is `apps/*/__tests__`, which the root `tsconfig.json` still excludes, so app test
 files are compiled by vitest and by nothing else; that item is open under Gates and coverage in
 `ROADMAP.md`. Coverage is thin in two packages: `packages/doctor` has one test file against 799
-lines of `check.ts`, and `packages/intel` is now covered for the retry path but not for
-`triage`, `synthesize`, `advise` or `weekly-review`.
+lines of `check.ts`, and `packages/intel` tests cover only `_parse.ts` and `prompts.ts`, not
+`client.ts`, `triage`, `synthesize`, `advise` or `weekly-review`.
 
 **Dependency pins.** The root `package.json` carries `overrides` for `seroval`, `seroval-plugins`
 (CVE-2026-59940) and `ws`. Forks inherit these.


### PR DESCRIPTION
STATUS.md carried numbers taken before four PRs merged, and — more importantly — warned about a hole that has since been closed.

**Re-measured on `main`** (not carried forward): 1963 tests / 155 files → **1982 / 157**. typecheck, oxlint and oxfmt all exit 0.

**Corrected the gate paragraph.** It warned that `apps/web` sits outside `bun run typecheck` — true when written, fixed by #82. A stale warning is worse than no warning, because it points attention at a solved problem. It now names the hole that *is* still open: the root `tsconfig.json` still excludes `apps/*/__tests__`, so app test files are compiled by vitest and by nothing else.

Also narrowed the `packages/intel` coverage note — the retry path is covered now (#83), but `triage`, `synthesize`, `advise` and `weekly-review` still aren't.

Worth noting the `events.jsonl` limitation line updated itself: the worker that shipped #81 rewrote it as part of its ripple pass, and added the `tail -F` caveat unprompted. Left as-is.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update `STATUS.md` with re-measured test counts and revised gate coverage notes
> - Refreshes the verification summary to `1982 tests / 157 files`, all measured on `main`
> - Renames the section to 'What the gate covers.' and notes that `apps/web` is now included in `bun run typecheck`, with a deliberate error under `apps/web/src` failing the root script
> - Clarifies that the remaining exclusion is `apps/*/__tests__` (compiled only by vitest), and adds coverage notes for `packages/doctor` and `packages/intel`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6729267.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->