### PR TITLE
fix: issue #385: Fix 2 shipped review finding(s) from merged PR #382

### DIFF
--- a/apps/server/__tests__/run-route.test.ts
+++ b/apps/server/__tests__/run-route.test.ts
@@ -178,6 +178,27 @@ describe("runPlay — verify-then-dispatch", () => {
     expect(playCalls[0]?.targets).toEqual(targets);
   });
 
+  it("verifies only manual targets in a mixed queue batch", async () => {
+    const targets = [
+      { founderEmail: "queued@x.dev", postTitle: "Queued" },
+      { founderEmail: "manual@x.dev", postTitle: "Manual" },
+    ];
+    nextVerify = { verified: [targets[1]!], dropped: [], receiptIds: [], costUsd: 0 };
+
+    const res = await runPlay(
+      makeRequest("show-hn", {
+        targets,
+        dedupeKeys: ["queue-key", null],
+        dryRun: false,
+      }),
+      { playName: "show-hn" },
+    );
+    await readSseFrames(res.body);
+
+    expect(captureVerifyArgs?.targets).toEqual([targets[1]]);
+    expect(playCalls[0]?.targets).toEqual(targets);
+  });
+
   it("emits a verify event when at least one target was dropped + only forwards verified targets", async () => {
     const targets = [
       { email: "good@x.dev", company: "Good" },

--- a/apps/server/src/api/run.ts
+++ b/apps/server/src/api/run.ts
@@ -123,21 +123,19 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
       let drafted: DraftedView[] = [];
 
       try {
-        // Queue runs skip verification, so their target indexes remain aligned
-        // with the parallel dedupe-key array. Manual runs omit the array and
-        // persistence remains a no-op.
-        if (body.dedupeKeys && body.dedupeKeys.length === body.targets.length) {
-          body.dedupeKeys.forEach((dedupeKey, index) => {
-            if (dedupeKey) indexToDedupeKey.set(index, dedupeKey);
-          });
-        }
-
+        // Fully queue-sourced runs skip verification, so their target indexes
+        // remain aligned with the parallel dedupe-key array. A mixed batch
+        // still verifies its manual rows and is remapped below.
         // Verify emails BEFORE dispatch so undeliverable rows are dropped
         // before LLM spend. Skipped on dryRun and for queue-sourced runs
         // (already verified at finder-enqueue time).
         const inputCount = body.targets.length;
         fromQueue =
-          Array.isArray(body.dedupeKeys) && body.dedupeKeys.length === body.targets.length;
+          Array.isArray(body.dedupeKeys) &&
+          body.dedupeKeys.length === body.targets.length &&
+          body.dedupeKeys.every(
+            (dedupeKey) => typeof dedupeKey === "string" && dedupeKey.length > 0,
+          );
         if (fromQueue) {
           verify = { verified: body.targets, dropped: [], receiptIds: [], costUsd: 0 };
         } else {
@@ -147,6 +145,16 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
             (t) => t.email ?? t.founderEmail ?? null,
             { playName, dryRun: body.dryRun, signal: runAbort.signal },
           );
+        }
+        // Draft indexes are relative to the verified array. Rebuild the queue
+        // mapping after verification so a dropped manual row in a mixed batch
+        // cannot shift a later queue draft onto the wrong dedupe key.
+        if (Array.isArray(body.dedupeKeys) && body.dedupeKeys.length === body.targets.length) {
+          const originalIndex = new Map(body.targets.map((target, index) => [target, index]));
+          verify.verified.forEach((target, index) => {
+            const dedupeKey = body.dedupeKeys?.[originalIndex.get(target) ?? -1];
+            if (dedupeKey) indexToDedupeKey.set(index, dedupeKey);
+          });
         }
         if (verify.dropped.length > 0) {
           send({

--- a/apps/server/src/api/run.ts
+++ b/apps/server/src/api/run.ts
@@ -123,28 +123,47 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
       let drafted: DraftedView[] = [];
 
       try {
-        // Fully queue-sourced runs skip verification, so their target indexes
-        // remain aligned with the parallel dedupe-key array. A mixed batch
-        // still verifies its manual rows and is remapped below.
         // Verify emails BEFORE dispatch so undeliverable rows are dropped
-        // before LLM spend. Skipped on dryRun and for queue-sourced runs
-        // (already verified at finder-enqueue time).
+        // before LLM spend. Queue-sourced rows were already verified at
+        // finder-enqueue time, so only manual rows in a mixed batch are sent
+        // through verification.
         const inputCount = body.targets.length;
-        fromQueue =
-          Array.isArray(body.dedupeKeys) &&
-          body.dedupeKeys.length === body.targets.length &&
-          body.dedupeKeys.every(
-            (dedupeKey) => typeof dedupeKey === "string" && dedupeKey.length > 0,
-          );
-        if (fromQueue) {
-          verify = { verified: body.targets, dropped: [], receiptIds: [], costUsd: 0 };
-        } else {
+        const hasAlignedDedupeKeys =
+          Array.isArray(body.dedupeKeys) && body.dedupeKeys.length === body.targets.length;
+        const queueIndexes = new Set<number>();
+        const manualTargets = body.targets.filter((_target, index) => {
+          const dedupeKey = hasAlignedDedupeKeys ? body.dedupeKeys?.[index] : null;
+          const isQueueTarget = typeof dedupeKey === "string" && dedupeKey.length > 0;
+          if (isQueueTarget) queueIndexes.add(index);
+          return !isQueueTarget;
+        });
+        fromQueue = queueIndexes.size > 0;
+
+        if (manualTargets.length > 0) {
           send({ kind: "stage", stage: "verifying" });
-          verify = await verifyAndFilterTargets(
-            body.targets as Array<{ email?: string; founderEmail?: string }>,
+          const manualVerify = await verifyAndFilterTargets(
+            manualTargets as Array<{ email?: string; founderEmail?: string }>,
             (t) => t.email ?? t.founderEmail ?? null,
             { playName, dryRun: body.dryRun, signal: runAbort.signal },
           );
+          const verifiedManualEmails = new Set(
+            manualVerify.verified.map((target) =>
+              (target.email ?? target.founderEmail ?? "").trim().toLowerCase(),
+            ),
+          );
+          verify = {
+            ...manualVerify,
+            verified: body.targets.filter((target, index) => {
+              if (queueIndexes.has(index)) return true;
+              const manualTarget = target as { email?: string; founderEmail?: string };
+              const email = (manualTarget.email ?? manualTarget.founderEmail ?? "")
+                .trim()
+                .toLowerCase();
+              return verifiedManualEmails.has(email);
+            }),
+          };
+        } else {
+          verify = { verified: body.targets, dropped: [], receiptIds: [], costUsd: 0 };
         }
         // Draft indexes are relative to the verified array. Rebuild the queue
         // mapping after verification so a dropped manual row in a mixed batch

--- a/apps/web/src/routes/run.$playName.tsx
+++ b/apps/web/src/routes/run.$playName.tsx
@@ -711,20 +711,7 @@ function RunPage() {
                   const restoredKeys = restoredRows.map(
                     (_, index) => runRecord.dedupeKeys[index] ?? null,
                   );
-                  // Stored targets retain their original order, while event
-                  // indexes are relative to the post-verification batch. Use
-                  // the persisted recipients when rebuilding a resumed run.
-                  const sentEmails = new Set(
-                    runRecord.prospectEmails.map((email) => email.toLowerCase()),
-                  );
-                  const retryableIndexes = restoredRows.flatMap((row, index) => {
-                    const email = (row.email ?? row.founderEmail ?? "").trim().toLowerCase();
-                    return email && sentEmails.has(email) ? [] : [index];
-                  });
-                  const retryable = {
-                    rows: retryableIndexes.map((index) => restoredRows[index]!),
-                    dedupeKeys: retryableIndexes.map((index) => restoredKeys[index] ?? null),
-                  };
+                  const retryable = pruneSentRows(runRecord.events, restoredRows, restoredKeys);
                   setRows(retryable.rows.length > 0 ? retryable.rows : [{ ...schema.defaultRow }]);
                   setDedupeKeys(retryable.rows.length > 0 ? retryable.dedupeKeys : [null]);
                 }

--- a/apps/web/src/routes/run.$playName.tsx
+++ b/apps/web/src/routes/run.$playName.tsx
@@ -711,7 +711,20 @@ function RunPage() {
                   const restoredKeys = restoredRows.map(
                     (_, index) => runRecord.dedupeKeys[index] ?? null,
                   );
-                  const retryable = pruneSentRows(runRecord.events, restoredRows, restoredKeys);
+                  // Stored targets retain their original order, while event
+                  // indexes are relative to the post-verification batch. Use
+                  // the persisted recipients when rebuilding a resumed run.
+                  const sentEmails = new Set(
+                    runRecord.prospectEmails.map((email) => email.toLowerCase()),
+                  );
+                  const retryableIndexes = restoredRows.flatMap((row, index) => {
+                    const email = (row.email ?? row.founderEmail ?? "").trim().toLowerCase();
+                    return email && sentEmails.has(email) ? [] : [index];
+                  });
+                  const retryable = {
+                    rows: retryableIndexes.map((index) => restoredRows[index]!),
+                    dedupeKeys: retryableIndexes.map((index) => restoredKeys[index] ?? null),
+                  };
                   setRows(retryable.rows.length > 0 ? retryable.rows : [{ ...schema.defaultRow }]);
                   setDedupeKeys(retryable.rows.length > 0 ? retryable.dedupeKeys : [null]);
                 }


### PR DESCRIPTION
Closes #385.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 371b3a65c496 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `runPlay` to verify only manual targets and realign dedupe keys in mixed batches
> - In `apps/server/src/api/run.ts`, the `runPlay` function now treats any target with a non-empty `dedupeKey` as queue-sourced and skips verification for those targets; only manual targets (null `dedupeKey`) are passed to `verifyAndFilterTargets`.
> - After verification, `indexToDedupeKey` is rebuilt by mapping each verified target back to its original index, preventing misalignment when manual targets are dropped.
> - The `stage: verifying` SSE event is now emitted only when manual targets exist; the `verify` event remains conditional on dropped targets.
> - Adds a test in [run-route.test.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/392/files#diff-bf3c563283ec890c0afba373ba01c22571dd3d8ae4a794b4a1e100df39852ba0) that enqueues a mixed batch and asserts only the manual target is verified while dispatch receives all targets.
> - Risk: queue-sourced targets with a non-empty `dedupeKey` now bypass `verifyAndFilterTargets` entirely; any validation previously applied to those targets will no longer run.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b609da5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->