### PR TITLE
fix: issue #344: Unresolved review findings from merged PR #343

### DIFF
--- a/packages/core/__tests__/timezone.test.ts
+++ b/packages/core/__tests__/timezone.test.ts
@@ -74,6 +74,31 @@ describe("formatLocalEventTime", () => {
     );
   });
 
+  it("validates calendar dates, including years before 100", () => {
+    expect(formatLocalEventTime("0001-01-01", "UTC")).toBe("Monday, January 1");
+    expect(formatLocalEventTime("0004-02-29", "UTC")).toBe("Sunday, February 29");
+    for (const invalid of ["0001-02-29", "2026-02-29", "2026-04-31", "2026-13-01"]) {
+      expect(formatLocalEventTime(invalid, "UTC")).toBeNull();
+    }
+  });
+
+  it("validates every wall-clock time component", () => {
+    expect(formatLocalEventTime("2026-08-26T19:30:59", "UTC")).toBe(
+      "Wednesday, August 26, 7:30 PM",
+    );
+    expect(formatLocalEventTime("2026-08-26T19:30:59.999", "UTC")).toBe(
+      "Wednesday, August 26, 7:30 PM",
+    );
+    for (const invalid of [
+      "2026-08-26T24:00:00",
+      "2026-08-26T19:60:00",
+      "2026-08-26T19:30:60",
+      "2026-08-26T19:30:99",
+    ]) {
+      expect(formatLocalEventTime(invalid, "UTC")).toBeNull();
+    }
+  });
+
   it("returns null (not 'Invalid Date') for a non-timestamp", () => {
     for (const junk of ["", "   ", "sometime next week", "TBD"]) {
       expect(formatLocalEventTime(junk, "America/Los_Angeles")).toBeNull();

--- a/packages/core/src/timezone.ts
+++ b/packages/core/src/timezone.ts
@@ -170,7 +170,7 @@ function namesForCalendarDate(
   monthLong: string;
   monthShort: string;
 } {
-  const at = new Date(Date.UTC(year, month - 1, day, 12));
+  const at = utcCalendarDate(year, month, day, 12);
   const long = partsOf(
     new Intl.DateTimeFormat("en-US", { timeZone: "UTC", weekday: "long", month: "long" }),
     at,
@@ -210,8 +210,16 @@ function twelveHour(hour24: number, minute: number): string {
  */
 function isValidDate(year: number, month: number, day: number): boolean {
   if (month < 1 || month > 12 || day < 1) return false;
-  const d = new Date(Date.UTC(year, month - 1, day, 12));
+  const d = utcCalendarDate(year, month, day, 12);
   return d.getUTCFullYear() === year && d.getUTCMonth() === month - 1 && d.getUTCDate() === day;
+}
+
+/** Build a UTC calendar date without Date.UTC's special handling of years 0-99. */
+function utcCalendarDate(year: number, month: number, day: number, hour = 0): Date {
+  const date = new Date(0);
+  date.setUTCFullYear(year, month - 1, day);
+  date.setUTCHours(hour, 0, 0, 0);
+  return date;
 }
 
 function wallClock(isoInstant: string, zone: string): WallClock | null {
@@ -242,7 +250,8 @@ function wallClock(isoInstant: string, zone: string): WallClock | null {
     if (!isValidDate(year, month, day)) return null;
     const h = Number(naive[4]);
     const min = Number(naive[5]);
-    if (h > 23 || min > 59) return null;
+    const sec = naive[6] === undefined ? 0 : Number(naive[6]);
+    if (h > 23 || min > 59 || sec > 59) return null;
     return {
       ...namesForCalendarDate(year, month, day),
       year,

--- a/packages/core/src/timezone.ts
+++ b/packages/core/src/timezone.ts
@@ -208,6 +208,12 @@ function twelveHour(hour24: number, minute: number): string {
  *
  * Returns null when the string is not a timestamp at all.
  */
+function isValidDate(year: number, month: number, day: number): boolean {
+  if (month < 1 || month > 12 || day < 1) return false;
+  const d = new Date(Date.UTC(year, month - 1, day, 12));
+  return d.getUTCFullYear() === year && d.getUTCMonth() === month - 1 && d.getUTCDate() === day;
+}
+
 function wallClock(isoInstant: string, zone: string): WallClock | null {
   const raw = (isoInstant ?? "").trim();
   if (raw.length === 0) return null;
@@ -217,6 +223,7 @@ function wallClock(isoInstant: string, zone: string): WallClock | null {
     const year = Number(dateOnly[1]);
     const month = Number(dateOnly[2]);
     const day = Number(dateOnly[3]);
+    if (!isValidDate(year, month, day)) return null;
     return {
       ...namesForCalendarDate(year, month, day),
       year,
@@ -232,12 +239,16 @@ function wallClock(isoInstant: string, zone: string): WallClock | null {
     const year = Number(naive[1]);
     const month = Number(naive[2]);
     const day = Number(naive[3]);
+    if (!isValidDate(year, month, day)) return null;
+    const h = Number(naive[4]);
+    const min = Number(naive[5]);
+    if (h > 23 || min > 59) return null;
     return {
       ...namesForCalendarDate(year, month, day),
       year,
       month,
       day,
-      time: twelveHour(Number(naive[4]), Number(naive[5])),
+      time: twelveHour(h, min),
       tzAbbr: null,
     };
   }

--- a/packages/prompts/luma-event-extract.md
+++ b/packages/prompts/luma-event-extract.md
@@ -32,7 +32,7 @@ A JSON object only:
 
 - `eventTitle`: the event name as displayed (e.g. "SF AI Builders Meetup"). Null if not clearly an event page.
 - `eventDateIso`: ISO 8601 date or datetime when stated. If only "Tuesday, June 10" is shown without year, infer the next future occurrence and emit a date-only ISO. Null if not stated.
-- `eventTimezone`: the IANA zone the page's times are in, when the page shows a zone (a "PDT" / "7:30 PM GMT+1" label, or the venue's city). Emit the IANA name — "America/Los_Angeles", not "PDT". Null if the page gives no zone and no venue city. Do NOT guess from your own clock.
+- `eventTimezone`: the IANA zone the page's times are in, when the page shows a zone (a "PDT" / "7:30 PM GMT+1" label, or the venue's city). Emit the IANA name — "America/Los_Angeles", not "PDT". Null if the page gives no zone and no venue city, or if the zone is ambiguous (e.g. an offset without a city, or a city not unique enough to resolve to a single IANA zone). Do NOT guess from your own clock.
 - `eventCity`: city or "Online" / "Virtual" / region. Null if not stated.
 - `eventDescription`: the event's own summary of what it's ABOUT — the topic/theme, format, and who it's for. Condense the page's description to 1-3 sentences, cap ~500 chars. Strip pure logistics (parking, sponsors, ticket prices, agenda timings) — keep only what conveys the subject. Null if the page shows no description.
 - `eventHasPassed`: true when the page explicitly shows "this event has ended" / past-tense framing / a date older than today. Default false when unclear.

--- a/packages/prompts/luma-event-extract.md
+++ b/packages/prompts/luma-event-extract.md
@@ -32,7 +32,7 @@ A JSON object only:
 
 - `eventTitle`: the event name as displayed (e.g. "SF AI Builders Meetup"). Null if not clearly an event page.
 - `eventDateIso`: ISO 8601 date or datetime when stated. If only "Tuesday, June 10" is shown without year, infer the next future occurrence and emit a date-only ISO. Null if not stated.
-- `eventTimezone`: the IANA zone the page's times are in, when the page shows a zone (a "PDT" / "7:30 PM GMT+1" label, or the venue's city). Emit the IANA name — "America/Los_Angeles", not "PDT". Null if the page gives no zone and no venue city, or if the zone is ambiguous (e.g. an offset without a city, or a city not unique enough to resolve to a single IANA zone). Do NOT guess from your own clock.
+- `eventTimezone`: the IANA zone the page's times are in, when the page shows an unambiguous zone (a "PDT" label or the venue's city). Emit the IANA name — "America/Los_Angeles", not "PDT". Null if the page gives no zone and no venue city, or if the zone is ambiguous (e.g. "7:30 PM GMT+1" without a city, or a city not unique enough to resolve to a single IANA zone). Do NOT guess from your own clock.
 - `eventCity`: city or "Online" / "Virtual" / region. Null if not stated.
 - `eventDescription`: the event's own summary of what it's ABOUT — the topic/theme, format, and who it's for. Condense the page's description to 1-3 sentences, cap ~500 chars. Strip pure logistics (parking, sponsors, ticket prices, agenda timings) — keep only what conveys the subject. Null if the page shows no description.
 - `eventHasPassed`: true when the page explicitly shows "this event has ended" / past-tense framing / a date older than today. Default false when unclear.


### PR DESCRIPTION
Closes #344.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 0a0af4a79b94 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

**Review note:** review FAIL at the 2-round correction cap — findings filed: https://github.com/oneshot-agent/oneshot-gtm/issues/363

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `wallClock` date validation and `utcCalendarDate` handling for years 0–99
> - Adds `isValidDate` and `utcCalendarDate` helpers in [timezone.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/368/files#diff-94adc50ff0fda0971352ebe3126d036cb2263d8f35afc4a144bb0207cc9224b7) to correctly handle years 0–99 (avoiding `Date.UTC`'s two-digit-year special behavior) and reject invalid calendar dates such as non-leap Feb 29
> - Updates `wallClock` to return `null` for invalid calendar dates and out-of-range hour/minute/second values in `DATE_ONLY` and `NAIVE_DATETIME` inputs; fully qualified instants are unchanged
> - Updates `namesForCalendarDate` to use `utcCalendarDate` so weekday and month names are correct for years 0–99
> - Clarifies the `eventTimezone` extraction rule in [luma-event-extract.md](https://github.com/oneshot-agent/oneshot-gtm/pull/368/files#diff-dd75d9a79270ddf6d4e8eea5957fa847d5e0a4e604fba1c566df63520cd061cb): return `null` when the timezone is ambiguous rather than guessing
> - Adds test cases in [timezone.test.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/368/files#diff-a4339ccd6fc58be10739bfcc849627adc35c9260b4fcefa34767a9671d95d8b7) for calendar date validation, leap-day correctness, and wall-clock time component validation
> - Behavioral Change: `wallClock` now rejects inputs that previously produced invalid or miscomputed `Date` values (e.g., Feb 29 on non-leap years, hours > 23); callers receiving `null` must handle it
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d760568. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->