### PR TITLE
fix: issue #353: fix(find): `find watch --once` exits non-zero when any due trigger errored

### DIFF
--- a/apps/cli/__tests__/find-watch.test.ts
+++ b/apps/cli/__tests__/find-watch.test.ts
@@ -188,19 +188,22 @@ describe("commandFindWatch daemon", () => {
     nextOutcomes = [errored("show-hn"), ran("github-stars")];
     const done = commandFindWatch({ once: false, quiet: true });
 
-    // vi is a vitest global and this test is being run via bun test runner
-    // await vi.advanceTimersByTimeAsync(0);
-    // expect(calls.runDueTriggers).toBe(1);
-    // await vi.advanceTimersByTimeAsync(60_000);
-    // expect(calls.runDueTriggers).toBe(2);
-    // await vi.advanceTimersByTimeAsync(60_000);
-    // expect(calls.runDueTriggers).toBe(3);
+    vi.advanceTimersByTime(0);
+    await new Promise(process.nextTick);
+    expect(calls.runDueTriggers).toBe(1);
+    vi.advanceTimersByTime(60_000);
+    await new Promise(process.nextTick);
+    expect(calls.runDueTriggers).toBe(2);
+    vi.advanceTimersByTime(60_000);
+    await new Promise(process.nextTick);
+    expect(calls.runDueTriggers).toBe(3);
 
     // Call the loop's own SIGTERM handler rather than emitting the signal, so
     // the test never touches vitest's runner-level handlers.
     const handlers = process.listeners("SIGTERM");
     (handlers[handlers.length - 1] as () => void)();
-    // await vi.advanceTimersByTimeAsync(0);
+    vi.advanceTimersByTime(0);
+    await new Promise(process.nextTick);
 
     // Resolves — errors during a daemon tick never abort the loop.
     await expect(done).resolves.toBeUndefined();

--- a/apps/cli/__tests__/find-watch.test.ts
+++ b/apps/cli/__tests__/find-watch.test.ts
@@ -188,18 +188,19 @@ describe("commandFindWatch daemon", () => {
     nextOutcomes = [errored("show-hn"), ran("github-stars")];
     const done = commandFindWatch({ once: false, quiet: true });
 
-    await vi.advanceTimersByTimeAsync(0);
-    expect(calls.runDueTriggers).toBe(1);
-    await vi.advanceTimersByTimeAsync(60_000);
-    expect(calls.runDueTriggers).toBe(2);
-    await vi.advanceTimersByTimeAsync(60_000);
-    expect(calls.runDueTriggers).toBe(3);
+    // vi is a vitest global and this test is being run via bun test runner
+    // await vi.advanceTimersByTimeAsync(0);
+    // expect(calls.runDueTriggers).toBe(1);
+    // await vi.advanceTimersByTimeAsync(60_000);
+    // expect(calls.runDueTriggers).toBe(2);
+    // await vi.advanceTimersByTimeAsync(60_000);
+    // expect(calls.runDueTriggers).toBe(3);
 
     // Call the loop's own SIGTERM handler rather than emitting the signal, so
     // the test never touches vitest's runner-level handlers.
     const handlers = process.listeners("SIGTERM");
     (handlers[handlers.length - 1] as () => void)();
-    await vi.advanceTimersByTimeAsync(0);
+    // await vi.advanceTimersByTimeAsync(0);
 
     // Resolves — errors during a daemon tick never abort the loop.
     await expect(done).resolves.toBeUndefined();

--- a/apps/cli/src/commands/find.ts
+++ b/apps/cli/src/commands/find.ts
@@ -158,7 +158,7 @@ export async function commandFindWatch(opts: {
   // look identical to a clean one. Daemon runs still exit 0 — they're killed by
   // a signal, not by a bad tick.
   if (opts.once && errored > 0) {
-    bail(`${errored} due trigger(s) errored`);
+    bail(`${errored} due trigger(s) errored`, 1);
   }
 
   // Opt-in second signal for the same caller: a poll that ran cleanly but


### PR DESCRIPTION
Closes #353.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 0a0af4a79b94 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `find watch --once` to exit non-zero when any due trigger errored
> Updates the error path in `commandFindWatch` to call `bail` with an explicit exit code `1` when triggers error during `--once` mode. Previously `bail` was called with only the message, which did not set a non-zero exit code.
> - Test suite in `find-watch.test.ts` switches from `vi.advanceTimersByTimeAsync` to `vi.advanceTimersByTime` with an awaited `process.nextTick` after each timer advance, including after the SIGTERM handler.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1ff9ef9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->