### PR TITLE
fix: issue #354: feat(server): webhook intake endpoints for cal-no-show and signup

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -17,7 +17,7 @@ Public — issues mirror the items below, PRs welcome. Items carry an effort tag
 
 Today every finder polls. These turn it push.
 
-- [ ] **Webhook intake** — `POST /api/triggers/cal-no-show` + `POST /api/triggers/signup` → ICP-filter → enqueue into `demo-no-show` / `concierge`.
+- [x] **Webhook intake** — `POST /api/triggers/cal-no-show` + `POST /api/triggers/signup` → ICP-filter → enqueue into `demo-no-show` / `concierge`.
 - [ ] **Webhook signing + replay protection** for those endpoints.
 - [ ] **Warm-signal escalation** in cadence (open-tracking → auto phone call). Blocked: needs OneShot to surface open events.
 

--- a/apps/server/__tests__/webhook-triggers-route.test.ts
+++ b/apps/server/__tests__/webhook-triggers-route.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const enqueued: Array<Record<string, unknown>> = [];
+let icpMatch: boolean | null = true;
+
+vi.mock("@oneshot-gtm/core", () => ({
+  getLedger: () => ({
+    enqueueTarget: (row: Record<string, unknown>) => {
+      enqueued.push(row);
+      return 42;
+    },
+  }),
+}));
+
+vi.mock("@oneshot-gtm/find", () => ({
+  resolveIcp: () => "technical SaaS founders",
+  icpFilter: async () => ({ match: icpMatch, reason: icpMatch ? "fits" : "not a fit" }),
+}));
+
+const { calNoShowWebhookRoute, signupWebhookRoute } =
+  await import("../src/api/webhook-triggers.ts");
+
+function request(path: string, body: unknown): Request {
+  return new Request(`http://localhost/api/triggers/${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  enqueued.length = 0;
+  icpMatch = true;
+});
+
+describe("webhook trigger intake", () => {
+  it("ICP-filters and enqueues accepted events into their plays", async () => {
+    const noShow = {
+      name: "Ada",
+      email: "ada@example.com",
+      phone: "+15555550100",
+      company: "Analytical Engines",
+      missedAt: "2026-09-01T10:00:00Z",
+      rescheduleLink: "https://example.com/reschedule",
+    };
+    const signup = {
+      name: "Grace",
+      email: "grace@example.com",
+      phone: "+15555550101",
+      signupContext: "Started a team trial",
+    };
+
+    expect((await calNoShowWebhookRoute(request("cal-no-show", noShow))).status).toBe(202);
+    expect((await signupWebhookRoute(request("signup", signup))).status).toBe(202);
+    expect(enqueued).toMatchObject([
+      { playName: "demo-no-show", payload: noShow, source: "webhook:cal-no-show" },
+      { playName: "concierge", payload: signup, source: "webhook:signup" },
+    ]);
+  });
+
+  it("does not enqueue an ICP rejection", async () => {
+    icpMatch = false;
+    const res = await signupWebhookRoute(
+      request("signup", { name: "Pat", email: "pat@example.com", phone: "+15555550102" }),
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ accepted: false, reason: "not a fit" });
+    expect(enqueued).toHaveLength(0);
+  });
+
+  it("returns a JSON 400 for malformed and unknown payloads", async () => {
+    const missing = await calNoShowWebhookRoute(
+      request("cal-no-show", { event: "calendar.cancelled", mystery: true }),
+    );
+    expect(missing.status).toBe(400);
+    expect(missing.headers.get("content-type")).toContain("application/json");
+    expect(await missing.json()).toHaveProperty("error");
+
+    const malformed = await signupWebhookRoute(request("signup", "{"));
+    expect(malformed.status).toBe(400);
+    expect(await malformed.json()).toEqual({ error: "invalid JSON body" });
+    expect(enqueued).toHaveLength(0);
+  });
+});

--- a/apps/server/src/api/webhook-triggers.ts
+++ b/apps/server/src/api/webhook-triggers.ts
@@ -1,0 +1,128 @@
+import { getLedger } from "@oneshot-gtm/core";
+import { icpFilter, resolveIcp } from "@oneshot-gtm/find";
+import type { ConciergeTarget, DemoNoShowTarget } from "@oneshot-gtm/plays";
+import { jsonResponse } from "../server.ts";
+
+type WebhookKind = "cal-no-show" | "signup";
+
+export async function calNoShowWebhookRoute(req: Request): Promise<Response> {
+  return intakeWebhook(req, "cal-no-show");
+}
+
+export async function signupWebhookRoute(req: Request): Promise<Response> {
+  return intakeWebhook(req, "signup");
+}
+
+async function intakeWebhook(req: Request, kind: WebhookKind): Promise<Response> {
+  if (!isJsonRequest(req)) {
+    return jsonResponse({ error: "content-type must be application/json" }, 400, req);
+  }
+
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return jsonResponse({ error: "invalid JSON body" }, 400, req);
+  }
+
+  let payload: ConciergeTarget | DemoNoShowTarget;
+  let company: string | null;
+  let context: string;
+  let eventIdentity: string;
+  if (kind === "signup") {
+    const parsed = parseSignup(raw);
+    if (!parsed.ok) return jsonResponse({ error: parsed.error }, 400, req);
+    payload = parsed.value;
+    company = null;
+    context = payload.signupContext ?? "new signup";
+    eventIdentity = payload.email;
+  } else {
+    const parsed = parseCalNoShow(raw);
+    if (!parsed.ok) return jsonResponse({ error: parsed.error }, 400, req);
+    payload = parsed.value;
+    company = payload.company;
+    context = payload.whatTheyWanted ?? `missed demo at ${payload.missedAt}`;
+    eventIdentity = `${payload.email}:${payload.missedAt}`;
+  }
+  const filter = await icpFilter({
+    icp: resolveIcp(),
+    candidate: {
+      title: company ? `${payload.name} at ${company}` : payload.name,
+      summary: context,
+      author: payload.name,
+      url: payload.linkedinUrl ?? null,
+    },
+  });
+
+  if (filter.match !== true) {
+    return jsonResponse({ accepted: false, reason: filter.reason }, 200, req);
+  }
+
+  const playName = kind === "signup" ? "concierge" : "demo-no-show";
+  const id = getLedger().enqueueTarget({
+    playName,
+    payload,
+    dedupeKey: `webhook:${kind}:${eventIdentity.toLowerCase()}`,
+    source: `webhook:${kind}`,
+  });
+  return jsonResponse({ accepted: true, queued: id !== null, id }, 202, req);
+}
+
+type ParseResult<T> = { ok: true; value: T } | { ok: false; error: string };
+
+function parseSignup(raw: unknown): ParseResult<ConciergeTarget> {
+  if (!isRecord(raw)) return badPayload();
+  const required = requireStrings(raw, ["name", "email", "phone"]);
+  if (required) return { ok: false, error: required };
+  if (!validEmail(raw["email"] as string)) return { ok: false, error: "email must be valid" };
+  const optional = optionalStrings(raw, ["signupContext", "callWindow", "linkedinUrl"]);
+  if (optional) return { ok: false, error: optional };
+  return { ok: true, value: raw as unknown as ConciergeTarget };
+}
+
+function parseCalNoShow(raw: unknown): ParseResult<DemoNoShowTarget> {
+  if (!isRecord(raw)) return badPayload();
+  const required = requireStrings(raw, ["name", "email", "company", "missedAt", "rescheduleLink"]);
+  if (required) return { ok: false, error: required };
+  if (!validEmail(raw["email"] as string)) return { ok: false, error: "email must be valid" };
+  const optional = optionalStrings(raw, ["phone", "whatTheyWanted", "linkedinUrl"]);
+  if (optional) return { ok: false, error: optional };
+  return { ok: true, value: raw as unknown as DemoNoShowTarget };
+}
+
+function isJsonRequest(req: Request): boolean {
+  return (
+    (req.headers.get("content-type") ?? "").toLowerCase().split(";", 1)[0]?.trim() ===
+    "application/json"
+  );
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function requireStrings(value: Record<string, unknown>, fields: string[]): string | null {
+  for (const field of fields) {
+    if (typeof value[field] !== "string" || value[field].trim().length === 0) {
+      return `${field} (non-empty string) required`;
+    }
+  }
+  return null;
+}
+
+function optionalStrings(value: Record<string, unknown>, fields: string[]): string | null {
+  for (const field of fields) {
+    if (value[field] !== undefined && typeof value[field] !== "string") {
+      return `${field} must be a string`;
+    }
+  }
+  return null;
+}
+
+function validEmail(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+function badPayload<T>(): ParseResult<T> {
+  return { ok: false, error: "payload must be a JSON object" };
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -44,6 +44,7 @@ import {
   setTriggerEnabledRoute,
 } from "./api/triggers.ts";
 import { addProspectRoute } from "./api/prospects.ts";
+import { calNoShowWebhookRoute, signupWebhookRoute } from "./api/webhook-triggers.ts";
 
 interface ServerOptions {
   port: number;
@@ -119,6 +120,8 @@ const routes: RouteEntry[] = [
   route("POST", "/api/queue/:id/send-draft", sendDraftRoute),
   route("POST", "/api/queue/:id/mark-sent", markSentRoute),
   route("GET", "/api/triggers", listTriggersRoute),
+  route("POST", "/api/triggers/cal-no-show", calNoShowWebhookRoute),
+  route("POST", "/api/triggers/signup", signupWebhookRoute),
   route("POST", "/api/triggers/:name/enabled", setTriggerEnabledRoute),
   route("POST", "/api/triggers/:name/config", setTriggerConfigRoute),
   route("POST", "/api/triggers/:name/run", runTriggerRoute),


### PR DESCRIPTION
Closes #354.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 0a0af4a79b94 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add webhook intake endpoints for `cal-no-show` and `signup`
> - Registers POST routes `/api/triggers/cal-no-show` and `/api/triggers/signup` in [server.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/383/files#diff-a8f34e8f17024480f0ca046c8ea4a8af3b525fe68940b703ba496fa4aa4ddfbd) 
> - `intakeWebhook` in [webhook-triggers.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/383/files#diff-fc274a1522490680d01b7cc16b1f5541ad6d752d6aaba3e29ee6c89f1001f7ff) validates JSON content-type, parses payloads via `parseCalNoShow` or `parseSignup`, and applies ICP filtering
> - Matching payloads generate a `dedupeKey`, enqueue via `getLedger().enqueueTarget`, and return a 202 response with `accepted:true`
> - Behavioral Change: `intakeWebhook` returns 200 with `accepted:false` when ICP filtering rejects a payload, and `isJsonRequest` rejects non-JSON requests with 400
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0d8e07a. 3 files reviewed, 2 issues evaluated, 0 issues filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->