### PR TITLE
fix: issue #359: feat(find): learning-loop v1 — feed recent ICP decisions into `icpFilter` as in-context examples

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -44,7 +44,7 @@ The verify gate has holes an agent can close without touching product behaviour.
 
 The ICP filter currently judges each candidate cold — `icpFilter` in `packages/find/src/_filter.ts` sends the model nothing but `{ icp, candidate }`.
 
-- [ ] **v1** — feed the last ~20 `(candidate, decision, reason)` tuples from `target_queue` into each `icpFilter` call as in-context examples. No schema change.
+- [x] **v1** — feed the last ~20 `(candidate, decision, reason)` tuples from `target_queue` into each `icpFilter` call as in-context examples. No schema change.
 - [ ] **v2** — periodic job proposes a tighter ICP one-liner from accumulated decisions; founder approves the rewrite in `/queue`.
 - [ ] **Per-source weighting** — track approval rate per finder, deprioritize noisy sources automatically.
 

--- a/apps/cli/__tests__/__snapshots__/install-service.test.ts.snap
+++ b/apps/cli/__tests__/__snapshots__/install-service.test.ts.snap
@@ -55,3 +55,59 @@ RestartSec=30
 WantedBy=default.target
 "
 `;
+
+exports[`renderLaunchdPlist matches the template snapshot 1`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.oneshot-gtm.find-watch</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/homebrew/bin/bun</string>
+    <string>/Users/jo/oneshot-gtm/apps/cli/src/main.ts</string>
+    <string>find</string>
+    <string>watch</string>
+    <string>--quiet</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>ONESHOT_GTM_HOME</key>
+    <string>/Users/jo/.oneshot-gtm</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/bin:/bin</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>/Users/jo/.oneshot-gtm/find-watch.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/jo/.oneshot-gtm/find-watch.log</string>
+</dict>
+</plist>
+"
+`;
+
+exports[`renderSystemdUnit matches the template snapshot 1`] = `
+"[Unit]
+Description=oneshot-gtm find watch — poll registered triggers and enqueue candidates
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart="/opt/homebrew/bin/bun" "/Users/jo/oneshot-gtm/apps/cli/src/main.ts" find watch --quiet
+Environment="ONESHOT_GTM_HOME=/Users/jo/.oneshot-gtm"
+Environment="PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=default.target
+"
+`;

--- a/packages/core/__tests__/ledger-extra.test.ts
+++ b/packages/core/__tests__/ledger-extra.test.ts
@@ -26,6 +26,51 @@ afterEach(() => {
   }
 });
 
