### PR TITLE
fix: issue #100: test(repo): assert the README's own command, play and finder counts against the code

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ bun run cli -- find drain podcast-guest --dry-run  # preview approved /queue row
 bun run cli -- cadence advance                     # daily tick: poll inbox, fire follow-ups
 ```
 
-48 commands — thirteen groups, plus `init`, `doctor` and `ui` at the top level. `bun run cli -- --help` (or `oneshot-gtm --help` once linked) is the reference:
+49 commands — thirteen groups, plus `init`, `doctor` and `ui` at the top level. `bun run cli -- --help` (or `oneshot-gtm --help` once linked) is the reference:
 
 | Group                    | Commands                                                                                                                                                        |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -294,7 +294,7 @@ Add a OneShot domain and mailbox from `/setup` or `identities add` — pick a pr
 
 ```
 apps/
-  cli/        47-command CLI (commander); src/demo/ seeds the demo install, src/main.ts picks the workspace
+  cli/        49-command CLI (commander); src/demo/ seeds the demo install, src/main.ts picks the workspace
   server/     Bun.serve + SSE; tsdown bundle published as `oneshot-gtm-server`
   web/        Vite + React 19 + TanStack + Base UI — 9 pages, run form, strategist dock, privacy mode
 packages/

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -652,10 +652,18 @@ handoff
 // instead of commander's default non-zero exit.
 attachHelpFallbacks(program);
 
