### PR TITLE
fix(reply): ground reply drafts and stop discarding the research that grounds them

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ bun run cli -- find drain podcast-guest --dry-run  # preview approved /queue row
 bun run cli -- cadence advance                     # daily tick: poll inbox, fire follow-ups
 ```
 
-49 commands — thirteen groups, plus `init`, `doctor` and `ui` at the top level. `bun run cli -- --help` (or `oneshot-gtm --help` once linked) is the reference:
+50 commands — thirteen groups, plus `init`, `doctor` and `ui` at the top level. `bun run cli -- --help` (or `oneshot-gtm --help` once linked) is the reference:
 
 | Group                    | Commands                                                                                                                                                                       |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
@@ -90,7 +90,7 @@ bun run cli -- cadence advance                     # daily tick: poll inbox, fir
 | `identities`             | `list` · `add` · `remove <id>` — the sender pool                                                                                                                               |
 | `smartlead`              | `connect` — API key + pick Smartlead mailboxes into the pool (send-only)                                                                                                       |
 | `domains`                | `list` · `pause <domain>` · `resume <domain>` — provisioned OneShot domains                                                                                                    |
-| `find`                   | `watch` · `drain <play>` · `enrich-linkedin` — `--fail-on-empty` makes `watch --once` and `drain` [exit 2 on a run that produced nothing](#background-monitoring-as-a-service) |
+| `find`                   | `watch` · `drain <play>` · `enrich-linkedin` · `research-prospects` — `--fail-on-empty` makes `watch --once` and `drain` [exit 2 on a run that produced nothing](#background-monitoring-as-a-service) |
 | `motion`                 | `post-funding` `concierge` `demo-no-show` `competitor-switch` `hiring-signal` `podcast-guest` — each takes `--target <file>`; `breakup-revive` reads the ledger                |
 | `cadence`                | `advance` — poll inbound, fire due steps                                                                                                                                       |
 | `discover`               | `icp interview-prep` · `icp synthesize` · `pmf classify` · `pmf survey` · `pmf survey-collect`                                                                                 |
@@ -313,7 +313,7 @@ Add a OneShot domain and mailbox from `/setup` or `identities add` — pick a pr
 
 ```
 apps/
-  cli/        49-command CLI (commander); src/demo/ seeds the demo install, src/main.ts picks the workspace
+  cli/        50-command CLI (commander); src/demo/ seeds the demo install, src/main.ts picks the workspace
   server/     Bun.serve + SSE; tsdown bundle published as `oneshot-gtm-server`
   web/        Vite + React 19 + TanStack + Base UI — 9 pages, run form, strategist dock, privacy mode
 packages/

