### PR TITLE
fix: issue #386: Fix 2 shipped review finding(s) from merged PR #383

### DIFF
--- a/apps/server/src/api/webhook-triggers.ts
+++ b/apps/server/src/api/webhook-triggers.ts
@@ -45,7 +45,7 @@ async function intakeWebhook(req: Request, kind: WebhookKind): Promise<Response>
     eventIdentity = `${payload.email}:${payload.missedAt}`;
   }
   const filter = await icpFilter({
-    icp: resolveIcp(),
+    icp: await resolveIcp(),
     candidate: {
       title: company ? `${payload.name} at ${company}` : payload.name,
       summary: context,


### PR DESCRIPTION
Closes #386.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 371b3a65c496 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
(cached verify — HEAD, base and verify list unchanged)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `icpFilter` call in `intakeWebhook` to await `resolveIcp()`
> The `intakeWebhook` handler in [webhook-triggers.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/390/files#diff-fc274a1522490680d01b7cc16b1f5541ad6d752d6aaba3e29ee6c89f1001f7ff) was passing a Promise to `icpFilter` instead of the resolved ICP value. Adding `await` to `resolveIcp()` ensures `icpFilter` runs against the actual ICP configuration, so the `{accepted, reason}` response reflects the correct `filter.match` result.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66f5767.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->