### PR TITLE
fix: issue #373: Fix 1 shipped review finding(s) from merged PR #368

### DIFF
--- a/packages/prompts/luma-event-extract.md
+++ b/packages/prompts/luma-event-extract.md
@@ -32,7 +32,7 @@ A JSON object only:
 
 - `eventTitle`: the event name as displayed (e.g. "SF AI Builders Meetup"). Null if not clearly an event page.
 - `eventDateIso`: ISO 8601 date or datetime when stated. If only "Tuesday, June 10" is shown without year, infer the next future occurrence and emit a date-only ISO. Null if not stated.
-- `eventTimezone`: the IANA zone the page's times are in, when the page shows an unambiguous zone (a "PDT" label or the venue's city). Emit the IANA name — "America/Los_Angeles", not "PDT". Null if the page gives no zone and no venue city, or if the zone is ambiguous (e.g. "7:30 PM GMT+1" without a city, or a city not unique enough to resolve to a single IANA zone). Do NOT guess from your own clock.
+- `eventTimezone`: the IANA zone the page's times are in, when the page shows an unambiguous zone (for example, a uniquely identifying venue city). Emit the IANA name — "America/Los_Angeles", not a timezone abbreviation. Null if the page gives no zone or venue city, or if the zone is ambiguous (including bare abbreviations such as "PDT" or offsets such as "7:30 PM GMT+1" without a city). Do NOT guess from your own clock.
 - `eventCity`: city or "Online" / "Virtual" / region. Null if not stated.
 - `eventDescription`: the event's own summary of what it's ABOUT — the topic/theme, format, and who it's for. Condense the page's description to 1-3 sentences, cap ~500 chars. Strip pure logistics (parking, sponsors, ticket prices, agenda timings) — keep only what conveys the subject. Null if the page shows no description.
 - `eventHasPassed`: true when the page explicitly shows "this event has ended" / past-tense framing / a date older than today. Default false when unclear.


### PR DESCRIPTION
Closes #373.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 27f017738cec (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `eventTimezone` rule in `luma-event-extract` prompt to reject bare abbreviations
> - Updates the `eventTimezone` rule to reject timezone abbreviations (e.g. "PDT") and bare numeric offsets as disambiguators, requiring a uniquely identifying venue city instead
> - Instructs output to use IANA names and disallow abbreviations, treating bare abbreviations or offsets without a city as ambiguous cases that yield null
> - Behavioral Change: `eventTimezone` will now be null for events previously resolved via abbreviations or offsets alone
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bf2278f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->