### PR TITLE
fix: issue #341: Unresolved review findings from merged PR #322

### DIFF
--- a/apps/server/__tests__/run-route.test.ts
+++ b/apps/server/__tests__/run-route.test.ts
@@ -108,7 +108,7 @@ vi.mock("@oneshot-gtm/plays", async () => {
   };
 });
 
-const { runPlay } = await import("../src/api/run.ts");
+const { cancelRunRoute, runPlay } = await import("../src/api/run.ts");
 
 function makeRequest(playName: string, body: unknown, signal?: AbortSignal): Request {
   return new Request(`http://127.0.0.1:3030/api/run/${playName}`, {
@@ -286,6 +286,41 @@ describe("runPlay — verify-then-dispatch", () => {
     expect(row?.prospectEmails).toEqual(["a@x.dev", "b@x.dev"]);
   });
 
+  it("persists drafts completed before dispatch rejects on cancellation", async () => {
+    const target = { founderEmail: "partial@x.dev" };
+    getLedger().enqueueTarget({
+      playName: "show-hn",
+      payload: target,
+      dedupeKey: "queue-partial",
+      source: "test",
+      initialStatus: "approved",
+    });
+    runOverride = (input) => {
+      input.onProgress?.(0, {
+        subject: "partial subject",
+        body: "partial body",
+        flags: [],
+        sent: false,
+        receiptIds: [],
+      });
+      return Promise.reject(new RunCancelledError("cancelled by user"));
+    };
+    const res = await runPlay(
+      makeRequest("show-hn", {
+        targets: [target],
+        dedupeKeys: ["queue-partial"],
+        dryRun: true,
+      }),
+      { playName: "show-hn" },
+    );
+    await readSseFrames(res.body);
+    const row = getLedger().getQueueRowByDedupe("show-hn", "queue-partial");
+    expect(JSON.parse(row?.last_draft_json ?? "{}")).toMatchObject({
+      subject: "partial subject",
+      body: "partial body",
+    });
+  });
+
   it("reports a real error as an error even when the client already disconnected", async () => {
     // Disconnect fires the run's abort, but what actually ended the run was an
     // SDK failure — it must land as `error`, not get relabelled a cancellation.
@@ -323,5 +358,16 @@ describe("runPlay — verify-then-dispatch", () => {
       playName: "show-hn",
     });
     expect(noTargets.status).toBe(400);
+  });
+});
+
+describe("cancelRunRoute — origin validation", () => {
+  it("rejects a hostname that merely starts with localhost", async () => {
+    const req = new Request("http://127.0.0.1/api/run/1/cancel", {
+      method: "POST",
+      headers: { origin: "http://localhost.evil.example" },
+    });
+    const res = await cancelRunRoute(req, { runId: "1" });
+    expect(res.status).toBe(403);
   });
 });

--- a/apps/server/src/api/run.ts
+++ b/apps/server/src/api/run.ts
@@ -47,6 +47,7 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
     playName,
     dryRun: body.dryRun,
     targets: body.targets,
+    dedupeKeys: body.dedupeKeys,
   });
   // Emails that actually sent, for the /cadences?sinceRun=N deep-link.
   const sentEmails: string[] = [];
