### PR TITLE
fix: issue #337: feat(cli): `--fail-on-empty` — exit non-zero when a play or trigger run yields zero candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,22 +82,22 @@ bun run cli -- cadence advance                     # daily tick: poll inbox, fir
 
 48 commands — thirteen groups, plus `init`, `doctor` and `ui` at the top level. `bun run cli -- --help` (or `oneshot-gtm --help` once linked) is the reference:
 
-| Group                    | Commands                                                                                                                                                        |
-| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `init` · `doctor` · `ui` | setup wizard · health check · open the dashboard                                                                                                                |
-| `config`                 | `llm` · `founder` · `keys` · `telemetry on\|off`                                                                                                                |
-| `gmail`                  | `auth` (OAuth a sending account) · `placement` (inbox-placement canary)                                                                                         |
-| `identities`             | `list` · `add` · `remove <id>` — the sender pool                                                                                                                |
-| `smartlead`              | `connect` — API key + pick Smartlead mailboxes into the pool (send-only)                                                                                        |
-| `domains`                | `list` · `pause <domain>` · `resume <domain>` — provisioned OneShot domains                                                                                     |
-| `find`                   | `watch` · `drain <play>` · `enrich-linkedin`                                                                                                                    |
-| `motion`                 | `post-funding` `concierge` `demo-no-show` `competitor-switch` `hiring-signal` `podcast-guest` — each takes `--target <file>`; `breakup-revive` reads the ledger |
-| `cadence`                | `advance` — poll inbound, fire due steps                                                                                                                        |
-| `discover`               | `icp interview-prep` · `icp synthesize` · `pmf classify` · `pmf survey` · `pmf survey-collect`                                                                  |
-| `intel`                  | `advise` · `personalize` · `triage-replies` · `weekly-review`                                                                                                   |
-| `handoff`                | `readiness` · `templatize` · `first-ae`                                                                                                                         |
-| `demo`                   | `seed` · `ui` · `reset` — a fictional install for screenshots and video                                                                                         |
-| `workspace`              | `list` · `create <name>` · `use <name>` · `current` · `path <name>` · `remove <name>` — one isolated install per product; `--workspace <name>` on any command   |
+| Group                    | Commands                                                                                                                                                                       |
+| ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `init` · `doctor` · `ui` | setup wizard · health check · open the dashboard                                                                                                                               |
+| `config`                 | `llm` · `founder` · `keys` · `telemetry on\|off`                                                                                                                               |
+| `gmail`                  | `auth` (OAuth a sending account) · `placement` (inbox-placement canary)                                                                                                        |
+| `identities`             | `list` · `add` · `remove <id>` — the sender pool                                                                                                                               |
+| `smartlead`              | `connect` — API key + pick Smartlead mailboxes into the pool (send-only)                                                                                                       |
+| `domains`                | `list` · `pause <domain>` · `resume <domain>` — provisioned OneShot domains                                                                                                    |
+| `find`                   | `watch` · `drain <play>` · `enrich-linkedin` — `--fail-on-empty` makes `watch --once` and `drain` [exit 2 on a run that produced nothing](#background-monitoring-as-a-service) |
+| `motion`                 | `post-funding` `concierge` `demo-no-show` `competitor-switch` `hiring-signal` `podcast-guest` — each takes `--target <file>`; `breakup-revive` reads the ledger                |
+| `cadence`                | `advance` — poll inbound, fire due steps                                                                                                                                       |
+| `discover`               | `icp interview-prep` · `icp synthesize` · `pmf classify` · `pmf survey` · `pmf survey-collect`                                                                                 |
+| `intel`                  | `advise` · `personalize` · `triage-replies` · `weekly-review`                                                                                                                  |
+| `handoff`                | `readiness` · `templatize` · `first-ae`                                                                                                                                        |
+| `demo`                   | `seed` · `ui` · `reset` — a fictional install for screenshots and video                                                                                                        |
+| `workspace`              | `list` · `create <name>` · `use <name>` · `current` · `path <name>` · `remove <name>` — one isolated install per product; `--workspace <name>` on any command                  |
 
 Spend, CAC, RoCS and outcome logging deliberately have no CLI group — they live on the dashboard's Measure and Cadences pages so there's one source of truth. The `/api/measure/*` routes are there if you'd rather script them.
 
@@ -233,6 +233,25 @@ schtasks /Delete /TN "oneshot-gtm find watch" /F
 ```
 
 The classic cron route works the same way on any platform: `*/15 * * * * ONESHOT_GTM_HOME=$HOME/.oneshot-gtm /path/to/bun /path/to/apps/cli/src/main.ts find watch --once --quiet`.
+
+**Exit codes for scheduled runs.** `find watch --once` exits `1` when a due trigger errored. Add `--fail-on-empty` and a run that worked but produced nothing exits `2` instead of `0`, with one line on stderr naming the triggers and the zero count — enough for a cron wrapper to tell a dry run from a productive one without reading the ledger. `find drain <play>` takes the same flag. Both are opt-in: without it, exit codes are exactly what they were.
+
+|       | `find watch --once`                                | `find drain <play>`                                     |
+| ----- | -------------------------------------------------- | ------------------------------------------------------- |
+| **0** | candidates queued, or `--fail-on-empty` not passed | rows drained, or `--fail-on-empty` not passed           |
+| **1** | a due trigger errored (with or without the flag)   | with the flag: a row errored, or the drain itself threw |
+| **2** | with the flag: ran clean, queued nothing           | with the flag: no approved rows to drain                |
+
+Errors win over emptiness: a run that both errored and produced nothing exits `1`, not `2`. "Queued nothing" counts candidates that reached the queue, not raw hits scanned — a poll whose every hit was a duplicate or off-ICP left the ledger untouched and reads as empty. `--fail-on-empty` needs `--once`; on the daemon (which never ends on its own) it's rejected rather than ignored.
+
+```bash
+oneshot-gtm find watch --once --quiet --fail-on-empty
+case $? in
+  0) ;;                                  # candidates queued
+  2) echo "nothing found this tick" ;;   # idle, not broken
+  *) echo "watch failed" >&2 ;;
+esac
+```
 
 ### The plays
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 49 CLI commands, 17 plays, 11 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-08-29** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2010 tests / 158 files** · typecheck + oxlint + oxfmt clean, all measured on `main`.
+Last verified **2026-08-30** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2081 tests / 161 files** · typecheck + oxlint + oxfmt clean.
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/apps/cli/__tests__/find-drain.test.ts
+++ b/apps/cli/__tests__/find-drain.test.ts
@@ -114,4 +114,21 @@ describe("commandFindDrain --fail-on-empty", () => {
       commandFindDrain({ play: "podcast-guest", dryRun: false, failOnEmpty: true }),
     ).rejects.toThrow("ledger locked");
   });
+
+  it("exits 1 (not 2) when an invalid play has no approved rows", async () => {
+    // Regression test for finding PRRT_kwDOSKzrBs6dhQnV: drainQueue validates
+    // the play before checking if rows are empty, so the CLI sees the error
+    // first and exits 1 (invalid play) instead of 2 (empty drain).
+    nextOutcome = outcome({
+      drained: 0,
+      errors: [{ id: -1, message: "drain: unsupported play 'no-such-play'" }],
+    });
+    const err = await commandFindDrain({
+      play: "no-such-play",
+      dryRun: false,
+      failOnEmpty: true,
+    }).catch((e: unknown) => e);
+    expect((err as InstanceType<typeof CommandExit>).code).toBe(1);
+    expect(stdout.join("")).toContain("unsupported play");
+  });
 });

--- a/apps/cli/__tests__/find-drain.test.ts
+++ b/apps/cli/__tests__/find-drain.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DrainOutcome } from "@oneshot-gtm/find";
+
+/**
+ * Stubbed drain: `--fail-on-empty`'s exit code has to be provable without a
+ * ledger, an LLM call or a send, so `drainQueue` just replays whatever outcome
+ * the case set (or throws, for the failure path).
+ */
+let nextOutcome: DrainOutcome = { drained: 0, sent: 0, deferred: 0, errors: [] };
+let nextThrow: Error | null = null;
+
+vi.mock("@oneshot-gtm/find", () => ({
+  drainQueue: async () => {
+    if (nextThrow) throw nextThrow;
+    return nextOutcome;
+  },
+  // Imported by the module under test (find watch); never called here.
+  runDueTriggers: async () => {
+    throw new Error("runDueTriggers must not run in these tests");
+  },
+  nextSleepMs: () => 60_000,
+}));
+
+const { commandFindDrain } = await import("../src/commands/find.ts");
+const { CommandExit } = await import("../src/output.ts");
+
+function outcome(over: Partial<DrainOutcome> = {}): DrainOutcome {
+  return { drained: 0, sent: 0, deferred: 0, errors: [], ...over };
+}
+
+let stdout: string[] = [];
+let stderr: string[] = [];
+let writeSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  nextOutcome = outcome();
+  nextThrow = null;
+  stdout = [];
+  stderr = [];
+  writeSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    stdout.push(String(chunk));
+    return true;
+  });
+  errSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+    stderr.push(String(chunk));
+    return true;
+  });
+});
+
+afterEach(() => {
+  writeSpy.mockRestore();
+  errSpy.mockRestore();
+});
+
+describe("commandFindDrain without --fail-on-empty", () => {
+  it("exits 0 when nothing was drained", async () => {
+    nextOutcome = outcome({ drained: 0 });
+    await expect(
+      commandFindDrain({ play: "podcast-guest", dryRun: true }),
+    ).resolves.toBeUndefined();
+    expect(stdout.join("")).toContain("No approved rows");
+    expect(stderr.join("")).toBe("");
+  });
+
+  it("exits 0 even when rows errored", async () => {
+    nextOutcome = outcome({ drained: 2, sent: 1, errors: [{ id: 7, message: "send failed" }] });
+    await expect(
+      commandFindDrain({ play: "podcast-guest", dryRun: false }),
+    ).resolves.toBeUndefined();
+    expect(stdout.join("")).toContain("send failed");
+  });
+});
+
+describe("commandFindDrain --fail-on-empty", () => {
+  it("exits 2 and names the play when nothing was drained", async () => {
+    nextOutcome = outcome({ drained: 0 });
+    const err = await commandFindDrain({
+      play: "podcast-guest",
+      dryRun: true,
+      failOnEmpty: true,
+    }).catch((e: unknown) => e);
+    expect(err).toBeInstanceOf(CommandExit);
+    expect((err as InstanceType<typeof CommandExit>).code).toBe(2);
+    const line = stderr.join("");
+    expect(line).toContain("find drain podcast-guest");
+    expect(line).toContain("0 rows drained");
+    expect(line.trimEnd().split("\n")).toHaveLength(1);
+  });
+
+  it("exits 0 when at least one row was drained", async () => {
+    nextOutcome = outcome({ drained: 3, sent: 3 });
+    await expect(
+      commandFindDrain({ play: "podcast-guest", dryRun: false, failOnEmpty: true }),
+    ).resolves.toBeUndefined();
+    expect(stderr.join("")).toBe("");
+  });
+
+  it("exits 1 when a row errored", async () => {
+    nextOutcome = outcome({ drained: 2, sent: 1, errors: [{ id: 7, message: "send failed" }] });
+    const err = await commandFindDrain({
+      play: "podcast-guest",
+      dryRun: false,
+      failOnEmpty: true,
+    }).catch((e: unknown) => e);
+    expect((err as InstanceType<typeof CommandExit>).code).toBe(1);
+    // The empty-run line is for empty runs only; this one is broken, not idle.
+    expect(stderr.join("")).toBe("");
+  });
+
+  it("propagates a drain failure as a thrown error (exit 1 at the top level)", async () => {
+    nextThrow = new Error("ledger locked");
+    await expect(
+      commandFindDrain({ play: "podcast-guest", dryRun: false, failOnEmpty: true }),
+    ).rejects.toThrow("ledger locked");
+  });
+});

--- a/apps/cli/__tests__/find-watch.test.ts
+++ b/apps/cli/__tests__/find-watch.test.ts
@@ -33,8 +33,23 @@ const RESULT: FinderResult = {
   costUsd: 0.12,
 };
 
+/** Fired, scanned candidates, kept none — the ledger is exactly as it was. */
+const EMPTY_RESULT: FinderResult = {
+  source: "stub",
+  candidates: 4,
+  droppedIcp: 1,
+  droppedDuplicate: 3,
+  droppedEnrichment: 0,
+  enqueued: 0,
+  costUsd: 0.04,
+};
+
 function ran(name: string): TriggerRunOutcome {
   return { name, fired: true, result: RESULT, nextDueInMs: 3600_000 };
+}
+
+function ranEmpty(name: string): TriggerRunOutcome {
+  return { name, fired: true, result: EMPTY_RESULT, nextDueInMs: 3600_000 };
 }
 
 function errored(name: string, error = "boom"): TriggerRunOutcome {
@@ -46,20 +61,28 @@ function notDue(name: string): TriggerRunOutcome {
 }
 
 let stdout: string[] = [];
+let stderr: string[] = [];
 let writeSpy: ReturnType<typeof vi.spyOn>;
+let errSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   calls.runDueTriggers = 0;
   nextOutcomes = [];
   stdout = [];
+  stderr = [];
   writeSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
     stdout.push(String(chunk));
+    return true;
+  });
+  errSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
+    stderr.push(String(chunk));
     return true;
   });
 });
 
 afterEach(() => {
   writeSpy.mockRestore();
+  errSpy.mockRestore();
 });
 
 describe("commandFindWatch --once", () => {
@@ -83,6 +106,12 @@ describe("commandFindWatch --once", () => {
     await expect(commandFindWatch({ once: true, quiet: true })).resolves.toBeUndefined();
   });
 
+  it("exits 0 on an empty run without the flag", async () => {
+    nextOutcomes = [ranEmpty("show-hn"), notDue("github-stars")];
+    await expect(commandFindWatch({ once: true, quiet: true })).resolves.toBeUndefined();
+    expect(stderr.join("")).toBe("");
+  });
+
   it("leaves no signal handlers behind", async () => {
     const before = process.listenerCount("SIGTERM") + process.listenerCount("SIGINT");
     nextOutcomes = [ran("show-hn")];
@@ -90,6 +119,59 @@ describe("commandFindWatch --once", () => {
     nextOutcomes = [errored("show-hn")];
     await commandFindWatch({ once: true, quiet: true }).catch(() => {});
     expect(process.listenerCount("SIGTERM") + process.listenerCount("SIGINT")).toBe(before);
+  });
+});
+
+describe("commandFindWatch --once --fail-on-empty", () => {
+  it("exits 2 and names the triggers when nothing was queued", async () => {
+    nextOutcomes = [ranEmpty("show-hn"), ranEmpty("github-stars")];
+    const err = await commandFindWatch({ once: true, quiet: true, failOnEmpty: true }).catch(
+      (e: unknown) => e,
+    );
+    expect(err).toBeInstanceOf(CommandExit);
+    expect((err as InstanceType<typeof CommandExit>).code).toBe(2);
+    const line = stderr.join("");
+    expect(line).toContain("0 candidates queued");
+    expect(line).toContain("show-hn");
+    expect(line).toContain("github-stars");
+    // One line, on stderr — stdout keeps the human report.
+    expect(line.trimEnd().split("\n")).toHaveLength(1);
+    expect(stdout.join("")).toContain("candidates=4");
+  });
+
+  it("exits 2 when no trigger was even due", async () => {
+    nextOutcomes = [notDue("show-hn")];
+    const err = await commandFindWatch({ once: true, quiet: true, failOnEmpty: true }).catch(
+      (e: unknown) => e,
+    );
+    expect((err as InstanceType<typeof CommandExit>).code).toBe(2);
+    expect(stderr.join("")).toContain("no triggers due");
+  });
+
+  it("exits 0 when at least one candidate was queued", async () => {
+    nextOutcomes = [ranEmpty("show-hn"), ran("github-stars")];
+    await expect(
+      commandFindWatch({ once: true, quiet: true, failOnEmpty: true }),
+    ).resolves.toBeUndefined();
+    expect(stderr.join("")).toBe("");
+  });
+
+  it("exits 1, not 2, when a trigger errored on an otherwise empty run", async () => {
+    nextOutcomes = [ranEmpty("show-hn"), errored("github-stars", "GitHub 403")];
+    const err = await commandFindWatch({ once: true, quiet: true, failOnEmpty: true }).catch(
+      (e: unknown) => e,
+    );
+    expect((err as InstanceType<typeof CommandExit>).code).toBe(1);
+    expect(stderr.join("")).toBe("");
+  });
+
+  it("counts kept candidates, not raw ones scanned", async () => {
+    // 4 scanned, 0 kept: nothing reached the queue, so this is an empty run.
+    nextOutcomes = [ranEmpty("show-hn")];
+    const err = await commandFindWatch({ once: true, quiet: true, failOnEmpty: true }).catch(
+      (e: unknown) => e,
+    );
+    expect((err as InstanceType<typeof CommandExit>).code).toBe(2);
   });
 });
 

--- a/apps/cli/src/commands/find.ts
+++ b/apps/cli/src/commands/find.ts
@@ -1,5 +1,5 @@
 import { drainQueue, nextSleepMs, runDueTriggers, type FinderResult } from "@oneshot-gtm/find";
-import { bail, c, fail, header, note, ok } from "../output.ts";
+import { bail, bailEmpty, c, fail, header, note, ok } from "../output.ts";
 
 export async function commandFindDrain(opts: {
   play: string;
@@ -7,6 +7,7 @@ export async function commandFindDrain(opts: {
   dryRun: boolean;
   senderCohort?: string;
   offer?: string;
+  failOnEmpty?: boolean;
 }): Promise<void> {
   header(`find drain ${opts.play} ${opts.dryRun ? c.dim("(dry-run)") : ""}`);
   const result = await drainQueue({
@@ -18,15 +19,25 @@ export async function commandFindDrain(opts: {
   });
   if (result.drained === 0) {
     note(`No approved rows for ${c.cyan(opts.play)}. Approve some in the dashboard at /queue.`);
+    // Nothing was claimed, so there is nothing that could have errored — an
+    // empty drain under the flag is always the idle case, never the broken one.
+    if (opts.failOnEmpty) bailEmpty(`find drain ${opts.play}: 0 rows drained`);
     return;
   }
   ok(`drained ${result.drained} row(s); ${result.sent} ${opts.dryRun ? "would be sent" : "sent"}.`);
   if (result.errors.length > 0) {
     for (const e of result.errors) fail(`#${e.id}: ${e.message}`);
