### PR TITLE
fix: issue #374: Fix 5 shipped review finding(s) from merged PR #369

### DIFF
--- a/apps/cli/__tests__/__snapshots__/install-service.test.ts.snap
+++ b/apps/cli/__tests__/__snapshots__/install-service.test.ts.snap
@@ -38,24 +38,6 @@ exports[`renderLaunchdPlist > matches the template snapshot 1`] = `
 "
 `;
 
-exports[`renderSystemdUnit > matches the template snapshot 1`] = `
-"[Unit]
-Description=oneshot-gtm find watch — poll registered triggers and enqueue candidates
-After=network-online.target
-
-[Service]
-Type=simple
-ExecStart="/opt/homebrew/bin/bun" "/Users/jo/oneshot-gtm/apps/cli/src/main.ts" find watch --quiet
-Environment="ONESHOT_GTM_HOME=/Users/jo/.oneshot-gtm"
-Environment="PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
-Restart=on-failure
-RestartSec=30
-
-[Install]
-WantedBy=default.target
-"
-`;
-
 exports[`renderLaunchdPlist matches the template snapshot 1`] = `
 "<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -91,6 +73,24 @@ exports[`renderLaunchdPlist matches the template snapshot 1`] = `
   <string>/Users/jo/.oneshot-gtm/find-watch.log</string>
 </dict>
 </plist>