@@ -186,6 +187,9 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
           playName,
           filteredBody,
           (index, d) => {
+            // dispatchPlay rejects on cancellation, so its returned batch is
+            // unavailable. Retain completed drafts as they arrive.
+            drafted[index] = d;
             draftedCount++;
             send({ kind: "draft", index, subject: d.subject, body: d.body, flags: d.flags });
             if (d.receiptIds.length > 0) {
@@ -295,13 +299,27 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
           typeof emailToDedupeKey !== "undefined" &&
           emailToDedupeKey.size > 0
         ) {
-          persistDraftsToQueue({
-            playName,
-            verifiedTargets: verify.verified as Array<{ email?: string; founderEmail?: string }>,
-            drafted,
-            dryRun: body.dryRun,
-            emailToDedupeKey,
-          });
+          try {
+            persistDraftsToQueue({
+              playName,
+              verifiedTargets: verify.verified as Array<{ email?: string; founderEmail?: string }>,
+              drafted,
+              dryRun: body.dryRun,
+              emailToDedupeKey,
+            });
+          } catch (err) {
+            // Guard setup as well as individual writes so terminal status,
+            // cleanup, and telemetry still happen if ledger access fails.
+            logEvent(
+              "error.swallowed",
+              {
+                kind: "run.persistDraftsToQueue",
+                play: playName,
+                message_120: ((err as Error).message ?? "").slice(0, 120),
+              },
+              "warn",
+            );
+          }
         }
 
         // The abort can also land without anything throwing — a play that
@@ -363,11 +381,7 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
   // Loopback-only CORS for SSE: mirror loopback origins, omit the header
   // otherwise (the outer fetch handler already enforces a loopback Host).
   const origin = req.headers.get("origin") ?? "";
-  const isLoopback =
-    origin === "" ||
-    origin.startsWith("http://127.0.0.1") ||
-    origin.startsWith("http://localhost") ||
-    origin.startsWith("http://[::1]");
+  const isLoopback = isLoopbackOrigin(origin);
   const sseHeaders: Record<string, string> = {
     "content-type": "text/event-stream; charset=utf-8",
     "cache-control": "no-cache, no-transform",
@@ -382,6 +396,21 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
     status: 200,
     headers: sseHeaders,
   });
+}
+
+/** Accept absent Origin (same-origin/non-browser clients) or an exact HTTP loopback host. */
+function isLoopbackOrigin(origin: string): boolean {
+  if (origin === "") return true;
+  try {
+    const url = new URL(origin);
+    return (
+      url.protocol === "http:" &&
+      (url.hostname === "localhost" || url.hostname === "127.0.0.1" || url.hostname === "[::1]") &&
+      url.origin === origin
+    );
+  } catch {
+    return false;
+  }
 }
 
 /** Cap on the caller-supplied reason so a stray body can't bloat the row. */
