### PR TITLE
fix: issue #375: Fix 4 shipped review finding(s) from merged PR #371

### DIFF
--- a/apps/cli/__tests__/__snapshots__/install-service.test.ts.snap
+++ b/apps/cli/__tests__/__snapshots__/install-service.test.ts.snap
@@ -38,24 +38,6 @@ exports[`renderLaunchdPlist > matches the template snapshot 1`] = `
 "
 `;
 
-exports[`renderSystemdUnit > matches the template snapshot 1`] = `
-"[Unit]
-Description=oneshot-gtm find watch — poll registered triggers and enqueue candidates
-After=network-online.target
-
-[Service]
-Type=simple
-ExecStart="/opt/homebrew/bin/bun" "/Users/jo/oneshot-gtm/apps/cli/src/main.ts" find watch --quiet
-Environment="ONESHOT_GTM_HOME=/Users/jo/.oneshot-gtm"
-Environment="PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
-Restart=on-failure
-RestartSec=30
-
-[Install]
-WantedBy=default.target
-"
-`;
-
 exports[`renderLaunchdPlist matches the template snapshot 1`] = `
 "<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -91,6 +73,24 @@ exports[`renderLaunchdPlist matches the template snapshot 1`] = `
   <string>/Users/jo/.oneshot-gtm/find-watch.log</string>
 </dict>
 </plist>
