### PR TITLE
fix: issue #349: Unresolved review findings from merged PR #348

### DIFF
--- a/apps/cli/__tests__/json-output.test.ts
+++ b/apps/cli/__tests__/json-output.test.ts
@@ -621,8 +621,8 @@ describe("domains list --json", () => {
       dailySent: 0,
       dailyLimit: 20,
     });
-    // Clean pool: no domainsError flag.
-    expect(parsed).not.toHaveProperty("domainsError");
+    // Clean pool: no domainsError flag if using the old shape, but we now always emit it.
+    expect(parsed.domainsError).toBe(false);
   });
 
   it("empty pool emits an empty array, not an error flag", async () => {
@@ -632,7 +632,7 @@ describe("domains list --json", () => {
     const stdout = stdoutChunks.join("");
     const parsed = JSON.parse(stdout);
     expect(parsed.domains).toEqual([]);
-    expect(parsed).not.toHaveProperty("domainsError");
+    expect(parsed.domainsError).toBe(false);
   });
 
   it("flags domainsError when the pool is unreachable", async () => {

--- a/apps/cli/src/commands/identities.ts
+++ b/apps/cli/src/commands/identities.ts
@@ -200,6 +200,7 @@ export async function commandDomainsList(opts: { json?: boolean } = {}): Promise
   if (opts.json) {
     emitJson({
       command: "domains list",
+      domainsError,
       domains: domains.map((d) => ({
         domain: d.domain,
         poolStatus: d.pool_status,


### PR DESCRIPTION
Closes #349.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 0a0af4a79b94 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Always include `domainsError` boolean in `domains list --json` output
> The JSON output for the `domains list` command previously omitted `domainsError` on success, making it inconsistent. The emitted object now always sets `domainsError` to `false` on success and `true` when the pool is unreachable. Tests in [json-output.test.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/362/files#diff-2d22f16c091d9cfd4348bdd34cc68e952ce405a4295b129699b89c445507f56d) are updated to assert `parsed.domainsError === false` rather than checking for absence.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 932c3ab.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->