### PR TITLE
fix: issue #387: Fix 2 shipped review finding(s) from merged PR #383

### DIFF
--- a/apps/server/src/api/webhook-triggers.ts
+++ b/apps/server/src/api/webhook-triggers.ts
@@ -35,14 +35,14 @@ async function intakeWebhook(req: Request, kind: WebhookKind): Promise<Response>
     payload = parsed.value;
     company = null;
     context = payload.signupContext ?? "new signup";
-    eventIdentity = payload.email;
+    eventIdentity = payload.email.toLowerCase();
   } else {
     const parsed = parseCalNoShow(raw);
     if (!parsed.ok) return jsonResponse({ error: parsed.error }, 400, req);
     payload = parsed.value;
     company = payload.company;
     context = payload.whatTheyWanted ?? `missed demo at ${payload.missedAt}`;
-    eventIdentity = `${payload.email}:${payload.missedAt}`;
+    eventIdentity = `${payload.email.toLowerCase()}:${payload.missedAt}`;
   }
   const filter = await icpFilter({
     icp: resolveIcp(),
@@ -62,7 +62,7 @@ async function intakeWebhook(req: Request, kind: WebhookKind): Promise<Response>
   const id = getLedger().enqueueTarget({
     playName,
     payload,
-    dedupeKey: `webhook:${kind}:${eventIdentity.toLowerCase()}`,
+    dedupeKey: `webhook:${kind}:${eventIdentity}`,
     source: `webhook:${kind}`,
   });
   return jsonResponse({ accepted: true, queued: id !== null, id }, 202, req);

--- a/apps/server/src/api/webhook-triggers.ts
+++ b/apps/server/src/api/webhook-triggers.ts
@@ -35,14 +35,14 @@ async function intakeWebhook(req: Request, kind: WebhookKind): Promise<Response>
     payload = parsed.value;
     company = null;
     context = payload.signupContext ?? "new signup";
-    eventIdentity = payload.email.toLowerCase();
+    eventIdentity = payload.email;
   } else {
     const parsed = parseCalNoShow(raw);
     if (!parsed.ok) return jsonResponse({ error: parsed.error }, 400, req);
     payload = parsed.value;
     company = payload.company;
     context = payload.whatTheyWanted ?? `missed demo at ${payload.missedAt}`;
-    eventIdentity = `${payload.email.toLowerCase()}:${payload.missedAt}`;
+    eventIdentity = `${payload.email}:${payload.missedAt}`;
   }
   const filter = await icpFilter({
     icp: resolveIcp(),
@@ -62,7 +62,7 @@ async function intakeWebhook(req: Request, kind: WebhookKind): Promise<Response>
   const id = getLedger().enqueueTarget({
     playName,
     payload,
-    dedupeKey: `webhook:${kind}:${eventIdentity}`,
+    dedupeKey: `webhook:${kind}:${eventIdentity.toLowerCase()}`,
     source: `webhook:${kind}`,
   });
   return jsonResponse({ accepted: true, queued: id !== null, id }, 202, req);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,5 +19,6 @@ export * from "./parallel.ts";
 export * from "./dossier.ts";
 export * from "./run-cancel.ts";
 export * from "./types.ts";
+export { activeSendCount } from "./inflight.ts";
 export * from "./reply-classify.ts";
 export * from "./timezone.ts";


### PR DESCRIPTION
Closes #387.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 371b3a65c496 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Export `activeSendCount` from package's public `index.ts`
> Adds a named re-export for `activeSendCount` from `./inflight.ts` in [index.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/391/files#diff-9a4ceebe7c6f86856371906c3f061d3b56b7457022b05179884a113e7ced67e8). Consumers can now import it from the core package entrypoint.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf40413.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->