### PR TITLE
fix: issue #345: fix(web): surface the server's JSON error body in `getJson` instead of discarding it

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -67,7 +67,7 @@ The ICP filter currently judges each candidate cold — `icpFilter` in `packages
 
 ## Tech debt
 
-- [ ] **Surface the server's error body on GET** · S — `getJson` in `apps/web/src/api/client.ts` throws `${status} ${statusText}: ${path}` and discards the `{ error }` JSON the server sends; `postJson` right below it reads the body. A 409 from a not-ready trigger reaches the dashboard as "409 Conflict" with the reason thrown away.
+- [x] **Surface the server's error body on GET** · S — `getJson` in `apps/web/src/api/client.ts` throws `${status} ${statusText}: ${path}` and discards the `{ error }` JSON the server sends; `postJson` right below it reads the body. A 409 from a not-ready trigger reaches the dashboard as "409 Conflict" with the reason thrown away, hiding the missing config field.
       _Done when:_ `getJson` parses the error body the same way `postJson` does and falls back to the status line when the body isn't JSON; covered by a test with a mocked `fetch`.
 - [ ] **Extract the pure logic out of `queue.tsx`** · M — the route is 1869 lines, the largest file in `apps/web`, and its selection, filter, bulk-approve and drain-eligibility rules are inlined where no test can reach them. `src/lib/` already holds this shape of helper (`drainButton.ts`, `pruneSentRows.ts`, `replyFilter.ts`).
       _Done when:_ those rules move to `src/lib/` as pure functions with tests, the route imports them, and the rendered markup is byte-identical for a fixed props fixture.

--- a/apps/web/src/api/__tests__/client.test.ts
+++ b/apps/web/src/api/__tests__/client.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+import { api } from "../client";
+
+const originalFetch = global.fetch;
+
+describe("api client getJson handling", () => {
+  afterEach(() => {
+    global.fetch = originalFetch;
+    vi.resetAllMocks();
+  });
+
+  it("surfaces JSON { error } body on 409", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 409,
+      statusText: "Conflict",
+      text: () => Promise.resolve(JSON.stringify({ error: "Missing config field" })),
+    });
+
+    await expect(api.home()).rejects.toThrow("Missing config field");
+  });
+
+  it("falls back to status string on non-JSON body", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      text: () => Promise.resolve("Plain text error from server"),
+    });
+
+    await expect(api.home()).rejects.toThrow("400 Bad Request: /home");
+  });
+
+  it("falls back to status string on empty body", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      statusText: "Unauthorized",
+      text: () => Promise.resolve(""),
+    });
+
+    await expect(api.home()).rejects.toThrow("401 Unauthorized: /home");
+  });
+
+  it("falls back to status string on network-like failure without valid JSON", async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 502,
+      statusText: "Bad Gateway",
+      text: () => Promise.reject(new Error("Network connection closed")),
+    });
+
+    await expect(api.home()).rejects.toThrow("502 Bad Gateway: /home");
+  });
+});

--- a/apps/web/src/api/__tests__/client.test.ts
+++ b/apps/web/src/api/__tests__/client.test.ts
@@ -3,6 +3,12 @@ import { api } from "../client";
 
 const originalFetch = global.fetch;
 
+// vi.fn() is a Mock, not the full `typeof fetch` (which carries `preconnect`),
+// so assigning it to global.fetch fails typecheck. Cast in one place.
+function mockFetch(response: Partial<Response>): void {
+  global.fetch = vi.fn().mockResolvedValue(response) as unknown as typeof fetch;
+}
+
 describe("api client getJson handling", () => {
   afterEach(() => {
     global.fetch = originalFetch;
@@ -10,7 +16,7 @@ describe("api client getJson handling", () => {
   });
 
   it("surfaces JSON { error } body on 409", async () => {
-    global.fetch = vi.fn().mockResolvedValue({
+    mockFetch({
       ok: false,
       status: 409,
       statusText: "Conflict",
@@ -21,7 +27,7 @@ describe("api client getJson handling", () => {
   });
 
   it("falls back to status string on non-JSON body", async () => {
-    global.fetch = vi.fn().mockResolvedValue({
+    mockFetch({
       ok: false,
       status: 400,
       statusText: "Bad Request",
@@ -32,7 +38,7 @@ describe("api client getJson handling", () => {
   });
 
   it("falls back to status string on empty body", async () => {
-    global.fetch = vi.fn().mockResolvedValue({
+    mockFetch({
       ok: false,
       status: 401,
       statusText: "Unauthorized",
@@ -43,7 +49,7 @@ describe("api client getJson handling", () => {
   });
 
   it("falls back to status string on network-like failure without valid JSON", async () => {
-    global.fetch = vi.fn().mockResolvedValue({
+    mockFetch({
       ok: false,
       status: 502,
       statusText: "Bad Gateway",

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -42,7 +42,20 @@ const BASE = "/api";
 
 async function getJson<T>(path: string): Promise<T> {
   const res = await fetch(BASE + path);
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}: ${path}`);
+  if (!res.ok) {
+    const fallback = `${res.status} ${res.statusText}: ${path}`;
+    let message = fallback;
+    try {
+      const text = await res.text();
+      if (text) {
+        const body = JSON.parse(text) as { error?: unknown };
+        if (typeof body.error === "string" && body.error) message = body.error;
+      }
+    } catch {
+      // body absent, empty, or not JSON — keep the fallback message
+    }
+    throw new Error(message);
+  }
   return (await res.json()) as T;
 }
 


### PR DESCRIPTION
Closes #345.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 8ddb229df209 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `getJson` to surface server JSON error body instead of discarding it
> - Updates `getJson` in [client.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/351/files#diff-1e909407d4cde2a3cc538df6b21b2c154dd5e5b8bac7b3a1f63dce2284f0a192) to read and parse the response body when the HTTP status is not OK, using `body.error` as the rejection message when present and non-empty
> - Falls back to the previous `status statusText: path` message when the body is absent, empty, non-JSON, or lacks a string `error` field
> - Adds unit tests in [client.test.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/351/files#diff-0d0e9d52b32f2acf7262d11f03995840b630c53987ed77be359ec3c9b8ebd083) covering JSON error bodies, non-JSON bodies, empty bodies, and body-read failures
> - Marks the corresponding tech-debt item as completed in [ROADMAP.md](https://github.com/oneshot-agent/oneshot-gtm/pull/351/files#diff-683343bdf93f55ed3cada86151abb8051282e1936e58d4e0a04beca95dff6e51)
> - Behavioral Change: callers that catch errors from `getJson` will now see server-provided error text instead of the generic status line when the server returns JSON with an `error` string
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 72ef71d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->