+    // Error beats emptiness: a caller that opted into exit-code signalling gets
+    // 1 for a drain that hit row errors, not the 0 a clean drain returns.
+    if (opts.failOnEmpty) bail(`find drain ${opts.play}: ${result.errors.length} row(s) errored`);
   }
 }
 
-export async function commandFindWatch(opts: { once: boolean; quiet: boolean }): Promise<void> {
+export async function commandFindWatch(opts: {
+  once: boolean;
+  quiet: boolean;
+  failOnEmpty?: boolean;
+}): Promise<void> {
   header(`find watch ${opts.once ? c.dim("(--once)") : c.dim("(daemon)")}`);
   let cancelled = false;
   let wake: (() => void) | null = null;
@@ -38,22 +49,31 @@ export async function commandFindWatch(opts: { once: boolean; quiet: boolean }):
   process.on("SIGINT", shutdown);
   process.on("SIGTERM", shutdown);
 
-  // Errors in the most recent tick. Only --once reads it; the daemon reports
+  // State of the most recent tick. Only --once reads it; the daemon reports
   // each error and keeps polling (one flaky finder must not stop the others).
   let errored = 0;
+  let queued = 0;
+  let firedNames: string[] = [];
   try {
     for (;;) {
       const outcomes = await runDueTriggers();
       errored = 0;
+      queued = 0;
+      firedNames = [];
       for (const o of outcomes) {
         if (!o.fired) {
           if (!opts.quiet) note(`${o.name}: skipped (next due in ${humanMs(o.nextDueInMs)})`);
           continue;
         }
+        firedNames.push(o.name);
         if (o.error !== undefined) {
           errored++;
           fail(`${o.name}: error — ${o.error}`);
         } else if (o.result) {
+          // `enqueued`, not `candidates`: the question --fail-on-empty answers
+          // is "did anything land in the queue", and a run whose every hit was
+          // a duplicate or off-ICP left the ledger exactly as it found it.
+          queued += o.result.enqueued;
           printSummaryLine(o.name, o.result);
         }
       }
@@ -78,6 +98,18 @@ export async function commandFindWatch(opts: { once: boolean; quiet: boolean }):
   // a signal, not by a bad tick.
   if (opts.once && errored > 0) {
     bail(`${errored} due trigger(s) errored`);
+  }
+
+  // Opt-in second signal for the same caller: a poll that ran cleanly but
+  // queued nothing exits 2, so cron can tell a dry run from a productive one
+  // without reading the ledger. The error check above runs first on purpose —
+  // a broken run reports as broken (1) even though it was also empty.
+  if (opts.once && opts.failOnEmpty && queued === 0) {
+    bailEmpty(
+      `find watch --once: 0 candidates queued (${
+        firedNames.length > 0 ? `triggers: ${firedNames.join(", ")}` : "no triggers due"
+      })`,
+    );
   }
 }
 

--- a/apps/cli/src/commands/find.ts
+++ b/apps/cli/src/commands/find.ts
@@ -17,20 +17,25 @@ export async function commandFindDrain(opts: {
     ...(opts.senderCohort ? { senderCohort: opts.senderCohort } : {}),
     ...(opts.offer ? { freeForCohortOffer: opts.offer } : {}),
   });
+
+  // Errors beat emptiness: a drain with row errors (or an invalid play) exits 1,
+  // not the 0 a clean drain returns nor the 2 an idle drain under --fail-on-empty
+  // returns. Check this before checking drained === 0, so an invalid play with no
+  // approved rows exits 1 (unsupported-play error) instead of 2 (empty drain).
+  if (result.errors.length > 0) {
+    for (const e of result.errors) fail(`#${e.id}: ${e.message}`);
+    if (opts.failOnEmpty) bail(`find drain ${opts.play}: ${result.errors.length} row(s) errored`);
+    // Without the flag, a drain with errors still exits 0 (the legacy behavior).
+  }
+
   if (result.drained === 0) {
     note(`No approved rows for ${c.cyan(opts.play)}. Approve some in the dashboard at /queue.`);
-    // Nothing was claimed, so there is nothing that could have errored — an
-    // empty drain under the flag is always the idle case, never the broken one.
+    // Nothing was claimed, and we already checked that there were no errors, so
+    // this is the idle case, never the broken one.
     if (opts.failOnEmpty) bailEmpty(`find drain ${opts.play}: 0 rows drained`);
     return;
   }
   ok(`drained ${result.drained} row(s); ${result.sent} ${opts.dryRun ? "would be sent" : "sent"}.`);
-  if (result.errors.length > 0) {
-    for (const e of result.errors) fail(`#${e.id}: ${e.message}`);
-    // Error beats emptiness: a caller that opted into exit-code signalling gets
-    // 1 for a drain that hit row errors, not the 0 a clean drain returns.
-    if (opts.failOnEmpty) bail(`find drain ${opts.play}: ${result.errors.length} row(s) errored`);
-  }
 }
 
 export async function commandFindWatch(opts: {

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -308,13 +308,31 @@ find
     "with --install-service: write the file to the platform-conventional path instead of stdout",
     false,
   )
+  .option(
+    "--fail-on-empty",
+    "with --once: exit 2 (not 0) when the run queued no candidates, so cron can spot a dry run",
+    false,
+  )
   .description("Daemon: continuously poll registered triggers and enqueue new candidates")
   .action(
     runOrFail(
-      (opts: { once: boolean; quiet: boolean; installService: boolean; write: boolean }) => {
+      (opts: {
+        once: boolean;
+        quiet: boolean;
+        installService: boolean;
+        write: boolean;
+        failOnEmpty: boolean;
+      }) => {
         if (opts.installService) return commandInstallService({ write: opts.write });
         if (opts.write) bail("--write only makes sense with --install-service");
-        return commandFindWatch({ once: opts.once, quiet: opts.quiet });
+        // A daemon run never ends of its own accord, so it has no empty result
+        // to report — refuse the combination rather than silently ignore it.
+        if (opts.failOnEmpty && !opts.once) bail("--fail-on-empty only makes sense with --once");
+        return commandFindWatch({
+          once: opts.once,
+          quiet: opts.quiet,
+          failOnEmpty: opts.failOnEmpty,
+        });
       },
     ),
   );
@@ -324,16 +342,28 @@ find
   .option("--sender-cohort <tag>", "REQUIRED for accelerator-batch (your cohort tag)")
   .option("--offer <text>", "free-for-cohort offer text (accelerator-batch only)")
   .option("--dry-run", "preview drain; don't actually send", false)
+  .option(
+    "--fail-on-empty",
+    "exit 2 (not 0) when no approved rows were drained; 1 if any row errored",
+    false,
+  )
   .description("Pull approved rows for a play and run the existing motion play on them")
   .action(
     runOrFail(
       async (
         play: string,
-        opts: { limit?: number; senderCohort?: string; offer?: string; dryRun: boolean },
+        opts: {
+          limit?: number;
+          senderCohort?: string;
+          offer?: string;
+          dryRun: boolean;
+          failOnEmpty: boolean;
+        },
       ) => {
         await commandFindDrain({
           play,
           dryRun: opts.dryRun,
+          failOnEmpty: opts.failOnEmpty,
           ...(opts.limit ? { limit: opts.limit } : {}),
           ...(opts.senderCohort ? { senderCohort: opts.senderCohort } : {}),
           ...(opts.offer ? { offer: opts.offer } : {}),

--- a/apps/cli/src/output.ts
+++ b/apps/cli/src/output.ts
@@ -55,6 +55,23 @@ export function bail(message: string, code = 1): never {
   throw new CommandExit(code);
 }
 
+/**
+ * Exit code for "the run worked, it just produced nothing" under
+ * `--fail-on-empty`. Deliberately distinct from bail()'s 1 so a scheduled
+ * caller can tell an idle run apart from a broken one.
+ */
+export const EXIT_EMPTY = 2;
+
+/**
+ * Print the empty-run line to stderr and abort with EXIT_EMPTY. stderr (not
+ * stdout) because this line is the machine-facing signal a cron wrapper greps
+ * — stdout stays the human report — and it carries no colour or glyph.
+ */
+export function bailEmpty(message: string): never {
+  process.stderr.write(`${message}\n`);
+  throw new CommandExit(EXIT_EMPTY);
+}
+
 export function note(s: string): void {
   process.stdout.write(`${c.dim(s)}\n`);
 }

--- a/packages/find/src/drain.ts
+++ b/packages/find/src/drain.ts
@@ -50,15 +50,19 @@ export async function drainQueue(opts: DrainOpts): Promise<DrainOutcome> {
   }
   const outcome: DrainOutcome = { drained: rows.length, sent: 0, deferred: 0, errors: [] };
 
-  if (rows.length === 0) return outcome;
-
-  // Global precondition: the play must exist. accelerator-batch no longer
-  // needs a drain-level senderCohort — finder rows carry their own (stamped
-  // from trigger config), and the play falls back to the run-level option.
+  // Global precondition: the play must exist. Validate after initializing outcome
+  // but before checking whether rows are empty, so an unknown play adds an error
+  // to the outcome (exit 1 when the CLI sees it) instead of returning an empty
+  // outcome (exit 2 under --fail-on-empty), regardless of queue state.
+  // accelerator-batch no longer needs a drain-level senderCohort — finder rows
+  // carry their own (stamped from trigger config), and the play falls back to
+  // the run-level option.
   if (!isSupportedPlay(opts.playName)) {
     outcome.errors.push({ id: -1, message: `drain: unsupported play '${opts.playName}'` });
     return outcome;
   }
+
+  if (rows.length === 0) return outcome;
 
   for (let r = 0; r < rows.length; r++) {
     const row = rows[r]!;


### PR DESCRIPTION
Closes #337.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 0f721308ab0a (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--fail-on-empty` flag to `commandFindDrain` and `commandFindWatch`
> - Adds a `--fail-on-empty` option to `find watch --once` and `find drain <play>` that causes the command to exit with code 2 when zero candidates are enqueued.
> - Introduces `bailEmpty` in [output.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/338/files#diff-68bb2f64bda50f197df4b420fdb954f8809ba30bea4601eaf5addc1841991e7b) to write a single line to stderr and throw `CommandExit` with code 2. `find watch` counts `enqueued` rows rather than raw candidates.
> - Updates `drainQueue` in [drain.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/338/files#diff-eeda471048512476d8ac1e9e94c31606a10ad65523bc8af129eb6a8ed90b20c3) to check for unsupported play before checking for empty rows.
> - Risk: `drainQueue` now appends an error to `outcome.errors` for unsupported plays even when `rows.length === 0`, altering the outcome for empty queues with unsupported plays.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 61a03d7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->