### PR TITLE
fix: issue #384: Fix 2 shipped review finding(s) from merged PR #382

### DIFF
--- a/apps/server/src/api/run.ts
+++ b/apps/server/src/api/run.ts
@@ -178,9 +178,13 @@ export async function runPlay(req: Request, params: Record<string, string>): Pro
         if (verify.dropped.length > 0) {
           send({
             kind: "verify",
-            total: inputCount,
+            total: body.targets.length,
             verified: verify.verified.length,
-            dropped: verify.dropped.map((d) => ({ email: d.email, reason: d.reason })),
+            dropped: verify.dropped.map((d) => ({
+              email: d.email,
+              reason: d.reason,
+              index: d.index,
+            })),
           });
         }
         // If verify dropped every target, skip dispatch entirely — the play

--- a/apps/web/__tests__/pruneSentRows.test.ts
+++ b/apps/web/__tests__/pruneSentRows.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { RunPlayEvent } from "@oneshot-gtm/shared-types";
-import { pruneSentRows } from "../src/lib/pruneSentRows";
+import { pruneSentRows, remapFilteredEventIndexes } from "../src/lib/pruneSentRows";
 
 const r = (label: string): Record<string, string> => ({ email: `${label}@x.dev`, name: label });
 
@@ -54,5 +54,52 @@ describe("pruneSentRows", () => {
     const out = pruneSentRows(events, rows, keys);
     expect(out.rows).toEqual([r("a")]);
     expect(out.dedupeKeys).toEqual([null]);
+  });
+});
+
+describe("remapFilteredEventIndexes", () => {
+  it("maps filtered live indexes back to the full rows array", () => {
+    const rows = [r("a"), r("b"), r("c")];
+    const events: RunPlayEvent[] = [
+      {
+        kind: "verify",
+        total: 3,
+        verified: 2,
+        dropped: [{ email: "b@x.dev", reason: "bad", index: 1 }],
+      },
+      { kind: "send", index: 1, receiptIds: [42] },
+    ];
+
+    const mapped = remapFilteredEventIndexes(events, rows);
+    expect(mapped[1]).toEqual({ kind: "send", index: 2, receiptIds: [42] });
+    expect(pruneSentRows(mapped, rows, ["a", "b", "c"]).rows).toEqual([r("a"), r("b")]);
+  });
+
+  it("recovers missing drop indexes in older records by email", () => {
+    const rows = [r("a"), r("b"), r("c")];
+    const events: RunPlayEvent[] = [
+      { kind: "verify", total: 3, verified: 2, dropped: [{ email: "b@x.dev", reason: "bad" }] },
+      { kind: "send", index: 1, receiptIds: [42] },
+    ];
+
+    expect(remapFilteredEventIndexes(events, rows)[1]).toEqual({
+      kind: "send",
+      index: 2,
+      receiptIds: [42],
+    });
+  });
+
+  it("does not identity-map indexed events when a legacy drop cannot be resolved", () => {
+    const events: RunPlayEvent[] = [
+      {
+        kind: "verify",
+        total: 2,
+        verified: 1,
+        dropped: [{ email: "unknown@x.dev", reason: "bad" }],
+      },
+      { kind: "send", index: 0, receiptIds: [42] },
+    ];
+
+    expect(remapFilteredEventIndexes(events, [r("a"), r("b")])).toEqual([events[0]]);
   });
 });

--- a/apps/web/src/lib/pruneSentRows.ts
+++ b/apps/web/src/lib/pruneSentRows.ts
@@ -1,5 +1,73 @@
 import type { RunPlayEvent } from "@oneshot-gtm/shared-types";
 
