### PR TITLE
feat(find): per-source approval-rate weighting — deprioritize noisy finders (#361)

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -46,7 +46,7 @@ The ICP filter currently judges each candidate cold — `icpFilter` in `packages
 
 - [x] **v1** — feed the last ~20 `(candidate, decision, reason)` tuples from `target_queue` into each `icpFilter` call as in-context examples. No schema change.
 - [ ] **v2** — periodic job proposes a tighter ICP one-liner from accumulated decisions; founder approves the rewrite in `/queue`.
-- [ ] **Per-source weighting** — track approval rate per finder, deprioritize noisy sources automatically.
+- [x] **Per-source weighting** — track approval rate per finder, deprioritize noisy sources automatically.
 
 ## Operations
 

--- a/apps/cli/src/commands/doctor.ts
+++ b/apps/cli/src/commands/doctor.ts
@@ -34,6 +34,13 @@ export async function commandDoctor(opts: { json?: boolean } = {}): Promise<void
         severity: r.severity,
         message: r.message,
         ...(r.hint ? { hint: r.hint } : {}),
+        ...(r.approvalRate !== undefined ? { approvalRate: r.approvalRate } : {}),
+        ...(r.approved !== undefined ? { approved: r.approved } : {}),
+        ...(r.reviewed !== undefined ? { reviewed: r.reviewed } : {}),
+        ...(r.threshold !== undefined ? { threshold: r.threshold } : {}),
+        ...(r.windowDays !== undefined ? { windowDays: r.windowDays } : {}),
+        ...(r.minSamples !== undefined ? { minSamples: r.minSamples } : {}),
+        ...(r.deprioritized !== undefined ? { deprioritized: r.deprioritized } : {}),
       })),
     });
   }

--- a/apps/cli/src/commands/find.ts
+++ b/apps/cli/src/commands/find.ts
@@ -116,6 +116,7 @@ export async function commandFindWatch(opts: {
   quiet: boolean;
   failOnEmpty?: boolean;
   json?: boolean;
+  ignoreApprovalRate?: boolean;
 }): Promise<void> {
   setJsonMode(opts.json ?? false);
   header(`find watch ${opts.once ? c.dim("(--once)") : c.dim("(daemon)")}`);
@@ -138,14 +139,17 @@ export async function commandFindWatch(opts: {
   let lastTick: TriggerRunOutcome[] = [];
   try {
     for (;;) {
-      const outcomes = await runDueTriggers();
+      const outcomes = await runDueTriggers({ ignoreApprovalRate: opts.ignoreApprovalRate });
       lastTick = outcomes;
       errored = 0;
       queued = 0;
       firedNames = [];
       for (const o of outcomes) {
         if (!o.fired) {
-          if (!opts.quiet) note(`${o.name}: skipped (next due in ${humanMs(o.nextDueInMs)})`);
+          if (!opts.quiet)
+            note(
+              `${o.name}: skipped${o.skippedReason ? ` (${o.skippedReason})` : ` (next due in ${humanMs(o.nextDueInMs)})`}`,
+            );
           continue;
         }
         firedNames.push(o.name);
@@ -186,6 +190,7 @@ export async function commandFindWatch(opts: {
         name: o.name,
         fired: o.fired,
         nextDueInMs: o.nextDueInMs,
+        ...(o.skippedReason ? { skippedReason: o.skippedReason } : {}),
         ...(o.duration_ms != null ? { durationMs: o.duration_ms } : {}),
         ...(o.error !== undefined ? { error: o.error } : {}),
         ...(o.result ? { result: jsonFinderResult(o.result) } : {}),

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -339,6 +339,11 @@ find
   .option("--quiet", "log summary only, not per-trigger details", false)
   .option("--json", "output as JSON (with --once)")
   .option(
+    "--ignore-approval-rate",
+    "run due finders even when their trailing approval rate is below threshold",
+    false,
+  )
+  .option(
     "--install-service",
     "print a launchd plist (macOS) / systemd user unit (Linux) that runs this daemon; doesn't start watching",
     false,
@@ -363,6 +368,7 @@ find
         write: boolean;
         failOnEmpty: boolean;
         json?: boolean;
+        ignoreApprovalRate: boolean;
       }) => {
         if (opts.json && opts.installService) bail("--json cannot be used with --install-service");
         if (opts.installService) return commandInstallService({ write: opts.write });
@@ -376,6 +382,7 @@ find
           once: opts.once,
           quiet: opts.quiet,
           failOnEmpty: opts.failOnEmpty,
+          ignoreApprovalRate: opts.ignoreApprovalRate,
           ...(opts.json ? { json: opts.json } : {}),
         });
       },

--- a/apps/server/src/api/triggers.ts
+++ b/apps/server/src/api/triggers.ts
@@ -3,6 +3,7 @@ import {
   checkReadiness,
   effectiveIntervalMs,
   fireTriggerNow,
+  finderApprovalHealth,
   getTriggerRunningSince,
   isTriggerRunning,
   storedTriggerConfig,
@@ -44,6 +45,17 @@ export function toView(
   const readiness: Readiness = spec
     ? checkReadiness(spec, config ?? spec.defaultConfig)
     : { ready: true };
+  const approval = spec
+    ? finderApprovalHealth(name, config ?? spec.defaultConfig)
+    : {
+        rate: null,
+        reviewed: 0,
+        minSamples: 10,
+        threshold: 0.2,
+        windowDays: 30,
+        deprioritized: false,
+        reason: null,
+      };
   return {
     name,
     enabled: row ? Boolean(row.enabled) : defaultEnabled,
@@ -57,6 +69,13 @@ export function toView(
     runningSince: runningSinceMs != null ? new Date(runningSinceMs).toISOString() : null,
     ready: readiness.ready,
     notReadyReason: readiness.ready ? null : readiness.reason,
+    approvalRate: approval.rate,
+    approvalReviewed: approval.reviewed,
+    approvalMinSamples: approval.minSamples,
+    approvalRateThreshold: approval.threshold,
+    approvalRateWindowDays: approval.windowDays,
+    deprioritized: approval.deprioritized,
+    deprioritizedReason: approval.reason,
   };
 }
 

--- a/apps/web/src/components/home/DoctorPanel.tsx
+++ b/apps/web/src/components/home/DoctorPanel.tsx
@@ -11,6 +11,7 @@ const GROUP_ORDER: Array<{ key: DoctorGroup; label: string }> = [
   { key: "install", label: "install" },
   { key: "senders", label: "senders" },
   { key: "deliverability", label: "deliverability" },
+  { key: "finders", label: "finders" },
   { key: "spend", label: "spend" },
 ];
 

--- a/apps/web/src/routes/queue.tsx
+++ b/apps/web/src/routes/queue.tsx
@@ -1478,6 +1478,7 @@ function TriggerRowFragment(props: TriggerRowProps) {
   // Missing `ready` field = treat as ready (tolerate older servers).
   const notReady = t.ready === false;
   const notReadyReason = t.notReadyReason ?? "missing required config";
+  const approvalBlocked = t.deprioritized === true;
   // Block enabling an unready trigger but still allow disabling.
   const toggleDisabled = props.setEnabledPending || (notReady && !t.enabled);
   const runDisabled = props.running || notReady;
@@ -1584,7 +1585,11 @@ function TriggerRowFragment(props: TriggerRowProps) {
                 : "text-ink-muted",
           )}
         >
-          {notReady ? `not ready · ${notReadyReason}` : props.summary}
+          {notReady
+            ? `not ready · ${notReadyReason}`
+            : approvalBlocked
+              ? `deprioritized · ${t.deprioritizedReason ?? "low-approval-rate"} · ${((t.approvalRate ?? 0) * 100).toFixed(0)}% (${t.approvalReviewed}/${t.approvalMinSamples} min)`
+              : props.summary}
         </td>
         <td className="px-6 py-2 text-right">
           <div className="flex items-center justify-end gap-1">

--- a/packages/core/__tests__/ledger-extra.test.ts
+++ b/packages/core/__tests__/ledger-extra.test.ts
@@ -97,6 +97,26 @@ describe("listReceipts filters", () => {
   });
 });
 
+describe("finderApprovalStats", () => {
+  it("counts reviewed source variants and treats sent as approved", () => {
+    const add = (key: string, source: string): number =>
+      ledger.enqueueTarget({ playName: "github-stars", payload: {}, dedupeKey: key, source })!;
+    const approved = add("a", "find:github-stars:owner/repo");
+    const sent = add("b", "find:github-stars:other/repo");
+    const rejected = add("c", "find:github-stars");
+    add("pending", "find:github-stars");
+    ledger.setQueueStatus({ id: approved, status: "approved" });
+    ledger.setQueueStatus({ id: sent, status: "sent" });
+    ledger.setQueueStatus({ id: rejected, status: "rejected" });
+
+    expect(ledger.finderApprovalStats({ finder: "github-stars", sinceIso: "2000-01-01" })).toEqual({
+      approved: 2,
+      reviewed: 3,
+      rate: 2 / 3,
+    });
+  });
+});
+
 describe("recordReceipt — cost handling", () => {
   // Post-SDK-0.15.2 + post-wrapper-cleanup: every wrapper in core/oneshot.ts
   // forwards `result.cost` as explicit costUsd. recordReceipt no longer

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -2777,6 +2777,34 @@ export class Ledger {
     return out;
   }
 
+  /** Reviewed queue outcomes for one finder inside a trailing time window. */
+  finderApprovalStats(input: { finder: string; sinceIso: string }): {
+    approved: number;
+    reviewed: number;
+    rate: number | null;
+  } {
+    // post-funding-auto predates the registry name and writes find:post-funding.
+    const sourceName = input.finder === "post-funding-auto" ? "post-funding" : input.finder;
+    const source = `find:${sourceName}`;
+    const row = this.db
+      .query(
+        `SELECT
+           SUM(CASE WHEN status IN ('approved','sent') THEN 1 ELSE 0 END) AS approved,
+           COUNT(*) AS reviewed
+         FROM target_queue
+         WHERE (source = ? OR source LIKE ?)
+           AND status IN ('approved','rejected','sent')
+           AND reviewed_at >= ?`,
+      )
+      .get(source, `${source}:%`, input.sinceIso) as {
+      approved: number | null;
+      reviewed: number;
+    };
+    const approved = row.approved ?? 0;
+    const reviewed = row.reviewed ?? 0;
+    return { approved, reviewed, rate: reviewed > 0 ? approved / reviewed : null };
+  }
+
   // ── runs (per-/run-page dispatch records) ──────────────────────────────────
   // One row per /run Execute click; the SSE endpoint persists events/counters,
   // the UI rebuilds progress from the row, and the cold-boot sweep flips

--- a/packages/doctor/__tests__/workspace-checks.test.ts
+++ b/packages/doctor/__tests__/workspace-checks.test.ts
@@ -71,7 +71,7 @@ describe("doctor workspace checks", () => {
 
   it("every check carries a valid group (the dashboard panel keys sections off it)", async () => {
     const checks = await runDoctor();
-    const valid = new Set(["install", "senders", "deliverability", "spend"]);
+    const valid = new Set(["install", "senders", "deliverability", "finders", "spend"]);
     for (const c of checks) {
       expect(valid.has(c.group), `check '${c.name}' has group '${c.group}'`).toBe(true);
     }

--- a/packages/doctor/package.json
+++ b/packages/doctor/package.json
@@ -13,6 +13,7 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "@oneshot-gtm/core": "workspace:*"
+    "@oneshot-gtm/core": "workspace:*",
+    "@oneshot-gtm/find": "workspace:*"
   }
 }

--- a/packages/doctor/src/check.ts
+++ b/packages/doctor/src/check.ts
@@ -24,11 +24,12 @@ import {
   listWorkspaces,
   loadGmailTokens,
 } from "@oneshot-gtm/core";
+import { finderApprovalHealth, storedTriggerConfig, TRIGGERS } from "@oneshot-gtm/find";
 
 type CheckSeverity = "ok" | "warn" | "fail";
 
 /** Section a check renders under in the dashboard's grouped Doctor panel. */
-type CheckGroup = "install" | "senders" | "deliverability" | "spend";
+type CheckGroup = "install" | "senders" | "deliverability" | "finders" | "spend";
 
 interface CheckResult {
   name: string;
@@ -36,6 +37,42 @@ interface CheckResult {
   severity: CheckSeverity;
   message: string;
   hint?: string;
+  approvalRate?: number | null;
+  approved?: number;
+  reviewed?: number;
+  threshold?: number;
+  windowDays?: number;
+  minSamples?: number;
+  deprioritized?: boolean;
+}
+
+function finderApprovalChecks(): CheckResult[] {
+  const ledger = getLedger();
+  return TRIGGERS.map((spec) => {
+    const health = finderApprovalHealth(
+      spec.name,
+      storedTriggerConfig(ledger.getTrigger(spec.name), spec),
+    );
+    const pct = health.rate == null ? "no reviewed rows" : `${(health.rate * 100).toFixed(1)}%`;
+    return {
+      name: `finder ${spec.name}`,
+      group: "finders",
+      severity: health.deprioritized ? "warn" : "ok",
+      message: health.sufficientData
+        ? `${pct} approved (${health.approved}/${health.reviewed}, ${health.windowDays}d)${health.deprioritized ? " — deprioritized: low-approval-rate" : ""}`
+        : `${pct} (${health.reviewed}/${health.minSamples} reviewed minimum) — insufficient data, no penalty`,
+      ...(health.deprioritized
+        ? { hint: "tune approvalRateThreshold in the trigger config or use --ignore-approval-rate" }
+        : {}),
+      approvalRate: health.rate,
+      approved: health.approved,
+      reviewed: health.reviewed,
+      threshold: health.threshold,
+      windowDays: health.windowDays,
+      minSamples: health.minSamples,
+      deprioritized: health.deprioritized,
+    };
+  });
 }
 
 /** Trailing window for the bounce rate — long enough to accumulate signal at founder-scale volume. */
@@ -775,6 +812,16 @@ export async function runDoctor(): Promise<CheckResult[]> {
   // the "never tested" prompt.
   results.push(...deliverabilityChecks());
   results.push(placementCheck());
+  try {
+    results.push(...finderApprovalChecks());
+  } catch (err) {
+    results.push({
+      name: "finder approval rates",
+      group: "finders",
+      severity: "warn",
+      message: `could not evaluate: ${(err as Error).message}`,
+    });
+  }
 
   if (oneshotEnvReady()) {
     try {

--- a/packages/find/__tests__/registry-claim.test.ts
+++ b/packages/find/__tests__/registry-claim.test.ts
@@ -44,6 +44,7 @@ vi.mock("@oneshot-gtm/core", async () => {
       updateTriggerLastPoll: (input: { name: string }) => {
         calls.updateTriggerLastPoll.push(input.name);
       },
+      finderApprovalStats: () => ({ approved: 0, reviewed: 0, rate: null }),
       // Methods downstream finders might call — only invoked on claim success,
       // which we deliberately disable in these tests, so no-op stubs suffice.
       isQueueDuplicate: () => false,

--- a/packages/find/__tests__/registry.test.ts
+++ b/packages/find/__tests__/registry.test.ts
@@ -2,6 +2,7 @@ import type { TriggerRow } from "@oneshot-gtm/core";
 import { describe, expect, it } from "vitest";
 import {
   checkReadiness,
+  evaluateFinderApprovalHealth,
   effectiveIntervalMs,
   freshRunningStartedAtMs,
   MAX_RUN_AGE_MS,
@@ -11,6 +12,36 @@ import {
   type TriggerRunOutcome,
   type TriggerSpec,
 } from "../src/registry.ts";
+
+describe("finder approval health", () => {
+  it("does not deprioritize at the threshold boundary, only below it", () => {
+    expect(
+      evaluateFinderApprovalHealth({ approved: 2, reviewed: 10, threshold: 0.2, minSamples: 10 })
+        .deprioritized,
+    ).toBe(false);
+    const below = evaluateFinderApprovalHealth({
+      approved: 1,
+      reviewed: 10,
+      threshold: 0.2,
+      minSamples: 10,
+    });
+    expect(below.deprioritized).toBe(true);
+    expect(below.reason).toBe("low-approval-rate");
+  });
+
+  it("applies no penalty when reviewed data is insufficient", () => {
+    const health = evaluateFinderApprovalHealth({
+      approved: 0,
+      reviewed: 9,
+      threshold: 0.2,
+      minSamples: 10,
+    });
+    expect(health.rate).toBe(0);
+    expect(health.sufficientData).toBe(false);
+    expect(health.deprioritized).toBe(false);
+    expect(health.reason).toBeNull();
+  });
+});
 
 describe("nextSleepMs", () => {
   it("defaults to 1h when there are no outcomes", () => {

--- a/packages/find/src/registry.ts
+++ b/packages/find/src/registry.ts
@@ -602,6 +602,74 @@ export interface TriggerRunOutcome {
   duration_ms?: number;
   /** ms until this trigger is next due */
   nextDueInMs: number;
+  /** Named scheduler skip reason (disabled/not-due remain unnamed). */
+  skippedReason?: string;
+}
+
+export const DEFAULT_APPROVAL_RATE_THRESHOLD = 0.2;
+export const DEFAULT_APPROVAL_RATE_WINDOW_DAYS = 30;
+export const DEFAULT_APPROVAL_RATE_MIN_SAMPLES = 10;
+
+export interface FinderApprovalHealth {
+  approved: number;
+  reviewed: number;
+  rate: number | null;
+  threshold: number;
+  windowDays: number;
+  minSamples: number;
+  sufficientData: boolean;
+  deprioritized: boolean;
+  reason: string | null;
+}
+
+/** Pure boundary logic shared by scheduler, API, doctor, and tests. */
+export function evaluateFinderApprovalHealth(input: {
+  approved: number;
+  reviewed: number;
+  threshold?: number;
+  windowDays?: number;
+  minSamples?: number;
+}): FinderApprovalHealth {
+  const threshold = input.threshold ?? DEFAULT_APPROVAL_RATE_THRESHOLD;
+  const windowDays = input.windowDays ?? DEFAULT_APPROVAL_RATE_WINDOW_DAYS;
+  const minSamples = input.minSamples ?? DEFAULT_APPROVAL_RATE_MIN_SAMPLES;
+  const rate = input.reviewed > 0 ? input.approved / input.reviewed : null;
+  const sufficientData = input.reviewed >= minSamples;
+  const deprioritized = sufficientData && rate !== null && rate < threshold;
+  return {
+    ...input,
+    rate,
+    threshold,
+    windowDays,
+    minSamples,
+    sufficientData,
+    deprioritized,
+    reason: deprioritized ? "low-approval-rate" : null,
+  };
+}
+
+export function finderApprovalHealth(
+  name: string,
+  config: Record<string, unknown>,
+): FinderApprovalHealth {
+  const numberOr = (key: string, fallback: number): number => {
+    const value = config[key];
+    return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : fallback;
+  };
+  const threshold = Math.min(1, numberOr("approvalRateThreshold", DEFAULT_APPROVAL_RATE_THRESHOLD));
+  const windowDays = Math.max(
+    1,
+    numberOr("approvalRateWindowDays", DEFAULT_APPROVAL_RATE_WINDOW_DAYS),
+  );
+  const minSamples = Math.max(
+    1,
+    Math.floor(numberOr("approvalRateMinSamples", DEFAULT_APPROVAL_RATE_MIN_SAMPLES)),
+  );
+  const stats = getLedger().finderApprovalStats({
+    finder: name,
+    sinceIso: new Date(Date.now() - windowDays * 86_400_000).toISOString(),
+  });
+  return evaluateFinderApprovalHealth({ ...stats, threshold, windowDays, minSamples });
 }
 
 /**
@@ -784,7 +852,9 @@ export async function runTriggerNow(name: string): Promise<TriggerRunOutcome> {
  * Run every registered trigger that's due. Persists last_polled_at + last_run_summary.
  * Returns one outcome per trigger so the caller can log + decide sleep duration.
  */
-export async function runDueTriggers(): Promise<TriggerRunOutcome[]> {
+export async function runDueTriggers(
+  options: { ignoreApprovalRate?: boolean } = {},
+): Promise<TriggerRunOutcome[]> {
   startRun();
   const ledger = getLedger();
   const now = Date.now();
@@ -815,11 +885,35 @@ export async function runDueTriggers(): Promise<TriggerRunOutcome[]> {
     // picked up on the next tick, not the next interval boundary.
     const readiness = checkReadiness(spec, config);
     if (!readiness.ready) {
-      outcomes.push({ name: spec.name, fired: false, nextDueInMs: intervalMs });
+      outcomes.push({
+        name: spec.name,
+        fired: false,
+        nextDueInMs: intervalMs,
+        skippedReason: readiness.reason,
+      });
       logEvent("trigger.run.skipped", {
         name: spec.name,
         source: "watch",
         reason: readiness.reason,
+      });
+      continue;
+    }
+
+    const approval = finderApprovalHealth(spec.name, config);
+    if (approval.deprioritized && !options.ignoreApprovalRate) {
+      outcomes.push({
+        name: spec.name,
+        fired: false,
+        nextDueInMs: intervalMs,
+        skippedReason: approval.reason ?? "low-approval-rate",
+      });
+      logEvent("trigger.run.skipped", {
+        name: spec.name,
+        source: "watch",
+        reason: approval.reason,
+        approval_rate: approval.rate,
+        reviewed: approval.reviewed,
+        threshold: approval.threshold,
       });
       continue;
     }

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -226,7 +226,7 @@ export type WalletMode = "cdp" | "private-key";
 export type KeySource = "env" | "file" | null;
 
 /** Section a doctor check renders under in the dashboard's grouped panel. */
-export type DoctorGroup = "install" | "senders" | "deliverability" | "spend";
+export type DoctorGroup = "install" | "senders" | "deliverability" | "finders" | "spend";
 
 export interface DoctorCheck {
   name: string;
@@ -235,6 +235,13 @@ export interface DoctorCheck {
   severity: "ok" | "warn" | "fail";
   message: string;
   hint?: string;
+  approvalRate?: number | null;
+  approved?: number;
+  reviewed?: number;
+  threshold?: number;
+  windowDays?: number;
+  minSamples?: number;
+  deprioritized?: boolean;
 }
 
 export interface SetupRequest {
@@ -778,6 +785,13 @@ export interface TriggerView {
   ready: boolean;
   /** Human-readable reason when `ready === false`; null otherwise. */
   notReadyReason: string | null;
+  approvalRate: number | null;
+  approvalReviewed: number;
+  approvalMinSamples: number;
+  approvalRateThreshold: number;
+  approvalRateWindowDays: number;
+  deprioritized: boolean;
+  deprioritizedReason: string | null;
 }
 
 export interface DeriveIcpResult {


### PR DESCRIPTION
Closes #361.

Implements per-source approval-rate weighting so noisy finders are automatically deprioritized. Touches `packages/find/src/registry.ts` (weighting + claim), `packages/core/src/ledger.ts`, `packages/doctor/src/check.ts`, `packages/shared-types`, CLI/web surfaces, with tests.

**Verification (loop-doctor / codex):** full gate run green on this HEAD — `bun run test` 173 files / 2262 tests pass, `bun run typecheck` clean, `bun run lint` clean (pre-existing warnings only), `bun run fmt:check` clean.

**Why opened by hand:** the card was created off-convention on `ai/gtm/issue-361-retry`; dev-runner's egress only routes `ai/<board>/issue-<n>` branches, so it could not group/review/PR this one. Work re-homed onto the canonical `ai/gtm/issue-361`. Squash-merge recommended (single implementer commit).

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Deprioritize noisy finders by approval rate in `runDueTriggers` scheduler
> - Introduces per-source approval-rate weighting. The `runDueTriggers` scheduler skips triggers for finders with an approval rate below a threshold.
> - Adds `Ledger.finderApprovalStats` to aggregate approved and reviewed counts over a trailing window, and `evaluateFinderApprovalHealth` to compute health metrics.
> - Exposes approval metrics in `TriggerView` and `DoctorCheck`. The Doctor panel and queue page display deprioritization status and metrics.
> - Behavioral Change: `runDueTriggers` now skips low-approval triggers by default. Use `--ignore-approval-rate` to override. Outcomes include `skippedReason`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7ca1beb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->