+describe("recentIcpDecisions", () => {
+  it("returns the newest reviewed labels and keeps sent rows as approvals", () => {
+    const rejected = ledger.enqueueTarget({
+      playName: "show-hn",
+      payload: { title: "Wine meetup" },
+      dedupeKey: "reject",
+      source: "test",
+      initialStatus: "rejected",
+      notes: "wrong industry",
+    });
+    const approved = ledger.enqueueTarget({
+      playName: "show-hn",
+      payload: { title: "Agent builders" },
+      dedupeKey: "approve",
+      source: "test",
+      notes: "right topic",
+    });
+    ledger.setQueueStatus({ id: approved!, status: "approved" });
+    const sent = ledger.enqueueTarget({
+      playName: "show-hn",
+      payload: { title: "Agent SDK" },
+      dedupeKey: "sent",
+      source: "test",
+    });
+    ledger.setQueueStatus({ id: sent!, status: "sent", notes: "founder approved" });
+    ledger.enqueueTarget({
+      playName: "show-hn",
+      payload: { title: "Not reviewed" },
+      dedupeKey: "pending",
+      source: "test",
+    });
+
+    expect(ledger.recentIcpDecisions(2)).toEqual([
+      { candidate: { title: "Agent SDK" }, decision: true, reason: "founder approved" },
+      { candidate: { title: "Agent builders" }, decision: true, reason: "right topic" },
+    ]);
+    expect(ledger.recentIcpDecisions()).toContainEqual({
+      candidate: { title: "Wine meetup" },
+      decision: false,
+      reason: "wrong industry",
+    });
+    expect(rejected).not.toBeNull();
+  });
+});
+
 describe("listReceipts filters", () => {
   it("filters by playName", () => {
     ledger.recordReceipt({ playName: "show-hn", callType: "email.send", costUsd: 0.1 });

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -11,6 +11,7 @@ import type {
   CanaryResultRecord,
   GmailPlacement,
   InboxReplyRecord,
+  IcpDecisionExample,
   InterviewRecord,
   ProspectRecord,
   QueueRow,
@@ -2288,6 +2289,39 @@ export class Ledger {
   }
 
   // ── target_queue ────────────────────────────────────────────────────────────
+
+  /** Recent reviewed rows for few-shot ICP classification. */
+  recentIcpDecisions(limit = 20): IcpDecisionExample[] {
+    const rows = this.db
+      .query(
+        `SELECT payload_json, status, notes
+         FROM target_queue
+         WHERE reviewed_at IS NOT NULL
+           AND json_valid(payload_json)
+           AND status IN ('approved', 'rejected', 'sent')
+         ORDER BY reviewed_at DESC, id DESC
+         LIMIT ?`,
+      )
+      .all(Math.max(1, Math.floor(limit))) as Array<{
+      payload_json: string;
+      status: "approved" | "rejected" | "sent";
+      notes: string | null;
+    }>;
+
+    return rows.flatMap((row) => {
+      try {
+        return [
+          {
+            candidate: JSON.parse(row.payload_json) as unknown,
+            decision: row.status !== "rejected",
+            reason: row.notes,
+          },
+        ];
+      } catch {
+        return [];
+      }
+    });
+  }
 
   /**
    * Insert a row into target_queue. Returns the new id, or null if a row with

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -2299,6 +2299,7 @@ export class Ledger {
          WHERE reviewed_at IS NOT NULL
            AND json_valid(payload_json)
            AND status IN ('approved', 'rejected', 'sent')
+           AND NOT (status = 'rejected' AND notes = 'Automated rejection')
          ORDER BY reviewed_at DESC, id DESC
          LIMIT ?`,
       )

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -2299,7 +2299,7 @@ export class Ledger {
          WHERE reviewed_at IS NOT NULL
            AND json_valid(payload_json)
            AND status IN ('approved', 'rejected', 'sent')
-           AND NOT (status = 'rejected' AND notes = 'Automated rejection')
+           AND NOT (status = 'rejected' AND notes LIKE 'auto:%')
          ORDER BY reviewed_at DESC, id DESC
          LIMIT ?`,
       )

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -285,6 +285,13 @@ export interface OneShotConfig {
 
 export type QueueStatus = "pending" | "approved" | "rejected" | "sent" | "expired";
 
+/** A reviewed queue row, projected into an ICP classifier example. */
+export interface IcpDecisionExample {
+  candidate: unknown;
+  decision: boolean;
+  reason: string | null;
+}
+
 export interface QueueRow {
   id: number;
   play_name: string;

--- a/packages/find/__tests__/icp-filter.test.ts
+++ b/packages/find/__tests__/icp-filter.test.ts
@@ -4,6 +4,10 @@ import { describe, expect, it, vi } from "vitest";
 // (which would abort the whole finder run) — it should drop the candidate.
 
 let completeShouldThrow = false;
+let capturedUser = "";
+const examples = [
+  { candidate: { company: "Prior Co" }, decision: false, reason: "wrong industry" },
+];
 
 vi.mock("@oneshot-gtm/intel", () => ({
   loadPrompt: () => "icp-filter system prompt",
@@ -14,7 +18,8 @@ vi.mock("@oneshot-gtm/intel", () => ({
       return fb;
     }
   },
-  complete: async () => {
+  complete: async (input: { messages: Array<{ role: string; content: string }> }) => {
+    capturedUser = input.messages.find((message) => message.role === "user")?.content ?? "";
     if (completeShouldThrow) {
       throw new Error("Job 035ebe1e-9080-431d-b8be-cba5fd7f0bc6 timed out after 121");
     }
@@ -23,7 +28,11 @@ vi.mock("@oneshot-gtm/intel", () => ({
 }));
 vi.mock("@oneshot-gtm/core", async () => {
   const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
-  return { ...actual, logEvent: () => {} };
+  return {
+    ...actual,
+    getLedger: () => ({ recentIcpDecisions: () => examples }),
+    logEvent: () => {},
+  };
 });
 
 const { icpFilter } = await import("../src/_filter.ts");
@@ -49,5 +58,10 @@ describe("icpFilter — failure isolation", () => {
     completeShouldThrow = false;
     const res = await icpFilter({ icp: "B2B SaaS", candidate: { title: "Acme" } });
     expect(res.match).toBe(true);
+    expect(JSON.parse(capturedUser)).toEqual({
+      icp: "B2B SaaS",
+      candidate: { title: "Acme" },
+      examples,
+    });
   });
 });

--- a/packages/find/src/_filter.ts
+++ b/packages/find/src/_filter.ts
@@ -1,4 +1,4 @@
-import { loadConfig, logEvent } from "@oneshot-gtm/core";
+import { getLedger, loadConfig, logEvent } from "@oneshot-gtm/core";
 import { complete, loadPrompt, tryParseJsonObject } from "@oneshot-gtm/intel";
 
 export interface IcpFilterResult {
@@ -43,9 +43,25 @@ export async function icpFilter(input: {
     return { match: true, reason: "no ICP set; pass-through" };
   }
   const system = loadPrompt("icp-filter");
+  let examples: ReturnType<ReturnType<typeof getLedger>["recentIcpDecisions"]> = [];
+  try {
+    examples = getLedger().recentIcpDecisions(20);
+  } catch (err) {
+    // Learning context is optional: a damaged/locked ledger must not turn a
+    // usable classifier into a finder-wide failure.
+    logEvent(
+      "error.swallowed",
+      {
+        kind: "icp-filter-examples",
+        message_120: ((err as Error).message ?? "").slice(0, 120),
+      },
+      "warn",
+    );
+  }
   const user = JSON.stringify({
     icp: input.icp,
     candidate: input.candidate,
+    examples,
   });
   let decision: IcpFilterResult;
   try {

--- a/packages/prompts/icp-filter.md
+++ b/packages/prompts/icp-filter.md
@@ -8,6 +8,9 @@ Recalibrated 2026-08-25. The old rule was "default to false when uncertain" — 
 
 - `icp`: a statement of who the founder is targeting
 - `candidate`: a found prospect-source with title / url / summary / author / signals
+- `examples`: up to 20 recent queue decisions, with a boolean `decision` and optional `reason`
+
+Treat `examples` as demonstrations of prior ICP judgment and queue review outcomes. Apply the demonstrated preferences to the current `candidate`, while using `icp` as the governing definition. Do not classify an example again.
 
 ## Output
 


### PR DESCRIPTION
Closes #359.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 0a0af4a79b94 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

**Review note:** review FAIL at the 2-round correction cap — findings filed: https://github.com/oneshot-agent/oneshot-gtm/issues/365

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Feed recent ICP decisions into `icpFilter` as in-context examples
> - Adds `Ledger.recentIcpDecisions(limit=20)` to query reviewed `target_queue` rows and map them to `IcpDecisionExample` objects, treating `approved` and `sent` as approvals while excluding `auto:`-prefixed rejections.
> - Updates `icpFilter` in [packages/find/src/_filter.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/372/files#diff-031f13f015d5f1cd7f088af1dec30b6322ed598108a0355e5fc6011b1d313d69) to fetch up to 20 recent decisions via `getLedger().recentIcpDecisions(20)` and include them in the LLM user payload alongside `icp` and `candidate`. Errors are swallowed and logged as `icp-filter-examples` warn events so filtering proceeds without examples.
> - Adds the `IcpDecisionExample` interface in [packages/core/src/types.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/372/files#diff-4c2458380e50c967c70d7afe819dc7412180f9f817043f27441de3498e4d0479) and documents the new `examples` input in [packages/prompts/icp-filter.md](https://github.com/oneshot-agent/oneshot-gtm/pull/372/files#diff-0aba1885a6074b924097cb951e8619647130f43d39c444a35e668fa32dc1610a).
> - Risk: `icpFilter` now calls `getLedger()` on every invocation; a ledger failure degrades to no examples but does not block filtering. Reviewers should verify the try/catch in [packages/find/src/_filter.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/372/files#diff-031f13f015d5f1cd7f088af1dec30b6322ed598108a0355e5fc6011b1d313d69) covers all ledger access paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 6513cc9. 5 files reviewed, 6 issues evaluated, 1 issue filtered, 3 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>packages/find/src/_filter.ts — 1 comment posted, 3 evaluated, 1 filtered</summary>
>
> - [line 64](https://github.com/oneshot-agent/oneshot-gtm/blob/6513cc9f1c3f3fdecf7dcf6e19d0b73f67489807/packages/find/src/_filter.ts#L64): Adding `examples` to the classifier request serializes complete historical queue payloads and sends them to `complete`, rather than a minimal ICP label. Reviewed targets can contain resolved `email`, `phone`, and LinkedIn fields (for example the job-change target persisted at `packages/find/src/job-change.ts:258-271`), so every subsequent source-level ICP classification discloses up to 20 unrelated prospects' contact data to the configured LLM provider. Projecting examples to the title/summary fields needed for classification, and excluding contact fields, is required. <b>[ Cross-file consolidated ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->