+type IndexedRunPlayEvent = Extract<RunPlayEvent, { index: number }>;
+
+/**
+ * Verification removes invalid targets before dispatch, so draft/send/error
+ * indexes refer to the filtered target array. Translate them back to indexes
+ * in the original rows before using them to mutate the form.
+ *
+ * Older persisted verify events may not contain dropped indexes. Recover those
+ * by email; if any drop is still ambiguous, discard indexed events so callers
+ * fail safe instead of treating filtered indexes as original indexes.
+ */
+export function remapFilteredEventIndexes(
+  events: RunPlayEvent[],
+  rows: Record<string, string>[],
+): RunPlayEvent[] {
+  const verifyEvent = events.find(
+    (event): event is Extract<RunPlayEvent, { kind: "verify" }> => event.kind === "verify",
+  );
+  if (!verifyEvent) return events;
+
+  const droppedIndexes = new Set<number>();
+  const unresolvedDrops: typeof verifyEvent.dropped = [];
+  for (const dropped of verifyEvent.dropped) {
+    if (
+      typeof dropped.index === "number" &&
+      dropped.index >= 0 &&
+      dropped.index < rows.length &&
+      !droppedIndexes.has(dropped.index)
+    ) {
+      droppedIndexes.add(dropped.index);
+    } else {
+      unresolvedDrops.push(dropped);
+    }
+  }
+
+  for (const dropped of unresolvedDrops) {
+    const droppedEmail = dropped.email.trim().toLowerCase();
+    const originalIndex = rows.findIndex((row, index) => {
+      if (droppedIndexes.has(index)) return false;
+      const rowEmail = (row["email"] ?? row["founderEmail"] ?? "").trim().toLowerCase();
+      return rowEmail === droppedEmail;
+    });
+    if (originalIndex === -1) {
+      return events.filter((event): event is Exclude<RunPlayEvent, IndexedRunPlayEvent> => {
+        return event.kind !== "draft" && event.kind !== "send" && event.kind !== "error";
+      });
+    }
+    droppedIndexes.add(originalIndex);
+  }
+
+  const postDropToOriginal = new Map<number, number>();
+  let postDropIndex = 0;
+  for (let originalIndex = 0; originalIndex < rows.length; originalIndex++) {
+    if (!droppedIndexes.has(originalIndex)) {
+      postDropToOriginal.set(postDropIndex, originalIndex);
+      postDropIndex++;
+    }
+  }
+
+  return events.map((event) => {
+    if (event.kind === "draft" || event.kind === "send" || event.kind === "error") {
+      const originalIndex = postDropToOriginal.get(event.index);
+      if (originalIndex !== undefined) return { ...event, index: originalIndex };
+    }
+    return event;
+  });
+}
+
 /**
  * After a /api/run SSE stream finishes, drop the row entries that
  * successfully sent (kind="send" with non-empty receiptIds) so the form

--- a/apps/web/src/routes/run.$playName.tsx
+++ b/apps/web/src/routes/run.$playName.tsx
@@ -711,7 +711,39 @@ function RunPage() {
                   const restoredKeys = restoredRows.map(
                     (_, index) => runRecord.dedupeKeys[index] ?? null,
                   );
-                  const retryable = pruneSentRows(runRecord.events, restoredRows, restoredKeys);
+                  const verifyEvent = runRecord.events.find(
+                    (e): e is Extract<RunPlayEvent, { kind: "verify" }> => e.kind === "verify",
+                  );
+                  const postDropToOriginal = new Map<number, number>();
+                  if (verifyEvent) {
+                    const dropped = new Set(
+                      verifyEvent.dropped
+                        .map((d) => d.index)
+                        .filter((idx): idx is number => typeof idx === "number"),
+                    );
+                    let postIdx = 0;
+                    for (let i = 0; i < restoredRows.length; i++) {
+                      if (!dropped.has(i)) {
+                        postDropToOriginal.set(postIdx, i);
+                        postIdx++;
+                      }
+                    }
+                  } else {
+                    for (let i = 0; i < restoredRows.length; i++) {
+                      postDropToOriginal.set(i, i);
+                    }
+                  }
+
+                  const mappedEvents = runRecord.events.map((ev) => {
+                    if (ev.kind === "draft" || ev.kind === "send" || ev.kind === "error") {
+                      const origIndex = postDropToOriginal.get(ev.index);
+                      if (origIndex !== undefined) {
+                        return { ...ev, index: origIndex };
+                      }
+                    }
+                    return ev;
+                  });
+                  const retryable = pruneSentRows(mappedEvents, restoredRows, restoredKeys);
                   setRows(retryable.rows.length > 0 ? retryable.rows : [{ ...schema.defaultRow }]);
                   setDedupeKeys(retryable.rows.length > 0 ? retryable.dedupeKeys : [null]);
                 }
@@ -742,8 +774,8 @@ function RunPage() {
             {verifyEvent.dropped.length} dropped
           </div>
           <div className="mt-1 font-mono text-[11px] text-ink-muted">
-            {verifyEvent.dropped.map((d) => (
-              <div key={`${d.email}::${d.reason}`}>
+            {verifyEvent.dropped.map((d, idx) => (
+              <div key={`${d.email}::${d.reason}::${idx}`}>
                 {d.email ? mask("email", d.email) : "(missing)"} — {d.reason}
               </div>
             ))}

--- a/apps/web/src/routes/run.$playName.tsx
+++ b/apps/web/src/routes/run.$playName.tsx
@@ -15,7 +15,7 @@ import { Field, Input, Textarea } from "../components/primitives/Field.tsx";
 import { cn } from "../lib/cn.ts";
 import { PLAY_SCHEMAS } from "../lib/playSchemas.ts";
 import { useMask } from "../lib/privacy.tsx";
-import { pruneSentRows } from "../lib/pruneSentRows.ts";
+import { pruneSentRows, remapFilteredEventIndexes } from "../lib/pruneSentRows.ts";
 
 /**
  * Search-param contract for arrivals from the `/queue` drain modal: `fromQueue=1`
@@ -401,7 +401,8 @@ function RunPage() {
       // After a real-send run, drop rows whose draft actually shipped so
       // they can't be resent by a second submission of the same form.
       // Held / errored / unsent rows stay so the founder can edit and retry.
-      const pruned = pruneSentRows(streamedEvents, rowsSnapshot, dedupeKeysSnapshot);
+      const mappedEvents = remapFilteredEventIndexes(streamedEvents, rowsSnapshot);
+      const pruned = pruneSentRows(mappedEvents, rowsSnapshot, dedupeKeysSnapshot);
       if (pruned.prunedCount > 0) {
         setRows(pruned.rows);
         setDedupeKeys(pruned.dedupeKeys);
@@ -711,38 +712,7 @@ function RunPage() {
                   const restoredKeys = restoredRows.map(
                     (_, index) => runRecord.dedupeKeys[index] ?? null,
                   );
-                  const verifyEvent = runRecord.events.find(
-                    (e): e is Extract<RunPlayEvent, { kind: "verify" }> => e.kind === "verify",
-                  );
-                  const postDropToOriginal = new Map<number, number>();
-                  if (verifyEvent) {
-                    const dropped = new Set(
-                      verifyEvent.dropped
-                        .map((d) => d.index)
-                        .filter((idx): idx is number => typeof idx === "number"),
-                    );
-                    let postIdx = 0;
-                    for (let i = 0; i < restoredRows.length; i++) {
-                      if (!dropped.has(i)) {
-                        postDropToOriginal.set(postIdx, i);
-                        postIdx++;
-                      }
-                    }
-                  } else {
-                    for (let i = 0; i < restoredRows.length; i++) {
-                      postDropToOriginal.set(i, i);
-                    }
-                  }
-
-                  const mappedEvents = runRecord.events.map((ev) => {
-                    if (ev.kind === "draft" || ev.kind === "send" || ev.kind === "error") {
-                      const origIndex = postDropToOriginal.get(ev.index);
-                      if (origIndex !== undefined) {
-                        return { ...ev, index: origIndex };
-                      }
-                    }
-                    return ev;
-                  });
+                  const mappedEvents = remapFilteredEventIndexes(runRecord.events, restoredRows);
                   const retryable = pruneSentRows(mappedEvents, restoredRows, restoredKeys);
                   setRows(retryable.rows.length > 0 ? retryable.rows : [{ ...schema.defaultRow }]);
                   setDedupeKeys(retryable.rows.length > 0 ? retryable.dedupeKeys : [null]);

--- a/packages/plays/src/_lib.ts
+++ b/packages/plays/src/_lib.ts
@@ -686,7 +686,7 @@ export function firstNameFrom(name: string | null | undefined): string | null {
 
 interface VerifyAndFilterResult<T> {
   verified: T[];
-  dropped: Array<{ target: T; email: string; reason: string }>;
+  dropped: Array<{ target: T; email: string; reason: string; index?: number }>;
   receiptIds: number[];
   costUsd: number;
 }
@@ -755,26 +755,32 @@ export async function verifyAndFilterTargets<T>(
     if (v.receiptId > 0) receiptIds.push(v.receiptId);
   }
 
+  let i = 0;
   for (const t of targets) {
     const email = emailFor.get(t);
     if (!email) {
-      dropped.push({ target: t, email: "", reason: "missing email" });
+      dropped.push({ target: t, email: "", reason: "missing email", index: i });
+      i++;
       continue;
     }
     const v = byEmail.get(email);
     if (!v) {
-      dropped.push({ target: t, email, reason: "undeliverable" });
+      dropped.push({ target: t, email, reason: "undeliverable", index: i });
+      i++;
       continue;
     }
     if (v.errored) {
-      dropped.push({ target: t, email, reason: `verify-error: ${v.message}` });
+      dropped.push({ target: t, email, reason: `verify-error: ${v.message}`, index: i });
+      i++;
       continue;
     }
     if (!v.deliverable) {
-      dropped.push({ target: t, email, reason: "undeliverable" });
+      dropped.push({ target: t, email, reason: "undeliverable", index: i });
+      i++;
       continue;
     }
     verified.push(t);
+    i++;
   }
 
   return { verified, dropped, receiptIds, costUsd };

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -866,7 +866,7 @@ export type RunPlayEvent =
       kind: "verify";
       total: number;
       verified: number;
-      dropped: Array<{ email: string; reason: string }>;
+      dropped: Array<{ email: string; reason: string; index?: number }>;
     }
   | { kind: "stage"; stage: string }
   | { kind: "draft"; index: number; subject: string; body: string; flags: string[] }


### PR DESCRIPTION
Closes #384.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 371b3a65c496 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

**Review note:** review FAIL at the 2-round correction cap — findings filed: https://github.com/oneshot-agent/oneshot-gtm/issues/393

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix dropped-target index alignment in `verify` SSE event and `pruneSentRows`
> - `verifyAndFilterTargets` now includes the original `index` on each dropped target, and the `verify` SSE event reports `total` as `body.targets.length` instead of `inputCount`
> - Adds `remapFilteredEventIndexes` in [pruneSentRows.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/394/files#diff-8849dc9155e99159e893b67b42138e9097dbd6397c7b20d695845529119a7eeb) to translate draft/send/error event indexes from the post-verification filtered array back to original row indexes, with email-based recovery for legacy records that lack drop indexes
> - [RunPage](https://github.com/oneshot-agent/oneshot-gtm/pull/394/files#diff-a41369a17db72d666888d998125772e6cd6f1c02a49d20021a82722bafe6dd20) applies `remapFilteredEventIndexes` before `pruneSentRows` both after SSE completion and when resuming a saved run, fixing row misalignment when verification drops inputs
> - Risk: when legacy dropped records cannot be unambiguously matched by email, `remapFilteredEventIndexes` discards all indexed events as a fail-safe — verify this behavior in [pruneSentRows.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/394/files#diff-8849dc9155e99159e893b67b42138e9097dbd6397c7b20d695845529119a7eeb) does not silently hide retryable rows for older run records
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 9ab6791. 5 files reviewed, 3 issues evaluated, 2 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>apps/server/src/api/run.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 186](https://github.com/oneshot-agent/oneshot-gtm/blob/9ab67917bb2beab90df62dd2c1570817fdeb73fd/apps/server/src/api/run.ts#L186): The forwarded `d.index` is relative to `manualTargets`, not to `body.targets`. In a mixed batch (for example a queue row at original index 0 followed by a manual row at index 1 whose email is dropped), `verifyAndFilterTargets(manualTargets)` returns `index: 0`, and this emits that value as if it identified the original input row. Consumers then associate the verification drop with the queue row, defeating the row-index mapping this event is meant to provide. <b>[ Cross-file consolidated ]</b>
> </details>
>
> <details>
> <summary>packages/plays/src/_lib.ts — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 761](https://github.com/oneshot-agent/oneshot-gtm/blob/9ab67917bb2beab90df62dd2c1570817fdeb73fd/packages/plays/src/_lib.ts#L761): `verifyAndFilterTargets` assigns each dropped target an index within the `manualTargets` array, but `runPlay` later emits that index as if it were an index in the original `body.targets` array. In a mixed queue/manual submission with a queue row before a manually entered undeliverable row, the drop is emitted as index `0`; the client remapper then treats the queue row as dropped and shifts a subsequent `send` onto the manual row. `pruneSentRows` consequently removes the unsent manual row while retaining the row that was actually emailed, allowing a duplicate send on the next submission. <b>[ Cross-file consolidated ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->