--- a/apps/cli/__tests__/research-prospects.test.ts
+++ b/apps/cli/__tests__/research-prospects.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from "vitest";
+import {
+  hasSignal,
+  parseScopes,
+  researchUrl,
+  resolveCap,
+} from "../src/commands/research-prospects.ts";
+
+// Pure helpers for the paid dossier backfill. Every one of these guards spend:
+// a mis-parsed scope, an unclamped limit, or a signal-less payload each mean
+// either buying rows we didn't intend to or storing a dossier that says nothing.
+
+describe("parseScopes", () => {
+  it("defaults to the three scopes that change behaviour", () => {
+    expect(parseScopes(undefined)).toEqual(["active", "replied", "unjudged"]);
+    expect(parseScopes("  ")).toEqual(["active", "replied", "unjudged"]);
+  });
+
+  it("parses, trims, lowercases and dedupes", () => {
+    expect(parseScopes(" Active , replied ,active ")).toEqual(["active", "replied"]);
+  });
+
+  it("REJECTS an unknown scope rather than silently ignoring it", () => {
+    // Dropping a typo'd scope would quietly change which rows a paid run buys.
+    expect(() => parseScopes("active,activve")).toThrow(/unknown --scope/);
+    expect(() => parseScopes("everything")).toThrow(/Valid: active, replied, unjudged, all/);
+  });
+});
+
+describe("resolveCap", () => {
+  it("passes a sane limit through and floors it", () => {
+    expect(resolveCap(250)).toBe(250);
+    expect(resolveCap(7.9)).toBe(7);
+  });
+
+  it("never WIDENS a paid run on bad input", () => {
+    expect(resolveCap(undefined)).toBeUndefined();
+    expect(resolveCap(Number.NaN)).toBe(0);
+    expect(resolveCap(-5)).toBe(0);
+  });
+});
+
+describe("researchUrl", () => {
+  it("prefers source_profile_url — it is never repurposed", () => {
+    expect(
+      researchUrl({
+        source_profile_url: "https://github.com/rishibanota",
+        linkedin_url: "https://linkedin.com/in/x",
+      }),
+    ).toBe("https://github.com/rishibanota");
+  });
+
+  it("falls back to linkedin_url, else null", () => {
+    expect(researchUrl({ source_profile_url: null, linkedin_url: "https://li.com/in/x" })).toBe(
+      "https://li.com/in/x",
+    );
+    expect(researchUrl({ source_profile_url: "  ", linkedin_url: null })).toBeNull();
+    expect(researchUrl({ source_profile_url: null, linkedin_url: null })).toBeNull();
+  });
+});
+
+describe("hasSignal", () => {
+  it("accepts a payload that actually says something, flat or nested", () => {
+    expect(hasSignal({ title: "Graduate Teaching Assistant" })).toBe(true);
+    expect(hasSignal({ enrichment: { company: "Acme" } })).toBe(true);
+    expect(hasSignal({ experience: [{ title: "CTO" }] })).toBe(true);
+    expect(hasSignal({ articles: [{ title: "x" }] })).toBe(true);
+  });
+
+  it("rejects an empty payload — storing it would poison the Tier-1 read", () => {
+    expect(hasSignal({ enrichment: {}, articles: [] })).toBe(false);
+    expect(hasSignal({})).toBe(false);
+    expect(hasSignal(undefined)).toBe(false);
+    expect(hasSignal(null)).toBe(false);
+  });
+
+  it("rejects a full key set whose values are all empty", () => {
+    // What a real lookup returns when it finds nothing: every key present,
+    // every value null. Counting keys would call this a hit.
+    expect(
+      hasSignal({
+        email: "a@b.c",
+        title: null,
+        company: null,
+        summary: "",
+        experience: [],
+        education: [],
+        skills: [],
+        enrichment: { title: null, company: null, summary: "", experience: [] },
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects a location-only dossier — it grounds nothing but would still block Tier-2", () => {
+    expect(hasSignal({ location: "United States", summary: "" })).toBe(false);
+  });
+
+  it("rejects the role-based-mailbox placeholder — a fact about the inbox, not the person", () => {
+    expect(hasSignal({ summary: "hi@niklasfrick.com is a role based email address." })).toBe(false);
+    expect(hasSignal({ enrichment: { summary: "hi@avi.mn is a role based email address." } })).toBe(
+      false,
+    );
+  });
+});

--- a/apps/cli/src/commands/research-prospects.ts
+++ b/apps/cli/src/commands/research-prospects.ts
@@ -1,0 +1,193 @@
+import { getLedger, hasDossierSignal, parallelMap } from "@oneshot-gtm/core";
+import { isCircuitOpen, safeDeepResearchPerson } from "@oneshot-gtm/find";
+import { c, header, note, ok, warn } from "../output.ts";
+
+/**
+ * Backfill research dossiers onto existing prospects.
+ *
+ * `prospects.dossier_json` is READ as free Tier-1 context when drafting a reply
+ * (apps/server/src/api/_reply-research.ts) but nothing in production ever wrote
+ * it — so every reply draft fell through to paid enrich + webRead, and the
+ * research the finders already bought was computed and discarded. This fills
+ * the column so that work is done once and reused.
+ *
+ * Sibling of `enrich-linkedin`: same shape (capped, dry-runnable, bounded
+ * concurrency, breaker-aware), different call. Concurrency defaults lower
+ * because deepResearchPerson runs minutes, not seconds.
+ */
+
+const RESEARCH_COST_USD = 0.05;
+/** Matches the slice the finders already use for a queued dossier. */
+const DOSSIER_SLICE = 6000;
+
+export type ResearchScope = "active" | "replied" | "unjudged" | "all";
+const SCOPES: readonly ResearchScope[] = ["active", "replied", "unjudged", "all"];
+
+export interface ResearchProspectsOpts {
+  dryRun: boolean;
+  limit?: number;
+  concurrency?: number;
+  /** Re-research rows that already hold a dossier. */
+  refresh: boolean;
+  scope?: string;
+}
+
+/**
+ * Parse `--scope`. Unknown names are rejected rather than ignored: silently
+ * dropping a typo'd scope would change which rows a PAID run touches.
+ */
+export function parseScopes(raw: string | undefined): ResearchScope[] {
+  if (!raw || raw.trim() === "") return ["active", "replied", "unjudged"];
+  const parts = raw
+    .split(",")
+    .map((s) => s.trim().toLowerCase())
+    .filter((s) => s.length > 0);
+  const bad = parts.filter((s) => !SCOPES.includes(s as ResearchScope));
+  if (bad.length > 0) {
+    throw new Error(`unknown --scope value(s): ${bad.join(", ")}. Valid: ${SCOPES.join(", ")}`);
+  }
+  return [...new Set(parts)] as ResearchScope[];
+}
+
+/**
+ * How many rows this run may research, or undefined for "no cap". Mirrors
+ * enrich-linkedin's resolveCap: a bad `--limit` must never WIDEN a paid run,
+ * so NaN collapses to 0 rather than to the whole ledger.
+ */
+export function resolveCap(limit: number | undefined): number | undefined {
+  if (limit === undefined) return undefined;
+  if (!Number.isFinite(limit)) return 0;
+  return Math.max(0, Math.floor(limit));
+}
+
+/** The social URL deepResearchPerson should chase, if any. */
+export function researchUrl(row: {
+  source_profile_url: string | null;
+  linkedin_url: string | null;
+}): string | null {
+  const source = row.source_profile_url?.trim();
+  if (source) return source;
+  const linkedin = row.linkedin_url?.trim();
+  return linkedin ? linkedin : null;
+}
+
+/**
+ * True when the payload carries something worth persisting. Delegates to the
+ * shared gate so this command and the play send-path agree on what counts —
+ * they write the same column, and _reply-research.ts reads any non-empty value
+ * as a free Tier-1 hit that suppresses paid research.
+ */
+export function hasSignal(payload: unknown): boolean {
+  return hasDossierSignal(payload);
+}
+
+export async function commandResearchProspects(opts: ResearchProspectsOpts): Promise<void> {
+  header(`research-prospects ${opts.dryRun ? c.dim("(dry-run)") : ""}`);
+  const ledger = getLedger();
+  const scopes = parseScopes(opts.scope);
+
+  // Read the backlog, then cap in memory — same reasoning as enrich-linkedin:
+  // pushing --limit into SQL would make it mean "consider N" not "research N".
+  const rows = ledger.listProspectsForResearch({
+    scopes,
+    includeResearched: opts.refresh,
+    limit: 100_000,
+  });
+  const cap = resolveCap(opts.limit);
+  const candidates = cap === undefined ? rows : rows.slice(0, cap);
+
+  process.stdout.write(
+    `${c.dim("scope:")} ${scopes.join(",")}` +
+      `  ${c.dim("without a dossier:")} ${rows.length}` +
+      `  ${c.dim("to research:")} ${candidates.length}` +
+      (cap !== undefined && rows.length > candidates.length
+        ? `  ${c.dim("held back by --limit:")} ${rows.length - candidates.length}`
+        : "") +
+      `\n${c.dim("Est. cost:")} ~$${(candidates.length * RESEARCH_COST_USD).toFixed(2)}` +
+      `  ${c.dim("(~2-5 min each, cached 90d)")}\n\n`,
+  );
+
+  if (candidates.length === 0) {
+    note("Nothing to research.");
+    return;
+  }
+
+  if (opts.dryRun) {
+    for (const r of candidates.slice(0, 30)) {
+      process.stdout.write(
+        `  ${c.dim("·")} ${(r.name ?? "").slice(0, 26).padEnd(28)} ` +
+          `${c.dim(researchUrl(r) ?? r.email ?? "")}\n`,
+      );
+    }
+    if (candidates.length > 30) note(`… and ${candidates.length - 30} more`);
+    process.stdout.write("\n");
+    ok("dry run — nothing researched, nothing written.");
+    return;
+  }
+
+  let costUsd = 0;
+  let written = 0;
+  let empty = 0;
+  let failed = 0;
+  let cached = 0;
+  let haltedAt: number | null = null;
+
+  await parallelMap(candidates, opts.concurrency ?? 3, async (row, index) => {
+    // The wrapper is failure-safe on its own, but bailing here avoids walking
+    // hundreds of rows during an outage just to no-op each one.
+    if (isCircuitOpen()) {
+      haltedAt ??= index;
+      return;
+    }
+    const url = researchUrl(row);
+    const email = row.email?.trim();
+    const res = await safeDeepResearchPerson(
+      {
+        ...(url ? { socialMediaUrl: url } : {}),
+        ...(email ? { email } : {}),
+        ...(row.name ? { name: row.name } : {}),
+        ...(row.company && row.company !== "(unknown)" ? { company: row.company } : {}),
+      },
+      {
+        playName: "research-prospects",
+        memo: `backfill dossier for prospect ${row.id}`,
+        decisionContext: { source: "research-prospects", prospectId: row.id, scope: scopes },
+      },
+    );
+    // receiptId 0 = served without billing (cache hit, or the failure
+    // sentinel). The cached payload still carries the ORIGINAL call's `cost`,
+    // so adding it unconditionally would report spend that never happened.
+    const billed = res.receiptId !== 0;
+    if (billed) costUsd += res.result?.cost ?? 0;
+
+    const payload = res.result?.result;
+    if (res.result?.status === "failed") {
+      failed++;
+      return;
+    }
+    // Counted only for calls that returned real data, so `cached` and `failed`
+    // stay mutually exclusive (a negative-cache hit is a failure, not a saving).
+    if (!billed) cached++;
+    if (!hasSignal(payload)) {
+      empty++;
+      return;
+    }
+    ledger.setProspectDossier(row.id, JSON.stringify(payload, null, 2).slice(0, DOSSIER_SLICE));
+    written++;
+    process.stdout.write(
+      `  ${c.green("→")} ${(row.name ?? "").slice(0, 26).padEnd(28)} ${c.dim(url ?? email ?? "")}\n`,
+    );
+  });
+
+  process.stdout.write("\n");
+  if (haltedAt !== null) {
+    warn(
+      `Circuit breaker opened after ~${haltedAt} rows — the research backend is failing. ` +
+        `Re-run to pick up where this left off.`,
+    );
+  }
+  ok(
+    `researched ${written}  ${c.dim("no signal:")} ${empty}  ${c.dim("failed:")} ${failed}  ` +
+      `${c.dim("free (cached):")} ${cached}  ${c.dim("spent:")} $${costUsd.toFixed(2)}`,
+  );
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -62,6 +62,7 @@ import {
   commandWorkspaceUse,
 } from "./commands/workspace.ts";
 import { commandEnrichLinkedIn } from "./commands/enrich-linkedin.ts";
+import { commandResearchProspects } from "./commands/research-prospects.ts";
 import { commandFindDrain, commandFindWatch } from "./commands/find.ts";
 import { commandInstallService } from "./commands/install-service.ts";
 import {
@@ -401,6 +402,44 @@ find
           skipHandles: opts.skipHandles,
           ...(opts.limit ? { limit: opts.limit } : {}),
           ...(opts.play ? { play: opts.play } : {}),
+          ...(opts.concurrency ? { concurrency: opts.concurrency } : {}),
+        });
+      },
+    ),
+  );
+
+find
+  .command("research-prospects")
+  // Defaulted like enrich-linkedin, and lower: each row is a ~$0.05 / 2-5 min
+  // call, so an unflagged run must not quietly bill for hundreds.
+  .option(
+    "--limit <n>",
+    "max prospects to research (default 250)",
+    (v) => Number.parseInt(v, 10),
+    250,
+  )
+  .option(
+    "--scope <list>",
+    "comma-separated: active,replied,unjudged,all (default active,replied,unjudged)",
+  )
+  .option("--concurrency <n>", "parallel research calls (default 3)", (v) => Number.parseInt(v, 10))
+  .option("--refresh", "re-research prospects that already have a dossier", false)
+  .option("--dry-run", "list candidates and estimated cost; research nothing", false)
+  .description("Backfill research dossiers onto existing prospects (~$0.05 each)")
+  .action(
+    runOrFail(
+      async (opts: {
+        limit?: number;
+        scope?: string;
+        concurrency?: number;
+        refresh: boolean;
+        dryRun: boolean;
+      }) => {
+        await commandResearchProspects({
+          dryRun: opts.dryRun,
+          refresh: opts.refresh,
+          ...(opts.limit ? { limit: opts.limit } : {}),
+          ...(opts.scope ? { scope: opts.scope } : {}),
           ...(opts.concurrency ? { concurrency: opts.concurrency } : {}),
         });
       },

--- a/apps/server/__tests__/reply-research.test.ts
+++ b/apps/server/__tests__/reply-research.test.ts
@@ -32,7 +32,8 @@ vi.mock("@oneshot-gtm/plays", async () => {
   return { ...actual, safeEnrich: safeEnrichMock };
 });
 
-const { gatherReplyContext, siteDomainFor } = await import("../src/api/_reply-research.ts");
+const { gatherReplyContext, profileUrlFor, siteDomainFor } =
+  await import("../src/api/_reply-research.ts");
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -158,6 +159,115 @@ describe("gatherReplyContext", () => {
       threadKey: "t1",
     });
     expect(ctx.threadSent).toEqual([{ body: "already replied once", sentAt: "2026-08-20" }]);
+  });
+});
+
+describe("dud-domain senders fall back to the finder's profile URL", () => {
+  // A stargazer replies from gmail: no company site to read, nothing for
+  // enrich to key on. Before this, the drafter got zero facts about them and
+  // recycled whatever the intro email had asserted.
+  it("reads source_profile_url when the email domain is a dud", async () => {
+    ledger.getProspectById.mockReturnValue({
+      dossier_json: null,
+      source_profile_url: "https://github.com/rishibanota",
+    });
+    webReadMock.mockResolvedValue({
+      result: { markdown: "remembrandt — local agent memory", cost: 0.01 },
+      receiptId: 43,
+    });
+
+    const ctx = await gatherReplyContext({
+      fromEmail: "someone@gmail.com",
+      prospectId: 647,
+      threadKey: null,
+    });
+
+    expect(webReadMock).toHaveBeenCalledWith(
+      { url: "https://github.com/rishibanota" },
+      expect.objectContaining({ playName: "inbox-reply" }),
+    );
+    expect(ctx.dossier).toContain("PROFILE (https://github.com/rishibanota)");
+    expect(ctx.dossier).toContain("remembrandt");
+    expect(ctx.costUsd).toBe(0.01);
+    // The dud domain still buys no enrich — this is one page read, not a tier.
+    expect(safeEnrichMock).not.toHaveBeenCalled();
+  });
+
+  it("spends nothing when a dud-domain prospect has no profile URL", async () => {
+    ledger.getProspectById.mockReturnValue({ dossier_json: null, source_profile_url: null });
+    const ctx = await gatherReplyContext({
+      fromEmail: "someone@gmail.com",
+      prospectId: 647,
+      threadKey: null,
+    });
+    expect(webReadMock).not.toHaveBeenCalled();
+    expect(ctx.dossier).toBeNull();
+    expect(ctx.costUsd).toBe(0);
+  });
+
+  it("skips the profile read for non-human inbound (skipPaid)", async () => {
+    ledger.getProspectById.mockReturnValue({
+      dossier_json: null,
+      source_profile_url: "https://github.com/rishibanota",
+    });
+    const ctx = await gatherReplyContext({
+      fromEmail: "someone@gmail.com",
+      prospectId: 647,
+      threadKey: null,
+      skipPaid: true,
+    });
+    expect(webReadMock).not.toHaveBeenCalled();
+    expect(ctx.dossier).toBeNull();
+  });
+
+  it("prefers a stored dossier over the profile read", async () => {
+    ledger.getProspectById.mockReturnValue({
+      // Carries real signal (a title), so it is a genuine Tier-1 hit — the
+      // shape the demo seeder and the research backfill both write.
+      dossier_json: '{"title":"CTO","company":"Acme","hook":"already known"}',
+      source_profile_url: "https://github.com/rishibanota",
+    });
+    const ctx = await gatherReplyContext({
+      fromEmail: "someone@gmail.com",
+      prospectId: 647,
+      threadKey: null,
+    });
+    expect(webReadMock).not.toHaveBeenCalled();
+    expect(ctx.dossier).toContain("already known");
+  });
+
+  it("a CONTENTLESS stored dossier does not block the profile read", async () => {
+    // A failed enrich serializes to a non-empty string. Treating that as a
+    // Tier-1 hit would hand the drafter no facts AND skip the tier that has some.
+    ledger.getProspectById.mockReturnValue({
+      dossier_json: JSON.stringify({ status: "failed", profile: null, cost: 0 }),
+      source_profile_url: "https://github.com/rishibanota",
+    });
+    webReadMock.mockResolvedValue({
+      result: { markdown: "remembrandt — local agent memory", cost: 0.01 },
+      receiptId: 43,
+    });
+
+    const ctx = await gatherReplyContext({
+      fromEmail: "someone@gmail.com",
+      prospectId: 647,
+      threadKey: null,
+    });
+
+    expect(webReadMock).toHaveBeenCalled();
+    expect(ctx.dossier).toContain("remembrandt");
+    expect(ctx.dossier).not.toContain("failed");
+  });
+
+  it("profileUrlFor rejects anything that isn't a fetchable profile page", () => {
+    expect(profileUrlFor("https://github.com/rishibanota")).toBe("https://github.com/rishibanota");
+    expect(profileUrlFor(null)).toBeNull();
+    expect(profileUrlFor("   ")).toBeNull();
+    expect(profileUrlFor("rishibanota")).toBeNull();
+    expect(profileUrlFor("mailto:a@b.com")).toBeNull();
+    // A bare host is the finder's fallback, not a person's profile.
+    expect(profileUrlFor("https://github.com")).toBeNull();
+    expect(profileUrlFor("https://github.com/")).toBeNull();
   });
 });
 