+"
+`;
+
+exports[`renderSystemdUnit > matches the template snapshot 1`] = `
+"[Unit]
+Description=oneshot-gtm find watch — poll registered triggers and enqueue candidates
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart="/opt/homebrew/bin/bun" "/Users/jo/oneshot-gtm/apps/cli/src/main.ts" find watch --quiet
+Environment="ONESHOT_GTM_HOME=/Users/jo/.oneshot-gtm"
+Environment="PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=default.target
 "
 `;
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -7,7 +7,7 @@ import {
   type TelemetryOutcome,
 } from "@oneshot-gtm/core";
 import { isSupportedPlay } from "@oneshot-gtm/plays";
-import { bail, CommandExit, fail } from "./output.ts";
+import { bail, CommandExit, fail, setJsonMode } from "./output.ts";
 import { extractInvocation, type Invocation } from "./dispatch.ts";
 import { runInit } from "./commands/init.ts";
 import {
@@ -327,6 +327,7 @@ find
         failOnEmpty: boolean;
         json?: boolean;
       }) => {
+        setJsonMode(opts.json ?? false);
         if (!isSupportedPlay(opts.play)) bail(`unknown play: ${opts.play}`);
         await commandFindImport(opts);
       },

--- a/packages/core/__tests__/ledger-extra.test.ts
+++ b/packages/core/__tests__/ledger-extra.test.ts
@@ -263,6 +263,29 @@ describe("isEmailPendingInQueue (cross-play pending dedup)", () => {
   });
 });
 
+describe("removePendingQueueTarget", () => {
+  it("removes only unreviewed reservations", () => {
+    const pendingId = ledger.enqueueTarget({
+      playName: "profile-intro",
+      payload: {},
+      dedupeKey: "pending",
+      source: "test",
+    })!;
+    const approvedId = ledger.enqueueTarget({
+      playName: "profile-intro",
+      payload: {},
+      dedupeKey: "approved",
+      source: "test",
+    })!;
+    ledger.setQueueStatus({ id: approvedId, status: "approved" });
+
+    expect(ledger.removePendingQueueTarget(pendingId)).toBe(true);
+    expect(ledger.getQueueRow(pendingId)).toBeNull();
+    expect(ledger.removePendingQueueTarget(approvedId)).toBe(false);
+    expect(ledger.getQueueRow(approvedId)?.status).toBe("approved");
+  });
+});
+
 describe("approvedCountsByPlay", () => {
   it("counts approved rows per play and omits plays with none", () => {
     const enqueue = (playName: string, key: string, status?: "approved" | "sent"): void => {

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -2570,6 +2570,14 @@ export class Ledger {
     return (this.db.query("SELECT * FROM target_queue WHERE id = ?").get(id) as QueueRow) ?? null;
   }
 
+  /** Remove an unreviewed queue reservation, leaving reviewed rows untouched. */
+  removePendingQueueTarget(id: number): boolean {
+    const result = this.db
+      .prepare("DELETE FROM target_queue WHERE id = ? AND status = 'pending'")
+      .run(id);
+    return result.changes > 0;
+  }
+
   setQueueStatus(input: { id: number; status: QueueStatus; notes?: string }): void {
     const now = new Date().toISOString();
     // Every status transition clears `send_started_at` — a deliberate status

--- a/packages/find/__tests__/csv-import.test.ts
+++ b/packages/find/__tests__/csv-import.test.ts
@@ -20,6 +20,11 @@ const ledger = {
     queue.push(input);
     return queue.length;
   },
+  setQueueStatus: (input: { id: number; status: string; notes?: string }) => {
+    if (input.status === "rejected") queue.splice(input.id - 1, 1);
+  },
+  removePendingQueueTarget: (id: number) => queue.splice(id - 1, 1).length > 0,
+  setQueueNotes: () => {},
 };
 
 vi.mock("@oneshot-gtm/core", () => ({
@@ -80,6 +85,13 @@ describe("bulk CSV import", () => {
     });
   });
 
+  it("maps the exact explicitly named header when normalized headers collide", () => {
+    const prepared = prepareCsvImport("E-mail,Email\nselected@example.test,other@example.test", [
+      "E-mail=email",
+    ]);
+    expect(prepared.mapping.email).toBe("E-mail");
+  });
+
   it("dedupes against an existing queue entry", async () => {
     const email = "queued-existing@example.test";
     ledger.enqueueTarget({
@@ -94,6 +106,27 @@ describe("bulk CSV import", () => {
       text: `email,name,company,title\n${email},Duplicate,Acme,Founder`,
     });
     expect(result).toMatchObject({ imported: 0, skipped: 1, errors: [] });
+  });
+
+  it("atomically reserves a candidate before classification", async () => {
+    let release!: () => void;
+    qualifyPersonMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => (release = () => resolve({ verdict: "pass", reason: "stub" }))),
+    );
+    const input = {
+      playName: "profile-intro",
+      text: "email,name,company,title\nsame@example.test,Same,Acme,Founder",
+    };
+
+    const first = importCsv(input);
+    expect(qualifyPersonMock).toHaveBeenCalledTimes(1);
+    const second = await importCsv(input);
+    expect(second).toMatchObject({ imported: 0, skipped: 1 });
+    expect(qualifyPersonMock).toHaveBeenCalledTimes(1);
+
+    release();
+    await expect(first).resolves.toMatchObject({ imported: 1, skipped: 0 });
   });
 
   it("applies deduplication during a dry run without enqueueing", async () => {
@@ -136,7 +169,7 @@ describe("bulk CSV import", () => {
     expect(qualifyPersonMock).not.toHaveBeenCalled();
   });
 
-  it("limits each invocation to 100 source rows", async () => {
+  it("imports every source row", async () => {
     const rows = Array.from(
       { length: 101 },
       (_, index) => `person-${index}@example.test,Person ${index},Acme,Founder`,
@@ -146,8 +179,8 @@ describe("bulk CSV import", () => {
       text: ["email,name,company,title", ...rows].join("\n"),
     });
 
-    expect(result).toMatchObject({ imported: 100, skipped: 0, rowCount: 100 });
-    expect(queue).toHaveLength(100);
-    expect(qualifyPersonMock).toHaveBeenCalledTimes(100);
+    expect(result).toMatchObject({ imported: 101, skipped: 0, rowCount: 101 });
+    expect(queue).toHaveLength(101);
+    expect(qualifyPersonMock).toHaveBeenCalledTimes(101);
   });
 });

--- a/packages/find/src/csv-import.ts
+++ b/packages/find/src/csv-import.ts
@@ -17,9 +17,6 @@ export interface CsvImportResult {
   errors: CsvImportError[];
 }
 
-/** Maximum number of source rows handled by one invocation. */
-export const CSV_IMPORT_BATCH_LIMIT = 100;
-
 export interface ParsedCsvImport {
   headers: string[];
   mapping: CsvColumnMapping;
@@ -95,7 +92,7 @@ export function parseMapOverrides(values: string[]): Record<string, CsvImportFie
     if (eq < 1 || !CSV_IMPORT_FIELDS.includes(field as CsvImportField)) {
       throw new Error(`invalid --map '${value}'; expected column=email|name|company|title`);
     }
-    overrides[normalizeHeader(column)] = field as CsvImportField;
+    overrides[column] = field as CsvImportField;
   }
   return overrides;
 }
@@ -107,17 +104,23 @@ export function prepareCsvImport(text: string, mapValues: string[] = []): Parsed
   if (headers.every((h) => h === "")) throw new Error("CSV header is empty");
   const normalizedHeaders = headers.map(normalizeHeader);
   const overrides = parseMapOverrides(mapValues);
-  for (const column of Object.keys(overrides)) {
-    if (!normalizedHeaders.includes(column)) throw new Error(`mapped column not found: ${column}`);
-  }
-
   const mapping: CsvColumnMapping = {};
   // Explicit mappings win even when a different column happens to match an
   // alias (for example `Email` plus `Verified Email --map "Verified Email=email"`).
-  for (let i = 0; i < headers.length; i++) {
-    const normalized = normalizedHeaders[i]!;
-    const override = overrides[normalized];
-    if (override) mapping[override] = headers[i]!;
+  for (const [column, field] of Object.entries(overrides)) {
+    let index = headers.indexOf(column);
+    if (index === -1) {
+      const normalized = normalizeHeader(column);
+      const matches = normalizedHeaders.flatMap((header, candidate) =>
+        header === normalized ? [candidate] : [],
+      );
+      if (matches.length === 0) throw new Error(`mapped column not found: ${column}`);
+      if (matches.length > 1) {
+        throw new Error(`mapped column is ambiguous: ${column}; use the exact header text`);
+      }
+      index = matches[0]!;
+    }
+    mapping[field] = headers[index]!;
   }
   for (let i = 0; i < headers.length; i++) {
     const normalized = normalizedHeaders[i]!;
@@ -146,9 +149,8 @@ export async function importCsv(input: {
   ) as Partial<Record<CsvImportField, number>>;
 
   const admitted: Array<{ row: number; payload: Record<string, string>; email: string }> = [];
-  const batch = prepared.rows.slice(0, CSV_IMPORT_BATCH_LIMIT);
-  for (let i = 0; i < batch.length; i++) {
-    const values = batch[i]!;
+  for (let i = 0; i < prepared.rows.length; i++) {
+    const values = prepared.rows[i]!;
     if (values.every((v) => v.trim() === "")) {
       result.skipped++;
       result.errors.push({ row: i + 2, message: "empty row" });
@@ -202,37 +204,54 @@ export async function importCsv(input: {
   // above, but the potentially paid person classifier is never invoked.
   if (input.dryRun) {
     result.imported = unique.length;
-    return { ...result, mapping: prepared.mapping, rowCount: batch.length };
+    return { ...result, mapping: prepared.mapping, rowCount: prepared.rows.length };
   }
 
   const icp = resolveIcp();
   const ledger = getLedger();
   for (const candidate of unique) {
-    const verdict = await qualifyPerson({
-      icp,
-      person: {
-        name: candidate.payload.name,
-        company: candidate.payload.company,
-        roleText: candidate.payload.title,
-        evidence: "CSV import",
-      },
-    });
-    if (verdict.verdict === "reject" || verdict.verdict === "transient") {
-      result.skipped++;
-      if (verdict.verdict === "transient") {
-        result.errors.push({ row: candidate.row, message: verdict.reason });
-      }
-      continue;
-    }
     const dedupeKey = `email:${candidate.email}`;
+    // Reserve the unique key before the paid classifier. Concurrent imports
+    // then race on the atomic INSERT, not on the earlier read-only dedupe check.
     const id = ledger.enqueueTarget({
       playName: input.playName,
       payload: candidate.payload,
       dedupeKey,
       source: "find:csv-import",
+      notes: "CSV import: ICP classification in progress",
     });
-    if (id == null) result.skipped++;
-    else result.imported++;
+    if (id == null) {
+      result.skipped++;
+      continue;
+    }
+    let verdict: Awaited<ReturnType<typeof qualifyPerson>>;
+    try {
+      verdict = await qualifyPerson({
+        icp,
+        person: {
+          name: candidate.payload.name,
+          company: candidate.payload.company,
+          roleText: candidate.payload.title,
+          evidence: "CSV import",
+        },
+      });
+    } catch (error) {
+      ledger.removePendingQueueTarget(id);
+      throw error;
+    }
+    if (verdict.verdict === "reject" || verdict.verdict === "transient") {
+      result.skipped++;
+      if (verdict.verdict === "transient") {
+        // A transient failure must remain retryable on a later invocation.
+        ledger.removePendingQueueTarget(id);
+        result.errors.push({ row: candidate.row, message: verdict.reason });
+      } else {
+        ledger.setQueueStatus({ id, status: "rejected", notes: verdict.reason });
+      }
+      continue;
+    }
+    ledger.setQueueNotes({ id, notes: "CSV import: ICP accepted" });
+    result.imported++;
   }
-  return { ...result, mapping: prepared.mapping, rowCount: batch.length };
+  return { ...result, mapping: prepared.mapping, rowCount: prepared.rows.length };
 }


### PR DESCRIPTION
Closes #375.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 27f017738cec (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CSV import reservation, header mapping, and JSON mode handling
> - Removes the hard 100-row `CSV_IMPORT_BATCH_LIMIT` in `importCsv`; all parsed rows are now processed and `rowCount` reflects the full set.
> - Adds atomic queue reservation before classification in `importCsv` using an email-based `dedupeKey`; pending rows are cleaned up via the new `Ledger.removePendingQueueTarget` on classifier errors or transient verdicts, rejects are recorded via `setQueueStatus`, and accepts update queue notes.
> - Changes `parseMapOverrides` and `prepareCsvImport` to match explicit mappings against exact header text, falling back to normalized match only when no exact match exists; throws if normalization is ambiguous across multiple headers.
> - Wires `setJsonMode(opts.json ?? false)` into the CLI `find import` command action in `index.ts`.
> - Behavioral Change: explicit mapping override keys must now use exact header text rather than normalized form; ambiguous normalized headers that previously resolved silently now throw. `removePendingQueueTarget` in [ledger.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/379/files#diff-717d28717ccfb3e17791019e23031dc0feeec16ff1e3b3462975264e3734098e) only deletes rows with `status = 'pending'`, so approved or rejected rows are never removed.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized cf2dece. 3 files reviewed, 2 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->