+"
+`;
+
+exports[`renderSystemdUnit > matches the template snapshot 1`] = `
+"[Unit]
+Description=oneshot-gtm find watch — poll registered triggers and enqueue candidates
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart="/opt/homebrew/bin/bun" "/Users/jo/oneshot-gtm/apps/cli/src/main.ts" find watch --quiet
+Environment="ONESHOT_GTM_HOME=/Users/jo/.oneshot-gtm"
+Environment="PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=default.target
 "
 `;
 

--- a/apps/server/src/api/run.ts
+++ b/apps/server/src/api/run.ts
@@ -113,34 +113,22 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
       // First frame: tell the UI its runId so it can switch to progress mode.
       send({ kind: "runStarted", runId, startedAt });
 
-      let emailToDedupeKey = new Map<string, string>();
-      let verify: { verified: unknown[]; dropped: any[]; receiptIds: number[]; costUsd: number } = {
+      const indexToDedupeKey = new Map<number, string>();
+      let verify: Awaited<ReturnType<typeof verifyAndFilterTargets>> = {
         verified: [],
         dropped: [],
         receiptIds: [],
         costUsd: 0,
       };
-      let drafted: Parameters<typeof dispatchPlay> extends [
-        any,
-        any,
-        (index: number, view: infer V) => void,
-        ...any[],
-      ]
-        ? V[]
-        : any[] = [];
+      let drafted: DraftedView[] = [];
 
       try {
-        // Build email → dedupeKey map BEFORE the verify filter drops rows —
-        // verify changes target indices but not emails. Manual /run entries
-        // omit `dedupeKeys`; the map stays empty and persistence is a no-op.
-        emailToDedupeKey = new Map<string, string>();
+        // Queue runs skip verification, so their target indexes remain aligned
+        // with the parallel dedupe-key array. Manual runs omit the array and
+        // persistence remains a no-op.
         if (body.dedupeKeys && body.dedupeKeys.length === body.targets.length) {
-          const keys = body.dedupeKeys;
-          body.targets.forEach((t, i) => {
-            const target = t as { email?: string; founderEmail?: string };
-            const email = target.email ?? target.founderEmail;
-            const dedupeKey = keys[i];
-            if (email && dedupeKey) emailToDedupeKey.set(String(i), dedupeKey);
+          body.dedupeKeys.forEach((dedupeKey, index) => {
+            if (dedupeKey) indexToDedupeKey.set(index, dedupeKey);
           });
         }
 
@@ -295,18 +283,13 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
       } finally {
         // Persist drafts to their originating queue rows for /queue review.
         // Best-effort — a SQLite hiccup here must not surface to the user.
-        if (
-          typeof verify !== "undefined" &&
-          typeof emailToDedupeKey !== "undefined" &&
-          emailToDedupeKey.size > 0
-        ) {
+        if (indexToDedupeKey.size > 0) {
           try {
             persistDraftsToQueue({
               playName,
-              verifiedTargets: verify.verified as Array<{ email?: string; founderEmail?: string }>,
               drafted,
               dryRun: body.dryRun,
-              emailToDedupeKey,
+              indexToDedupeKey,
             });
           } catch (err) {
             // Guard setup as well as individual writes so terminal status,
@@ -502,22 +485,15 @@ export async function cancelRunRoute(
  */
 function persistDraftsToQueue(input: {
   playName: string;
-  verifiedTargets: Array<{ email?: string; founderEmail?: string }>;
   drafted: DraftedView[];
   dryRun: boolean;
-  // Maps verified target index -> queue dedupe key
-  emailToDedupeKey: Map<string, string>;
+  indexToDedupeKey: ReadonlyMap<number, string>;
 }): void {
   const ledger = getLedger();
   for (let i = 0; i < input.drafted.length; i++) {
-    const target = input.verifiedTargets[i];
     const draft = input.drafted[i];
-    if (!target || !draft) continue;
-    // Verify drops rows, so its indexes don't match original `body.targets`.
-    // Wait... if fromQueue is true (which is the only time dedupeKeys are set),
-    // verify.verified is exactly `body.targets`, because it skips the verify step!
-    // So the index `i` of verifiedTargets here matches the original `i` in emailToDedupeKey!
-    const dedupeKey = input.emailToDedupeKey.get(String(i));
+    if (!draft) continue;
+    const dedupeKey = input.indexToDedupeKey.get(i);
     if (!dedupeKey) continue;
     try {
       const row = ledger.getQueueRowByDedupe(input.playName, dedupeKey);

--- a/apps/web/src/routes/run.$playName.tsx
+++ b/apps/web/src/routes/run.$playName.tsx
@@ -695,10 +695,25 @@ function RunPage() {
                 setEvents([]);
                 setError(null);
                 if (runRecord?.targets) {
-                  setRows(runRecord.targets as Record<string, string>[]);
-                  setDedupeKeys(
-                    runRecord.targets.map((_, index) => runRecord.dedupeKeys[index] ?? null),
+                  const restoredRows = runRecord.targets.map((target) => {
+                    const row: Record<string, string> = {};
+                    if (!target || typeof target !== "object" || Array.isArray(target)) return row;
+                    for (const [key, value] of Object.entries(target)) {
+                      row[key] =
+                        value == null
+                          ? ""
+                          : typeof value === "string"
+                            ? value
+                            : JSON.stringify(value);
+                    }
+                    return row;
+                  });
+                  const restoredKeys = restoredRows.map(
+                    (_, index) => runRecord.dedupeKeys[index] ?? null,
                   );
+                  const retryable = pruneSentRows(runRecord.events, restoredRows, restoredKeys);
+                  setRows(retryable.rows.length > 0 ? retryable.rows : [{ ...schema.defaultRow }]);
+                  setDedupeKeys(retryable.rows.length > 0 ? retryable.dedupeKeys : [null]);
                 }
                 void navigate({ search: (prev) => ({ ...prev, runId: undefined }) });
               }}

--- a/packages/plays/src/breakup-revive.ts
+++ b/packages/plays/src/breakup-revive.ts
@@ -43,11 +43,11 @@ export interface BreakupReviveOptions {
   valueDrop?: string;
   /** Abort signal for the run — see `runEmailPlay`'s `signal`. */
   signal?: AbortSignal;
-  /** Live progress callback */
-  onProgress?: (index: number, draft: any) => void;
+  /** Called after each target completes, with the target's original index. */
+  onProgress?: (index: number, draft: BreakupReviveDraft) => void;
 }
 
-interface BreakupReviveDraft {
+export interface BreakupReviveDraft {
   prospectEmail: string | null;
   prospectName: string | null;
   daysCold: number;
@@ -69,8 +69,9 @@ export async function runBreakupRevive(
   const targets = opts.targets ?? ledgerScanTargets(opts);
   const drafted: BreakupReviveDraft[] = [];
 
-  for (const t of targets) {
+  for (const [index, t] of targets.entries()) {
     if (!t.email) continue;
+    let result: BreakupReviveDraft;
     try {
       // Custom serial loop, so it repeats runEmailPlay's guards itself.
       throwIfCancelled(opts.signal, `${PLAY_NAME} draft`);
@@ -108,7 +109,7 @@ export async function runBreakupRevive(
         allowRecontact: true,
       });
 
-      const res = {
+      result = {
         prospectEmail: t.email,
         prospectName: t.name,
         daysCold: t.daysCold,
@@ -118,8 +119,6 @@ export async function runBreakupRevive(
         sent: send.sent,
         flags,
       };
-      drafted.push(res);
-      opts.onProgress?.(drafted.length - 1, res as any);
     } catch (err) {
       // Daily-cap deferral is not a per-target failure — abort the run so the
       // caller leaves remaining targets queued instead of stamping error drafts.
@@ -128,7 +127,7 @@ export async function runBreakupRevive(
       if (isRunCancelled(err)) throw err;
       logTargetError({ playName: PLAY_NAME, to: t.email, err });
       const stub = errorDraft((err as Error)?.message);
-      const res = {
+      result = {
         prospectEmail: t.email,
         prospectName: t.name,
         daysCold: t.daysCold,
@@ -138,9 +137,11 @@ export async function runBreakupRevive(
         sent: stub.sent,
         flags: stub.flags,
       };
-      drafted.push(res);
-      opts.onProgress?.(drafted.length - 1, res as any);
     }
+    drafted.push(result);
+    // Keep observer failures distinct from a target's draft/send failure. In
+    // particular, do not manufacture a second error draft and callback.
+    opts.onProgress?.(index, result);
   }
 
   return { drafted };

--- a/packages/plays/src/breakup-revive.ts
+++ b/packages/plays/src/breakup-revive.ts
@@ -67,7 +67,7 @@ export async function runBreakupRevive(
   }
 
   const targets = opts.targets ?? ledgerScanTargets(opts);
-  const drafted: BreakupReviveDraft[] = new Array(targets.length);
+  const drafted: BreakupReviveDraft[] = [];
 
   for (const [index, t] of targets.entries()) {
     if (!t.email) continue;
@@ -138,7 +138,7 @@ export async function runBreakupRevive(
         flags: stub.flags,
       };
     }
-    drafted[index] = result;
+    drafted.push(result);
     // Keep observer failures distinct from a target's draft/send failure. In
     // particular, do not manufacture a second error draft and callback.
     opts.onProgress?.(index, result);

--- a/packages/plays/src/breakup-revive.ts
+++ b/packages/plays/src/breakup-revive.ts
@@ -67,7 +67,7 @@ export async function runBreakupRevive(
   }
 
   const targets = opts.targets ?? ledgerScanTargets(opts);
-  const drafted: BreakupReviveDraft[] = [];
+  const drafted: BreakupReviveDraft[] = new Array(targets.length);
 
   for (const [index, t] of targets.entries()) {
     if (!t.email) continue;
@@ -138,7 +138,7 @@ export async function runBreakupRevive(
         flags: stub.flags,
       };
     }
-    drafted.push(result);
+    drafted[index] = result;
     // Keep observer failures distinct from a target's draft/send failure. In
     // particular, do not manufacture a second error draft and callback.
     opts.onProgress?.(index, result);


### PR DESCRIPTION
Closes #374.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 27f017738cec (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

**Review note:** review FAIL at the 2-round correction cap — findings filed: https://github.com/oneshot-agent/oneshot-gtm/issues/381

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix draft persistence, `runBreakupRevive` `onProgress`, and `RunPage` retry
> - `persistDraftsToQueue` and the `runPlay` handler use a new `indexToDedupeKey` map based on the original target index instead of an email-based map, fixing queue-sourced run persistence.
> - `RunPage` 'Run again' handler reconstructs form rows as strings, restores dedupeKeys by index, and pre-fills only retryable rows via `pruneSentRows`.
> - `runBreakupRevive` calls `onProgress` exactly once per processed target with its original index, isolating observer failures from target failures.
> - Behavioral Change: `BreakupReviveOptions.onProgress` signature changed to `(index: number, draft: BreakupReviveDraft)`; existing callers with untyped callbacks must update.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized b3b4091. 3 files reviewed, 2 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->