@@ -412,11 +441,7 @@ export async function cancelRunRoute(
   // body for a cancel, making it a simple request that CORS preflight does not
   // protect.
   const origin = req.headers.get("origin") ?? "";
-  const isLoopback =
-    origin === "" ||
-    origin.startsWith("http://127.0.0.1") ||
-    origin.startsWith("http://localhost") ||
-    origin.startsWith("http://[::1]");
+  const isLoopback = isLoopbackOrigin(origin);
   if (!isLoopback) {
     return jsonResponse({ error: "cross-origin cancellation rejected" }, 403, req);
   }

--- a/apps/server/src/api/run.ts
+++ b/apps/server/src/api/run.ts
@@ -135,11 +135,12 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
         // omit `dedupeKeys`; the map stays empty and persistence is a no-op.
         emailToDedupeKey = new Map<string, string>();
         if (body.dedupeKeys && body.dedupeKeys.length === body.targets.length) {
+          const keys = body.dedupeKeys;
           body.targets.forEach((t, i) => {
             const target = t as { email?: string; founderEmail?: string };
             const email = target.email ?? target.founderEmail;
-            const key = body.dedupeKeys?.[i];
-            if (email && key) emailToDedupeKey.set(email, key);
+            const dedupeKey = keys[i];
+            if (email && dedupeKey) emailToDedupeKey.set(String(i), dedupeKey);
           });
         }
 
@@ -504,6 +505,7 @@ function persistDraftsToQueue(input: {
   verifiedTargets: Array<{ email?: string; founderEmail?: string }>;
   drafted: DraftedView[];
   dryRun: boolean;
+  // Maps verified target index -> queue dedupe key
   emailToDedupeKey: Map<string, string>;
 }): void {
   const ledger = getLedger();
@@ -511,9 +513,11 @@ function persistDraftsToQueue(input: {
     const target = input.verifiedTargets[i];
     const draft = input.drafted[i];
     if (!target || !draft) continue;
-    const email = target.email ?? target.founderEmail;
-    if (!email) continue;
-    const dedupeKey = input.emailToDedupeKey.get(email);
+    // Verify drops rows, so its indexes don't match original `body.targets`.
+    // Wait... if fromQueue is true (which is the only time dedupeKeys are set),
+    // verify.verified is exactly `body.targets`, because it skips the verify step!
+    // So the index `i` of verifiedTargets here matches the original `i` in emailToDedupeKey!
+    const dedupeKey = input.emailToDedupeKey.get(String(i));
     if (!dedupeKey) continue;
     try {
       const row = ledger.getQueueRowByDedupe(input.playName, dedupeKey);

--- a/apps/server/src/api/run.ts
+++ b/apps/server/src/api/run.ts
@@ -112,11 +112,27 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
       // First frame: tell the UI its runId so it can switch to progress mode.
       send({ kind: "runStarted", runId, startedAt });
 
+      let emailToDedupeKey = new Map<string, string>();
+      let verify: { verified: unknown[]; dropped: any[]; receiptIds: number[]; costUsd: number } = {
+        verified: [],
+        dropped: [],
+        receiptIds: [],
+        costUsd: 0,
+      };
+      let drafted: Parameters<typeof dispatchPlay> extends [
+        any,
+        any,
+        (index: number, view: infer V) => void,
+        ...any[],
+      ]
+        ? V[]
+        : any[] = [];
+
       try {
         // Build email → dedupeKey map BEFORE the verify filter drops rows —
         // verify changes target indices but not emails. Manual /run entries
         // omit `dedupeKeys`; the map stays empty and persistence is a no-op.
-        const emailToDedupeKey = new Map<string, string>();
+        emailToDedupeKey = new Map<string, string>();
         if (body.dedupeKeys && body.dedupeKeys.length === body.targets.length) {
           body.targets.forEach((t, i) => {
             const target = t as { email?: string; founderEmail?: string };
@@ -132,7 +148,6 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
         const inputCount = body.targets.length;
         fromQueue =
           Array.isArray(body.dedupeKeys) && body.dedupeKeys.length === body.targets.length;
-        let verify: Awaited<ReturnType<typeof verifyAndFilterTargets>>;
         if (fromQueue) {
           verify = { verified: body.targets, dropped: [], receiptIds: [], costUsd: 0 };
         } else {
@@ -154,6 +169,10 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
         // If verify dropped every target, skip dispatch entirely — the play
         // could throw an irrelevant pre-check error on an empty array.
         if (verify.verified.length === 0 && inputCount > 0) {
+          if (runAbort.signal.aborted) {
+            cancelledReason = cancelReasonOf(runAbort.signal);
+            return;
+          }
           send({ kind: "done", total: 0, sent: 0 });
           finished = true;
           return;
@@ -163,7 +182,7 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
         send({ kind: "stage", stage: body.dryRun ? "drafting" : "drafting + sending" });
         // Per-target callback: fires draft/send events live so counters tick
         // per target instead of jumping at the end.
-        const drafted = await dispatchPlay(
+        drafted = await dispatchPlay(
           playName,
           filteredBody,
           (index, d) => {
@@ -199,18 +218,6 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
         );
         send({ kind: "done", total: drafted.length, sent: sentCount });
         finished = true;
-
-        // Persist drafts to their originating queue rows for /queue review.
-        // Best-effort — a SQLite hiccup here must not surface to the user.
-        if (emailToDedupeKey.size > 0) {
-          persistDraftsToQueue({
-            playName,
-            verifiedTargets: verify.verified as Array<{ email?: string; founderEmail?: string }>,
-            drafted,
-            dryRun: body.dryRun,
-            emailToDedupeKey,
-          });
-        }
       } catch (err) {
         // A cancellation is not a failure: the run was told to stop, and every
         // target behind the abort point billed nothing. Handled before the
@@ -231,55 +238,72 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
             },
             "warn",
           );
-          return;
-        }
-        runOutcome = "error";
-        // The run ended on its own terms, badly — not because the client left.
-        // Mark it settled so a disconnect that follows (or caused nothing but
-        // an abort on the way out) can't relabel a real failure a cancellation.
-        finished = true;
-        // Log the full error server-side — the SSE event only carries a short
-        // message, and the SDK's generic "Tool request failed" is useless
-        // without status/body/stack.
-        const e = err as Error & {
-          cause?: unknown;
-          statusCode?: number;
-          responseBody?: string;
-        };
-        const causeMsg =
-          e?.cause instanceof Error ? e.cause.message : e?.cause ? String(e.cause) : null;
-        logEvent(
-          "run.pipeline_error",
-          {
-            play: playName,
-            message_200: (e?.message ?? "").slice(0, 200),
-            // SDK ToolError carries the failing call's HTTP status + body.
-            status_code: typeof e?.statusCode === "number" ? e.statusCode : null,
-            response_body_400:
-              typeof e?.responseBody === "string" ? e.responseBody.slice(0, 400) : null,
-            cause_200: causeMsg ? causeMsg.slice(0, 200) : null,
-            stack_300: (e?.stack ?? "").slice(0, 300),
-          },
-          "error",
-        );
-        // Surface the real reason to the UI from the response body
-        // (e.g. {"error":"domain_not_owned"}).
-        let uiMessage = e?.message ?? "run failed";
-        if (typeof e?.statusCode === "number") {
-          let detail = "";
-          try {
-            const parsed = JSON.parse(e.responseBody ?? "") as {
-              message?: string;
-              error?: string;
-            };
-            detail = parsed.message ?? parsed.error ?? "";
-          } catch {
-            detail = (e.responseBody ?? "").slice(0, 160);
+          // fall through to finally block for persistence instead of returning early
+        } else {
+          runOutcome = "error";
+          // The run ended on its own terms, badly — not because the client left.
+          // Mark it settled so a disconnect that follows (or caused nothing but
+          // an abort on the way out) can't relabel a real failure a cancellation.
+          finished = true;
+          // Log the full error server-side — the SSE event only carries a short
+          // message, and the SDK's generic "Tool request failed" is useless
+          // without status/body/stack.
+          const e = err as Error & {
+            cause?: unknown;
+            statusCode?: number;
+            responseBody?: string;
+          };
+          const causeMsg =
+            e?.cause instanceof Error ? e.cause.message : e?.cause ? String(e.cause) : null;
+          logEvent(
+            "run.pipeline_error",
+            {
+              play: playName,
+              message_200: (e?.message ?? "").slice(0, 200),
+              // SDK ToolError carries the failing call's HTTP status + body.
+              status_code: typeof e?.statusCode === "number" ? e.statusCode : null,
+              response_body_400:
+                typeof e?.responseBody === "string" ? e.responseBody.slice(0, 400) : null,
+              cause_200: causeMsg ? causeMsg.slice(0, 200) : null,
+              stack_300: (e?.stack ?? "").slice(0, 300),
+            },
+            "error",
+          );
+          // Surface the real reason to the UI from the response body
+          // (e.g. {"error":"domain_not_owned"}).
+          let uiMessage = e?.message ?? "run failed";
+          if (typeof e?.statusCode === "number") {
+            let detail = "";
+            try {
+              const parsed = JSON.parse(e.responseBody ?? "") as {
+                message?: string;
+                error?: string;
+              };
+              detail = parsed.message ?? parsed.error ?? "";
+            } catch {
+              detail = (e.responseBody ?? "").slice(0, 160);
+            }
+            uiMessage = `${uiMessage} (HTTP ${e.statusCode})${detail ? ` — ${detail}` : ""}`;
           }
-          uiMessage = `${uiMessage} (HTTP ${e.statusCode})${detail ? ` — ${detail}` : ""}`;
+          send({ kind: "error", index: -1, message: uiMessage });
         }
-        send({ kind: "error", index: -1, message: uiMessage });
       } finally {
+        // Persist drafts to their originating queue rows for /queue review.
+        // Best-effort — a SQLite hiccup here must not surface to the user.
+        if (
+          typeof verify !== "undefined" &&
+          typeof emailToDedupeKey !== "undefined" &&
+          emailToDedupeKey.size > 0
+        ) {
+          persistDraftsToQueue({
+            playName,
+            verifiedTargets: verify.verified as Array<{ email?: string; founderEmail?: string }>,
+            drafted,
+            dryRun: body.dryRun,
+            emailToDedupeKey,
+          });
+        }
+
         // The abort can also land without anything throwing — a play that
         // never reached a guarded boundary, or the last target finishing
         // between the abort and the next check. An aborted run that never
@@ -384,6 +408,19 @@ export async function cancelRunRoute(
   req: Request,
   params: Record<string, string>,
 ): Promise<Response> {
+  // Simple CSRF check for this state-changing POST. The dashboard sends no
+  // body for a cancel, making it a simple request that CORS preflight does not
+  // protect.
+  const origin = req.headers.get("origin") ?? "";
+  const isLoopback =
+    origin === "" ||
+    origin.startsWith("http://127.0.0.1") ||
+    origin.startsWith("http://localhost") ||
+    origin.startsWith("http://[::1]");
+  if (!isLoopback) {
+    return jsonResponse({ error: "cross-origin cancellation rejected" }, 403, req);
+  }
+
   const rawRunId = params["runId"] ?? "";
   if (!/^\d+$/.test(rawRunId)) return jsonResponse({ error: "bad run id" }, 400, req);
   const runId = Number.parseInt(rawRunId, 10);

--- a/apps/server/src/api/runs.ts
+++ b/apps/server/src/api/runs.ts
@@ -27,6 +27,7 @@ export function getRunRoute(req: Request, params: Record<string, string>): Respo
     sentCount: run.sentCount,
     errorCount: run.errorCount,
     targets: run.targets,
+    dedupeKeys: run.dedupeKeys,
     events: run.events as RunPlayEvent[],
     prospectEmails: run.prospectEmails,
     cancelReason: run.cancelReason ?? null,

--- a/apps/web/__tests__/timeAgo.test.ts
+++ b/apps/web/__tests__/timeAgo.test.ts
@@ -38,7 +38,7 @@ describe("timeAgo", () => {
   const NOW = new Date("2026-06-06T22:00:00Z").getTime();
   beforeEach(() => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date(NOW));
+    vi.setSystemTime(NOW);
   });
   afterEach(() => {
     vi.useRealTimers();

--- a/apps/web/src/routes/run.$playName.tsx
+++ b/apps/web/src/routes/run.$playName.tsx
@@ -694,6 +694,10 @@ function RunPage() {
               onClick={() => {
                 setEvents([]);
                 setError(null);
+                if (runRecord?.targets) {
+                  setRows(runRecord.targets as Record<string, string>[]);
+                  // RunRecord doesn't hold dedupeKeys; we'll let verifyAndFilterTargets re-assign them
+                }
                 void navigate({ search: (prev) => ({ ...prev, runId: undefined }) });
               }}
             >

--- a/apps/web/src/routes/run.$playName.tsx
+++ b/apps/web/src/routes/run.$playName.tsx
@@ -696,7 +696,9 @@ function RunPage() {
                 setError(null);
                 if (runRecord?.targets) {
                   setRows(runRecord.targets as Record<string, string>[]);
-                  // RunRecord doesn't hold dedupeKeys; we'll let verifyAndFilterTargets re-assign them
+                  setDedupeKeys(
+                    runRecord.targets.map((_, index) => runRecord.dedupeKeys[index] ?? null),
+                  );
                 }
                 void navigate({ search: (prev) => ({ ...prev, runId: undefined }) });
               }}

--- a/packages/core/__tests__/ledger.test.ts
+++ b/packages/core/__tests__/ledger.test.ts
@@ -701,6 +701,7 @@ describe("Ledger runs", () => {
         { email: "a@x.dev", name: "A" },
         { email: "b@x.dev", name: "B" },
       ],
+      dedupeKeys: ["queue-a", null],
     });
     expect(runId).toBeGreaterThan(0);
     expect(startedAt).toMatch(/^\d{4}-/);
@@ -713,6 +714,7 @@ describe("Ledger runs", () => {
       draftedCount: 0,
       sentCount: 0,
       errorCount: 0,
+      dedupeKeys: ["queue-a", null],
       completedAt: null,
     });
     expect(run?.targets).toHaveLength(2);

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -291,6 +291,7 @@ export class Ledger {
         sent_count INTEGER NOT NULL DEFAULT 0,
         error_count INTEGER NOT NULL DEFAULT 0,
         targets_json TEXT NOT NULL,
+        dedupe_keys_json TEXT NOT NULL DEFAULT '[]',
         events_json TEXT NOT NULL DEFAULT '[]',
         prospect_emails_json TEXT NOT NULL DEFAULT '[]'
       );
@@ -525,6 +526,8 @@ export class Ledger {
     // install; older installs carry the narrower CHECK and need the rebuild.
     this.widenRunsStatusCheck();
     this.addColumnIfMissing("runs", "cancel_reason", "TEXT");
+    this.addColumnIfMissing("runs", "dedupe_keys_json", "TEXT");
+    this.db.exec(`UPDATE runs SET dedupe_keys_json = '[]' WHERE dedupe_keys_json IS NULL`);
   }
 
   /**
@@ -2736,15 +2739,20 @@ export class Ledger {
   // the UI rebuilds progress from the row, and the cold-boot sweep flips
   // stranded `running` rows to `interrupted`.
 
-  createRun(input: { playName: string; dryRun: boolean; targets: unknown[] }): {
+  createRun(input: {
+    playName: string;
+    dryRun: boolean;
+    targets: unknown[];
+    dedupeKeys?: Array<string | null>;
+  }): {
     runId: number;
     startedAt: string;
   } {
     const startedAt = new Date().toISOString();
     const result = this.db
       .prepare(
-        `INSERT INTO runs(play_name, dry_run, status, started_at, target_count, targets_json)
-         VALUES(?, ?, 'running', ?, ?, ?)`,
+        `INSERT INTO runs(play_name, dry_run, status, started_at, target_count, targets_json, dedupe_keys_json)
+         VALUES(?, ?, 'running', ?, ?, ?, ?)`,
       )
       .run(
         input.playName,
@@ -2752,6 +2760,7 @@ export class Ledger {
         startedAt,
         input.targets.length,
         JSON.stringify(input.targets),
+        JSON.stringify(input.dedupeKeys ?? []),
       );
     return { runId: Number(result.lastInsertRowid), startedAt };
   }
@@ -2882,6 +2891,7 @@ export class Ledger {
     sentCount: number;
     errorCount: number;
     targets: unknown[];
+    dedupeKeys: Array<string | null>;
     events: unknown[];
     prospectEmails: string[];
     cancelReason: string | null;
@@ -2898,6 +2908,7 @@ export class Ledger {
       sent_count: number;
       error_count: number;
       targets_json: string;
+      dedupe_keys_json: string;
       events_json: string;
       prospect_emails_json: string;
       cancel_reason: string | null;
@@ -2915,6 +2926,7 @@ export class Ledger {
       sentCount: row.sent_count,
       errorCount: row.error_count,
       targets: safeParseJsonArray(row.targets_json),
+      dedupeKeys: safeParseJsonArray(row.dedupe_keys_json) as Array<string | null>,
       events: safeParseJsonArray(row.events_json),
       prospectEmails: safeParseJsonArray(row.prospect_emails_json) as string[],
       cancelReason: row.cancel_reason ?? null,

--- a/packages/plays/src/breakup-revive.ts
+++ b/packages/plays/src/breakup-revive.ts
@@ -43,6 +43,8 @@ export interface BreakupReviveOptions {
   valueDrop?: string;
   /** Abort signal for the run — see `runEmailPlay`'s `signal`. */
   signal?: AbortSignal;
+  /** Live progress callback */
+  onProgress?: (index: number, draft: any) => void;
 }
 
 interface BreakupReviveDraft {
@@ -106,7 +108,7 @@ export async function runBreakupRevive(
         allowRecontact: true,
       });
 
-      drafted.push({
+      const res = {
         prospectEmail: t.email,
         prospectName: t.name,
         daysCold: t.daysCold,
@@ -115,7 +117,9 @@ export async function runBreakupRevive(
         receiptIds: send.receiptIds,
         sent: send.sent,
         flags,
-      });
+      };
+      drafted.push(res);
+      opts.onProgress?.(drafted.length - 1, res as any);
     } catch (err) {
       // Daily-cap deferral is not a per-target failure — abort the run so the
       // caller leaves remaining targets queued instead of stamping error drafts.
@@ -124,7 +128,7 @@ export async function runBreakupRevive(
       if (isRunCancelled(err)) throw err;
       logTargetError({ playName: PLAY_NAME, to: t.email, err });
       const stub = errorDraft((err as Error)?.message);
-      drafted.push({
+      const res = {
         prospectEmail: t.email,
         prospectName: t.name,
         daysCold: t.daysCold,
@@ -133,7 +137,9 @@ export async function runBreakupRevive(
         receiptIds: stub.receiptIds,
         sent: stub.sent,
         flags: stub.flags,
-      });
+      };
+      drafted.push(res);
+      opts.onProgress?.(drafted.length - 1, res as any);
     }
   }
 

--- a/packages/plays/src/registry.ts
+++ b/packages/plays/src/registry.ts
@@ -182,13 +182,12 @@ export const PLAYS: Record<string, PlayDispatch> = {
       }),
   },
   "breakup-revive": {
-    // Custom loop (not runEmailPlay). Silently ignores onProgress for now;
-    // counters will jump at the end. Acceptable until breakup-revive grows
-    // a parallelMap-style worker pool.
+    // Custom loop (not runEmailPlay).
     run: (o) =>
       runBreakupRevive({
         dryRun: o.dryRun,
         targets: o.targets as BreakupReviveTarget[],
+        ...progressOpt(o),
         ...signalOpt(o),
       }),
   },

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -906,6 +906,8 @@ export interface RunRecord {
   errorCount: number;
   /** Original targets array as posted to /api/run/:playName. */
   targets: unknown[];
+  /** Queue-origin keys parallel to targets; empty for manually entered runs. */
+  dedupeKeys: Array<string | null>;
   /** All SSE events accumulated so far (or all of them, when status !== 'running'). */
   events: RunPlayEvent[];
   /** Emails that were actually sent — used by /cadences?sinceRun to filter. */


### PR DESCRIPTION
Closes #341.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 0a0af4a79b94 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

**Review note:** review FAIL at the 2-round correction cap — findings filed: https://github.com/oneshot-agent/oneshot-gtm/issues/366

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Persist drafts on cancellation and add `dedupeKeys` to runs
> - Addresses unresolved review findings from PR #322: drafts completed before a dispatch rejection are now saved because `persistDraftsToQueue` runs in a `finally` block in [run.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/369/files#diff-112a47a2c9470b0932d4828c0e3cdd7dea908d3f274866201d639eec0c4c76f7)
> - Adds a `dedupe_keys_json` column to the `runs` table via `Ledger.migrate` in [ledger.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/369/files#diff-717d28717ccfb3e17791019e23031dc0feeec16ff1e3b3462975264e3734098e); `createRun` and `getRun` read/write it, and `GET /api/runs/:id` and the Run page expose it
> - Centralizes loopback origin validation in `isLoopbackOrigin` in [run.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/369/files#diff-112a47a2c9470b0932d4828c0e3cdd7dea908d3f274866201d639eec0c4c76f7); `cancelRunRoute` now rejects non-loopback origins with 403 and `runPlay` uses the same check for SSE
> - Wires `onProgress` into the breakup-revive play via [registry.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/369/files#diff-0d9bcab9ce6ba6b29a7fda911b1208dc5623e39f201e4db7e49b2ba05853f99e) so it emits per-target progress like other plays
> - Risk: `emailToDedupeKey` contract changed from email-keyed to index-keyed (`persistDraftsToQueue` in [run.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/369/files#diff-112a47a2c9470b0932d4828c0e3cdd7dea908d3f274866201d639eec0c4c76f7) now looks up by verified target index); out-of-tree callers assuming email-based lookup will break. Migration backfills `dedupe_keys_json` with `'[]'` for existing rows.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a35ce90. 7 files reviewed, 6 issues evaluated, 1 issue filtered, 5 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/server/src/api/run.ts — 1 comment posted, 2 evaluated, 1 filtered</summary>
>
> - [line 50](https://github.com/oneshot-agent/oneshot-gtm/blob/a35ce90dc771298e3aa7caa1182983b6ab0bc83b/apps/server/src/api/run.ts#L50): `runPlay` now calls `createRun` with `dedupeKeys`, which makes `createRun` insert `dedupe_keys_json`. On an existing pre-cancellation database, `migrate()` adds that column and then `widenRunsStatusCheck()` rebuilds `runs` but its `runs_widened` definition and copy query omit `dedupe_keys_json`; the renamed table therefore lacks the column. Every later run then fails at this `createRun` call with SQLite `no column named dedupe_keys_json`. <b>[ Out of scope (triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->