-program.parseAsync(process.argv).catch((err) => {
-  fail((err as Error).message);
-  process.exit(1);
-});
+// The command tree itself is worth reading without running it — the README
+// count guard walks it to check the documented command total. Importing this
+// module used to parse process.argv as a side effect, which under a test
+// runner means parsing the runner's own argv.
+export { program };
+
+if (!process.env["ONESHOT_GTM_CLI_NO_PARSE"]) {
+  program.parseAsync(process.argv).catch((err) => {
+    fail((err as Error).message);
+    process.exit(1);
+  });
+}
 
 function runOrFail<A extends unknown[]>(fn: (...args: A) => void | Promise<void>) {
   return async (...args: A) => {

--- a/repo/__tests__/readme-counts.test.ts
+++ b/repo/__tests__/readme-counts.test.ts
@@ -5,6 +5,11 @@
  * finders ship — and those numbers go stale the moment someone adds a
  * command without re-counting. Each one here is derived from the code that
  * defines it, so the README can only drift for as long as this test is red.
+ *
+ * Some of those numbers appear twice: as digits in the tables and spelled out
+ * in the prose above them ("Seventeen of them", "Eleven **finders**"). Both are
+ * claims a visitor reads, and both drift on the same commit, so both are
+ * asserted.
  */
 import * as fs from "node:fs";
 import * as path from "node:path";
@@ -21,6 +26,7 @@ import { runConcierge } from "../../packages/plays/src/concierge.ts";
 import { runDemoNoShow } from "../../packages/plays/src/demo-no-show.ts";
 
 const NON_EMAIL_PLAYS = [runConcierge, runDemoNoShow];
+const playCount = Object.keys(PLAYS).length + NON_EMAIL_PLAYS.length;
 
 const REPO_ROOT = path.resolve(import.meta.dirname, "../..");
 const README = fs.readFileSync(path.join(REPO_ROOT, "README.md"), "utf8");
@@ -39,7 +45,7 @@ function countLeafCommands(cmd: Command): number {
 }
 
 /** Pull a single capture group out of the README, failing loudly if the prose moved. */
-function readmeNumber(pattern: RegExp, label: string): number {
+function readmeCapture(pattern: RegExp, label: string): string {
   const match = README.match(pattern);
   if (!match?.[1]) {
     throw new Error(
@@ -47,7 +53,77 @@ function readmeNumber(pattern: RegExp, label: string): number {
         `Update the pattern in this test alongside the prose.`,
     );
   }
-  return Number(match[1]);
+  return match[1];
+}
+
+function readmeNumber(pattern: RegExp, label: string): number {
+  return Number(readmeCapture(pattern, label));
+}
+
+const ONES: Record<string, number> = {
+  zero: 0,
+  one: 1,
+  two: 2,
+  three: 3,
+  four: 4,
+  five: 5,
+  six: 6,
+  seven: 7,
+  eight: 8,
+  nine: 9,
+  ten: 10,
+  eleven: 11,
+  twelve: 12,
+  thirteen: 13,
+  fourteen: 14,
+  fifteen: 15,
+  sixteen: 16,
+  seventeen: 17,
+  eighteen: 18,
+  nineteen: 19,
+};
+
+const TENS: Record<string, number> = {
+  twenty: 20,
+  thirty: 30,
+  forty: 40,
+  fifty: 50,
+  sixty: 60,
+  seventy: 70,
+  eighty: 80,
+  ninety: 90,
+};
+
+/**
+ * Turn a spelled-out count ("seventeen", "twenty-one") into a number. The
+ * README writes its counts as words in prose and as digits in the tables, and
+ * both drift together — so the word forms need the same guard the digits get.
+ */
+function wordToNumber(word: string): number {
+  const parts = word.toLowerCase().split("-");
+  if (parts.length === 1) {
+    const single = ONES[parts[0]!] ?? TENS[parts[0]!];
+    if (single === undefined) {
+      throw new Error(
+        `"${word}" is not a number word this test knows. Extend ONES/TENS if the ` +
+          `count grew past what they cover.`,
+      );
+    }
+    return single;
+  }
+  const [tens, ones] = parts;
+  if (parts.length !== 2 || TENS[tens!] === undefined || ONES[ones!] === undefined) {
+    throw new Error(
+      `"${word}" is not a number word this test knows. Extend ONES/TENS if the ` +
+        `count grew past what they cover.`,
+    );
+  }
+  return TENS[tens!]! + ONES[ones!]!;
+}
+
+/** Same as `readmeNumber`, but for a count the README spells out in prose. */
+function readmeWordNumber(pattern: RegExp, label: string): number {
+  return wordToNumber(readmeCapture(pattern, label));
 }
 
 let commandCount: number;
@@ -77,13 +153,31 @@ describe("README counts match the code", () => {
 
   it("quotes the right number of plays", () => {
     const claimed = readmeNumber(/(\d+) outreach plays/, "N outreach plays");
-    const actual = Object.keys(PLAYS).length + NON_EMAIL_PLAYS.length;
-    expect(claimed, `README claims ${claimed} plays but code has ${actual}`).toBe(actual);
+    expect(claimed, `README claims ${claimed} plays but code has ${playCount}`).toBe(playCount);
+  });
+
+  // "Seventeen of them." opens the play list a visitor actually reads, and it
+  // goes stale on exactly the commits the digit form does.
+  it("spells out the right number of plays in the play list", () => {
+    const claimed = readmeWordNumber(/^([A-Za-z]+(?:-[A-Za-z]+)?) of them\./m, "'<Word> of them'");
+    expect(claimed, `README spells out ${claimed} plays but code has ${playCount}`).toBe(playCount);
   });
 
   it("quotes the right number of finders", () => {
     const claimed = readmeNumber(/(\d+) finders/, "N finders");
     expect(claimed, `README claims ${claimed} finders but code has ${TRIGGERS.length}`).toBe(
+      TRIGGERS.length,
+    );
+  });
+
+  // Likewise "Eleven **finders** discover prospects" — the sentence that
+  // introduces the finder table, one section above the digit form.
+  it("spells out the right number of finders above the finder table", () => {
+    const claimed = readmeWordNumber(
+      /^([A-Za-z]+(?:-[A-Za-z]+)?) \*\*finders\*\*/m,
+      "'<Word> **finders**'",
+    );
+    expect(claimed, `README spells out ${claimed} finders but code has ${TRIGGERS.length}`).toBe(
       TRIGGERS.length,
     );
   });

--- a/repo/__tests__/readme-counts.test.ts
+++ b/repo/__tests__/readme-counts.test.ts
@@ -1,0 +1,104 @@
+/**
+ * README count guard.
+ *
+ * The README advertises hard numbers — how many CLI commands, plays and
+ * finders ship — and those numbers go stale the moment someone adds a
+ * command without re-counting. Each one here is derived from the code that
+ * defines it, so the README can only drift for as long as this test is red.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { beforeAll, describe, expect, it } from "vitest";
+import type { Command } from "commander";
+import { PLAYS } from "../../packages/plays/src/registry.ts";
+import { TRIGGERS } from "../../packages/find/src/registry.ts";
+// `PLAYS` is the *email* dispatch table, so it is two short of the play count
+// the README quotes: concierge is a voice play and demo-no-show is SMS, and
+// both are invoked straight from the CLI's `motion` group rather than through
+// the shared email runner. Importing their runners keeps the +2 honest — delete
+// either file and this test stops compiling rather than quietly under-counting.
+import { runConcierge } from "../../packages/plays/src/concierge.ts";
+import { runDemoNoShow } from "../../packages/plays/src/demo-no-show.ts";
+
+const NON_EMAIL_PLAYS = [runConcierge, runDemoNoShow];
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "../..");
+const README = fs.readFileSync(path.join(REPO_ROOT, "README.md"), "utf8");
+
+/**
+ * A leaf command is one a user can actually invoke — `find drain`, not the
+ * `find` group that only exists to hold it. Groups print help and exit, so
+ * counting them would inflate the total the README quotes.
+ */
+function countLeafCommands(cmd: Command): number {
+  let leaves = 0;
+  for (const sub of cmd.commands) {
+    leaves += sub.commands.length === 0 ? 1 : countLeafCommands(sub);
+  }
+  return leaves;
+}
+
+/** Pull a single capture group out of the README, failing loudly if the prose moved. */
+function readmeNumber(pattern: RegExp, label: string): number {
+  const match = README.match(pattern);
+  if (!match?.[1]) {
+    throw new Error(
+      `README.md no longer contains a "${label}" count matching ${pattern}. ` +
+        `Update the pattern in this test alongside the prose.`,
+    );
+  }
+  return Number(match[1]);
+}
+
+let commandCount: number;
+
+beforeAll(async () => {
+  // index.ts parses process.argv at import time when it is the real CLI entry
+  // point; the sentinel suppresses that so we get the command tree only.
+  process.env["ONESHOT_GTM_CLI_NO_PARSE"] = "1";
+  const { program } = await import("../../apps/cli/src/index.ts");
+  commandCount = countLeafCommands(program);
+});
+
+describe("README counts match the code", () => {
+  it("quotes the right number of CLI commands in the command table", () => {
+    const claimed = readmeNumber(/^(\d+) commands —/m, "N commands");
+    expect(claimed, `README claims ${claimed} commands but code has ${commandCount}`).toBe(
+      commandCount,
+    );
+  });
+
+  it("quotes the right number of CLI commands in the layout tree", () => {
+    const claimed = readmeNumber(/(\d+)-command CLI/, "N-command CLI");
+    expect(claimed, `README claims a ${claimed}-command CLI but code has ${commandCount}`).toBe(
+      commandCount,
+    );
+  });
+
+  it("quotes the right number of plays", () => {
+    const claimed = readmeNumber(/(\d+) outreach plays/, "N outreach plays");
+    const actual = Object.keys(PLAYS).length + NON_EMAIL_PLAYS.length;
+    expect(claimed, `README claims ${claimed} plays but code has ${actual}`).toBe(actual);
+  });
+
+  it("quotes the right number of finders", () => {
+    const claimed = readmeNumber(/(\d+) finders/, "N finders");
+    expect(claimed, `README claims ${claimed} finders but code has ${TRIGGERS.length}`).toBe(
+      TRIGGERS.length,
+    );
+  });
+
+  // The README also quotes "N cases across M files" for the test suite, and
+  // those two numbers are deliberately NOT asserted here. They are the one
+  // pair a test cannot check honestly: any commit that adds or removes a test
+  // changes them, and this file is itself a test — so the assertion would fail
+  // against the very commit that updates the README to the correct figure, and
+  // the correct figure depends on whether this test's own cases are counted.
+  // A self-referential guard like that reports red on every green change. The
+  // suite totals are spot-checked against a real `bun run test` run instead.
+  // We do still confirm the sentence exists, so a reformat can't silently drop
+  // the numbers the maintainer is expected to refresh.
+  it("still states the test-suite totals for a human to refresh", () => {
+    expect(README).toMatch(/(\d+) cases across (\d+) files/);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,7 +3,13 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["packages/**/__tests__/**/*.test.ts", "apps/**/__tests__/**/*.test.ts"],
+    include: [
+      "packages/**/__tests__/**/*.test.ts",
+      "apps/**/__tests__/**/*.test.ts",
+      // repo/ holds tests about the repository itself (docs vs. code drift),
+      // not about a single package.
+      "repo/__tests__/**/*.test.ts",
+    ],
     exclude: ["**/node_modules/**", "**/dist/**"],
     // Redirect every test's data-dir I/O to a throwaway temp dir so the suite
     // never reads or mutates the developer's real ~/.oneshot-gtm. See setup file.


### PR DESCRIPTION
Closes #100.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 0f721308ab0a (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add test asserting README command, play, and finder counts against code
> - Adds a Vitest suite in [readme-counts.test.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/105/files#diff-8a0b3b352a1d801165e9f9633cf3bd10a0619207a3a79771b50a388369423cb8) that derives CLI leaf-command, play, and finder counts from the code and asserts they match the numbers in [README.md](https://github.com/oneshot-agent/oneshot-gtm/pull/105/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5)
> - Updates README command count from 48 to 49 to reflect the current CLI
> - Guards `program.parseAsync` in [index.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/105/files#diff-4565ec586fe8103913bc7f7abc9b548cb8f4d8403669752a5f10874118093bce) with the `ONESHOT_GTM_CLI_NO_PARSE` env var so the module can be imported without argv side effects; also exports the Commander `program` object
> - Extends [vitest.config.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/105/files#diff-2ee894bf23aa44ff4ce12a3da8af19ab20180474ebf2176dbe5f2eea3f96dc92) to include `repo/__tests__/**/*.test.ts`
> - Behavioral Change: importing `apps/cli/src/index.ts` no longer parses `process.argv` when `ONESHOT_GTM_CLI_NO_PARSE` is set; default behavior (no env var) is unchanged
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0ba0a02.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->