--- a/apps/server/src/api/_reply-research.ts
+++ b/apps/server/src/api/_reply-research.ts
@@ -1,6 +1,7 @@
 import {
   ENRICH_CACHE_TTL_MS,
   getLedger,
+  hasDossierSignal,
   isTransientToolError,
   logEvent,
   webRead,
@@ -65,14 +66,40 @@ export async function gatherReplyContext(input: {
   let researched = false;
 
   // Tier 1: the dossier we already own.
-  const stored =
-    input.prospectId != null ? ledger.getProspectById(input.prospectId)?.dossier_json : null;
-  if (stored?.trim()) {
+  //
+  // hasDossierSignal, not a bare trim: a contentless dossier (a failed enrich
+  // serialized to `{"status":"failed",...}`, or a person lookup that found
+  // nobody) is non-empty but says nothing, and accepting it here would skip
+  // the paid tiers below and hand the drafter no facts at all. Writers are
+  // gated too; this guards rows written before that gate existed.
+  const prospect = input.prospectId != null ? ledger.getProspectById(input.prospectId) : null;
+  const stored = prospect?.dossier_json;
+  if (stored?.trim() && hasDossierSignal(stored)) {
     parts.push(stored.slice(0, DOSSIER_SLICE));
   } else {
     // Tier 2: paid research, bounded and gated.
     const domain = emailDomain(input.fromEmail)?.toLowerCase() ?? null;
-    if (!input.skipPaid && !isDudDomain(domain)) {
+    if (input.skipPaid) {
+      // Non-human inbound (OOO, unsubscribe): no one to ground a draft for.
+    } else if (isDudDomain(domain)) {
+      // Tier 2b: a personal-provider address has no company site to read and
+      // nothing for enrich to key on, so both are skipped — which used to
+      // leave the drafter with zero facts about the sender. The finder's
+      // source_profile_url (GitHub / X / Luma) is the one handle we do own.
+      // webRead, not deepResearchPerson: this runs behind the founder's
+      // "draft reply" click, and deepResearchPerson is a 2-5 minute async call.
+      const profileUrl = profileUrlFor(prospect?.source_profile_url ?? null);
+      if (profileUrl) {
+        const page = await readSenderPage(profileUrl, profileUrl);
+        if (page) {
+          parts.push(`PROFILE (${profileUrl}):\n${page.text}`);
+          if (page.paid) {
+            researched = true;
+            costUsd += page.costUsd;
+          }
+        }
+      }
+    } else {
       try {
         const enr = await safeEnrich(
           { email: input.fromEmail },
@@ -101,12 +128,13 @@ export async function gatherReplyContext(input: {
         );
       }
 
-      const site = await readSenderSite(siteDomainFor(domain!));
-      if (site) {
-        parts.push(`WEBSITE (${domain}):\n${site.text}`);
-        if (site.paid) {
+      const site = siteDomainFor(domain!);
+      const page = await readSenderPage(`https://${site}`, site);
+      if (page) {
+        parts.push(`WEBSITE (${domain}):\n${page.text}`);
+        if (page.paid) {
           researched = true;
-          costUsd += site.costUsd;
+          costUsd += page.costUsd;
         }
       }
     }
@@ -131,6 +159,27 @@ function bestEffort(fn: () => void): void {
 }
 
 /**
+ * Normalize the finder's stored profile URL into something safe to fetch.
+ * These rows are written by our own finders, so this is a guard against bad
+ * data (a bare handle, a `mailto:`), not against an attacker. Returns null
+ * when there is nothing fetchable.
+ */
+export function profileUrlFor(raw: string | null): string | null {
+  const trimmed = (raw ?? "").trim();
+  if (!trimmed) return null;
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    return null;
+  }
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") return null;
+  // A bare profile host with no path is the finder's fallback, not a profile.
+  if (parsed.pathname === "/" || parsed.pathname === "") return null;
+  return parsed.toString();
+}
+
+/**
  * Strip a well-known mail-ish first label (mail.example.com serves MX, not a
  * website). A full public-suffix list is deliberately out of scope, so
  * multi-label TLDs pass through unchanged.
@@ -142,18 +191,20 @@ export function siteDomainFor(domain: string): string {
 }
 
 /**
- * Read the sender's site, cached in enrichment_cache under `webread:<domain>`
+ * Read one page about the sender — their company site, or the profile URL the
+ * finder sourced them from — cached in enrichment_cache under `webread:<label>`
  * (30d TTL + negative-cache semantics). Returns null on any failure;
  * transient errors are NOT negative-cached (an outage must not suppress
  * research for a month). The cache write rides the LIVE promise, not the
  * deadline race — a read settling after the deadline was still PAID for and
  * must reach the cache.
  */
-async function readSenderSite(
-  domain: string,
+async function readSenderPage(
+  url: string,
+  label: string,
 ): Promise<{ text: string; paid: boolean; costUsd: number } | null> {
   const ledger = getLedger();
-  const cacheKey = `webread:${domain}`;
+  const cacheKey = `webread:${label}`;
 
   let cached: ReturnType<typeof ledger.getCachedEnrichment> = null;
   try {
@@ -175,10 +226,10 @@ async function readSenderSite(
   }
 
   const live = webRead(
-    { url: `https://${domain}` },
+    { url },
     {
       playName: PLAY_NAME,
-      memo: `read sender's site (${domain}) before drafting a reply`,
+      memo: `read sender's page (${label}) before drafting a reply`,
     },
   ).then((read) => {
     const text = (read.result.markdown ?? "").trim().slice(0, WEBREAD_SLICE);
@@ -189,7 +240,7 @@ async function readSenderSite(
   live.catch(() => {});
 
   try {
-    const read = await withDeadline(live, WEBREAD_DEADLINE_MS, `webRead ${domain}`);
+    const read = await withDeadline(live, WEBREAD_DEADLINE_MS, `webRead ${label}`);
     const text = (read.result.markdown ?? "").trim().slice(0, WEBREAD_SLICE);
     if (!text) return null;
     const c = (read.result as unknown as { cost?: number }).cost;
@@ -202,7 +253,7 @@ async function readSenderSite(
     }
     logEvent(
       "inbox.reply.research.webread_failed",
-      { domain, message_120: ((err as Error).message ?? "").slice(0, 120) },
+      { domain: label, message_120: ((err as Error).message ?? "").slice(0, 120) },
       "warn",
     );
     return null;

--- a/packages/core/__tests__/dossier.test.ts
+++ b/packages/core/__tests__/dossier.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { hasDossierSignal } from "../src/dossier.ts";
+
+// The gate that decides whether a dossier is worth writing to
+// prospects.dossier_json. It is load-bearing: _reply-research.ts treats any
+// non-empty value as a free Tier-1 hit and skips paid research, so a
+// contentless dossier is worse than no dossier at all.
+
+describe("hasDossierSignal — real payloads that must be REJECTED", () => {
+  it("rejects a failed enrich, which still serializes to a non-empty object", () => {
+    // What standardEnrich stores when safeEnrich fails. A bare .trim() check
+    // passes this, stores it, and suppresses the reply drafter's paid tiers.
+    expect(hasDossierSignal(JSON.stringify({ status: "failed", profile: null, cost: 0 }))).toBe(
+      false,
+    );
+    expect(hasDossierSignal({ status: "failed", profile: null, cost: 0 })).toBe(false);
+  });
+
+  it("rejects a person lookup that found nobody — full key set, empty values", () => {
+    expect(
+      hasDossierSignal({
+        email: "a@b.c",
+        title: null,
+        company: null,
+        summary: "",
+        experience: [],
+        education: [],
+        skills: [],
+        enrichment: { title: null, company: null, summary: "", experience: [] },
+      }),
+    ).toBe(false);
+  });
+
+  it("rejects the role-based-mailbox placeholder — a fact about the inbox", () => {
+    expect(hasDossierSignal({ summary: "hi@niklasfrick.com is a role based email address." })).toBe(
+      false,
+    );
+    expect(
+      hasDossierSignal({ enrichment: { summary: "hi@avi.mn is a role based email address." } }),
+    ).toBe(false);
+  });
+
+  it("rejects a location-only dossier — grounds nothing, still blocks Tier-2", () => {
+    expect(hasDossierSignal({ location: "United States", summary: "" })).toBe(false);
+  });
+
+  it("rejects blank and missing values", () => {
+    expect(hasDossierSignal(null)).toBe(false);
+    expect(hasDossierSignal(undefined)).toBe(false);
+    expect(hasDossierSignal("")).toBe(false);
+    expect(hasDossierSignal("   ")).toBe(false);
+    expect(hasDossierSignal({})).toBe(false);
+    expect(hasDossierSignal("{}")).toBe(false);
+    expect(hasDossierSignal(42)).toBe(false);
+  });
+
+  it("rejects a failure even when it carries other keys", () => {
+    expect(hasDossierSignal({ status: "FAILED", title: "CTO" })).toBe(false);
+  });
+});
+
+describe("hasDossierSignal — payloads that must be ACCEPTED", () => {
+  it("accepts real content, flat or nested", () => {
+    expect(hasDossierSignal({ title: "Graduate Teaching Assistant" })).toBe(true);
+    expect(hasDossierSignal({ enrichment: { company: "Acme" } })).toBe(true);
+    expect(hasDossierSignal({ profile: { title: "Staff Engineer" } })).toBe(true);
+    expect(hasDossierSignal({ result: { enrichment: { bio: "builds agent infra" } } })).toBe(true);
+  });
+
+  it("accepts non-empty list fields and articles", () => {
+    expect(hasDossierSignal({ experience: [{ title: "CTO" }] })).toBe(true);
+    expect(hasDossierSignal({ skills: ["rust"] })).toBe(true);
+    expect(hasDossierSignal({ articles: [{ title: "x" }] })).toBe(true);
+  });
+
+  it("accepts a successful enrich envelope", () => {
+    expect(
+      hasDossierSignal(
+        JSON.stringify({ status: "completed", profile: { title: "Founder" }, cost: 0.005 }),
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts prose a play assembled — that is genuine context, not a payload", () => {
+    expect(hasDossierSignal("Founder at Acme; ships agent infra.")).toBe(true);
+  });
+
+  it("keeps a TRUNCATED payload rather than discarding research already paid for", () => {
+    // Dossiers are sliced to 6000 chars, so a stored payload may not re-parse.
+    const truncated = `{"status":"completed","profile":{"title":"Head of Platform","comp`;
+    expect(hasDossierSignal(truncated)).toBe(true);
+  });
+});

--- a/packages/core/__tests__/prospect-research.test.ts
+++ b/packages/core/__tests__/prospect-research.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { Ledger } from "../src/ledger.ts";
+
+// Dossier persistence + the research candidate selector. `dossier_json` was
+// read as free Tier-1 context by the reply drafter but never written by
+// anything in production, so these are the writers that close that gap.
+
+let dbPath: string;
+let ledger: Ledger;
+
+beforeEach(() => {
+  dbPath = join(
+    tmpdir(),
+    `oneshot-gtm-research-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`,
+  );
+  ledger = new Ledger(dbPath);
+});
+
+afterEach(() => {
+  ledger.close();
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      rmSync(`${dbPath}${suffix}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+function add(email: string, extra: Record<string, unknown> = {}): number {
+  return ledger.upsertProspect({ email, name: "Pat", source: "repo-interest", ...extra });
+}
+
+describe("setProspectDossier", () => {
+  it("writes a dossier onto a prospect that has none", () => {
+    const id = add("a@x.dev");
+    ledger.setProspectDossier(id, "role: staff engineer");
+    expect(ledger.getProspectById(id)?.dossier_json).toBe("role: staff engineer");
+  });
+
+  it("OVERWRITES an existing dossier — unlike the write-once identity path", () => {
+    const id = add("b@x.dev", { dossier_json: "stale" });
+    ledger.setProspectDossier(id, "fresh");
+    expect(ledger.getProspectById(id)?.dossier_json).toBe("fresh");
+    // Contrast: updateProspectIdentity is COALESCE-guarded and cannot clobber.
+    ledger.updateProspectIdentity(id, { company: "Acme" });
+    expect(ledger.updateProspectIdentity(id, { company: "Other" })).toBe(false);
+    expect(ledger.getProspectById(id)?.company).toBe("Acme");
+  });
+
+  it("clears with null", () => {
+    const id = add("c@x.dev", { dossier_json: "something" });
+    ledger.setProspectDossier(id, null);
+    expect(ledger.getProspectById(id)?.dossier_json).toBeNull();
+  });
+});
+
+describe("setProspectIcpVerdict", () => {
+  it("persists 'unclear' as a real verdict, distinct from never-judged", () => {
+    const id = add("d@x.dev");
+    expect(ledger.getProspectById(id)?.icp_verdict).toBeNull();
+    ledger.setProspectIcpVerdict(id, "unclear", "handle only, no role text");
+    expect(ledger.getProspectById(id)?.icp_verdict).toBe("unclear");
+    expect(ledger.getProspectById(id)?.icp_verdict_reason).toBe("handle only, no role text");
+  });
+
+  it("still flips between verdicts in either direction", () => {
+    const id = add("e@x.dev");
+    ledger.setProspectIcpVerdict(id, "unclear");
+    ledger.setProspectIcpVerdict(id, "pass", "builds agents");
+    expect(ledger.getProspectById(id)?.icp_verdict).toBe("pass");
+    ledger.setProspectIcpVerdict(id, "reject", "recruiter");
+    expect(ledger.getProspectById(id)?.icp_verdict).toBe("reject");
+  });
+});
+
+describe("listProspectsForResearch", () => {
+  it("selects unjudged rows that have a URL to chase", () => {
+    const withUrl = add("f@x.dev", { source_profile_url: "https://github.com/f" });
+    add("g@x.dev"); // unjudged but no URL — nothing to research against
+    const ids = ledger.listProspectsForResearch({ scopes: ["unjudged"] }).map((r) => r.id);
+    expect(ids).toContain(withUrl);
+    expect(ids).toHaveLength(1);
+  });
+
+  it("selects prospects with an active cadence", () => {
+    const id = add("h@x.dev", { source_profile_url: "https://github.com/h" });
+    ledger.setProspectIcpVerdict(id, "pass"); // judged, so 'unjudged' would miss it
+    ledger.enrollCadence({
+      prospectId: id,
+      playName: "repo-interest",
+      nextDueAt: new Date().toISOString(),
+    });
+    expect(ledger.listProspectsForResearch({ scopes: ["unjudged"] }).map((r) => r.id)).toEqual([]);
+    expect(ledger.listProspectsForResearch({ scopes: ["active"] }).map((r) => r.id)).toEqual([id]);
+  });
+
+  it("unions the scopes rather than intersecting them", () => {
+    const unjudged = add("i@x.dev", { source_profile_url: "https://github.com/i" });
+    const active = add("j@x.dev", { source_profile_url: "https://github.com/j" });
+    ledger.setProspectIcpVerdict(active, "pass");
+    ledger.enrollCadence({
+      prospectId: active,
+      playName: "repo-interest",
+      nextDueAt: new Date().toISOString(),
+    });
+    const ids = ledger
+      .listProspectsForResearch({ scopes: ["active", "unjudged"] })
+      .map((r) => r.id);
+    expect(ids.toSorted()).toEqual([unjudged, active].toSorted());
+  });
+
+  it("excludes rows that already hold a dossier, so a run resumes instead of re-buying", () => {
+    const done = add("k@x.dev", {
+      source_profile_url: "https://github.com/k",
+      dossier_json: "already researched",
+    });
+    expect(ledger.listProspectsForResearch({ scopes: ["unjudged"] }).map((r) => r.id)).toEqual([]);
+    expect(
+      ledger
+        .listProspectsForResearch({ scopes: ["unjudged"], includeResearched: true })
+        .map((r) => r.id),
+    ).toEqual([done]);
+  });
+
+  it("'all' still requires something for deepResearchPerson to key on", () => {
+    const keyed = add("l@x.dev");
+    const unkeyed = ledger.upsertProspect({ email: null, name: "No Contact" });
+    const ids = ledger.listProspectsForResearch({ scopes: ["all"] }).map((r) => r.id);
+    expect(ids).toContain(keyed);
+    expect(ids).not.toContain(unkeyed);
+  });
+
+  it("falls back to the default scopes when none are given", () => {
+    const id = add("m@x.dev", { source_profile_url: "https://github.com/m" });
+    // An empty list means "unspecified", not "match nothing" — same shape as
+    // the other list* helpers. It must never widen to every row, though: this
+    // one is picked up by the default `unjudged` scope, not by a missing filter.
+    expect(ledger.listProspectsForResearch({ scopes: [] as never }).map((r) => r.id)).toEqual([id]);
+    expect(ledger.listProspectsForResearch().map((r) => r.id)).toEqual([id]);
+  });
+
+  it("honours the limit", () => {
+    for (const e of ["n@x.dev", "o@x.dev", "p@x.dev"]) {
+      add(e, { source_profile_url: `https://github.com/${e}` });
+    }
+    expect(ledger.listProspectsForResearch({ scopes: ["unjudged"], limit: 2 })).toHaveLength(2);
+  });
+});

--- a/packages/core/src/dossier.ts
+++ b/packages/core/src/dossier.ts
@@ -1,0 +1,86 @@
+/**
+ * Is a research dossier worth persisting onto a prospect?
+ *
+ * This gate is load-bearing, not a tidiness check. `apps/server/src/api/
+ * _reply-research.ts` treats ANY non-empty `prospects.dossier_json` as a free
+ * Tier-1 hit and skips paid research entirely — so storing a dossier that says
+ * nothing leaves the reply drafter WORSE off than an empty column, because it
+ * suppresses the enrich/webRead/profile-URL tiers that would have found
+ * something. Two shapes reach this from real data and both look non-empty:
+ *
+ *   - a failed enrich:  {"status":"failed","profile":null,"cost":0}
+ *   - a person lookup that found nobody: every key present, every value null,
+ *     plus summary "<addr> is a role based email address" — a fact about the
+ *     MAILBOX, not the person.
+ */
+
+/** Fields that actually say something about a person. */
+const SIGNAL_FIELDS = [
+  "title",
+  "company",
+  "summary",
+  "bio",
+  "headline",
+  "experience",
+  "education",
+  "organizations",
+  "skills",
+] as const;
+
+/**
+ * `location` is deliberately absent: "United States" is a real value that
+ * grounds neither a reply nor an ICP judgement, and storing a dossier for it
+ * would still suppress the paid tiers.
+ */
+
+/** The provider's placeholder summary for a shared inbox — not role text. */
+const ROLE_MAILBOX = /is a role based email address/i;
+
+/** Nested places the payload shapes put the same keys. */
+const NESTED_KEYS = ["enrichment", "profile", "result"] as const;
+
+function substantive(scope: unknown): boolean {
+  if (!scope || typeof scope !== "object") return false;
+  const record = scope as Record<string, unknown>;
+  return SIGNAL_FIELDS.some((field) => {
+    const value = record[field];
+    if (Array.isArray(value)) return value.length > 0;
+    if (typeof value !== "string") return false;
+    const trimmed = value.trim();
+    return trimmed.length > 0 && !ROLE_MAILBOX.test(trimmed);
+  });
+}
+
+/**
+ * True when `value` carries something worth storing. Accepts the parsed
+ * payload or the serialized string a play assembled — prose that isn't JSON is
+ * real dossier text and always counts.
+ */
+export function hasDossierSignal(value: unknown): boolean {
+  if (value === null || value === undefined) return false;
+
+  if (typeof value === "string") {
+    const text = value.trim();
+    if (text === "") return false;
+    // Only strings that PARSE are payloads to inspect; anything else is the
+    // prose a play wrote for its prompt, which is genuine context.
+    if (!/^[[{]/.test(text)) return true;
+    try {
+      return hasDossierSignal(JSON.parse(text));
+    } catch {
+      // Truncated JSON (dossiers are sliced) — treat as prose rather than
+      // discarding context we already paid for.
+      return true;
+    }
+  }
+
+  if (Array.isArray(value)) return value.some((v) => hasDossierSignal(v));
+  if (typeof value !== "object") return false;
+
+  const body = value as Record<string, unknown>;
+  // An explicit failure sentinel is never signal, whatever else it carries.
+  if (typeof body.status === "string" && body.status.toLowerCase() === "failed") return false;
+  if (Array.isArray(body.articles) && body.articles.length > 0) return true;
+  if (substantive(body)) return true;
+  return NESTED_KEYS.some((key) => key in body && hasDossierSignal(body[key]));
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -16,5 +16,6 @@ export * from "./canary.ts";
 export * from "./identities.ts";
 export * from "./send-routing.ts";
 export * from "./parallel.ts";
+export * from "./dossier.ts";
 export * from "./types.ts";
 export * from "./reply-classify.ts";

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -33,6 +33,19 @@ export const ENRICH_FAILURE_TTL_MS = 3 * 24 * 3600 * 1000;
  */
 export const ENRICH_DEADLINE_MS = 120_000;
 
+/**
+ * How long a SUCCESSFUL person dossier (deepResearchPerson) is reused. Longer
+ * than the enrich TTL: a person's org history and profiles change slowly, and
+ * the call costs 10x as much (~$0.05 vs ~$0.005).
+ */
+export const RESEARCH_CACHE_TTL_MS = 90 * 24 * 3600 * 1000;
+/**
+ * Hard ceiling on one deepResearchPerson call. Its own doc comment puts it at
+ * 2-5 minutes, so this sits above that rather than at the enrich ceiling — the
+ * call is legitimately slow, and racing it at 120s would abandon work we paid for.
+ */
+export const RESEARCH_DEADLINE_MS = 360_000;
+
 /** How long a FOUND LinkedIn URL is reused. Profile URLs effectively never change. */
 export const LINKEDIN_CACHE_TTL_MS = 30 * 24 * 3600 * 1000;
 /**
@@ -1552,11 +1565,35 @@ export class Ledger {
    * Record the person-level ICP verdict for a prospect. Overwrites — a
    * re-audit with better data (a real title instead of a stale event bio)
    * must be able to flip an earlier call in either direction.
+   *
+   * `unclear` is a real, persisted verdict: qualifyPerson is 4-state, and
+   * writing its ambiguity as NULL made "we looked and couldn't tell"
+   * indistinguishable from "never judged", so those rows were re-judged (and
+   * re-paid for) on every audit run. Suppression is unaffected — the cadence
+   * gate tests `=== "reject"`, so `unclear` fails open exactly as NULL did.
+   * `transient` is never persisted; it stays a retry signal.
    */
-  setProspectIcpVerdict(id: number, verdict: "pass" | "reject", reason?: string | null): void {
+  setProspectIcpVerdict(
+    id: number,
+    verdict: "pass" | "reject" | "unclear",
+    reason?: string | null,
+  ): void {
     this.db
       .prepare("UPDATE prospects SET icp_verdict = ?, icp_verdict_reason = ? WHERE id = ?")
       .run(verdict, reason ?? null, id);
+  }
+
+  /**
+   * Persist a research dossier onto an existing prospect.
+   *
+   * Deliberately NOT part of updateProspectIdentity: that method's column
+   * allowlist is write-once (COALESCE(NULLIF(col,''), ?)), which is right for
+   * identity fields but wrong here — re-researching a person must be able to
+   * refresh a stale dossier. Plain overwrite; callers decide whether to skip
+   * rows that already have one. Pass null to clear.
+   */
+  setProspectDossier(id: number, dossier: string | null): void {
+    this.db.prepare("UPDATE prospects SET dossier_json = ? WHERE id = ?").run(dossier, id);
   }
 
   /**
@@ -1594,6 +1631,82 @@ export class Ledger {
       email: string | null;
       source: string | null;
       source_profile_url: string | null;
+    }>;
+  }
+
+  /**
+   * Prospects worth buying a research dossier for, by scope:
+   *
+   * - `active`   — a cadence is still running, so a dossier changes what gets sent
+   * - `replied`  — a live conversation, where reply drafting reads the dossier
+   * - `unjudged` — no ICP verdict AND a profile URL to research, so the gate can judge
+   * - `all`      — every prospect
+   *
+   * Scopes union. Rows that already hold a dossier are excluded unless
+   * `includeResearched`, so an interrupted run resumes instead of re-buying.
+   * A row needs a social URL or an email — deepResearchPerson has nothing to
+   * chase otherwise.
+   */
+  listProspectsForResearch(
+    opts: {
+      scopes?: ReadonlyArray<"active" | "replied" | "unjudged" | "all">;
+      includeResearched?: boolean;
+      limit?: number;
+    } = {},
+  ): Array<{
+    id: number;
+    name: string | null;
+    company: string | null;
+    email: string | null;
+    source: string | null;
+    source_profile_url: string | null;
+    linkedin_url: string | null;
+  }> {
+    const scopes = opts.scopes?.length ? opts.scopes : (["active", "replied", "unjudged"] as const);
+    const any: string[] = [];
+    if (scopes.includes("all")) {
+      any.push("1 = 1");
+    } else {
+      if (scopes.includes("active")) {
+        any.push(
+          "EXISTS(SELECT 1 FROM cadence_state cs WHERE cs.prospect_id = p.id AND cs.status = 'active')",
+        );
+      }
+      if (scopes.includes("replied")) {
+        any.push("EXISTS(SELECT 1 FROM inbox_replies ir WHERE ir.prospect_id = p.id)");
+      }
+      if (scopes.includes("unjudged")) {
+        any.push(
+          "(p.icp_verdict IS NULL AND COALESCE(NULLIF(TRIM(p.source_profile_url), ''), NULLIF(TRIM(p.linkedin_url), '')) IS NOT NULL)",
+        );
+      }
+    }
+    if (any.length === 0) return [];
+
+    const where = [`(${any.join(" OR ")})`];
+    if (!opts.includeResearched)
+      where.push("(p.dossier_json IS NULL OR TRIM(p.dossier_json) = '')");
+    // Something for deepResearchPerson to key on.
+    where.push(
+      "(COALESCE(NULLIF(TRIM(p.source_profile_url), ''), NULLIF(TRIM(p.linkedin_url), '')) IS NOT NULL OR (p.email IS NOT NULL AND TRIM(p.email) != ''))",
+    );
+
+    return this.db
+      .query(
+        `SELECT p.id, p.name, p.company, p.email, p.source, p.source_profile_url, p.linkedin_url
+           FROM prospects p
+          WHERE ${where.join(" AND ")}
+          ORDER BY p.id DESC
+          LIMIT ?`,
+      )
+      .all(opts.limit ?? 100_000) as Array<{
+      id: number;
+      name: string | null;
+      company: string | null;
+      email: string | null;
+      source: string | null;
+      source_profile_url: string | null;
+      linkedin_url: string | null;
     }>;
   }
 

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -1568,9 +1568,11 @@ export class Ledger {
    *
    * `unclear` is a real, persisted verdict: qualifyPerson is 4-state, and
    * writing its ambiguity as NULL made "we looked and couldn't tell"
-   * indistinguishable from "never judged", so those rows were re-judged (and
-   * re-paid for) on every audit run. Suppression is unaffected — the cadence
-   * gate tests `=== "reject"`, so `unclear` fails open exactly as NULL did.
+   * indistinguishable from "never judged". It is PROVISIONAL, not settled —
+   * _qualify.ts escalates `unclear` rather than dropping a candidate, so a
+   * re-audit re-judges those rows (picking up role text that arrived since)
+   * and skips only pass/reject. Suppression is unaffected — the cadence gate
+   * tests `=== "reject"`, so `unclear` fails open exactly as NULL did.
    * `transient` is never persisted; it stays a retry signal.
    */
   setProspectIcpVerdict(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -86,7 +86,10 @@ export interface ProspectRecord {
   /** Job title at contact time, from the person-level ICP gate. NULL on rows
    *  contacted before the gate existed (pre 2026-08). */
   title: string | null;
-  /** Person-level ICP verdict: 'pass' | 'reject'. NULL = never judged. */
+  /** Person-level ICP verdict: 'pass' | 'reject' | 'unclear'. NULL = never
+   *  judged. 'unclear' means the gate looked and couldn't tell — distinct from
+   *  NULL so a re-audit skips it instead of re-buying the same lookup. Only
+   *  'reject' suppresses sending (packages/plays/src/_cadence.ts). */
   icp_verdict: string | null;
   /** Classifier's one-line reason for the verdict. */
   icp_verdict_reason: string | null;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -87,9 +87,10 @@ export interface ProspectRecord {
    *  contacted before the gate existed (pre 2026-08). */
   title: string | null;
   /** Person-level ICP verdict: 'pass' | 'reject' | 'unclear'. NULL = never
-   *  judged. 'unclear' means the gate looked and couldn't tell — distinct from
-   *  NULL so a re-audit skips it instead of re-buying the same lookup. Only
-   *  'reject' suppresses sending (packages/plays/src/_cadence.ts). */
+   *  judged. 'unclear' means the gate looked and had nothing to judge on —
+   *  distinct from NULL, and PROVISIONAL: a re-audit re-judges unclear rows
+   *  (so role text arriving later is used) while leaving pass/reject alone.
+   *  Only 'reject' suppresses sending (packages/plays/src/_cadence.ts). */
   icp_verdict: string | null;
   /** Classifier's one-line reason for the verdict. */
   icp_verdict_reason: string | null;

--- a/packages/find/__tests__/safe-deep-research.test.ts
+++ b/packages/find/__tests__/safe-deep-research.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Caching + failure contract for safeDeepResearchPerson. This call is the most
+// expensive and slowest in the toolbox (~$0.05, 2-5 min), so the rules that
+// matter are: never re-buy a cached person, never hang forever, and never
+// negative-cache a transient error (which would make someone un-researchable
+// for the whole failure TTL after the platform recovers).
+
+const calls = { deepResearchPerson: 0 };
+let behaviour: "ok" | "throw" | "hang" = "ok";
+let thrownMessage = "no data for this person";
+
+const cache = {
+  setCalls: [] as Array<{ key: string }>,
+  failureCalls: [] as Array<{ key: string; message: string }>,
+  cachedRow: null as { result_json: string; fetched_at: string; status?: string | null } | null,
+};
+
+const RESULT = {
+  status: "completed",
+  result: { enrichment: { firstname: "Pat", lastname: "Lee" } },
+  request_id: "req_1",
+  cost: 0.05,
+};
+
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    // A short deadline keeps the "hang" case fast; the production constant is 6 min.
+    RESEARCH_DEADLINE_MS: 25,
+    deepResearchPerson: async () => {
+      calls.deepResearchPerson++;
+      if (behaviour === "throw") throw new Error(thrownMessage);
+      if (behaviour === "hang") await new Promise((r) => setTimeout(r, 200));
+      return { result: RESULT, receiptId: 9 };
+    },
+    logEvent: () => {},
+    getLedger: () => ({
+      getCachedEnrichment: () => cache.cachedRow,
+      setCachedEnrichment: (key: string) => cache.setCalls.push({ key }),
+      setCachedEnrichmentFailure: (key: string, message: string) =>
+        cache.failureCalls.push({ key, message }),
+    }),
+  };
+});
+
+const { safeDeepResearchPerson, personCacheKey } = await import("../src/_sdk-safe.ts");
+
+const CTX = { playName: "test-play" };
+
+beforeEach(() => {
+  calls.deepResearchPerson = 0;
+  behaviour = "ok";
+  thrownMessage = "no data for this person";
+  cache.setCalls = [];
+  cache.failureCalls = [];
+  cache.cachedRow = null;
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe("personCacheKey", () => {
+  it("prefers the social URL — it identifies a person more precisely than an email", () => {
+    expect(personCacheKey({ socialMediaUrl: "https://GitHub.com/Pat", email: "pat@x.dev" })).toBe(
+      "person:https://github.com/pat",
+    );
+  });
+
+  it("falls back to the email, and is null when neither is usable", () => {
+    expect(personCacheKey({ email: "Pat@X.dev" })).toBe("person:pat@x.dev");
+    expect(personCacheKey({ name: "Pat" })).toBeNull();
+    expect(personCacheKey({ socialMediaUrl: "  " })).toBeNull();
+  });
+});
+
+describe("safeDeepResearchPerson", () => {
+  it("caches a successful research under the person key", async () => {
+    const out = await safeDeepResearchPerson({ socialMediaUrl: "https://github.com/pat" }, CTX);
+    expect(out.receiptId).toBe(9);
+    expect(calls.deepResearchPerson).toBe(1);
+    expect(cache.setCalls).toEqual([{ key: "person:https://github.com/pat" }]);
+  });
+
+  it("serves a fresh cache hit for free — no SDK call, receiptId 0", async () => {
+    cache.cachedRow = { result_json: JSON.stringify(RESULT), fetched_at: new Date().toISOString() };
+    const out = await safeDeepResearchPerson({ socialMediaUrl: "https://github.com/pat" }, CTX);
+    expect(calls.deepResearchPerson).toBe(0);
+    expect(out.receiptId).toBe(0);
+    expect(out.result.status).toBe("completed");
+  });
+
+  it("refetches past the 90d TTL", async () => {
+    cache.cachedRow = {
+      result_json: JSON.stringify(RESULT),
+      fetched_at: new Date(Date.now() - 91 * 24 * 3600 * 1000).toISOString(),
+    };
+    await safeDeepResearchPerson({ socialMediaUrl: "https://github.com/pat" }, CTX);
+    expect(calls.deepResearchPerson).toBe(1);
+  });
+
+  it("refetches through a corrupt cache row instead of throwing", async () => {
+    cache.cachedRow = { result_json: "{not json", fetched_at: new Date().toISOString() };
+    const out = await safeDeepResearchPerson({ socialMediaUrl: "https://github.com/pat" }, CTX);
+    expect(calls.deepResearchPerson).toBe(1);
+    expect(out.result.status).toBe("completed");
+  });
+
+  it("honours a negative cache entry without re-buying", async () => {
+    cache.cachedRow = {
+      result_json: JSON.stringify({ failed: true }),
+      fetched_at: new Date().toISOString(),
+      status: "failed",
+    };
+    const out = await safeDeepResearchPerson({ socialMediaUrl: "https://github.com/pat" }, CTX);
+    expect(calls.deepResearchPerson).toBe(0);
+    expect(out.result.status).toBe("failed");
+    expect(out.receiptId).toBe(0);
+  });
+
+  it("negative-caches a GENUINE failure and returns the sentinel, never throwing", async () => {
+    behaviour = "throw";
+    const out = await safeDeepResearchPerson({ socialMediaUrl: "https://github.com/pat" }, CTX);
+    expect(out.result.status).toBe("failed");
+    expect(out.result.cost).toBe(0);
+    expect(out.receiptId).toBe(0);
+    expect(cache.failureCalls).toEqual([
+      { key: "person:https://github.com/pat", message: "no data for this person" },
+    ]);
+  });
+
+  it("does NOT negative-cache a transient error", async () => {
+    behaviour = "throw";
+    thrownMessage = "tool execution failed";
+    const out = await safeDeepResearchPerson({ socialMediaUrl: "https://github.com/pat" }, CTX);
+    expect(out.result.status).toBe("failed");
+    expect(cache.failureCalls).toEqual([]);
+  });
+
+  it("treats a deadline breach as transient — no negative cache", async () => {
+    behaviour = "hang";
+    const out = await safeDeepResearchPerson({ socialMediaUrl: "https://github.com/pat" }, CTX);
+    expect(out.result.status).toBe("failed");
+    expect(cache.failureCalls).toEqual([]);
+  });
+
+  it("still caches a call that settles AFTER the deadline — it was paid for", async () => {
+    behaviour = "hang";
+    // Distinct key: the previous hang test's abandoned promise also settles
+    // during the wait below, so the assertion has to be attributable.
+    const key = "person:https://github.com/late";
+    await safeDeepResearchPerson({ socialMediaUrl: "https://github.com/late" }, CTX);
+    expect(cache.setCalls.map((c) => c.key)).not.toContain(key);
+    // The abandoned promise keeps running; its cache write lands when it settles.
+    await new Promise((r) => setTimeout(r, 250));
+    expect(cache.setCalls.map((c) => c.key)).toContain(key);
+  });
+
+  it("runs uncached when there is no key to cache under", async () => {
+    const out = await safeDeepResearchPerson({ name: "Pat" }, CTX);
+    expect(calls.deepResearchPerson).toBe(1);
+    expect(out.receiptId).toBe(9);
+    expect(cache.setCalls).toEqual([]);
+  });
+});

--- a/packages/find/src/_sdk-safe.ts
+++ b/packages/find/src/_sdk-safe.ts
@@ -1,8 +1,24 @@
-import { findEmail, logEvent, verifyEmail } from "@oneshot-gtm/core";
-import type { CallContext, FindEmailInput, VerifyEmailInput } from "@oneshot-gtm/core";
+import {
+  deepResearchPerson,
+  ENRICH_FAILURE_TTL_MS,
+  findEmail,
+  getLedger,
+  isTransientToolError,
+  logEvent,
+  RESEARCH_CACHE_TTL_MS,
+  RESEARCH_DEADLINE_MS,
+  verifyEmail,
+  withDeadline,
+} from "@oneshot-gtm/core";
+import type {
+  CallContext,
+  DeepResearchPersonInput,
+  FindEmailInput,
+  VerifyEmailInput,
+} from "@oneshot-gtm/core";
 
 /**
- * Per-candidate-safe wrappers for the two job-based contact-resolution SDK calls.
+ * Per-candidate-safe wrappers for the job-based contact-resolution SDK calls.
  *
  * Finders process candidates concurrently via `parallelMap` (errors propagate
  * through Promise.all) or in sequential loops. An unguarded throw from one
@@ -61,5 +77,102 @@ export async function safeVerifyEmail(
       },
       receiptId: 0,
     };
+  }
+}
+
+/**
+ * Cache key for a person dossier. Namespaced like `webread:<label>` so it can
+ * share the enrichment_cache table (which lives in the cross-workspace SHARED
+ * db — the whole point being that a person researched for one product is never
+ * re-bought for another). The social URL identifies a person more precisely
+ * than an email, so it wins when both are present.
+ */
+export function personCacheKey(input: DeepResearchPersonInput): string | null {
+  const url = input.socialMediaUrl?.trim().toLowerCase();
+  if (url) return `person:${url}`;
+  const email = input.email?.trim().toLowerCase();
+  return email ? `person:${email}` : null;
+}
+
+/** Graceful sentinel — same `receiptId: 0` / `cost: 0` shape as the cache-miss
+ *  sentinels in _enrich.ts, so callers spend nothing and drop just this row. */
+const FAILED_RESEARCH = {
+  status: "failed",
+  result: { enrichment: {} },
+  request_id: "",
+  cost: 0,
+} as unknown as Awaited<ReturnType<typeof deepResearchPerson>>["result"];
+
+/**
+ * deepResearchPerson that never throws, caches, and cannot hang forever.
+ *
+ * Modelled on `safeEnrich` (packages/plays/src/_lib.ts) rather than
+ * safeFindEmail, because this call is both the most expensive (~$0.05, 10x
+ * enrich) and the slowest (2-5 min by its own doc comment) in the toolbox —
+ * it needs caching and a deadline, not just a try/catch. Before this wrapper
+ * existed all three call sites hand-rolled a catch and none cached, so the
+ * same person could be researched repeatedly at full price.
+ */
+export async function safeDeepResearchPerson(
+  input: DeepResearchPersonInput,
+  ctx: CallContext,
+): Promise<Awaited<ReturnType<typeof deepResearchPerson>>> {
+  const ledger = getLedger();
+  const key = personCacheKey(input);
+
+  if (key) {
+    let cached: ReturnType<typeof ledger.getCachedEnrichment> = null;
+    try {
+      cached = ledger.getCachedEnrichment(key);
+    } catch {
+      // cache-READ failure = cache miss, never a research failure
+    }
+    if (cached) {
+      const ageMs = Date.now() - new Date(cached.fetched_at).getTime();
+      if (cached.status === "failed") {
+        // Negative entry: a recent genuine failure. Don't re-buy until it expires.
+        if (ageMs < ENRICH_FAILURE_TTL_MS) return { result: FAILED_RESEARCH, receiptId: 0 };
+      } else if (ageMs < RESEARCH_CACHE_TTL_MS) {
+        try {
+          return { result: JSON.parse(cached.result_json), receiptId: 0 };
+        } catch {
+          // corrupt cache row — fall through and refetch
+        }
+      }
+    }
+  }
+
+  try {
+    const live = deepResearchPerson(input, ctx);
+    // Cache writes ride the LIVE promise, not the deadline race: a call that
+    // outlives the deadline was still PAID for and must reach the cache.
+    live.then(
+      (out) => {
+        if (!key) return;
+        try {
+          ledger.setCachedEnrichment(key, JSON.stringify(out.result));
+        } catch {
+          // cache write is best-effort
+        }
+      },
+      () => {
+        // Handled by the catch below; this only silences the unhandled
+        // rejection from the promise the deadline race abandons.
+      },
+    );
+    return await withDeadline(live, RESEARCH_DEADLINE_MS, "deepResearchPerson");
+  } catch (err) {
+    swallow(ctx, "deep_research_person", err);
+    // Only negative-cache a GENUINE failure. Caching a transient platform error
+    // would make this person un-researchable for the whole failure TTL after
+    // the platform recovers.
+    if (key && !isTransientToolError(err)) {
+      try {
+        ledger.setCachedEnrichmentFailure(key, (err as Error).message ?? "research failed");
+      } catch {
+        // cache write is best-effort
+      }
+    }
+    return { result: FAILED_RESEARCH, receiptId: 0 };
   }
 }

--- a/packages/find/src/index.ts
+++ b/packages/find/src/index.ts
@@ -31,3 +31,4 @@ export * from "./_pending.ts";
 // resolver so results are cached and billed identically.
 export * from "./_linkedin.ts";
 export * from "./_breaker.ts";
+export * from "./_sdk-safe.ts";

--- a/packages/plays/__tests__/reply-gate.test.ts
+++ b/packages/plays/__tests__/reply-gate.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The reply gate: a reply must never re-introduce the founder, and must mirror
+// the sender's length. Regression suite for the draft that answered a 20-word
+// "most of it is vibe-coded" with a 110-word re-pitch that repeated the intro
+// email's credentials line verbatim.
+
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    loadConfig: () => ({
+      walletMode: "cdp",
+      llmProvider: "anthropic",
+      llmModel: "x",
+      telemetryEnabled: false,
+      founderName: "Mira",
+      founderEmail: null,
+      productOneLiner: "drop-in tracing",
+      productDomain: null,
+      sendingDomain: null,
+      emailProvider: "oneshot",
+      emailIdentities: null,
+      icpOneLiner: null,
+      cadenceOverrides: null,
+      // Both social-proof fields set: the reply must still not carry them.
+      founderCredentials: "Built Cloudflare's experimentation platform.",
+      productPortfolio: "Previously shipped a Zoom competitor to 500k MAU.",
+      partners: "Google Cloud, LangChain",
+      productBrief: null,
+      mobileSignature: false,
+      clientId: null,
+    }),
+  };
+});
+
+const completeMock = vi.fn();
+vi.mock("@oneshot-gtm/intel", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/intel")>("@oneshot-gtm/intel");
+  return { ...actual, complete: completeMock };
+});
+
+// No prospect match => getPriorStepsForProspect is never reached, so the
+// ledger stays out of this suite. Prior-email context arrives via threadSent.
+const { draftInboxReply, replyWordBudget, repeatsPriorText } = await import("../src/reply.ts");
+
+function draftReply(body: string) {
+  return { content: JSON.stringify({ body }) };
+}
+
+function userBlocks(): string[] {
+  const call = completeMock.mock.calls.at(-1)?.[0] as {
+    messages: Array<{ role: string; content: string }>;
+  };
+  return call.messages.filter((m) => m.role === "user").map((m) => m.content);
+}
+
+const BASE = { fromEmail: "rishi@gmail.com", subject: "Re: x", body: "tell me about payments" };
+
+beforeEach(() => {
+  completeMock.mockResolvedValue(draftReply("Short answer: yes, it settles per call."));
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("replyWordBudget", () => {
+  it("mirrors a one-line answer with a tight budget", () => {
+    // The actual inbound that broke: 20 words.
+    expect(
+      replyWordBudget(
+        "I did indeed reach but, to be honest most of it is vibe-coded. The project idea was given by AI itself.",
+      ),
+    ).toBe(45);
+  });
+
+  it("allows more room as the sender writes more", () => {
+    expect(replyWordBudget(Array.from({ length: 60 }, () => "word").join(" "))).toBe(95);
+    expect(replyWordBudget(Array.from({ length: 200 }, () => "word").join(" "))).toBe(135);
+  });
+
+  it("measures the new text only, not the quoted chain below it", () => {
+    const body = [
+      "ok.",
+      "",
+      "On Sat, Aug 29, 2026, J. Nicolas wrote:",
+      ...Array.from({ length: 200 }, () => "> padding"),
+    ].join("\n");
+    expect(replyWordBudget(body)).toBe(45);
+  });
+});
+
+describe("repeatsPriorText", () => {
+  it("catches the credentials line lifted out of the intro email", () => {
+    const intro =
+      "I'm J. Nicolas, and i previously shipped a zoom competitor to 500k mau before starting oneshot.";
+    const reply =
+      "Fair point. I'm J. Nicolas, and i previously shipped a zoom competitor to 500k mau before building oneshot.";
+    expect(repeatsPriorText(reply, [intro])).toBe(true);
+  });
+
+  it("ignores punctuation and case differences", () => {
+    expect(
+      repeatsPriorText("the agent just needs one set of credentials to access everything", [
+        "The agent, just needs ONE set of credentials — to access everything!",
+      ]),
+    ).toBe(true);
+  });
+
+  it("passes a genuinely fresh reply", () => {
+    const intro =
+      "I'm J. Nicolas, and i previously shipped a zoom competitor to 500k mau before starting oneshot.";
+    expect(repeatsPriorText("Makes sense. What broke first, auth or egress?", [intro])).toBe(false);
+  });
+
+  it("does not fire on a short draft or with no prior text", () => {
+    expect(repeatsPriorText("Thanks.", ["Thanks."])).toBe(false);
+    expect(repeatsPriorText("a much longer body than the ngram window needs here", [])).toBe(false);
+  });
+});
+
+describe("draftInboxReply gate", () => {
+  it("never puts a SOCIAL PROOF block in the reply prompt", async () => {
+    await draftInboxReply(BASE);
+    const block = userBlocks()[0]!;
+    expect(block).not.toContain("SOCIAL PROOF");
+    expect(block).not.toContain("CREDENTIALS:");
+    expect(block).not.toContain("PORTFOLIO:");
+    expect(block).not.toContain("PARTNERS:");
+  });
+
+  it("accepts a mirrored reply without a second LLM call", async () => {
+    await draftInboxReply({ ...BASE, body: "did you hit that wall too?" });
+    expect(completeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("repairs an over-long reply and keeps the rewrite", async () => {
+    const bloated = Array.from({ length: 120 }, () => "pitch").join(" ");
+    completeMock
+      .mockResolvedValueOnce(draftReply(bloated))
+      .mockResolvedValueOnce(draftReply("Yes, that's the wall. What broke first for you?"));
+
+    const out = await draftInboxReply({ ...BASE, body: "did you hit that wall too?" });
+
+    expect(completeMock).toHaveBeenCalledTimes(2);
+    expect(out.body).toBe("Yes, that's the wall. What broke first for you?");
+    // The corrective turn names the flag and the budget it has to hit.
+    const repair = userBlocks().at(-1)!;
+    expect(repair).toContain("body-too-long");
+    expect(repair).toContain("under 45");
+  });
+
+  it("repairs a reply that repeats an email already in the thread", async () => {
+    const intro = "I'm Mira, and i previously shipped a zoom competitor to 500k mau before this.";
+    completeMock
+      .mockResolvedValueOnce(draftReply(`Fair point. ${intro}`))
+      .mockResolvedValueOnce(draftReply("Fair point. What broke first?"));
+
+    const out = await draftInboxReply({
+      ...BASE,
+      body: "most of it is vibe-coded",
+      threadSent: [{ body: intro, sentAt: "2026-08-28" }],
+    });
+
+    expect(out.body).toBe("Fair point. What broke first?");
+    expect(userBlocks().at(-1)!).toContain("repeats-prior-email");
+  });
+
+  it("keeps the first draft when the repair is no cleaner", async () => {
+    const bloated = Array.from({ length: 120 }, () => "pitch").join(" ");
+    completeMock
+      .mockResolvedValueOnce(draftReply(bloated))
+      .mockResolvedValueOnce(draftReply(Array.from({ length: 200 }, () => "worse").join(" ")));
+
+    const out = await draftInboxReply({ ...BASE, body: "did you hit that wall too?" });
+    expect(out.body).toBe(bloated);
+  });
+
+  it("keeps the first draft when the repair call fails", async () => {
+    const bloated = Array.from({ length: 120 }, () => "pitch").join(" ");
+    completeMock
+      .mockResolvedValueOnce(draftReply(bloated))
+      .mockRejectedValueOnce(new Error("provider 503"));
+
+    const out = await draftInboxReply({ ...BASE, body: "did you hit that wall too?" });
+    expect(out.body).toBe(bloated);
+  });
+
+  it("still throws on an empty first draft", async () => {
+    completeMock.mockResolvedValueOnce(draftReply("   "));
+    await expect(draftInboxReply(BASE)).rejects.toThrow("empty reply draft");
+  });
+});

--- a/packages/plays/__tests__/reply-gate.test.ts
+++ b/packages/plays/__tests__/reply-gate.test.ts
@@ -167,6 +167,18 @@ describe("draftInboxReply gate", () => {
     expect(userBlocks().at(-1)!).toContain("repeats-prior-email");
   });
 
+  it("KEEPS a repair that only shortens, even though the flag is unchanged", async () => {
+    // The real failure this catches: a 101-word reply repaired to 60 still
+    // trips `body-too-long`, so comparing flag COUNTS alone discarded it and
+    // shipped the longer draft. Overage has to break the tie.
+    const long = Array.from({ length: 120 }, () => "pitch").join(" ");
+    const shorter = Array.from({ length: 60 }, () => "pitch").join(" ");
+    completeMock.mockResolvedValueOnce(draftReply(long)).mockResolvedValueOnce(draftReply(shorter));
+
+    const out = await draftInboxReply({ ...BASE, body: "did you hit that wall too?" });
+    expect(out.body).toBe(shorter);
+  });
+
   it("keeps the first draft when the repair is no cleaner", async () => {
     const bloated = Array.from({ length: 120 }, () => "pitch").join(" ");
     completeMock

--- a/packages/plays/src/_lib.ts
+++ b/packages/plays/src/_lib.ts
@@ -437,6 +437,11 @@ export interface SendDraftedOpts {
     source_profile_url?: string | null;
     /** Job title at contact time, from the person-level ICP gate. */
     title?: string | null;
+    /** Research the play assembled for this person while drafting. Persisted so
+     *  the reply drafter's free Tier-1 read (_reply-research.ts) has something
+     *  to use — before this it was always empty and every reply draft paid for
+     *  enrich + webRead again. Read as TEXT, never parsed. */
+    dossier_json?: string | null;
   };
   metadata?: Record<string, unknown>;
   dryRun: boolean;

--- a/packages/plays/src/_run-play.ts
+++ b/packages/plays/src/_run-play.ts
@@ -1,6 +1,7 @@
 import {
   deepResearch,
   getLedger,
+  hasDossierSignal,
   isSendDeferred,
   loadConfig,
   parallelMap,
@@ -22,6 +23,10 @@ import {
 import { enrollInCadence } from "./_cadence.ts";
 
 type AppConfig = ReturnType<typeof loadConfig>;
+
+/** Cap on the dossier persisted onto a prospect — matches the slice the
+ *  finders already apply to a queued dossier (x-reposters, add-prospect). */
+const DOSSIER_SLICE = 6000;
 
 /**
  * What a play's per-target `prepare` step hands back to the executor: the
@@ -186,6 +191,17 @@ export async function runEmailPlay<T, X = Record<string, never>>(
             // persisted without each play def naming the field.
             ...(typeof (target as { title?: unknown }).title === "string"
               ? { title: (target as { title: string }).title }
+              : {}),
+            // Persist the research this play just assembled. Every play returns
+            // a dossier from `prepare`, and until now all of it was thrown away
+            // the moment the draft was written — so the reply drafter's free
+            // Tier-1 read always missed and re-bought the same research.
+            // hasDossierSignal, not a bare trim: a FAILED enrich still
+            // serializes to `{"status":"failed",...}`, and storing that would
+            // register as a Tier-1 hit and suppress the paid research the
+            // reply drafter would otherwise do.
+            ...(hasDossierSignal(prep.dossier)
+              ? { dossier_json: prep.dossier.slice(0, DOSSIER_SLICE) }
               : {}),
           },
           ...(def.metadata ? { metadata: def.metadata(target) } : {}),

--- a/packages/plays/src/reply.ts
+++ b/packages/plays/src/reply.ts
@@ -1,7 +1,13 @@
 import { loadConfig, stripQuotedChain } from "@oneshot-gtm/core";
 import { complete, type LlmMessage, loadPrompt, tryParseJsonObject } from "@oneshot-gtm/intel";
 import { getPriorStepsForProspect, type PriorStepRow } from "./_cadence.ts";
-import { firstNameFrom, humanizeDraft, lintEmail, signatureDirective } from "./_lib.ts";
+import {
+  bodyWordsForLint,
+  firstNameFrom,
+  humanizeDraft,
+  lintEmail,
+  signatureDirective,
+} from "./_lib.ts";
 
 // stripQuotedChain moved to core (reply-classify.ts) — the classifier needs it
 // too. Re-exported so existing imports of this module keep working.
@@ -71,6 +77,26 @@ function lintReply(body: string, maxWords: number, priorTexts: readonly string[]
   const flags = lintEmail("x", body, maxWords).filter((f) => !f.startsWith("subject-"));
   if (repeatsPriorText(body, priorTexts)) flags.push("repeats-prior-email");
   return flags;
+}
+
+/**
+ * How bad a draft is: flag count first, then how far over the word budget it
+ * runs. The overage tiebreak matters — a repair that cuts 101 words to 60 is a
+ * real improvement but still carries the single `body-too-long` flag, so
+ * comparing flag counts alone would discard it and keep the worse draft.
+ */
+function replyPenalty(
+  body: string,
+  maxWords: number,
+  priorTexts: readonly string[],
+): [number, number] {
+  const flags = lintReply(body, maxWords, priorTexts);
+  return [flags.length, Math.max(0, bodyWordsForLint(body) - maxWords)];
+}
+
+/** Lexicographic compare: true when `a` is strictly better than `b`. */
+function better(a: [number, number], b: [number, number]): boolean {
+  return a[0] !== b[0] ? a[0] < b[0] : a[1] < b[1];
 }
 
 /** Parse the model's JSON and apply the deterministic autofixes (em-dash,
@@ -213,9 +239,15 @@ export async function draftInboxReply(input: DraftInboxReplyInput): Promise<{ bo
   const flags = lintReply(body, budget, priorTexts);
   if (flags.length > 0) {
     const repaired = await repairReply({ messages, first: res.content, flags, budget, input });
-    // Keep the rewrite only if it actually cleared flags — a repair that trades
-    // one violation for another is not an improvement worth the swap.
-    if (repaired && lintReply(repaired, budget, priorTexts).length < flags.length) body = repaired;
+    // Keep the rewrite only when it is strictly better — fewer flags, or the
+    // same flags but closer to the budget. A repair that trades one violation
+    // for another is not an improvement worth the swap.
+    if (
+      repaired &&
+      better(replyPenalty(repaired, budget, priorTexts), replyPenalty(body, budget, priorTexts))
+    ) {
+      body = repaired;
+    }
   }
   return { body };
 }

--- a/packages/plays/src/reply.ts
+++ b/packages/plays/src/reply.ts
@@ -1,7 +1,7 @@
 import { loadConfig, stripQuotedChain } from "@oneshot-gtm/core";
-import { complete, loadPrompt, tryParseJsonObject } from "@oneshot-gtm/intel";
+import { complete, type LlmMessage, loadPrompt, tryParseJsonObject } from "@oneshot-gtm/intel";
 import { getPriorStepsForProspect, type PriorStepRow } from "./_cadence.ts";
-import { firstNameFrom, humanizeDraft, signatureDirective, socialProofBlock } from "./_lib.ts";
+import { firstNameFrom, humanizeDraft, lintEmail, signatureDirective } from "./_lib.ts";
 
 // stripQuotedChain moved to core (reply-classify.ts) — the classifier needs it
 // too. Re-exported so existing imports of this module keep working.
@@ -9,6 +9,79 @@ export { stripQuotedChain };
 
 /** Mirror triage.ts's truncation — inbound bodies can be huge (quoted chains). */
 const INBOUND_BODY_MAX = 2000;
+
+/** Words in a body, quoted chain stripped — the unit both length rules use. */
+function wordCount(text: string): number {
+  return stripQuotedChain(text).split(/\s+/).filter(Boolean).length;
+}
+
+/**
+ * Mirror-their-length word budget, tracking the ladder in reply-email.md (a
+ * one-liner gets under 40 words back, a substantive message 40-90, a
+ * substantive technical one up to 130) with a little headroom so the gate
+ * fires on real overruns rather than on a draft landing a few words over.
+ */
+export function replyWordBudget(inboundBody: string): number {
+  const words = wordCount(inboundBody);
+  if (words <= 25) return 45;
+  if (words <= 90) return 95;
+  return 135;
+}
+
+/**
+ * Longest run of words a draft may share with an email already in this thread.
+ * The re-introduction that motivated this gate ("i previously shipped a zoom
+ * competitor to 500k mau", lifted from the intro into the reply) walked past a
+ * prose "do not re-introduce yourself" rule; an n-gram check does not care how
+ * the model justified it.
+ */
+const REPEAT_NGRAM = 8;
+
+function normalizeWords(text: string): string[] {
+  return stripQuotedChain(text)
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+/** True when the draft reuses REPEAT_NGRAM consecutive words from prior text. */
+export function repeatsPriorText(body: string, priorTexts: readonly string[]): boolean {
+  const draft = normalizeWords(body);
+  if (draft.length < REPEAT_NGRAM) return false;
+  const seen = new Set<string>();
+  for (const text of priorTexts) {
+    const words = normalizeWords(text);
+    for (let i = 0; i + REPEAT_NGRAM <= words.length; i++) {
+      seen.add(words.slice(i, i + REPEAT_NGRAM).join(" "));
+    }
+  }
+  if (seen.size === 0) return false;
+  for (let i = 0; i + REPEAT_NGRAM <= draft.length; i++) {
+    if (seen.has(draft.slice(i, i + REPEAT_NGRAM).join(" "))) return true;
+  }
+  return false;
+}
+
+/**
+ * Body-only lint: a reply keeps the inbound "Re: …", so subject flags are not
+ * ours to raise — lintEmail gets a dummy subject and they're dropped.
+ */
+function lintReply(body: string, maxWords: number, priorTexts: readonly string[]): string[] {
+  const flags = lintEmail("x", body, maxWords).filter((f) => !f.startsWith("subject-"));
+  if (repeatsPriorText(body, priorTexts)) flags.push("repeats-prior-email");
+  return flags;
+}
+
+/** Parse the model's JSON and apply the deterministic autofixes (em-dash,
+ *  curly quotes, emoji) BEFORE linting — otherwise the gate burns a retry on
+ *  what humanizeDraft already repairs. humanizeDraft wants a subject; the
+ *  reply has none, so pass a dummy. */
+function bodyFrom(raw: string): string {
+  const parsed = tryParseJsonObject<{ body?: string }>(raw, {});
+  const body = (parsed.body ?? "").trim();
+  return body ? humanizeDraft({ subject: "x", body }).body : "";
+}
 
 export interface DraftInboxReplyInput {
   /** Normalized sender address of the inbound email. */
@@ -93,7 +166,11 @@ export async function draftInboxReply(input: DraftInboxReplyInput): Promise<{ bo
         ].join("\n")
       : null;
 
-  const proofBlock = socialProofBlock();
+  // No SOCIAL PROOF block here, deliberately. It is an instruction ("pick the
+  // ONE beat that best fits this play"), and in a reply it contradicts the
+  // prompt's "do not re-introduce yourself or the product" — the credentials
+  // and portfolio lines only render as a self-introduction, which the prospect
+  // already read in the intro email. Social proof belongs in outbound drafts.
   const firstName = firstNameFrom(input.matched?.name ?? null);
   const user = [
     `FOUNDER: ${cfg.founderName ?? "(unknown)"}`,
@@ -116,22 +193,64 @@ export async function draftInboxReply(input: DraftInboxReplyInput): Promise<{ bo
     "INBOUND EMAIL (the message you are answering):",
     `Subject: ${input.subject}`,
     stripQuotedChain(input.body).slice(0, INBOUND_BODY_MAX),
-    ...(proofBlock ? ["", proofBlock] : []),
     ...(firstName ? ["", `PROSPECT_FIRST_NAME: ${firstName}`] : []),
   ].join("\n");
 
-  const res = await complete({
-    messages: [
-      { role: "system", content: system },
-      { role: "user", content: user },
-    ],
-    temperature: 0.6,
-    maxTokens: 500,
-  });
-  const parsed = tryParseJsonObject<{ body?: string }>(res.content, {});
-  const body = (parsed.body ?? "").trim();
+  const messages: LlmMessage[] = [
+    { role: "system", content: system },
+    { role: "user", content: user },
+  ];
+  const res = await complete({ messages, temperature: 0.6, maxTokens: 500 });
+  let body = bodyFrom(res.content);
   if (!body) throw new Error("the model returned an empty reply draft — try again");
-  // Same deterministic autofixes the outbound drafts get (em-dash, curly
-  // quotes, emoji). humanizeDraft wants a subject — pass a dummy.
-  return { body: humanizeDraft({ subject: "x", body }).body };
+
+  // The outbound plays lint their drafts and let sendDraftedEmail block on the
+  // flags. A reply has no send gate (the founder reviews it in the composer),
+  // so the gate is a single repair pass instead: cheaper than shipping a
+  // three-paragraph pitch at a one-line question.
+  const priorTexts = [...prior.map((r) => r.body!), ...(input.threadSent ?? []).map((t) => t.body)];
+  const budget = replyWordBudget(input.body);
+  const flags = lintReply(body, budget, priorTexts);
+  if (flags.length > 0) {
+    const repaired = await repairReply({ messages, first: res.content, flags, budget, input });
+    // Keep the rewrite only if it actually cleared flags — a repair that trades
+    // one violation for another is not an improvement worth the swap.
+    if (repaired && lintReply(repaired, budget, priorTexts).length < flags.length) body = repaired;
+  }
+  return { body };
+}
+
+/** One corrective turn, naming the flags the draft tripped. Returns "" when the
+ *  retry fails for any reason — a linted-but-imperfect draft still beats none. */
+async function repairReply(opts: {
+  messages: LlmMessage[];
+  first: string;
+  flags: string[];
+  budget: number;
+  input: DraftInboxReplyInput;
+}): Promise<string> {
+  const inboundWords = wordCount(opts.input.body);
+  try {
+    const res = await complete({
+      messages: [
+        ...opts.messages,
+        { role: "assistant", content: opts.first },
+        {
+          role: "user",
+          content: [
+            `That draft failed the reply gate: ${opts.flags.join(", ")}.`,
+            `They wrote ${inboundWords} words; yours must come in under ${opts.budget}, signature excluded.`,
+            "Rewrite it. Answer only what they actually said, and cut every sentence that pitches,",
+            "re-introduces you or the product, or repeats wording from an email already in this thread.",
+            "Same JSON shape.",
+          ].join(" "),
+        },
+      ],
+      temperature: 0.5,
+      maxTokens: 500,
+    });
+    return bodyFrom(res.content);
+  } catch {
+    return "";
+  }
 }

--- a/packages/prompts/reply-email.md
+++ b/packages/prompts/reply-email.md
@@ -12,7 +12,6 @@ You are the founder, personally answering an email a prospect wrote back to you.
 - THEIR EARLIER MESSAGES (optional): what the prospect already told you in this exchange — never re-ask any of it
 - THREAD — REPLIES YOU ALREADY SENT (optional): your earlier answers in this same conversation
 - INBOUND EMAIL: the message they just sent you (subject + body). THIS is what you're answering.
-- Optional SOCIAL PROOF block
 
 ## Reply rules
 
@@ -29,5 +28,7 @@ You are the founder, personally answering an email a prospect wrote back to you.
 - No capability lists, no feature dumps, no discounts or credits, no invented artifacts (decks, teardowns, case studies you don't have).
 - Forbidden phrases: "thanks for the feedback" as an opener, "I appreciate you taking the time", "circling back", "just to clarify", "hope this finds you well".
 - Do not re-introduce yourself or the product — they know who you are; PRIOR EMAILS already did that.
+  No credentials, no track record, no "I previously built X" line: if it reads like a sentence from a
+  first-touch email, it does not belong in a reply. Never reuse wording from PRIOR EMAILS or THREAD.
 
 Output as a JSON object only: { "body": string }.


### PR DESCRIPTION
## Why

A reply we sent to a prospect re-introduced the founder — *"i previously shipped a zoom competitor to 500k mau"* — to someone already mid-thread, conceded a point nobody had made, and answered a 20-word message with 110 words. Tracing it turned up three independent gaps that compound into one failure.

## What was wrong

**1. The prompt and the code disagreed.** `reply-email.md` says *"Do not re-introduce yourself or the product"*, then `reply.ts` appended `socialProofBlock()` — a **directive** ("pick the ONE beat that best fits this play") placed after that prose rule. The configured portfolio line reads *"Previously shipped a Zoom competitor to 500k MAU"*, which can only render as a self-introduction. Dropped from the reply path; social proof stays in outbound drafts.

**2. The reply path never linted.** Outbound plays call `lintEmail` and let `sendDraftedEmail` block on flags. A reply has no send gate, so it now runs a single repair pass against a mirror-their-length budget (ladder from the prompt's own rules) plus an 8-gram check against emails already in the thread. A prose rule didn't stop the credentials line being lifted verbatim; an n-gram check doesn't care how the model justified it. The rewrite is kept **only if it clears more flags than it adds**.

**3. Reply drafting had nothing to draw on.** `prospects.dossier_json` is read as free Tier-1 context by `_reply-research.ts` but **nothing in production ever wrote it** — NULL on every row — so every draft fell through to paid enrich + webRead. Meanwhile `receipts` showed 112 `research.person` calls ($5.00) already bought, used transiently, and discarded into no cache.

## What this does

- Plays persist the dossier `prepare()` already assembled (generic lift in `_run-play.ts`, same mechanism that carries `title`).
- `safeDeepResearchPerson` gives the most expensive and slowest call in the toolbox (~$0.05, 2–5 min) the caching, deadline and transient-aware negative caching every other paid call already had. Modelled on `safeEnrich`; cached 90d in the shared cross-workspace DB so a person researched for one product is never re-bought for another.
- `oneshot-gtm find research-prospects` backfills existing rows — sibling of `enrich-linkedin`: capped, dry-runnable, bounded concurrency, breaker-aware, resumable.
- Dud-domain senders (gmail &c.) skipped enrich *and* the site read and had nothing left to try. Reply research now reads the finder's `source_profile_url`, which is the one handle we do own for them.
- `setProspectIcpVerdict` accepts `unclear`. `qualifyPerson` is 4-state, but ambiguity was written as NULL — indistinguishable from never-judged. `unclear` is **provisional**: a re-audit re-judges those rows (so role text arriving later is used) and skips only `pass`/`reject`, which keeps the audit self-healing.

### The gate worth reviewing closely

`hasDossierSignal` (`packages/core/src/dossier.ts`) guards every writer **and** the Tier-1 read. This is load-bearing, not tidiness. Two real shapes look non-empty and say nothing:

```
{"status":"failed","profile":null,"cost":0}                    // a failed enrich
{"title":null,"company":null,"summary":"<addr> is a role based email address."}
```

Storing either registers as a Tier-1 hit and **suppresses the paid tiers**, leaving the drafter worse off than an empty column. It keeps prose and truncated JSON — dossiers are sliced to 6000 chars, so a stored payload may not re-parse, and discarding those would throw away research already paid for.

## Suppression is unchanged

The cadence gate tests `=== "reject"`, so `unclear` fails open exactly as NULL did. Nothing here widens what gets suppressed.

## Verification

`bun run typecheck` · `bun run lint` (0 errors) · `bun run fmt:check` · **2143 tests / 166 files passing** (+48 tests, +5 files).

Exercised against the **live** OneShot API, not just mocks: 40 dossiers persisted, cache hits billing $0.00, ~$4.7 spent. Two bugs were caught by that live run rather than by tests, and both are fixed here — cache hits were re-adding the original call's `cost` (phantom spend), and the first signal test accepted contentless payloads.

## Note for whoever merges

`STATUS.md` line 5 will conflict — #338, #322 and #102 all rewrite the same test-count line from the same base, so they already conflict with each other. Resolution is one line: re-run `npx vitest run` and write the real number.

https://claude.ai/code/session_01UdGsziQx4hWtBR9bZnk5KR

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ground reply drafts in stored research and lint them against length and repetition
> - Reworks [reply.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/340/files#diff-8470b0004c64bc895e4c98a5c8c751ecd497cc99a4e7f9b3e35965fb23df704a) `draftInboxReply` to drop the social proof block, enforce a word-count budget that mirrors inbound length, and reject drafts that repeat 8-word n-grams from prior thread text; a single corrective LLM turn rewrites violations and the better draft wins
> - Adds [dossier.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/340/files#diff-49ac43b0811844f9f078e51f8c5d2177aaf0db9455a6b8b346e82e29cd0ae97e) `hasDossierSignal` to gate persistence on substantive person signal, rejecting empty, failed, location-only, and role-mailbox placeholder payloads
> - Persists truncated dossier JSON (6000 chars) via `prospectMeta.dossier_json` in [_run-play.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/340/files#diff-51f0221e81e3c61f8a09445537ef875f1ab70fbf0c15361d3e868cfe7e4fae55) and new ledger method `setProspectDossier`, so reply research survives across plays instead of being discarded
> - Adds the `find research-prospects` CLI command in [research-prospects.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/340/files#diff-7253e42708c99905c795665329fbe976997ec0e416ecc0714a7ed204a16be8a3) for bulk dossier backfill with scoping, dry-run, concurrency, and circuit-breaker support
> - Introduces `safeDeepResearchPerson` in [_sdk-safe.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/340/files#diff-8e3d884af4c5f2bfff8049fd0edd17ffbdfe229d28fd3404a00a99470765bc40) with 90-day positive caching, negative caching for non-transient failures, and a 360s deadline so research never throws to callers
> - Risk: `readSenderPage` in [reply-research.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/340/files#diff-1c6b0e1dd50d7d2d2fa91b23f141dc2afba23860684c364018428ae9511f15cc) renames cache keys from `webread:<domain>` to `webread:<label>`, invalidating existing cache entries; `gatherReplyContext` now reads social profile URLs for dud-domain senders, adding a paid web read where none previously occurred
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6749bdc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->