### PR TITLE
fix: issue #397: Fix 1 shipped review finding(s) from merged PR #389

### DIFF
--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -2578,6 +2578,13 @@ export class Ledger {
     return result.changes > 0;
   }
 
+  removeExpiredQueueTarget(id: number): boolean {
+    const result = this.db
+      .prepare("DELETE FROM target_queue WHERE id = ? AND status = 'expired'")
+      .run(id);
+    return result.changes > 0;
+  }
+
   setQueueStatus(input: { id: number; status: QueueStatus; notes?: string }): void {
     const now = new Date().toISOString();
     // Every status transition clears `send_started_at` — a deliberate status

--- a/packages/find/__tests__/csv-import.test.ts
+++ b/packages/find/__tests__/csv-import.test.ts
@@ -38,6 +38,10 @@ const ledger = {
     if (queue[id - 1]?.status !== "pending") return false;
     return queue.splice(id - 1, 1).length > 0;
   },
+  removeExpiredQueueTarget: (id: number) => {
+    if (queue[id - 1]?.status !== "expired") return false;
+    return queue.splice(id - 1, 1).length > 0;
+  },
   setQueueNotes: () => {},
 };
 

--- a/packages/find/src/csv-import.ts
+++ b/packages/find/src/csv-import.ts
@@ -210,11 +210,7 @@ export async function importCsv(input: {
   const icp = resolveIcp();
   const ledger = getLedger();
   const removeReservation = (id: number): void => {
-    // Reservations are inserted as expired so bulk approval cannot pick them
-    // up while classification is running. Restore the unreviewed state before
-    // using the ledger's guarded reservation cleanup.
-    ledger.setQueueStatus({ id, status: "pending" });
-    ledger.removePendingQueueTarget(id);
+    ledger.removeExpiredQueueTarget(id);
   };
   for (const candidate of unique) {
     const dedupeKey = `email:${candidate.email}`;


### PR DESCRIPTION
Closes #397.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 072d7da048fc (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix CSV import reservation cleanup to delete `expired` rows directly
> - Adds `Ledger.removeExpiredQueueTarget` which deletes a `target_queue` row by id only when its status is `expired`, returning true if removed
> - Changes `importCsv` reservation cleanup to call `removeExpiredQueueTarget(id)` instead of first transitioning the row from `expired` to `pending` and then calling `removePendingQueueTarget`
> - Updates the in-test ledger mock in [csv-import.test.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/399/files#diff-8ec74433057053654fd65c299ea7d5b7f5fa840d15a9f0f019bab30e63102aca) to match production behavior
> - Behavioral Change: `importCsv` no longer performs an intermediate status change to `pending` before removing expired queue reservations
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 91465bc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->