### PR TITLE
fix: issue #98: feat(server): cancel an in-flight run — abort on client disconnect and via an explicit cancel route

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -40,7 +40,7 @@ The verify gate has holes an agent can close without touching product behaviour.
 - [ ] **Install-wide daily spend ceiling** · M — spend caps are per trigger run (`maxCostUsd`, `maxSpendPerRun` in `packages/find/src/registry.ts`). Eleven finders on their own intervals, plus drains and cadence steps, have no shared daily bound and no kill switch.
       _Done when:_ a configurable daily USD ceiling is checked before any paid call; crossing it halts finders and auto-drains with a named reason surfaced on the trigger cards and in `doctor`; manual sends from `/queue` still go through; the counter resets at local midnight and is covered by tests around the boundary.
       _Done when:_ `--once` exits 1 if any due trigger errored, 0 otherwise; the daemon loop keeps its current behaviour; both covered.
-- [ ] **Cancel an in-flight run** · M — `POST /api/run/:playName` streams drafts over SSE and there is no cancel path. Closing the tab abandons the stream while the run keeps drafting and spending.
+- [x] **Cancel an in-flight run** · M — `POST /api/run/:playName` streams drafts over SSE and there is no cancel path. Closing the tab abandons the stream while the run keeps drafting and spending.
       _Done when:_ a client disconnect or an explicit cancel aborts the run, the `runs` row lands in a terminal `cancelled` state, no further paid call is issued after the abort, and the cold-boot sweep still reconciles a run orphaned by process exit.
 
 ## Learning loop

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 49 CLI commands, 17 plays, 11 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-08-30** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2081 tests / 161 files** · typecheck + oxlint + oxfmt clean.
+Last verified **2026-08-30** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2099 tests / 162 files** · typecheck + oxlint + oxfmt clean, all measured on this branch.
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 49 CLI commands, 17 plays, 11 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-08-30** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2099 tests / 162 files** · typecheck + oxlint + oxfmt clean, all measured on this branch.
+Last verified **2026-08-30** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2081 tests / 161 files** · typecheck + oxlint + oxfmt clean.
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/apps/server/__tests__/run-route.test.ts
+++ b/apps/server/__tests__/run-route.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getLedger, RunCancelledError } from "@oneshot-gtm/core";
 import type { RunPlayEvent } from "@oneshot-gtm/shared-types";
 
 interface VerifyResult<T> {
@@ -17,6 +18,24 @@ let nextVerify: VerifyResult<unknown> = {
 let captureVerifyArgs: { targets: unknown[]; playName: string; dryRun: boolean } | null = null;
 
 const playCalls: { name: string; targets: unknown[] }[] = [];
+
+interface FakeDraft {
+  subject: string;
+  body: string;
+  flags: string[];
+  sent: boolean;
+  receiptIds: number[];
+}
+type FakeRunInput = {
+  targets: unknown[];
+  onProgress?: (index: number, draft: FakeDraft) => void;
+};
+/**
+ * Per-test override for the fake play's `run`, so a test can model what the
+ * happy-path fake can't: a play that rejects (cancelled, or plainly broken)
+ * while one of its workers is still in flight.
+ */
+let runOverride: ((input: FakeRunInput) => Promise<{ drafted: unknown[] }>) | null = null;
 
 vi.mock("@oneshot-gtm/plays", async () => {
   const actual = await vi.importActual<typeof import("@oneshot-gtm/plays")>("@oneshot-gtm/plays");
@@ -42,6 +61,7 @@ vi.mock("@oneshot-gtm/plays", async () => {
       ) => void;
     }) => {
       playCalls.push({ name, targets: input.targets });
+      if (runOverride) return runOverride(input);
       if (name === "show-hn") {
         const drafted = input.targets.map((_, i) => ({
           target: { postTitle: `t${i}` },
@@ -90,11 +110,12 @@ vi.mock("@oneshot-gtm/plays", async () => {
 
 const { runPlay } = await import("../src/api/run.ts");
 
-function makeRequest(playName: string, body: unknown): Request {
+function makeRequest(playName: string, body: unknown, signal?: AbortSignal): Request {
   return new Request(`http://127.0.0.1:3030/api/run/${playName}`, {
     method: "POST",
     headers: { "content-type": "application/json", origin: "http://127.0.0.1:3030" },
     body: JSON.stringify(body),
+    ...(signal ? { signal } : {}),
   });
 }
 
@@ -125,6 +146,7 @@ beforeEach(() => {
   nextVerify = { verified: [], dropped: [], receiptIds: [], costUsd: 0 };
   captureVerifyArgs = null;
   playCalls.length = 0;
+  runOverride = null;
 });
 
 afterEach(() => {
@@ -229,6 +251,60 @@ describe("runPlay — verify-then-dispatch", () => {
     expect(sends.map((f) => (f as { index: number }).index)).toEqual([0, 1]);
     const done = frames.find((f) => f.kind === "done");
     expect(done).toMatchObject({ kind: "done", total: 2 });
+  });
+
+  it("records a send reported after the cancel already wrote the row", async () => {
+    // The play's Promise.all rejects on the first cancelled worker while a
+    // sibling is still inside sendDraftedEmail. That sibling's email left and
+    // enrolled in a cadence, so it has to reach prospect_emails_json even
+    // though it lands after the terminal write — /cadences?sinceRun reads it.
+    const targets = [{ founderEmail: "a@x.dev" }, { founderEmail: "b@x.dev" }];
+    nextVerify = { verified: targets, dropped: [], receiptIds: [], costUsd: 0 };
+    const straggler: { fire: () => void } = { fire: () => {} };
+    const draft = (i: number): FakeDraft => ({
+      subject: `subj-${i}`,
+      body: `body-${i}`,
+      flags: [],
+      sent: true,
+      receiptIds: [100 + i],
+    });
+    runOverride = (input) => {
+      input.onProgress?.(0, draft(0));
+      straggler.fire = () => input.onProgress?.(1, draft(1));
+      return Promise.reject(new RunCancelledError("show-hn send: cancelled by user"));
+    };
+    const res = await runPlay(makeRequest("show-hn", { targets, dryRun: false }), {
+      playName: "show-hn",
+    });
+    const frames = await readSseFrames(res.body);
+    const started = frames.find((f) => f.kind === "runStarted") as { runId: number };
+    expect(frames.find((f) => f.kind === "cancelled")).toBeDefined();
+    // The stream is closed — i.e. the terminal ledger write already happened.
+    straggler.fire();
+    const row = getLedger().getRun(started.runId);
+    expect(row?.status).toBe("cancelled");
+    expect(row?.prospectEmails).toEqual(["a@x.dev", "b@x.dev"]);
+  });
+
+  it("reports a real error as an error even when the client already disconnected", async () => {
+    // Disconnect fires the run's abort, but what actually ended the run was an
+    // SDK failure — it must land as `error`, not get relabelled a cancellation.
+    const targets = [{ founderEmail: "a@x.dev" }];
+    nextVerify = { verified: targets, dropped: [], receiptIds: [], costUsd: 0 };
+    const clientGone = new AbortController();
+    runOverride = () => {
+      clientGone.abort("client disconnected");
+      return Promise.reject(new Error("SDK exploded"));
+    };
+    const res = await runPlay(
+      makeRequest("show-hn", { targets, dryRun: false }, clientGone.signal),
+      { playName: "show-hn" },
+    );
+    const frames = await readSseFrames(res.body);
+    const started = frames.find((f) => f.kind === "runStarted") as { runId: number };
+    expect(frames.find((f) => f.kind === "error")).toMatchObject({ message: "SDK exploded" });
+    expect(frames.find((f) => f.kind === "cancelled")).toBeUndefined();
+    expect(getLedger().getRun(started.runId)?.status).not.toBe("cancelled");
   });
 
   it("returns 400 when playName is not in SUPPORTED", async () => {

--- a/apps/server/src/api/_play-dispatch.ts
+++ b/apps/server/src/api/_play-dispatch.ts
@@ -38,11 +38,17 @@ export function toDraftedView(d: {
  * happen instead of batching at the end. The PlayDraft → DraftedView
  * projection is applied inside the wrapper so the callback gets the same
  * shape downstream code expects.
+ *
+ * `signal`: the run's cancellation signal, forwarded to the play so it can
+ * bail at its paid-call boundaries. When it fires mid-run this call rejects
+ * with a `RunCancelledError` (see `isRunCancelled`) instead of resolving with
+ * a partial batch — the drafts already finished were reported via `onProgress`.
  */
 export async function dispatchPlay(
   playName: string,
   body: RunPlayRequest,
   onProgress?: (index: number, view: DraftedView) => void,
+  signal?: AbortSignal,
 ): Promise<DraftedView[]> {
   const play = PLAYS[playName];
   if (!play) {
@@ -54,6 +60,7 @@ export async function dispatchPlay(
     targets: body.targets,
     ...(body.senderCohort ? { senderCohort: body.senderCohort } : {}),
     ...(body.freeForCohortOffer ? { freeForCohortOffer: body.freeForCohortOffer } : {}),
+    ...(signal ? { signal } : {}),
     ...(onProgress
       ? {
           onProgress: (index: number, draft: Parameters<typeof toDraftedView>[0]) =>

--- a/apps/server/src/api/run.ts
+++ b/apps/server/src/api/run.ts
@@ -82,10 +82,14 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
       // counters `done` would have.
       let sentCount = 0;
       let draftedCount = 0;
-      // Set once the pipeline emitted its `done` frame. The `finally` needs to
-      // tell "the run ended, then the client left" from "the client left, so
-      // the run ended" — only the second is a cancellation.
+      // Set once the run reached a terminal state of its own — a `done` frame
+      // or a real error. The `finally` needs to tell "the run ended, then the
+      // client left" from "the client left, so the run ended" — only the
+      // second is a cancellation.
       let finished = false;
+      // Set once the terminal ledger write happened. Past that point a send
+      // reported by a straggler worker has to be written again (see below).
+      let terminalWritten = false;
       // Non-null once the run is known to have been cancelled; carries the
       // reason that gets persisted on the row.
       let cancelledReason: string | null = null;
@@ -174,7 +178,20 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
                 | { email?: string; founderEmail?: string }
                 | undefined;
               const email = t?.email ?? t?.founderEmail;
-              if (email) sentEmails.push(email);
+              if (!email) return;
+              sentEmails.push(email);
+              // A cancellation rejects the play's Promise.all at once, but its
+              // sibling workers can still be inside sendDraftedEmail — they
+              // report here AFTER the terminal row was written. That email did
+              // leave and did enrol in the cadence, so re-write the list or
+              // /cadences?sinceRun silently omits its recipient.
+              if (terminalWritten) {
+                try {
+                  ledger.setRunSentEmails({ runId, sentEmails });
+                } catch {
+                  // ledger write failing is the sweeper's problem
+                }
+              }
             }
           },
           runAbort.signal,
@@ -216,6 +233,10 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
           return;
         }
         runOutcome = "error";
+        // The run ended on its own terms, badly — not because the client left.
+        // Mark it settled so a disconnect that follows (or caused nothing but
+        // an abort on the way out) can't relabel a real failure a cancellation.
+        finished = true;
         // Log the full error server-side — the SSE event only carries a short
         // message, and the SDK's generic "Tool request failed" is useless
         // without status/body/stack.
@@ -289,6 +310,9 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
         } catch {
           // sweeper safety net
         }
+        // Any send reported from here on is a straggler and writes its own row
+        // update — the array captured above is already in the database.
+        terminalWritten = true;
         // Release BEFORE closing the stream: past here there is nothing left
         // to abort, and a retained entry would leak a controller per run and
         // let a later cancel "succeed" against a run that already ended.

--- a/apps/server/src/api/run.ts
+++ b/apps/server/src/api/run.ts
@@ -65,6 +65,7 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
   // the stream's own `cancel()` below: between them they cover a closed tab, a
   // navigation, and a reader that simply stops pulling.
   req.signal.addEventListener("abort", () => abortOnce("client disconnected"), { once: true });
+  if (req.signal.aborted) abortOnce("client disconnected");
 
   const stream = new ReadableStream<Uint8Array>({
     cancel() {
@@ -383,7 +384,9 @@ export async function cancelRunRoute(
   req: Request,
   params: Record<string, string>,
 ): Promise<Response> {
-  const runId = Number.parseInt(params["runId"] ?? "", 10);
+  const rawRunId = params["runId"] ?? "";
+  if (!/^\d+$/.test(rawRunId)) return jsonResponse({ error: "bad run id" }, 400, req);
+  const runId = Number.parseInt(rawRunId, 10);
   if (!Number.isFinite(runId)) return jsonResponse({ error: "bad run id" }, 400, req);
 
   // Body is optional — the dashboard's stop button sends none.

--- a/apps/server/src/api/run.ts
+++ b/apps/server/src/api/run.ts
@@ -1,6 +1,20 @@
-import { getLedger, logEvent, type TelemetryOutcome } from "@oneshot-gtm/core";
+import {
+  abortRun,
+  cancelReasonOf,
+  getLedger,
+  isRunCancelled,
+  logEvent,
+  registerRunController,
+  releaseRunController,
+  type TelemetryOutcome,
+} from "@oneshot-gtm/core";
 import { verifyAndFilterTargets } from "@oneshot-gtm/plays";
-import { isRunnablePlay, type RunPlayEvent, type RunPlayRequest } from "@oneshot-gtm/shared-types";
+import {
+  isRunnablePlay,
+  type CancelRunResponse,
+  type RunPlayEvent,
+  type RunPlayRequest,
+} from "@oneshot-gtm/shared-types";
 import { jsonResponse } from "../server.ts";
 import { reportServerExecution } from "../telemetry.ts";
 import { dispatchPlay, type DraftedView } from "./_play-dispatch.ts";
@@ -37,7 +51,25 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
   // Emails that actually sent, for the /cadences?sinceRun=N deep-link.
   const sentEmails: string[] = [];
 
+  // The run's cancellation signal. Two things can fire it: the client going
+  // away (below) and POST /api/run/:runId/cancel, which reaches this
+  // controller through the process-local registry. Everything downstream —
+  // verify, every play, every paid call — reads the same signal, so an abort
+  // stops the spend instead of merely abandoning the stream.
+  const runAbort = new AbortController();
+  registerRunController(runId, runAbort);
+  const abortOnce = (reason: string): void => {
+    if (!runAbort.signal.aborted) runAbort.abort(reason);
+  };
+  // Bun aborts `req.signal` when the client disconnects. Belt and braces with
+  // the stream's own `cancel()` below: between them they cover a closed tab, a
+  // navigation, and a reader that simply stops pulling.
+  req.signal.addEventListener("abort", () => abortOnce("client disconnected"), { once: true });
+
   const stream = new ReadableStream<Uint8Array>({
+    cancel() {
+      abortOnce("client disconnected");
+    },
     async start(controller) {
       const encoder = new TextEncoder();
       const ledger = getLedger();
@@ -45,6 +77,18 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
       const t0 = performance.now();
       let runOutcome: TelemetryOutcome = "ok";
       let fromQueue = false;
+      // Hoisted out of the try so the cancel path can report what the run got
+      // through before the abort — the `cancelled` frame carries the same
+      // counters `done` would have.
+      let sentCount = 0;
+      let draftedCount = 0;
+      // Set once the pipeline emitted its `done` frame. The `finally` needs to
+      // tell "the run ended, then the client left" from "the client left, so
+      // the run ended" — only the second is a cancellation.
+      let finished = false;
+      // Non-null once the run is known to have been cancelled; carries the
+      // reason that gets persisted on the row.
+      let cancelledReason: string | null = null;
       const send = (event: RunPlayEvent): void => {
         // Persist FIRST — the resume view needs every event even after a
         // client disconnect. SSE write second; swallow if the client is gone.
@@ -91,7 +135,7 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
           verify = await verifyAndFilterTargets(
             body.targets as Array<{ email?: string; founderEmail?: string }>,
             (t) => t.email ?? t.founderEmail ?? null,
-            { playName, dryRun: body.dryRun },
+            { playName, dryRun: body.dryRun, signal: runAbort.signal },
           );
         }
         if (verify.dropped.length > 0) {
@@ -106,30 +150,37 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
         // could throw an irrelevant pre-check error on an empty array.
         if (verify.verified.length === 0 && inputCount > 0) {
           send({ kind: "done", total: 0, sent: 0 });
+          finished = true;
           return;
         }
         const filteredBody: RunPlayRequest = { ...body, targets: verify.verified };
 
         send({ kind: "stage", stage: body.dryRun ? "drafting" : "drafting + sending" });
-        let sentCount = 0;
         // Per-target callback: fires draft/send events live so counters tick
         // per target instead of jumping at the end.
-        const drafted = await dispatchPlay(playName, filteredBody, (index, d) => {
-          send({ kind: "draft", index, subject: d.subject, body: d.body, flags: d.flags });
-          if (d.receiptIds.length > 0) {
-            send({ kind: "send", index, receiptIds: d.receiptIds });
-          }
-          if (d.sent) {
-            sentCount++;
-            // Recover the email for the /cadences?sinceRun resolution.
-            const t = verify.verified[index] as
-              | { email?: string; founderEmail?: string }
-              | undefined;
-            const email = t?.email ?? t?.founderEmail;
-            if (email) sentEmails.push(email);
-          }
-        });
+        const drafted = await dispatchPlay(
+          playName,
+          filteredBody,
+          (index, d) => {
+            draftedCount++;
+            send({ kind: "draft", index, subject: d.subject, body: d.body, flags: d.flags });
+            if (d.receiptIds.length > 0) {
+              send({ kind: "send", index, receiptIds: d.receiptIds });
+            }
+            if (d.sent) {
+              sentCount++;
+              // Recover the email for the /cadences?sinceRun resolution.
+              const t = verify.verified[index] as
+                | { email?: string; founderEmail?: string }
+                | undefined;
+              const email = t?.email ?? t?.founderEmail;
+              if (email) sentEmails.push(email);
+            }
+          },
+          runAbort.signal,
+        );
         send({ kind: "done", total: drafted.length, sent: sentCount });
+        finished = true;
 
         // Persist drafts to their originating queue rows for /queue review.
         // Best-effort — a SQLite hiccup here must not surface to the user.
@@ -143,6 +194,27 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
           });
         }
       } catch (err) {
+        // A cancellation is not a failure: the run was told to stop, and every
+        // target behind the abort point billed nothing. Handled before the
+        // error path so it never lands as an `error` frame or an `error`
+        // telemetry outcome. The message carries the phase that was about to
+        // bill ("show-hn send: client disconnected"), which is exactly what
+        // the row's reason should say.
+        if (isRunCancelled(err)) {
+          cancelledReason = (err as Error).message || cancelReasonOf(runAbort.signal);
+          logEvent(
+            "run.cancelled",
+            {
+              play: playName,
+              run_id: runId,
+              reason_120: cancelledReason.slice(0, 120),
+              drafted: draftedCount,
+              sent: sentCount,
+            },
+            "warn",
+          );
+          return;
+        }
         runOutcome = "error";
         // Log the full error server-side — the SSE event only carries a short
         // message, and the SDK's generic "Tool request failed" is useless
@@ -186,13 +258,41 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
         }
         send({ kind: "error", index: -1, message: uiMessage });
       } finally {
-        // Flip the runs row to 'done' regardless of success/failure so the
-        // cold-boot sweep never sees a false 'running'.
+        // The abort can also land without anything throwing — a play that
+        // never reached a guarded boundary, or the last target finishing
+        // between the abort and the next check. An aborted run that never
+        // emitted `done` is a cancellation too; one that did is genuinely
+        // finished and stays `done` no matter when the client left.
+        if (!cancelledReason && !finished && runAbort.signal.aborted) {
+          cancelledReason = cancelReasonOf(runAbort.signal);
+        }
+        if (cancelledReason) {
+          // Terminal frame: same counters `done` would have carried, so a
+          // resumed view renders what the run got through before the stop.
+          send({
+            kind: "cancelled",
+            reason: cancelledReason,
+            total: draftedCount,
+            sent: sentCount,
+          });
+        }
+        // Flip the runs row to a terminal state regardless of
+        // success/failure/cancel so the cold-boot sweep never sees a false
+        // 'running'. `cancelRun` CASes on 'running', so it is a no-op when the
+        // cancel route already wrote the row.
         try {
-          getLedger().markRunComplete({ runId, status: "done", sentEmails });
+          if (cancelledReason) {
+            getLedger().cancelRun({ runId, reason: cancelledReason, sentEmails });
+          } else {
+            getLedger().markRunComplete({ runId, status: "done", sentEmails });
+          }
         } catch {
           // sweeper safety net
         }
+        // Release BEFORE closing the stream: past here there is nothing left
+        // to abort, and a retained entry would leak a controller per run and
+        // let a later cancel "succeed" against a run that already ended.
+        releaseRunController(runId);
         try {
           controller.close();
         } catch {
@@ -201,6 +301,7 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
         const flags: string[] = [];
         if (body.dryRun) flags.push("dry-run");
         if (fromQueue) flags.push("from-queue");
+        if (cancelledReason) flags.push("cancelled");
         void reportServerExecution(`server.run.${playName}`, {
           outcome: runOutcome,
           durationMs: performance.now() - t0,
@@ -232,6 +333,76 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
     status: 200,
     headers: sseHeaders,
   });
+}
+
+/** Cap on the caller-supplied reason so a stray body can't bloat the row. */
+const MAX_CANCEL_REASON = 200;
+const DEFAULT_UI_CANCEL_REASON = "cancelled by user";
+
+/**
+ * `POST /api/run/:runId/cancel` — stop an in-flight run.
+ *
+ * Two independent halves, because a `running` row and a live handler are not
+ * the same thing:
+ *  - `abortRun` fires the AbortController the SSE handler registered, which is
+ *    what actually stops the spend: every play checks the signal before each
+ *    paid call, so nothing bills past the next boundary.
+ *  - the ledger write makes the row terminal now rather than whenever the
+ *    handler unwinds — and covers the orphan case, where the run's process is
+ *    gone and no controller will ever unwind. `cancelRun` CASes on 'running',
+ *    so the handler's own write later is a harmless no-op.
+ *
+ * Cancelling an already-terminal run is a 200 no-op, not an error: the stop
+ * button races the run's own completion, and losing that race is not a fault.
+ */
+export async function cancelRunRoute(
+  req: Request,
+  params: Record<string, string>,
+): Promise<Response> {
+  const runId = Number.parseInt(params["runId"] ?? "", 10);
+  if (!Number.isFinite(runId)) return jsonResponse({ error: "bad run id" }, 400, req);
+
+  // Body is optional — the dashboard's stop button sends none.
+  let reason = DEFAULT_UI_CANCEL_REASON;
+  try {
+    const body = (await req.json()) as { reason?: unknown } | null;
+    if (body && typeof body.reason === "string" && body.reason.trim().length > 0) {
+      reason = body.reason.trim().slice(0, MAX_CANCEL_REASON);
+    }
+  } catch {
+    // no/!JSON body — the default reason stands
+  }
+
+  const run = getLedger().getRun(runId);
+  if (!run) return jsonResponse({ error: `run #${runId} not found` }, 404, req);
+  if (run.status !== "running") {
+    const view: CancelRunResponse = {
+      runId,
+      status: run.status,
+      cancelled: false,
+      aborted: false,
+      reason: run.cancelReason,
+    };
+    return jsonResponse(view, 200, req);
+  }
+
+  // Abort first: the sooner the signal fires, the fewer paid calls get past
+  // their boundary. The ledger write follows either way.
+  const aborted = abortRun(runId, reason);
+  const result = getLedger().cancelRun({ runId, reason });
+  logEvent(
+    "run.cancel_requested",
+    { run_id: runId, play: run.playName, aborted, cancelled: result.cancelled },
+    "warn",
+  );
+  const view: CancelRunResponse = {
+    runId,
+    status: result.status ?? run.status,
+    cancelled: result.cancelled,
+    aborted,
+    reason,
+  };
+  return jsonResponse(view, 200, req);
 }
 
 /**

--- a/apps/server/src/api/runs.ts
+++ b/apps/server/src/api/runs.ts
@@ -5,7 +5,7 @@ import { jsonResponse } from "../server.ts";
 /**
  * `GET /api/runs/:id` — snapshot of one /run-page dispatch. The UI polls this
  * every 2s while `status === 'running'`, then stops once `status` flips to
- * `done` or `interrupted`. The full events array is returned so the resume
+ * `done`, `interrupted` or `cancelled`. The full events array is returned so the resume
  * view can rebuild per-target rows identically to a live SSE consumer.
  */
 export function getRunRoute(req: Request, params: Record<string, string>): Response {
@@ -29,6 +29,7 @@ export function getRunRoute(req: Request, params: Record<string, string>): Respo
     targets: run.targets,
     events: run.events as RunPlayEvent[],
     prospectEmails: run.prospectEmails,
+    cancelReason: run.cancelReason ?? null,
   };
   return jsonResponse(view, 200, req);
 }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -25,7 +25,7 @@ import { strategistRoute } from "./api/strategist.ts";
 import { doctor } from "./api/doctor.ts";
 import { workspaceInfo, workspaceLaunch } from "./api/workspace.ts";
 import { pauseDomainRoute, resumeDomainRoute } from "./api/domains.ts";
-import { runPlay } from "./api/run.ts";
+import { cancelRunRoute, runPlay } from "./api/run.ts";
 import { getRunRoute } from "./api/runs.ts";
 import {
   approveAllRoute,
@@ -105,6 +105,9 @@ const routes: RouteEntry[] = [
   route("GET", "/api/workspace", workspaceInfo),
   route("POST", "/api/workspace/launch", workspaceLaunch),
   route("POST", "/api/run/:playName", runPlay),
+  // Distinct shape from the line above (three segments, not two), so the
+  // patterns can't collide however they are ordered.
+  route("POST", "/api/run/:runId/cancel", cancelRunRoute),
   route("GET", "/api/runs/:id", getRunRoute),
   route("POST", "/api/prospects/add", addProspectRoute),
   route("GET", "/api/queue", listQueueRoute),

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -2,6 +2,7 @@ import type {
   AddProspectResult,
   CadencesResult,
   CadenceView,
+  CancelRunResponse,
   DoctorCheck,
   DrainRequest,
   DrainResult,
@@ -67,6 +68,8 @@ export const api = {
     return getJson<CadencesResult>(`/cadences${qs.length > 0 ? `?${qs.join("&")}` : ""}`);
   },
   run: (id: number) => getJson<RunRecord>(`/runs/${id}`),
+  cancelRun: (id: number, reason?: string) =>
+    postJson<CancelRunResponse>(`/run/${id}/cancel`, reason ? { reason } : {}),
   cadenceForProspect: (id: number) => getJson<{ cadences: CadenceView[] }>(`/cadences/${id}`),
   stopCadence: (id: number, playName?: string) =>
     postJson<{ stopped: number }>(

--- a/apps/web/src/routes/run.$playName.tsx
+++ b/apps/web/src/routes/run.$playName.tsx
@@ -491,8 +491,8 @@ function RunPage() {
           <div className="mt-3 rounded-[var(--radius-sm)] border border-[color:var(--ink-blocked-2)] bg-[color:var(--ink-blocked-2)]/10 px-3 py-2 font-mono text-[12px] text-[color:var(--ink-blocked-2)]">
             Run #{runRecord.id} was cancelled
             {runRecord.cancelReason ? ` — ${runRecord.cancelReason}` : ""}. {runRecord.sentCount} of{" "}
-            {runRecord.targetCount} sent before the stop; the rest never billed. Click{" "}
-            <em>Run again</em> below to re-fire the remaining targets.
+            {runRecord.targetCount} sent before the stop; targets that hadn't started yet were never
+            billed. Click <em>Run again</em> below to re-fire the remaining targets.
           </div>
         )}
       </section>
@@ -643,7 +643,8 @@ function RunPage() {
           <div className="flex items-center gap-2 text-[12px] text-ink-muted">
             <Loader2 size={14} className="animate-spin" />
             <span>
-              Run #{search.runId} in progress · your progress is saved · feel free to navigate away.
+              Run #{search.runId} in progress · your progress is saved · closing or reloading this
+              tab stops the run.
             </span>
             <Button
               variant="ghost"

--- a/apps/web/src/routes/run.$playName.tsx
+++ b/apps/web/src/routes/run.$playName.tsx
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
-import { ArrowLeft, CheckCircle2, Loader2, Play, Plus, RefreshCw, Trash2 } from "lucide-react";
+import { ArrowLeft, CheckCircle2, Loader2, Play, Plus, RefreshCw, Trash2, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   parseQueueIds,
@@ -88,6 +88,8 @@ function RunPage() {
   // commonly a preview than a real send.
   const [dryRun, setDryRun] = useState(search.dryRun !== "0");
   const [running, setRunning] = useState(false);
+  // In-flight state for the Stop button, so a slow cancel can't be double-fired.
+  const [cancelling, setCancelling] = useState(false);
   const [events, setEvents] = useState<RunPlayEvent[]>([]);
   const [error, setError] = useState<string | null>(null);
   const navigate = Route.useNavigate();
@@ -114,7 +116,7 @@ function RunPage() {
     search.runId != null &&
     runQuery.isError &&
     /\b404\b/.test((runQuery.error as Error | null)?.message ?? "");
-  const mode: "edit" | "progress" | "done" | "interrupted" =
+  const mode: "edit" | "progress" | "done" | "interrupted" | "cancelled" =
     search.runId == null || runNotFound
       ? "edit"
       : runRecord == null
@@ -123,7 +125,9 @@ function RunPage() {
           ? "progress"
           : runRecord.status === "interrupted"
             ? "interrupted"
-            : "done";
+            : runRecord.status === "cancelled"
+              ? "cancelled"
+              : "done";
   // When the server-persisted record arrives, mirror its events into the
   // local stream array so the existing per-target rendering keeps working
   // unmodified. Local SSE writes still hit setEvents during a live submit;
@@ -244,6 +248,9 @@ function RunPage() {
   }, [events]);
 
   const doneEvent = events.find((e) => e.kind === "done");
+  // Terminal counterpart to `done` for an aborted run — present on both the
+  // live stream and the persisted resume view.
+  const cancelledEvent = events.find((e) => e.kind === "cancelled");
   const errorEvents = events.filter((e) => e.kind === "error");
   const verifyEvent = events.find((e) => e.kind === "verify");
   // Latest pipeline stage ("verifying" / "drafting + sending"), shown while the
@@ -480,6 +487,14 @@ function RunPage() {
             step-0 dedupe).
           </div>
         )}
+        {mode === "cancelled" && runRecord && (
+          <div className="mt-3 rounded-[var(--radius-sm)] border border-[color:var(--ink-blocked-2)] bg-[color:var(--ink-blocked-2)]/10 px-3 py-2 font-mono text-[12px] text-[color:var(--ink-blocked-2)]">
+            Run #{runRecord.id} was cancelled
+            {runRecord.cancelReason ? ` — ${runRecord.cancelReason}` : ""}. {runRecord.sentCount} of{" "}
+            {runRecord.targetCount} sent before the stop; the rest never billed. Click{" "}
+            <em>Run again</em> below to re-fire the remaining targets.
+          </div>
+        )}
       </section>
 
       {schema.extras && (
@@ -605,6 +620,9 @@ function RunPage() {
                 sent
               </span>
               {doneEvent?.kind === "done" && <span className="text-ink-muted">· done</span>}
+              {cancelledEvent?.kind === "cancelled" && (
+                <span className="text-ink-muted">· cancelled</span>
+              )}
             </>
           )}
           {running && aggregate.drafts === 0 && (
@@ -627,9 +645,30 @@ function RunPage() {
             <span>
               Run #{search.runId} in progress · your progress is saved · feel free to navigate away.
             </span>
+            <Button
+              variant="ghost"
+              disabled={cancelling}
+              onClick={() => {
+                if (search.runId == null) return;
+                setCancelling(true);
+                // Targets already drafted keep their rows; the ones behind the
+                // abort simply never bill. Refetch so the banner flips to the
+                // cancelled state as soon as the row lands.
+                void api
+                  .cancelRun(search.runId, "cancelled from the dashboard")
+                  .catch((e: unknown) => setError((e as Error).message))
+                  .finally(() => {
+                    setCancelling(false);
+                    void runQuery.refetch();
+                  });
+              }}
+            >
+              <X size={14} />
+              {cancelling ? "Stopping…" : "Stop run"}
+            </Button>
           </div>
         )}
-        {(mode === "done" || mode === "interrupted") && (
+        {(mode === "done" || mode === "interrupted" || mode === "cancelled") && (
           <div className="flex items-center gap-2">
             {search.runId != null && (runRecord?.sentCount ?? 0) > 0 && (
               <Button

--- a/apps/web/src/routes/run.$playName.tsx
+++ b/apps/web/src/routes/run.$playName.tsx
@@ -690,6 +690,7 @@ function RunPage() {
             )}
             <Button
               variant="ghost"
+              disabled={running}
               onClick={() => {
                 setEvents([]);
                 setError(null);

--- a/packages/core/__tests__/ledger-cancel-run.test.ts
+++ b/packages/core/__tests__/ledger-cancel-run.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { Ledger } from "../src/ledger.ts";
+
+let dbPath: string;
+let ledger: Ledger;
+
+beforeEach(() => {
+  dbPath = join(
+    tmpdir(),
+    `oneshot-gtm-cancel-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`,
+  );
+  ledger = new Ledger(dbPath);
+});
+
+afterEach(() => {
+  ledger.close();
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      rmSync(`${dbPath}${suffix}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+function newRun(playName = "show-hn"): number {
+  return ledger.createRun({ playName, dryRun: false, targets: [{ email: "a@x.dev" }] }).runId;
+}
+
+describe("Ledger.cancelRun", () => {
+  it("flips a running row to the terminal cancelled state with its reason", () => {
+    const runId = newRun();
+    const res = ledger.cancelRun({ runId, reason: "cancelled by user" });
+    expect(res).toEqual({ cancelled: true, status: "cancelled" });
+    const run = ledger.getRun(runId)!;
+    expect(run.status).toBe("cancelled");
+    expect(run.cancelReason).toBe("cancelled by user");
+    expect(run.completedAt).not.toBeNull();
+  });
+
+  it("records what actually sent before the abort", () => {
+    const runId = newRun();
+    ledger.cancelRun({ runId, reason: "client disconnected", sentEmails: ["a@x.dev"] });
+    expect(ledger.getRun(runId)?.prospectEmails).toEqual(["a@x.dev"]);
+  });
+
+  it("is a no-op — not an error — against a run that already finished", () => {
+    // Acceptance (d): the stop button races the run's own completion, and
+    // losing that race must not corrupt the row or throw.
+    const runId = newRun();
+    ledger.markRunComplete({ runId, status: "done", sentEmails: ["a@x.dev"] });
+    const completedAt = ledger.getRun(runId)?.completedAt;
+    const res = ledger.cancelRun({ runId, reason: "cancelled by user" });
+    expect(res).toEqual({ cancelled: false, status: "done" });
+    const run = ledger.getRun(runId)!;
+    expect(run.status).toBe("done");
+    expect(run.cancelReason).toBeNull();
+    expect(run.completedAt).toBe(completedAt);
+  });
+
+  it("only the first of two concurrent cancels reports having done it", () => {
+    const runId = newRun();
+    expect(ledger.cancelRun({ runId, reason: "route" }).cancelled).toBe(true);
+    const second = ledger.cancelRun({ runId, reason: "sse handler" });
+    expect(second).toEqual({ cancelled: false, status: "cancelled" });
+    // The first reason is the one that survives.
+    expect(ledger.getRun(runId)?.cancelReason).toBe("route");
+  });
+
+  it("still records the handler's sent emails when the route flipped the row first", () => {
+    // The two writers land in either order; the emails belong on the record
+    // regardless of which one won the CAS.
+    const runId = newRun();
+    ledger.cancelRun({ runId, reason: "cancelled by user" });
+    ledger.cancelRun({ runId, reason: "show-hn send: cancelled by user", sentEmails: ["a@x.dev"] });
+    expect(ledger.getRun(runId)?.prospectEmails).toEqual(["a@x.dev"]);
+    expect(ledger.getRun(runId)?.cancelReason).toBe("cancelled by user");
+  });
+
+  it("cannot be resurrected as 'done' by a late markRunComplete", () => {
+    const runId = newRun();
+    ledger.cancelRun({ runId, reason: "cancelled by user" });
+    ledger.markRunComplete({ runId, status: "done", sentEmails: [] });
+    expect(ledger.getRun(runId)?.status).toBe("cancelled");
+  });
+
+  it("reports a null status for a run that does not exist", () => {
+    expect(ledger.cancelRun({ runId: 987654, reason: "x" })).toEqual({
+      cancelled: false,
+      status: null,
+    });
+  });
+
+  it("leaves a cancelled row out of the running list and findable by status", () => {
+    const cancelled = newRun("show-hn");
+    const live = newRun("post-funding");
+    ledger.cancelRun({ runId: cancelled, reason: "cancelled by user" });
+    expect(ledger.listRuns({ status: "running" }).map((r) => r.id)).toEqual([live]);
+    expect(ledger.listRuns({ status: "cancelled" }).map((r) => r.id)).toEqual([cancelled]);
+  });
+});
+
+describe("sweepStaleRuns vs cancelled runs", () => {
+  it("leaves a cancelled row alone on cold boot (acceptance b)", () => {
+    const cancelled = newRun("show-hn");
+    ledger.cancelRun({ runId: cancelled, reason: "cancelled by user" });
+    const completedAt = ledger.getRun(cancelled)?.completedAt;
+
+    const swept = ledger.sweepStaleRuns({ now: new Date(), maxAgeMs: 0 });
+    expect(swept).toHaveLength(0);
+    const run = ledger.getRun(cancelled)!;
+    expect(run.status).toBe("cancelled");
+    expect(run.cancelReason).toBe("cancelled by user");
+    expect(run.completedAt).toBe(completedAt);
+  });
+
+  it("still reconciles a run orphaned by process exit (acceptance c)", () => {
+    // The row the dead process left behind: 'running', no controller anywhere.
+    const orphan = newRun("post-funding");
+    const cancelled = newRun("show-hn");
+    ledger.cancelRun({ runId: cancelled, reason: "cancelled by user" });
+
+    const swept = ledger.sweepStaleRuns({ now: new Date(), maxAgeMs: 0 });
+    expect(swept.map((s) => s.id)).toEqual([orphan]);
+    expect(ledger.getRun(orphan)?.status).toBe("interrupted");
+    expect(ledger.getRun(cancelled)?.status).toBe("cancelled");
+  });
+
+  it("does not report a row it did not actually write", () => {
+    // The sweep's SELECT and UPDATE are separate statements; a cancel landing
+    // between them must not produce a phantom 'swept' log line.
+    const runId = newRun();
+    const rows = ledger.listRuns({ status: "running" });
+    expect(rows.map((r) => r.id)).toEqual([runId]);
+    ledger.cancelRun({ runId, reason: "cancelled by user" });
+    expect(ledger.sweepStaleRuns({ now: new Date(), maxAgeMs: 0 })).toHaveLength(0);
+  });
+});
+
+describe("runs.status CHECK widening", () => {
+  it("admits 'cancelled' on a database created before the state existed", async () => {
+    // Dynamic import: `bun:sqlite` is only resolvable at runtime here, as the
+    // other ledger tests do it.
+    const { Database } = await import("bun:sqlite");
+    // A pre-v24 install: the CHECK constraint physically rejects the new
+    // state, and SQLite cannot ALTER it — so the open path has to rebuild.
+    ledger.close();
+    const legacyPath = join(
+      tmpdir(),
+      `oneshot-gtm-legacy-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`,
+    );
+    const raw = new Database(legacyPath);
+    raw.exec(`
+      CREATE TABLE runs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        play_name TEXT NOT NULL,
+        dry_run INTEGER NOT NULL,
+        status TEXT NOT NULL CHECK(status IN ('running','done','interrupted')),
+        started_at TEXT NOT NULL,
+        completed_at TEXT,
+        target_count INTEGER NOT NULL,
+        drafted_count INTEGER NOT NULL DEFAULT 0,
+        sent_count INTEGER NOT NULL DEFAULT 0,
+        error_count INTEGER NOT NULL DEFAULT 0,
+        targets_json TEXT NOT NULL,
+        events_json TEXT NOT NULL DEFAULT '[]',
+        prospect_emails_json TEXT NOT NULL DEFAULT '[]'
+      );
+      INSERT INTO runs (id, play_name, dry_run, status, started_at, target_count, targets_json,
+                        events_json, prospect_emails_json)
+        VALUES (5, 'show-hn', 0, 'running', '2026-08-01T00:00:00.000Z', 1, '[{"email":"a@x.dev"}]',
+                '[{"kind":"draft"}]', '["a@x.dev"]');
+    `);
+    raw.close();
+
+    const migrated = new Ledger(legacyPath);
+    try {
+      // The pre-existing row survives the rebuild intact, id included.
+      const before = migrated.getRun(5)!;
+      expect(before.playName).toBe("show-hn");
+      expect(before.status).toBe("running");
+      expect(before.events).toHaveLength(1);
+      expect(before.prospectEmails).toEqual(["a@x.dev"]);
+      expect(before.cancelReason).toBeNull();
+
+      expect(migrated.cancelRun({ runId: 5, reason: "cancelled by user" }).cancelled).toBe(true);
+      expect(migrated.getRun(5)?.status).toBe("cancelled");
+      // The status index came back with the rebuilt table.
+      expect(migrated.listRuns({ status: "cancelled" }).map((r) => r.id)).toEqual([5]);
+      // AUTOINCREMENT still hands out ids above the migrated row.
+      expect(
+        migrated.createRun({ playName: "post-funding", dryRun: true, targets: [{}] }).runId,
+      ).toBeGreaterThan(5);
+    } finally {
+      migrated.close();
+      for (const suffix of ["", "-wal", "-shm"]) {
+        try {
+          rmSync(`${legacyPath}${suffix}`);
+        } catch {
+          // ignore
+        }
+      }
+    }
+  });
+
+  it("is idempotent — re-opening a migrated database does not rebuild or lose rows", () => {
+    const runId = newRun();
+    ledger.cancelRun({ runId, reason: "cancelled by user" });
+    ledger.close();
+    const reopened = new Ledger(dbPath);
+    ledger = reopened; // so afterEach closes the live handle
+    expect(reopened.getRun(runId)?.status).toBe("cancelled");
+    expect(reopened.getRun(runId)?.cancelReason).toBe("cancelled by user");
+  });
+});

--- a/packages/core/__tests__/run-cancel.test.ts
+++ b/packages/core/__tests__/run-cancel.test.ts
@@ -1,0 +1,145 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  RunCancelledError,
+  abortRun,
+  cancelReasonOf,
+  isRunCancelled,
+  isRunInFlight,
+  registerRunController,
+  releaseRunController,
+  throwIfCancelled,
+} from "../src/run-cancel.ts";
+
+// The registry is module-global by design (one process, one set of live runs),
+// so every test cleans up after itself or the next one inherits a controller.
+const registered: number[] = [];
+function track(runId: number, controller: AbortController): void {
+  registerRunController(runId, controller);
+  registered.push(runId);
+}
+
+afterEach(() => {
+  for (const id of registered.splice(0)) releaseRunController(id);
+});
+
+describe("isRunCancelled", () => {
+  it("recognizes a RunCancelledError", () => {
+    expect(isRunCancelled(new RunCancelledError("stop"))).toBe(true);
+  });
+
+  it("recognizes one by name across a module boundary, where instanceof lies", () => {
+    // What a second copy of the class (dual-bundled package, worker thread)
+    // produces. The name check is the whole reason the class sets it.
+    const alien = new Error("stop");
+    alien.name = "RunCancelledError";
+    expect(alien instanceof RunCancelledError).toBe(false);
+    expect(isRunCancelled(alien)).toBe(true);
+  });
+
+  it("does not mistake an ordinary failure — or a non-Error — for a cancellation", () => {
+    expect(isRunCancelled(new Error("Tool request failed"))).toBe(false);
+    expect(isRunCancelled("run cancelled")).toBe(false);
+    expect(isRunCancelled(null)).toBe(false);
+    expect(isRunCancelled(undefined)).toBe(false);
+    expect(isRunCancelled({ name: "RunCancelledError" })).toBe(false);
+  });
+});
+
+describe("cancelReasonOf", () => {
+  it("reads back the string an abort was given", () => {
+    const c = new AbortController();
+    c.abort("client disconnected");
+    expect(cancelReasonOf(c.signal)).toBe("client disconnected");
+  });
+
+  it("falls back to the default rather than persisting a DOMException's shape", () => {
+    const c = new AbortController();
+    c.abort(); // reason defaults to an AbortError DOMException
+    // Either the exception's own message or the default — never "[object Object]".
+    expect(cancelReasonOf(c.signal)).not.toContain("[object");
+    expect(cancelReasonOf(c.signal).length).toBeGreaterThan(0);
+  });
+
+  it("defaults on an un-aborted or absent signal, and on a blank reason", () => {
+    expect(cancelReasonOf(undefined)).toBe("run cancelled");
+    expect(cancelReasonOf(new AbortController().signal)).toBe("run cancelled");
+    const blank = new AbortController();
+    blank.abort("   ");
+    expect(cancelReasonOf(blank.signal)).toBe("run cancelled");
+  });
+
+  it("trims the reason it stores", () => {
+    const c = new AbortController();
+    c.abort("  cancelled by user  ");
+    expect(cancelReasonOf(c.signal)).toBe("cancelled by user");
+  });
+});
+
+describe("throwIfCancelled", () => {
+  it("is a no-op before the abort — the guard must not cost a live run anything", () => {
+    const c = new AbortController();
+    expect(() => throwIfCancelled(c.signal, "show-hn send")).not.toThrow();
+    expect(() => throwIfCancelled(undefined, "show-hn send")).not.toThrow();
+  });
+
+  it("throws a RunCancelledError naming the phase that was about to bill", () => {
+    const c = new AbortController();
+    c.abort("cancelled by user");
+    try {
+      throwIfCancelled(c.signal, "show-hn send");
+      expect.unreachable("guard should have thrown");
+    } catch (err) {
+      expect(isRunCancelled(err)).toBe(true);
+      expect((err as Error).message).toBe("show-hn send: cancelled by user");
+    }
+  });
+});
+
+describe("the in-flight registry", () => {
+  it("aborts the controller the run registered, with the caller's reason", () => {
+    const c = new AbortController();
+    track(1001, c);
+    expect(isRunInFlight(1001)).toBe(true);
+    expect(abortRun(1001, "cancelled by user")).toBe(true);
+    expect(c.signal.aborted).toBe(true);
+    expect(cancelReasonOf(c.signal)).toBe("cancelled by user");
+  });
+
+  it("reports false for a run this process is not executing", () => {
+    // The orphan case: the row says 'running', but the process that owned it
+    // is gone. The route needs to tell that apart from a live abort.
+    expect(isRunInFlight(4242)).toBe(false);
+    expect(abortRun(4242, "cancelled by user")).toBe(false);
+  });
+
+  it("is idempotent, and the first reason wins", () => {
+    const c = new AbortController();
+    track(1002, c);
+    expect(abortRun(1002, "first")).toBe(true);
+    expect(abortRun(1002, "second")).toBe(true);
+    expect(cancelReasonOf(c.signal)).toBe("first");
+  });
+
+  it("stops reaching a released run, so a finished run can't be aborted", () => {
+    const c = new AbortController();
+    registerRunController(1003, c);
+    releaseRunController(1003);
+    expect(isRunInFlight(1003)).toBe(false);
+    expect(abortRun(1003, "too late")).toBe(false);
+    expect(c.signal.aborted).toBe(false);
+  });
+
+  it("releasing an unknown run is a no-op, not a throw", () => {
+    expect(() => releaseRunController(999999)).not.toThrow();
+  });
+
+  it("keeps runs independent — cancelling one leaves the others running", () => {
+    const a = new AbortController();
+    const b = new AbortController();
+    track(1004, a);
+    track(1005, b);
+    abortRun(1004, "cancelled by user");
+    expect(a.signal.aborted).toBe(true);
+    expect(b.signal.aborted).toBe(false);
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,5 +17,6 @@ export * from "./identities.ts";
 export * from "./send-routing.ts";
 export * from "./parallel.ts";
 export * from "./dossier.ts";
+export * from "./run-cancel.ts";
 export * from "./types.ts";
 export * from "./reply-classify.ts";

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -536,11 +536,18 @@ export class Ledger {
    * DROP TABLE takes the indexes with it, hence the recreate.
    */
   private widenRunsStatusCheck(): void {
-    const row = this.db
-      .query(`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'runs'`)
-      .get() as { sql: string | null } | null;
-    if (!row?.sql || row.sql.includes("'cancelled'")) return;
-    this.db.transaction(() => {
+    // Use explicit BEGIN IMMEDIATE so the schema probe happens while holding
+    // the write lock — concurrent processes that see the old schema won't both
+    // migrate it and destroy each other's cancel_reason data.
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const row = this.db
+        .query(`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'runs'`)
+        .get() as { sql: string | null } | null;
+      if (!row?.sql || row.sql.includes("'cancelled'")) {
+        this.db.exec("ROLLBACK");
+        return;
+      }
       this.db.exec(`
         CREATE TABLE runs_widened (
           id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -570,7 +577,11 @@ export class Ledger {
         CREATE INDEX IF NOT EXISTS idx_runs_started ON runs(started_at DESC);
         CREATE INDEX IF NOT EXISTS idx_runs_status ON runs(status);
       `);
-    })();
+      this.db.exec("COMMIT");
+    } catch (err) {
+      this.db.exec("ROLLBACK");
+      throw err;
+    }
   }
 
   /**

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -2813,6 +2813,18 @@ export class Ledger {
   }
 
   /**
+   * Overwrite the run's record of which prospects it actually emailed, in any
+   * status. Deliberately not CASed on 'running': a cancelled run's last sends
+   * land after the row went terminal (the play's workers finish one by one),
+   * and the /cadences?sinceRun deep-link needs them.
+   */
+  setRunSentEmails(input: { runId: number; sentEmails: string[] }): void {
+    this.db
+      .prepare(`UPDATE runs SET prospect_emails_json = ? WHERE id = ?`)
+      .run(JSON.stringify(input.sentEmails), input.runId);
+  }
+
+  /**
    * Flip a still-'running' row to the terminal 'cancelled' state with the
    * reason it ended. CAS on `status = 'running'` so this is a no-op — never an
    * error — against a run that already finished, and so it races safely with
@@ -2831,11 +2843,8 @@ export class Ledger {
     // unwinds, and the emails it collected still belong on the record. Only
     // that handler passes `sentEmails`, so the two callers can't clobber
     // each other whichever order they land in.
-    if (input.sentEmails) {
-      this.db
-        .prepare(`UPDATE runs SET prospect_emails_json = ? WHERE id = ?`)
-        .run(JSON.stringify(input.sentEmails), input.runId);
-    }
+    if (input.sentEmails)
+      this.setRunSentEmails({ runId: input.runId, sentEmails: input.sentEmails });
     const completedAt = new Date().toISOString();
     const result = this.db
       .prepare(

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -283,7 +283,7 @@ export class Ledger {
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         play_name TEXT NOT NULL,
         dry_run INTEGER NOT NULL,
-        status TEXT NOT NULL CHECK(status IN ('running','done','interrupted')),
+        status TEXT NOT NULL CHECK(status IN ('running','done','interrupted','cancelled')),
         started_at TEXT NOT NULL,
         completed_at TEXT,
         target_count INTEGER NOT NULL,
@@ -519,6 +519,58 @@ export class Ledger {
         harvested_at TEXT NOT NULL
       );
     `);
+    // v24: 'cancelled' — the terminal state a run lands in when the SSE client
+    // disconnects or POST /api/run/:runId/cancel fires, plus the reason that
+    // got it there. The CREATE TABLE above already allows it on a fresh
+    // install; older installs carry the narrower CHECK and need the rebuild.
+    this.widenRunsStatusCheck();
+    this.addColumnIfMissing("runs", "cancel_reason", "TEXT");
+  }
+
+  /**
+   * SQLite cannot ALTER a CHECK constraint, so admitting 'cancelled' into
+   * `runs.status` means rebuilding the table. The sqlite_master probe makes
+   * this a no-op on fresh installs and on every boot after the first. Only the
+   * original columns are copied — `cancel_reason` is added by the ALTER that
+   * follows, so this stays correct whichever order an install arrives in.
+   * DROP TABLE takes the indexes with it, hence the recreate.
+   */
+  private widenRunsStatusCheck(): void {
+    const row = this.db
+      .query(`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'runs'`)
+      .get() as { sql: string | null } | null;
+    if (!row?.sql || row.sql.includes("'cancelled'")) return;
+    this.db.transaction(() => {
+      this.db.exec(`
+        CREATE TABLE runs_widened (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          play_name TEXT NOT NULL,
+          dry_run INTEGER NOT NULL,
+          status TEXT NOT NULL CHECK(status IN ('running','done','interrupted','cancelled')),
+          started_at TEXT NOT NULL,
+          completed_at TEXT,
+          target_count INTEGER NOT NULL,
+          drafted_count INTEGER NOT NULL DEFAULT 0,
+          sent_count INTEGER NOT NULL DEFAULT 0,
+          error_count INTEGER NOT NULL DEFAULT 0,
+          targets_json TEXT NOT NULL,
+          events_json TEXT NOT NULL DEFAULT '[]',
+          prospect_emails_json TEXT NOT NULL DEFAULT '[]'
+        );
+        INSERT INTO runs_widened
+          (id, play_name, dry_run, status, started_at, completed_at, target_count,
+           drafted_count, sent_count, error_count, targets_json, events_json,
+           prospect_emails_json)
+          SELECT id, play_name, dry_run, status, started_at, completed_at, target_count,
+                 drafted_count, sent_count, error_count, targets_json, events_json,
+                 prospect_emails_json
+          FROM runs;
+        DROP TABLE runs;
+        ALTER TABLE runs_widened RENAME TO runs;
+        CREATE INDEX IF NOT EXISTS idx_runs_started ON runs(started_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_runs_status ON runs(status);
+      `);
+    })();
   }
 
   /**
@@ -2740,6 +2792,11 @@ export class Ledger {
       .run(JSON.stringify(events), drafted, sent, errors, input.runId);
   }
 
+  /**
+   * Terminal write for a run that finished on its own. Cancellation goes
+   * through `cancelRun` instead — it is the only writer of 'cancelled', so a
+   * cancelled row can never exist without the reason that explains it.
+   */
   markRunComplete(input: {
     runId: number;
     status: "done" | "interrupted";
@@ -2755,11 +2812,49 @@ export class Ledger {
       .run(input.status, completedAt, JSON.stringify(input.sentEmails ?? []), input.runId);
   }
 
+  /**
+   * Flip a still-'running' row to the terminal 'cancelled' state with the
+   * reason it ended. CAS on `status = 'running'` so this is a no-op — never an
+   * error — against a run that already finished, and so it races safely with
+   * the SSE handler's own completion write. `sentEmails` records what did go
+   * out before the abort, keeping the /cadences?sinceRun deep-link honest.
+   *
+   * Returns whether this call was the one that cancelled it, plus the row's
+   * status afterwards (null when there is no such run).
+   */
+  cancelRun(input: { runId: number; reason: string; sentEmails?: string[] }): {
+    cancelled: boolean;
+    status: "running" | "done" | "interrupted" | "cancelled" | null;
+  } {
+    // Sent-email bookkeeping is deliberately outside the CAS below: the cancel
+    // route may have flipped the row already by the time the SSE handler
+    // unwinds, and the emails it collected still belong on the record. Only
+    // that handler passes `sentEmails`, so the two callers can't clobber
+    // each other whichever order they land in.
+    if (input.sentEmails) {
+      this.db
+        .prepare(`UPDATE runs SET prospect_emails_json = ? WHERE id = ?`)
+        .run(JSON.stringify(input.sentEmails), input.runId);
+    }
+    const completedAt = new Date().toISOString();
+    const result = this.db
+      .prepare(
+        `UPDATE runs
+         SET status = 'cancelled', completed_at = ?, cancel_reason = ?
+         WHERE id = ? AND status = 'running'`,
+      )
+      .run(completedAt, input.reason, input.runId);
+    const row = this.db.query(`SELECT status FROM runs WHERE id = ?`).get(input.runId) as {
+      status: "running" | "done" | "interrupted" | "cancelled";
+    } | null;
+    return { cancelled: result.changes > 0, status: row?.status ?? null };
+  }
+
   getRun(runId: number): {
     id: number;
     playName: string;
     dryRun: boolean;
-    status: "running" | "done" | "interrupted";
+    status: "running" | "done" | "interrupted" | "cancelled";
     startedAt: string;
     completedAt: string | null;
     targetCount: number;
@@ -2769,12 +2864,13 @@ export class Ledger {
     targets: unknown[];
     events: unknown[];
     prospectEmails: string[];
+    cancelReason: string | null;
   } | null {
     const row = this.db.query(`SELECT * FROM runs WHERE id = ?`).get(runId) as {
       id: number;
       play_name: string;
       dry_run: number;
-      status: "running" | "done" | "interrupted";
+      status: "running" | "done" | "interrupted" | "cancelled";
       started_at: string;
       completed_at: string | null;
       target_count: number;
@@ -2784,6 +2880,7 @@ export class Ledger {
       targets_json: string;
       events_json: string;
       prospect_emails_json: string;
+      cancel_reason: string | null;
     } | null;
     if (!row) return null;
     return {
@@ -2800,6 +2897,7 @@ export class Ledger {
       targets: safeParseJsonArray(row.targets_json),
       events: safeParseJsonArray(row.events_json),
       prospectEmails: safeParseJsonArray(row.prospect_emails_json) as string[],
+      cancelReason: row.cancel_reason ?? null,
     };
   }
 
@@ -2810,10 +2908,12 @@ export class Ledger {
    * newest started_at first; capped at `limit` rows (default 5). When
    * `status` is set, filters via the existing `idx_runs_status` index.
    */
-  listRuns(opts: { status?: "running" | "done" | "interrupted"; limit?: number } = {}): Array<{
+  listRuns(
+    opts: { status?: "running" | "done" | "interrupted" | "cancelled"; limit?: number } = {},
+  ): Array<{
     id: number;
     playName: string;
-    status: "running" | "done" | "interrupted";
+    status: "running" | "done" | "interrupted" | "cancelled";
     startedAt: string;
     completedAt: string | null;
     targetCount: number;
@@ -2836,7 +2936,7 @@ export class Ledger {
       .all(...(args as never[])) as Array<{
       id: number;
       play_name: string;
-      status: "running" | "done" | "interrupted";
+      status: "running" | "done" | "interrupted" | "cancelled";
       started_at: string;
       completed_at: string | null;
       target_count: number;
@@ -2862,6 +2962,9 @@ export class Ledger {
    * (or any non-null when 0 — cold-boot semantics). Marks them as
    * 'interrupted' so the UI shows a truthful banner instead of an eternal
    * spinner. Returns the swept rows so the caller can log them.
+   *
+   * Terminal rows — including 'cancelled' — are never touched: a run the user
+   * cancelled must not be relabelled as a crash by the next cold boot.
    */
   sweepStaleRuns(input: { now: Date; maxAgeMs: number }): Array<{
     id: number;
@@ -2880,13 +2983,16 @@ export class Ledger {
       ageMs: number;
     }> = [];
     const update = this.db.prepare(
-      `UPDATE runs SET status = 'interrupted', completed_at = ? WHERE id = ?`,
+      // Re-check the status in the write: it closes the window between the
+      // SELECT above and here, where a concurrent cancel could land. A row
+      // that moved on under us reports 0 changes and stays out of `swept`.
+      `UPDATE runs SET status = 'interrupted', completed_at = ? WHERE id = ? AND status = 'running'`,
     );
     for (const row of rows) {
       const startedMs = new Date(row.started_at).getTime();
       if (Number.isFinite(startedMs) && startedMs > cutoffMs) continue;
       const ageMs = Number.isFinite(startedMs) ? input.now.getTime() - startedMs : -1;
-      update.run(input.now.toISOString(), row.id);
+      if (update.run(input.now.toISOString(), row.id).changes === 0) continue;
       swept.push({
         id: row.id,
         playName: row.play_name,

--- a/packages/core/src/run-cancel.ts
+++ b/packages/core/src/run-cancel.ts
@@ -1,0 +1,87 @@
+/**
+ * Run cancellation primitives, shared by the play executors (which check the
+ * signal) and the server (which owns it). Kept in core so `plays` and the
+ * server agree on one error identity without either depending on the other.
+ */
+
+/**
+ * Thrown at a paid-call boundary when the run's AbortSignal has already fired.
+ * Deliberately NOT a target failure: `runEmailPlay`'s per-target catch re-raises
+ * it (the same escape hatch `SendDeferredError` gets) so a cancelled target
+ * never lands as an errorDraft, and the run row ends `cancelled`, not `done`.
+ */
+export class RunCancelledError extends Error {
+  constructor(reason: string = DEFAULT_CANCEL_REASON) {
+    super(reason);
+    // Explicit name so isRunCancelled works across module instances /
+    // serialization boundaries where instanceof would lie.
+    this.name = "RunCancelledError";
+  }
+}
+
+export function isRunCancelled(err: unknown): boolean {
+  return err instanceof Error && err.name === "RunCancelledError";
+}
+
+const DEFAULT_CANCEL_REASON = "run cancelled";
+
+/**
+ * Read a human-usable reason off an AbortSignal. `AbortController.abort(x)`
+ * takes any value; ours pass a string, but `signal.reason` defaults to a
+ * DOMException, so normalize rather than persisting "[object Object]".
+ */
+export function cancelReasonOf(signal: AbortSignal | undefined): string {
+  const raw: unknown = signal?.reason;
+  if (typeof raw === "string" && raw.trim().length > 0) return raw.trim();
+  if (raw instanceof Error && raw.message) return raw.message;
+  return DEFAULT_CANCEL_REASON;
+}
+
+/**
+ * The guard that goes immediately before a paid call. `where` names the call
+ * site so the persisted reason says which phase was about to bill. Cheap
+ * enough to run per target per phase — the whole point is that nothing bills
+ * after the abort.
+ */
+export function throwIfCancelled(signal: AbortSignal | undefined, where: string): void {
+  if (!signal?.aborted) return;
+  throw new RunCancelledError(`${where}: ${cancelReasonOf(signal)}`);
+}
+
+/**
+ * In-flight runs by runId, so `POST /api/run/:runId/cancel` can reach the
+ * AbortController owned by the SSE handler that is streaming that run. Process-
+ * local by design: a run only exists inside the process that is executing it,
+ * and a run stranded by a process exit is the cold-boot sweep's job, not this
+ * map's. The SSE handler registers on start and releases in its `finally`, so
+ * nothing here outlives the run it belongs to.
+ */
+const inFlightRuns = new Map<number, AbortController>();
+
+export function registerRunController(runId: number, controller: AbortController): void {
+  inFlightRuns.set(runId, controller);
+}
+
+export function releaseRunController(runId: number): void {
+  inFlightRuns.delete(runId);
+}
+
+/**
+ * Abort the live run `runId`, if this process is the one running it. Returns
+ * false when there is no live controller — the caller (the cancel route) then
+ * knows the row is either already terminal or orphaned, and writes the ledger
+ * itself instead of waiting for a handler that will never unwind.
+ */
+export function abortRun(runId: number, reason: string): boolean {
+  const controller = inFlightRuns.get(runId);
+  if (!controller) return false;
+  // Idempotent: aborting an already-aborted controller is a no-op, and the
+  // first reason wins — which is the one the run will actually record.
+  controller.abort(reason);
+  return true;
+}
+
+/** Whether this process is currently executing `runId`. Exported for tests. */
+export function isRunInFlight(runId: number): boolean {
+  return inFlightRuns.has(runId);
+}

--- a/packages/plays/src/_lib.ts
+++ b/packages/plays/src/_lib.ts
@@ -10,6 +10,7 @@ import {
   logEvent,
   receiptUrlForId,
   sendEmail,
+  throwIfCancelled,
   trackSend,
   verifyEmail,
   withDeadline,
@@ -696,12 +697,17 @@ interface VerifyAndFilterResult<T> {
  * empty input; de-dupes verifyEmail calls so duplicates don't double-bill.
  * Finder-sourced rows through /queue → drain do NOT call this — they were
  * verified at enqueue time.
+ *
+ * `signal` is the run's cancellation signal: the whole batch fires in one
+ * Promise.all, so the boundary that matters is the one before it — a run
+ * cancelled during the pre-flight buys no verifications at all.
  */
 export async function verifyAndFilterTargets<T>(
   targets: T[],
   getEmail: (target: T) => string | null | undefined,
-  opts: { playName: string; dryRun: boolean },
+  opts: { playName: string; dryRun: boolean; signal?: AbortSignal },
 ): Promise<VerifyAndFilterResult<T>> {
+  throwIfCancelled(opts.signal, `${opts.playName} verify`);
   if (opts.dryRun || targets.length === 0) {
     return { verified: targets, dropped: [], receiptIds: [], costUsd: 0 };
   }

--- a/packages/plays/src/_run-play.ts
+++ b/packages/plays/src/_run-play.ts
@@ -2,9 +2,11 @@ import {
   deepResearch,
   getLedger,
   hasDossierSignal,
+  isRunCancelled,
   isSendDeferred,
   loadConfig,
   parallelMap,
+  throwIfCancelled,
   CONTACTED_ELSEWHERE_FLAG,
   recentTouchElsewhere,
 } from "@oneshot-gtm/core";
@@ -76,8 +78,13 @@ export interface EmailPlayDef<T, X = Record<string, never>> {
    * Enrichment / research / scrape phase. Owns all SDK calls that build
    * context for the draft. Use `standardEnrich` for the safeEnrich(+deepResearch)
    * shape; plays with browser/websearch context supply their own.
+   *
+   * `signal` is the run's cancellation signal. The executor already guards the
+   * boundary before `prepare` is entered, so a def that ignores the arg is
+   * still safe — forward it (or `throwIfCancelled` on it) when `prepare` makes
+   * more than one paid call, so the second one doesn't fire after an abort.
    */
-  prepare: (t: T, dryRun: boolean) => Promise<Prepared<X>>;
+  prepare: (t: T, dryRun: boolean, signal?: AbortSignal) => Promise<Prepared<X>>;
   buildInputBlock: (t: T, prep: Prepared<X>, cfg: AppConfig) => string;
   prospectMeta: (t: T) => SendDraftedOpts["prospectMeta"];
   metadata?: (t: T) => Record<string, unknown>;
@@ -116,6 +123,14 @@ export async function runEmailPlay<T, X = Record<string, never>>(
      * order. Consumers that need stable indexing read the `index` arg.
      */
     onProgress?: (index: number, draft: PlayDraft<T, X>) => void;
+    /**
+     * Cancellation signal for the whole run, owned by the /api/run SSE handler
+     * (it aborts on client disconnect and on POST /api/run/:runId/cancel).
+     * Checked at every paid-call boundary below, so an abort stops the spend
+     * within one in-flight SDK call per worker instead of at the end of the
+     * batch. Absent (CLI, drain) → the run is uncancellable, as before.
+     */
+    signal?: AbortSignal;
   },
 ): Promise<{ drafted: Array<PlayDraft<T, X>> }> {
   const cfg = loadConfig();
@@ -143,7 +158,11 @@ export async function runEmailPlay<T, X = Record<string, never>>(
     concurrency,
     async (target) => {
       try {
-        const prep = await def.prepare(target, opts.dryRun);
+        // Guard #1 — the whole target. Workers pull from a shared cursor, so
+        // every target still queued behind the abort dies here having billed
+        // nothing at all.
+        throwIfCancelled(opts.signal, `${def.playName} prepare`);
+        const prep = await def.prepare(target, opts.dryRun, opts.signal);
 
         // Append SOCIAL PROOF block when any of the three optional fields is
         // set. Prompts treat it as conditional input — present only when set,
@@ -165,6 +184,8 @@ export async function runEmailPlay<T, X = Record<string, never>>(
         if (firstName) {
           inputBlock = `${inputBlock}\n\nPROSPECT_FIRST_NAME: ${firstName}`;
         }
+        // Guard #2 — the LLM draft, the paid call `prepare` was feeding.
+        throwIfCancelled(opts.signal, `${def.playName} draft`);
         const draft = await draftEmailFromPrompt({
           promptName: def.promptName,
           inputBlock,
@@ -179,6 +200,10 @@ export async function runEmailPlay<T, X = Record<string, never>>(
         // sending to someone another workspace emailed this week.
         if (recentTouchElsewhere(def.toEmail(target))) flags.push(CONTACTED_ELSEWHERE_FLAG);
 
+        // Guard #3 — the send. The one call that both bills AND is visible to
+        // the prospect, so it is the boundary that matters most: past here the
+        // founder has an email in someone's inbox they asked us not to send.
+        throwIfCancelled(opts.signal, `${def.playName} send`);
         const send = await sendDraftedEmail({
           playName: def.playName,
           to: def.toEmail(target),
@@ -227,6 +252,10 @@ export async function runEmailPlay<T, X = Record<string, never>>(
         // Daily-cap deferral is not a per-target failure — propagate so the
         // caller (drain / SSE run) leaves remaining targets queued.
         if (isSendDeferred(err)) throw err;
+        // Neither is a cancellation: swallowing it here would turn every
+        // remaining target into an errorDraft and let the run finish 'done'.
+        // Propagating instead is what makes the run row land 'cancelled'.
+        if (isRunCancelled(err)) throw err;
         logTargetError({ playName: def.playName, to: def.toEmail(target), err });
         return {
           target,
@@ -249,21 +278,28 @@ export async function runEmailPlay<T, X = Record<string, never>>(
  * by email, never throws) and, on real sends only, a `deepResearch` dossier.
  * Pass `research` only when you want the research call to fire — callers gate it
  * on `!dryRun` (and, for accelerator-batch, on a launch URL being present).
+ *
+ * `signal` is forwarded by every play's `prepare`: this is the one place two
+ * paid calls sit back to back, so a run cancelled during the enrich must not go
+ * on to buy the dossier.
  */
 export async function standardEnrich(opts: {
   playName: string;
   enrichInput: Parameters<typeof safeEnrich>[0];
   enrichSlice: number;
   research?: { topic: string; slice?: number };
+  signal?: AbortSignal;
 }): Promise<Prepared> {
   const receiptIds: number[] = [];
 
+  throwIfCancelled(opts.signal, `${opts.playName} enrich`);
   const enr = await safeEnrich(opts.enrichInput, { playName: opts.playName });
   if (enr.receiptId) receiptIds.push(enr.receiptId);
   const enrichmentFailed = (enr.result as { status?: string }).status === "failed";
   let dossier = JSON.stringify(enr.result, null, 2).slice(0, opts.enrichSlice);
 
   if (opts.research) {
+    throwIfCancelled(opts.signal, `${opts.playName} research`);
     const research = await deepResearch(
       { topic: opts.research.topic, depth: "quick" },
       { playName: opts.playName },

--- a/packages/plays/src/accelerator-batch.ts
+++ b/packages/plays/src/accelerator-batch.ts
@@ -32,6 +32,8 @@ export interface AcceleratorBatchRunOptions {
   /** Run-level fallback applied to any target that doesn't carry its own. */
   senderCohort?: string;
   freeForCohortOffer?: string;
+  /** Abort signal for the run — see `runEmailPlay`'s `signal`. */
+  signal?: AbortSignal;
 }
 
 interface AcceleratorBatchDraft {
@@ -64,7 +66,7 @@ export function runAcceleratorBatch(
     toEmail: (t) => t.email,
     // Enrich on both preview and real send (cached by email); deepResearch is
     // real-send only AND only when a launch URL is present to anchor it.
-    prepare: (t, dryRun) =>
+    prepare: (t, dryRun, signal) =>
       standardEnrich({
         playName: PLAY_NAME,
         enrichInput: {
@@ -73,6 +75,7 @@ export function runAcceleratorBatch(
           name: t.name,
         },
         enrichSlice: 3500,
+        ...(signal ? { signal } : {}),
         ...(!dryRun && t.launchUrl
           ? {
               research: {

--- a/packages/plays/src/breakup-revive.ts
+++ b/packages/plays/src/breakup-revive.ts
@@ -1,4 +1,10 @@
-import { getLedger, isSendDeferred, loadConfig } from "@oneshot-gtm/core";
+import {
+  getLedger,
+  isRunCancelled,
+  isSendDeferred,
+  loadConfig,
+  throwIfCancelled,
+} from "@oneshot-gtm/core";
 import {
   draftEmailFromPrompt,
   errorDraft,
@@ -35,6 +41,8 @@ export interface BreakupReviveOptions {
   limit?: number;
   /** Optional value drop to lead with (a new feature, a benchmark, a case study you can offer). */
   valueDrop?: string;
+  /** Abort signal for the run — see `runEmailPlay`'s `signal`. */
+  signal?: AbortSignal;
 }
 
 interface BreakupReviveDraft {
@@ -62,6 +70,8 @@ export async function runBreakupRevive(
   for (const t of targets) {
     if (!t.email) continue;
     try {
+      // Custom serial loop, so it repeats runEmailPlay's guards itself.
+      throwIfCancelled(opts.signal, `${PLAY_NAME} draft`);
       const draft = await draftEmailFromPrompt({
         promptName: "breakup-revive-email",
         inputBlock: [
@@ -75,6 +85,7 @@ export async function runBreakupRevive(
 
       const flags = lintEmail(draft.subject, draft.body, 80);
 
+      throwIfCancelled(opts.signal, `${PLAY_NAME} send`);
       const send = await sendDraftedEmail({
         playName: PLAY_NAME,
         to: t.email,
@@ -109,6 +120,8 @@ export async function runBreakupRevive(
       // Daily-cap deferral is not a per-target failure — abort the run so the
       // caller leaves remaining targets queued instead of stamping error drafts.
       if (isSendDeferred(err)) throw err;
+      // Same for a cancellation: propagate so the run row lands 'cancelled'.
+      if (isRunCancelled(err)) throw err;
       logTargetError({ playName: PLAY_NAME, to: t.email, err });
       const stub = errorDraft((err as Error)?.message);
       drafted.push({

--- a/packages/plays/src/competitor-switch.ts
+++ b/packages/plays/src/competitor-switch.ts
@@ -1,4 +1,4 @@
-import { browserTask } from "@oneshot-gtm/core";
+import { browserTask, throwIfCancelled } from "@oneshot-gtm/core";
 import { emailDomain, safeEnrich } from "./_lib.ts";
 import { type EmailPlayDef, runEmailPlay } from "./_run-play.ts";
 import { competitorSwitchMetadata } from "./_metadata.ts";
@@ -36,6 +36,8 @@ export interface CompetitorSwitchRunOptions {
   ) => void;
   /** Skip the browser-scraping step even if evidenceUrl is set. */
   skipBrowserScrape?: boolean;
+  /** Abort signal for the run — see `runEmailPlay`'s `signal`. */
+  signal?: AbortSignal;
 }
 
 interface CompetitorSwitchDraft {
@@ -59,7 +61,7 @@ export function runCompetitorSwitch(
     maxBodyWords: 150,
     enrollCadence: true,
     toEmail: (t) => t.email,
-    prepare: async (t, dryRun) => {
+    prepare: async (t, dryRun, signal) => {
       const receiptIds: number[] = [];
       let scrapedEvidence: string | undefined;
 
@@ -92,6 +94,9 @@ export function runCompetitorSwitch(
         const haveEvidenceText =
           typeof t.evidenceText === "string" && t.evidenceText.trim().length > 0;
         if (t.evidenceUrl && !opts.skipBrowserScrape && !haveEvidenceText) {
+          // The priciest call in the play (~$0.30+, up to 3min). Never start
+          // one for a run the founder has already cancelled.
+          throwIfCancelled(signal, `${PLAY_NAME} scrape`);
           const browse = await browserTask(
             {
               task: `Read the page at ${t.evidenceUrl} and extract: (1) any specific complaints or pain points the user mentioned about ${t.competitor}, (2) any mentions of features they wished existed, (3) any context about company size or use case. Return concise structured JSON.`,

--- a/packages/plays/src/hiring-signal.ts
+++ b/packages/plays/src/hiring-signal.ts
@@ -1,4 +1,4 @@
-import { webRead, webSearch } from "@oneshot-gtm/core";
+import { throwIfCancelled, webRead, webSearch } from "@oneshot-gtm/core";
 import { type EmailPlayDef, runEmailPlay } from "./_run-play.ts";
 import { hiringSignalMetadata } from "./_metadata.ts";
 import { buildFollowUpEmail, registerSequence } from "./_cadence.ts";
@@ -32,6 +32,8 @@ export interface HiringSignalRunOptions {
   ) => void;
   /** Skip the web-search/read steps. */
   skipScrape?: boolean;
+  /** Abort signal for the run — see `runEmailPlay`'s `signal`. */
+  signal?: AbortSignal;
 }
 
 interface HiringSignalDraft {
@@ -58,7 +60,7 @@ export function runHiringSignal(
     enrollCadence: true,
     errorExtra: { jobPostHook: "(error)" },
     toEmail: (t) => t.email,
-    prepare: async (t, dryRun) => {
+    prepare: async (t, dryRun, signal) => {
       const receiptIds: number[] = [];
       let jobPostHook = NO_HOOK;
 
@@ -77,6 +79,9 @@ export function runHiringSignal(
         }
 
         if (jobUrl) {
+          // Second paid call of the phase — the search above may have landed
+          // after the abort, so re-check before buying the page read.
+          throwIfCancelled(signal, `${PLAY_NAME} job-post read`);
           const read = await webRead({ url: jobUrl }, { playName: PLAY_NAME });
           receiptIds.push(read.receiptId);
           const md = read.result.markdown ?? "";

--- a/packages/plays/src/job-change.ts
+++ b/packages/plays/src/job-change.ts
@@ -23,6 +23,8 @@ export interface JobChangeRunOptions {
     index: number,
     draft: { subject: string; body: string; flags: string[]; sent: boolean; receiptIds: number[] },
   ) => void;
+  /** Abort signal for the run — see `runEmailPlay`'s `signal`. */
+  signal?: AbortSignal;
 }
 
 interface JobChangeDraft {
@@ -44,7 +46,7 @@ const jobChangeDef: EmailPlayDef<JobChangeTarget> = {
   toEmail: (t) => t.email,
   // Enrich on both preview and real send (cached by email) so the reviewed
   // draft is personalized; the heavier deepResearch stays real-send only.
-  prepare: (t, dryRun) =>
+  prepare: (t, dryRun, signal) =>
     standardEnrich({
       playName: PLAY_NAME,
       enrichInput: {
@@ -53,6 +55,7 @@ const jobChangeDef: EmailPlayDef<JobChangeTarget> = {
         name: t.name,
       },
       enrichSlice: 4000,
+      ...(signal ? { signal } : {}),
       ...(dryRun
         ? {}
         : {

--- a/packages/plays/src/luma-events.ts
+++ b/packages/plays/src/luma-events.ts
@@ -100,6 +100,8 @@ export interface LumaEventsRunOptions {
     index: number,
     draft: { subject: string; body: string; flags: string[]; sent: boolean; receiptIds: number[] },
   ) => void;
+  /** Abort signal for the run — see `runEmailPlay`'s `signal`. */
+  signal?: AbortSignal;
 }
 
 interface LumaEventsDraft {

--- a/packages/plays/src/podcast-guest.ts
+++ b/packages/plays/src/podcast-guest.ts
@@ -33,6 +33,8 @@ export interface PodcastGuestRunOptions {
   ) => void;
   /** Skip the optional web-search dossier enrichment. */
   skipSearch?: boolean;
+  /** Abort signal for the run — see `runEmailPlay`'s `signal`. */
+  signal?: AbortSignal;
 }
 
 export interface PodcastGuestDraft {

--- a/packages/plays/src/post-funding.ts
+++ b/packages/plays/src/post-funding.ts
@@ -24,6 +24,8 @@ export interface PostFundingRunOptions {
     index: number,
     draft: { subject: string; body: string; flags: string[]; sent: boolean; receiptIds: number[] },
   ) => void;
+  /** Abort signal for the run — see `runEmailPlay`'s `signal`. */
+  signal?: AbortSignal;
 }
 
 export interface PostFundingDraft {
@@ -45,7 +47,7 @@ const postFundingDef: EmailPlayDef<PostFundingTarget> = {
   toEmail: (t) => t.email,
   // Enrich on both preview and real send (cached by email) so the reviewed
   // draft is personalized; the heavier deepResearch stays real-send only.
-  prepare: (t, dryRun) =>
+  prepare: (t, dryRun, signal) =>
     standardEnrich({
       playName: PLAY_NAME,
       enrichInput: {
@@ -54,6 +56,7 @@ const postFundingDef: EmailPlayDef<PostFundingTarget> = {
         name: t.name,
       },
       enrichSlice: 3500,
+      ...(signal ? { signal } : {}),
       ...(dryRun
         ? {}
         : {

--- a/packages/plays/src/profile-intro.ts
+++ b/packages/plays/src/profile-intro.ts
@@ -30,6 +30,8 @@ export interface ProfileIntroRunOptions {
     index: number,
     draft: { subject: string; body: string; flags: string[]; sent: boolean; receiptIds: number[] },
   ) => void;
+  /** Abort signal for the run — see `runEmailPlay`'s `signal`. */
+  signal?: AbortSignal;
 }
 
 interface ProfileIntroDraft {

--- a/packages/plays/src/registry.ts
+++ b/packages/plays/src/registry.ts
@@ -46,6 +46,14 @@ export interface PlayRunInput {
    * live ticks.
    */
   onProgress?: (index: number, draft: DraftedRow) => void;
+  /**
+   * Cancellation signal for the run. The /api/run SSE handler owns it and
+   * aborts on client disconnect or POST /api/run/:runId/cancel; every play
+   * checks it at its paid-call boundaries, so an abort stops the spend rather
+   * than just abandoning the stream. Callers without a cancel path (CLI, queue
+   * drain, scheduler) omit it and the run stays uncancellable, as before.
+   */
+  signal?: AbortSignal;
 }
 
 export interface PlayDispatch {
@@ -64,6 +72,11 @@ export interface PlayDispatch {
 type PlayProgressFn = (index: number, draft: DraftedRow) => void;
 const progressOpt = (o: PlayRunInput): { onProgress?: PlayProgressFn } =>
   o.onProgress ? { onProgress: o.onProgress } : {};
+// Same exactOptionalPropertyTypes dance for the run's cancellation signal:
+// spread it in only when the caller supplied one, so plays keep seeing an
+// absent field rather than an explicit `undefined`.
+const signalOpt = (o: PlayRunInput): { signal?: AbortSignal } =>
+  o.signal ? { signal: o.signal } : {};
 
 export const PLAYS: Record<string, PlayDispatch> = {
   "show-hn": {
@@ -72,6 +85,7 @@ export const PLAYS: Record<string, PlayDispatch> = {
         dryRun: o.dryRun,
         targets: o.targets as ShowHnTarget[],
         ...progressOpt(o),
+        ...signalOpt(o),
       }),
   },
   "job-change": {
@@ -80,6 +94,7 @@ export const PLAYS: Record<string, PlayDispatch> = {
         dryRun: o.dryRun,
         targets: o.targets as JobChangeTarget[],
         ...progressOpt(o),
+        ...signalOpt(o),
       }),
   },
   "post-funding": {
@@ -88,6 +103,7 @@ export const PLAYS: Record<string, PlayDispatch> = {
         dryRun: o.dryRun,
         targets: o.targets as PostFundingTarget[],
         ...progressOpt(o),
+        ...signalOpt(o),
       }),
   },
   "accelerator-batch": {
@@ -99,6 +115,7 @@ export const PLAYS: Record<string, PlayDispatch> = {
         ...(o.senderCohort ? { senderCohort: o.senderCohort } : {}),
         ...(o.freeForCohortOffer ? { freeForCohortOffer: o.freeForCohortOffer } : {}),
         ...progressOpt(o),
+        ...signalOpt(o),
       }),
   },
   "hiring-signal": {
@@ -107,6 +124,7 @@ export const PLAYS: Record<string, PlayDispatch> = {
         dryRun: o.dryRun,
         targets: o.targets as HiringSignalTarget[],
         ...progressOpt(o),
+        ...signalOpt(o),
       }),
   },
   "podcast-guest": {
@@ -115,6 +133,7 @@ export const PLAYS: Record<string, PlayDispatch> = {
         dryRun: o.dryRun,
         targets: o.targets as PodcastGuestTarget[],
         ...progressOpt(o),
+        ...signalOpt(o),
       }),
   },
   "competitor-switch": {
@@ -123,6 +142,7 @@ export const PLAYS: Record<string, PlayDispatch> = {
         dryRun: o.dryRun,
         targets: o.targets as CompetitorSwitchTarget[],
         ...progressOpt(o),
+        ...signalOpt(o),
       }),
   },
   "stack-consolidation": {
@@ -131,6 +151,7 @@ export const PLAYS: Record<string, PlayDispatch> = {
         dryRun: o.dryRun,
         targets: o.targets as StackConsolidationTarget[],
         ...progressOpt(o),
+        ...signalOpt(o),
       }),
   },
   "repo-interest": {
@@ -139,6 +160,7 @@ export const PLAYS: Record<string, PlayDispatch> = {
         dryRun: o.dryRun,
         targets: o.targets as RepoInterestTarget[],
         ...progressOpt(o),
+        ...signalOpt(o),
       }),
   },
   "luma-events": {
@@ -147,6 +169,7 @@ export const PLAYS: Record<string, PlayDispatch> = {
         dryRun: o.dryRun,
         targets: o.targets as LumaEventsTarget[],
         ...progressOpt(o),
+        ...signalOpt(o),
       }),
   },
   "profile-intro": {
@@ -155,13 +178,19 @@ export const PLAYS: Record<string, PlayDispatch> = {
         dryRun: o.dryRun,
         targets: o.targets as ProfileIntroTarget[],
         ...progressOpt(o),
+        ...signalOpt(o),
       }),
   },
   "breakup-revive": {
     // Custom loop (not runEmailPlay). Silently ignores onProgress for now;
     // counters will jump at the end. Acceptable until breakup-revive grows
     // a parallelMap-style worker pool.
-    run: (o) => runBreakupRevive({ dryRun: o.dryRun, targets: o.targets as BreakupReviveTarget[] }),
+    run: (o) =>
+      runBreakupRevive({
+        dryRun: o.dryRun,
+        targets: o.targets as BreakupReviveTarget[],
+        ...signalOpt(o),
+      }),
   },
   "x-repost-intro": {
     run: (o) =>
@@ -169,6 +198,7 @@ export const PLAYS: Record<string, PlayDispatch> = {
         dryRun: o.dryRun,
         targets: o.targets as XRepostIntroTarget[],
         ...progressOpt(o),
+        ...signalOpt(o),
       }),
   },
   "x-amplify": {
@@ -177,6 +207,7 @@ export const PLAYS: Record<string, PlayDispatch> = {
         dryRun: o.dryRun,
         targets: o.targets as XAmplifyTarget[],
         ...progressOpt(o),
+        ...signalOpt(o),
       }),
   },
   "x-amplify-dm": {
@@ -185,6 +216,7 @@ export const PLAYS: Record<string, PlayDispatch> = {
         dryRun: o.dryRun,
         targets: o.targets as XAmplifyDmTarget[],
         ...progressOpt(o),
+        ...signalOpt(o),
       }),
   },
 };

--- a/packages/plays/src/repo-interest.ts
+++ b/packages/plays/src/repo-interest.ts
@@ -54,6 +54,8 @@ export interface RepoInterestRunOptions {
     index: number,
     draft: { subject: string; body: string; flags: string[]; sent: boolean; receiptIds: number[] },
   ) => void;
+  /** Abort signal for the run — see `runEmailPlay`'s `signal`. */
+  signal?: AbortSignal;
 }
 
 export interface RepoInterestDraft {

--- a/packages/plays/src/show-hn.ts
+++ b/packages/plays/src/show-hn.ts
@@ -22,6 +22,8 @@ export interface ShowHnRunOptions {
     index: number,
     draft: { subject: string; body: string; flags: string[]; sent: boolean; receiptIds: number[] },
   ) => void;
+  /** Abort signal for the run — see `runEmailPlay`'s `signal`. */
+  signal?: AbortSignal;
 }
 
 export interface ShowHnRunResult {
@@ -44,11 +46,12 @@ const showHnDef: EmailPlayDef<ShowHnTarget> = {
   toEmail: (t) => t.founderEmail,
   // Enrich on both preview and real send (cached by email) so the reviewed
   // draft is personalized; the heavier deepResearch stays real-send only.
-  prepare: (t, dryRun) =>
+  prepare: (t, dryRun, signal) =>
     standardEnrich({
       playName: PLAY_NAME,
       enrichInput: { email: t.founderEmail, name: t.founderName },
       enrichSlice: 3500,
+      ...(signal ? { signal } : {}),
       ...(dryRun
         ? {}
         : {

--- a/packages/plays/src/stack-consolidation.ts
+++ b/packages/plays/src/stack-consolidation.ts
@@ -32,6 +32,8 @@ export interface StackConsolidationRunOptions {
     index: number,
     draft: { subject: string; body: string; flags: string[]; sent: boolean; receiptIds: number[] },
   ) => void;
+  /** Abort signal for the run — see `runEmailPlay`'s `signal`. */
+  signal?: AbortSignal;
 }
 
 export interface StackConsolidationDraft {

--- a/packages/plays/src/x-amplify-dm.ts
+++ b/packages/plays/src/x-amplify-dm.ts
@@ -100,6 +100,7 @@ export async function runXAmplifyDm(
           temperature: 0.7,
           maxTokens: 300,
         });
+        throwIfCancelled(opts.signal, `${PLAY_NAME} draft`);
         const body = res.content.trim();
         if (!body) throw new Error("empty draft from the model");
         return {

--- a/packages/plays/src/x-amplify-dm.ts
+++ b/packages/plays/src/x-amplify-dm.ts
@@ -1,4 +1,4 @@
-import { loadConfig, parallelMap } from "@oneshot-gtm/core";
+import { isRunCancelled, loadConfig, parallelMap, throwIfCancelled } from "@oneshot-gtm/core";
 import { complete, loadPrompt } from "@oneshot-gtm/intel";
 import { errorDraft, logTargetError } from "./_lib.ts";
 import type { DraftedRow } from "./registry.ts";
@@ -46,6 +46,8 @@ export interface XAmplifyDmRunOptions {
   dryRun: boolean;
   targets: XAmplifyDmTarget[];
   onProgress?: (index: number, draft: DraftedRow) => void;
+  /** Abort signal for the run — see `runEmailPlay`'s `signal`. */
+  signal?: AbortSignal;
 }
 
 interface XAmplifyDmDraft extends DraftedRow {
@@ -76,6 +78,9 @@ export async function runXAmplifyDm(
     4,
     async (t): Promise<XAmplifyDmDraft> => {
       try {
+        // Custom loop, so it repeats runEmailPlay's guard itself: the model
+        // call below is this play's only paid step.
+        throwIfCancelled(opts.signal, `${PLAY_NAME} draft`);
         const input = [
           `FOUNDER: ${cfg.founderName}`,
           `PRODUCT: ${cfg.productOneLiner}`,
@@ -108,6 +113,9 @@ export async function runXAmplifyDm(
           receiptIds: [],
         };
       } catch (err) {
+        // Cancellation is not a target failure — propagate so the run row
+        // lands 'cancelled' instead of a batch of error drafts.
+        if (isRunCancelled(err)) throw err;
         logTargetError({ playName: PLAY_NAME, err });
         return { target: t, ...errorDraft((err as Error)?.message) };
       }

--- a/packages/plays/src/x-amplify.ts
+++ b/packages/plays/src/x-amplify.ts
@@ -45,6 +45,8 @@ export interface XAmplifyRunOptions {
     index: number,
     draft: { subject: string; body: string; flags: string[]; sent: boolean; receiptIds: number[] },
   ) => void;
+  /** Abort signal for the run — see `runEmailPlay`'s `signal`. */
+  signal?: AbortSignal;
 }
 
 interface XAmplifyDraft {

--- a/packages/plays/src/x-repost-intro.ts
+++ b/packages/plays/src/x-repost-intro.ts
@@ -47,6 +47,8 @@ export interface XRepostIntroRunOptions {
     index: number,
     draft: { subject: string; body: string; flags: string[]; sent: boolean; receiptIds: number[] },
   ) => void;
+  /** Abort signal for the run — see `runEmailPlay`'s `signal`. */
+  signal?: AbortSignal;
 }
 
 interface XRepostIntroDraft {

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -873,18 +873,25 @@ export type RunPlayEvent =
   | { kind: "send"; index: number; receiptIds: number[] }
   | { kind: "error"; index: number; message: string }
   | { kind: "done"; total: number; sent: number }
+  /**
+   * Terminal frame for an aborted run — the client closed the SSE stream or
+   * POST /api/run/:runId/cancel fired. Distinct from `error`: nothing failed,
+   * the remaining targets simply never billed. `sent` counts what went out
+   * before the abort point.
+   */
+  | { kind: "cancelled"; reason: string; total: number; sent: number }
   /** First frame the server emits — gives the UI the runId so it can resume on nav-back. */
   | { kind: "runStarted"; runId: number; startedAt: string };
 
 /** Lifecycle status of a /run-page dispatch persisted in the `runs` table. */
-export type RunStatus = "running" | "done" | "interrupted";
+export type RunStatus = "running" | "done" | "interrupted" | "cancelled";
 
 /**
  * Snapshot of one /run-page dispatch — returned by GET /api/runs/:id so the UI
  * can rebuild the per-target progress view after navigate-away-and-back, AND
  * decide whether to keep polling (status === 'running') or stop (done /
- * interrupted). `events` is the accumulated SSE stream (same shape callers
- * see live), so the client renderer can be source-shared.
+ * interrupted / cancelled). `events` is the accumulated SSE stream (same shape
+ * callers see live), so the client renderer can be source-shared.
  */
 export interface RunRecord {
   id: number;
@@ -903,6 +910,27 @@ export interface RunRecord {
   events: RunPlayEvent[];
   /** Emails that were actually sent — used by /cadences?sinceRun to filter. */
   prospectEmails: string[];
+  /** Why a `cancelled` run ended (client disconnect vs explicit cancel). Null otherwise. */
+  cancelReason: string | null;
+}
+
+/**
+ * Result of `POST /api/run/:runId/cancel`. Always 200 for a run that exists —
+ * cancelling one that already finished is a no-op, and the caller tells the
+ * cases apart by the fields rather than by a status code.
+ *
+ * `cancelled` — this request is the one that flipped the row to 'cancelled'.
+ * `aborted`   — a live run in this process got the signal (false means the
+ *               row was terminal already, or the run was orphaned by a process
+ *               exit and only the ledger write applied).
+ * `status`    — the row's status after the call.
+ */
+export interface CancelRunResponse {
+  runId: number;
+  status: RunStatus;
+  cancelled: boolean;
+  aborted: boolean;
+  reason: string | null;
 }
 
 /** Workspace identity + roster served by GET /api/workspace. */


### PR DESCRIPTION
Closes #98.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 0f721308ab0a (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add run cancellation via client disconnect and `POST /api/run/:runId/cancel`
> - Introduces `AbortSignal` propagation through `dispatchPlay`, all play runners, and paid-call boundaries via `throwIfCancelled` guards in [run-cancel.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/322/files#diff-a529b2b2321e98241fd7fcc95679f663f531be6736ad6c4c2ed369625fff7723)
> - Adds `POST /api/run/:runId/cancel` route in [server.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/322/files#diff-a8f34e8f17024480f0ca046c8ea4a8af3b525fe68940b703ba496fa4aa4ddfbd) and a process-local `inFlightRuns` controller registry so cancel requests and client disconnects abort live runs
> - Migrates the ledger `runs` table in [ledger.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/322/files#diff-717d28717ccfb3e17791019e23031dc0feeec16ff1e3b3462975264e3734098e) to admit `'cancelled'` status, adds `cancel_reason` column, and introduces `Ledger.cancelRun` for atomic status transitions; `sweepStaleRuns` now guards against racing with concurrent cancellation
> - Updates the run page in [run.$playName.tsx](https://github.com/oneshot-agent/oneshot-gtm/pull/322/files#diff-a41369a17db72d666888d998125772e6cd6f1c02a49d20021a82722bafe6dd20) with a Stop button, cancelled banner, and `cancelled` terminal event handling; extends shared types in [index.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/322/files#diff-8bfc1c4b53bda948594b3bcdeaead8e4c4130ad092154633bf858b7447c5d62f) with `cancelled` event, status, `cancelReason` field, and `CancelRunResponse`
> - Behavioral Change: `runPlay` SSE stream can now emit a `cancelled` terminal frame instead of `error`; legacy databases undergo a one-time `runs` table rebuild via `widenRunsStatusCheck` to widen the status CHECK constraint
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a0656d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->