### PR TITLE
fix: issue #380: Fix 2 shipped review finding(s) from merged PR #379

### DIFF
--- a/packages/core/__tests__/ledger-extra.test.ts
+++ b/packages/core/__tests__/ledger-extra.test.ts
@@ -286,6 +286,28 @@ describe("removePendingQueueTarget", () => {
   });
 });
 
+describe("setQueueStatus pending", () => {
+  it("restores an unreviewed row and applies notes", () => {
+    const id = ledger.enqueueTarget({
+      playName: "profile-intro",
+      payload: {},
+      dedupeKey: "restore-pending",
+      source: "test",
+      initialStatus: "expired",
+      notes: "classification in progress",
+    })!;
+
+    expect(ledger.getQueueRow(id)?.reviewed_at).not.toBeNull();
+    ledger.setQueueStatus({ id, status: "pending", notes: "ready for review" });
+
+    expect(ledger.getQueueRow(id)).toMatchObject({
+      status: "pending",
+      reviewed_at: null,
+      notes: "ready for review",
+    });
+  });
+});
+
 describe("approvedCountsByPlay", () => {
   it("counts approved rows per play and omits plays with none", () => {
     const enqueue = (playName: string, key: string, status?: "approved" | "sent"): void => {

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -2604,6 +2604,16 @@ export class Ledger {
             ? [input.status, now, input.notes, input.id]
             : [input.status, now, input.id]),
         );
+    } else if (input.status === "pending") {
+      this.db
+        .prepare(
+          `UPDATE target_queue SET status = ?, reviewed_at = NULL, send_started_at = NULL ${input.notes !== undefined ? ", notes = ?" : ""} WHERE id = ?`,
+        )
+        .run(
+          ...(input.notes !== undefined
+            ? [input.status, input.notes, input.id]
+            : [input.status, input.id]),
+        );
     } else {
       this.db
         .prepare(`UPDATE target_queue SET status = ?, send_started_at = NULL WHERE id = ?`)

--- a/packages/find/__tests__/csv-import.test.ts
+++ b/packages/find/__tests__/csv-import.test.ts
@@ -1,14 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const qualifyPersonMock = vi.fn(async () => ({ verdict: "pass" as const, reason: "stub" }));
+const qualifyPersonMock = vi.fn(
+  async (): Promise<{ verdict: "pass" | "reject" | "transient"; reason: string }> => ({
+    verdict: "pass",
+    reason: "stub",
+  }),
+);
 
 interface QueueInput {
   playName: string;
   payload: Record<string, string>;
   dedupeKey: string;
   source: string;
+  initialStatus?: string;
+  notes?: string;
 }
-let queue: QueueInput[] = [];
+type QueueRow = QueueInput & { status: string; notes?: string };
+let queue: QueueRow[] = [];
 const ledger = {
   isQueueDuplicate: (playName: string, dedupeKey: string) =>
     queue.some((row) => row.playName === playName && row.dedupeKey === dedupeKey),
@@ -17,13 +25,19 @@ const ledger = {
     queue.some((row) => row.payload.email?.toLowerCase() === email.toLowerCase()),
   enqueueTarget: (input: QueueInput) => {
     if (ledger.isQueueDuplicate(input.playName, input.dedupeKey)) return null;
-    queue.push(input);
+    queue.push({ ...input, status: input.initialStatus ?? "pending" });
     return queue.length;
   },
   setQueueStatus: (input: { id: number; status: string; notes?: string }) => {
-    if (input.status === "rejected") queue.splice(input.id - 1, 1);
+    const row = queue[input.id - 1];
+    if (!row) return;
+    row.status = input.status;
+    if (input.notes !== undefined) row.notes = input.notes;
   },
-  removePendingQueueTarget: (id: number) => queue.splice(id - 1, 1).length > 0,
+  removePendingQueueTarget: (id: number) => {
+    if (queue[id - 1]?.status !== "pending") return false;
+    return queue.splice(id - 1, 1).length > 0;
+  },
   setQueueNotes: () => {},
 };
 
@@ -127,6 +141,18 @@ describe("bulk CSV import", () => {
 
     release();
     await expect(first).resolves.toMatchObject({ imported: 1, skipped: 0 });
+  });
+
+  it("removes the expired reservation when classification fails transiently", async () => {
+    qualifyPersonMock.mockResolvedValueOnce({ verdict: "transient", reason: "try later" });
+
+    const result = await importCsv({
+      playName: "profile-intro",
+      text: "email,name,company,title\nretry@example.test,Retry,Acme,Founder",
+    });
+
+    expect(result).toMatchObject({ imported: 0, skipped: 1 });
+    expect(queue).toHaveLength(0);
   });
 
   it("applies deduplication during a dry run without enqueueing", async () => {

--- a/packages/find/src/csv-import.ts
+++ b/packages/find/src/csv-import.ts
@@ -209,6 +209,13 @@ export async function importCsv(input: {
 
   const icp = resolveIcp();
   const ledger = getLedger();
+  const removeReservation = (id: number): void => {
+    // Reservations are inserted as expired so bulk approval cannot pick them
+    // up while classification is running. Restore the unreviewed state before
+    // using the ledger's guarded reservation cleanup.
+    ledger.setQueueStatus({ id, status: "pending" });
+    ledger.removePendingQueueTarget(id);
+  };
   for (const candidate of unique) {
     const dedupeKey = `email:${candidate.email}`;
     // Reserve the unique key before the paid classifier. Concurrent imports
@@ -237,14 +244,14 @@ export async function importCsv(input: {
         },
       });
     } catch (error) {
-      ledger.removePendingQueueTarget(id);
+      removeReservation(id);
       throw error;
     }
     if (verdict.verdict === "reject" || verdict.verdict === "transient") {
       result.skipped++;
       if (verdict.verdict === "transient") {
         // A transient failure must remain retryable on a later invocation.
-        ledger.removePendingQueueTarget(id);
+        removeReservation(id);
         result.errors.push({ row: candidate.row, message: verdict.reason });
       } else {
         ledger.setQueueStatus({ id, status: "rejected", notes: verdict.reason });

--- a/packages/find/src/csv-import.ts
+++ b/packages/find/src/csv-import.ts
@@ -219,6 +219,7 @@ export async function importCsv(input: {
       dedupeKey,
       source: "find:csv-import",
       notes: "CSV import: ICP classification in progress",
+      initialStatus: "expired", // abuse expired as a transient state before classification to prevent approveAllPending from picking it up
     });
     if (id == null) {
       result.skipped++;
@@ -250,7 +251,8 @@ export async function importCsv(input: {
       }
       continue;
     }
-    ledger.setQueueNotes({ id, notes: "CSV import: ICP accepted" });
+    // Now that classification passed, we put it into pending
+    ledger.setQueueStatus({ id, status: "pending", notes: "CSV import: ICP accepted" });
     result.imported++;
   }
   return { ...result, mapping: prepared.mapping, rowCount: prepared.rows.length };


### PR DESCRIPTION
Closes #380.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 6bb20b79aaa8 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

**Review note:** review FAIL at the 2-round correction cap — findings filed: https://github.com/oneshot-agent/oneshot-gtm/issues/388

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CSV import reservation flow and add `pending` branch to `Ledger.setQueueStatus`
> - CSV import now enqueues dedupe reservations with `initialStatus` `"expired"` and an in-progress note, preventing premature bulk approval while classification runs.
> - On successful classification, `importCsv` calls `setQueueStatus` with `"pending"` and the acceptance note instead of `setQueueNotes`; on classifier errors or transient verdicts, a new `removeReservation` helper restores the row to `"pending"` then removes it via `removePendingQueueTarget`.
> - `Ledger.setQueueStatus` gains an explicit `"pending"` branch that sets `reviewed_at` to `NULL`, `send_started_at` to `NULL`, and updates `notes` only when provided.
> - Risk: `removePendingQueueTarget` now only removes rows whose `status` is `"pending"`; any caller relying on removal of non-pending rows will no longer get that behavior. The `"pending"` branch in `setQueueStatus` also clears `reviewed_at`, unlike the previous generic fallback.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 2ba7ea5. 2 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->