### PR TITLE
fix: issue #360: feat(measure): `measure benchmark` — opt-in cohort comparison from the live telemetry table

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ bun run cli -- find drain podcast-guest --dry-run  # preview approved /queue row
 bun run cli -- cadence advance                     # daily tick: poll inbox, fire follow-ups
 ```
 
-51 commands — thirteen groups, plus `init`, `doctor` and `ui` at the top level. `bun run cli -- --help` (or `oneshot-gtm --help` once linked) is the reference:
+52 commands — fourteen groups, plus `init`, `doctor` and `ui` at the top level. `bun run cli -- --help` (or `oneshot-gtm --help` once linked) is the reference:
 
 | Group                    | Commands                                                                                                                                                                                                                                    |
 | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -94,12 +94,13 @@ bun run cli -- cadence advance                     # daily tick: poll inbox, fir
 | `motion`                 | `post-funding` `concierge` `demo-no-show` `competitor-switch` `hiring-signal` `podcast-guest` — each takes `--target <file>`; `breakup-revive` reads the ledger                                                                             |
 | `cadence`                | `advance` — poll inbound, fire due steps                                                                                                                                                                                                    |
 | `discover`               | `icp interview-prep` · `icp synthesize` · `pmf classify` · `pmf survey` · `pmf survey-collect`                                                                                                                                              |
+| `measure`                | `benchmark` — compare this install's command activity with the opt-in telemetry cohort; supports `--json`                                                                                                                                   |
 | `intel`                  | `advise` · `personalize` · `triage-replies` · `weekly-review`                                                                                                                                                                               |
 | `handoff`                | `readiness` · `templatize` · `first-ae`                                                                                                                                                                                                     |
 | `demo`                   | `seed` · `ui` · `reset` — a fictional install for screenshots and video                                                                                                                                                                     |
 | `workspace`              | `list` · `create <name>` · `use <name>` · `current` · `path <name>` · `remove <name>` — one isolated install per product; `--workspace <name>` on any command                                                                               |
 
-Spend, CAC, RoCS and outcome logging deliberately have no CLI group — they live on the dashboard's Measure and Cadences pages so there's one source of truth. The `/api/measure/*` routes are there if you'd rather script them, or add `--json` to a read-only command (`doctor`, `identities list`, `domains list`, `workspace list`) for machine-readable output.
+Spend, CAC, RoCS and outcome logging remain in the dashboard's Measure and Cadences pages so there's one source of truth. The CLI's `measure benchmark` surface is limited to anonymous telemetry comparisons. The `/api/measure/*` routes are there if you'd rather script local ledger metrics, or add `--json` to a read-only command for machine-readable output.
 
 ### Dashboard
 
@@ -313,7 +314,7 @@ Add a OneShot domain and mailbox from `/setup` or `identities add` — pick a pr
 
 ```
 apps/
-  cli/        51-command CLI (commander); src/demo/ seeds the demo install, src/main.ts picks the workspace
+  cli/        52-command CLI (commander); src/demo/ seeds the demo install, src/main.ts picks the workspace
   server/     Bun.serve + SSE; tsdown bundle published as `oneshot-gtm-server`
   web/        Vite + React 19 + TanStack + Base UI — 9 pages, run form, strategist dock, privacy mode
 packages/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,7 +57,7 @@ The ICP filter currently judges each candidate cold — `icpFilter` in `packages
 
 ## Measurement
 
-- [ ] **`measure benchmark`** — opt-in cohort comparisons. Unblocked: the telemetry endpoint is live.
+- [x] **`measure benchmark`** — opt-in cohort comparisons, with human and versioned JSON output. The command does not contact the aggregate endpoint when telemetry sharing is disabled.
 - [ ] **Public benchmarks page** reading aggregates from the telemetry table. The pipeline exists; this is the surface.
 
 ## Integrations

--- a/TELEMETRY.md
+++ b/TELEMETRY.md
@@ -40,6 +40,8 @@ To point the CLI at a different ingest endpoint (e.g. a local receiver while dev
 
 Sent to a single first-party endpoint owned by OneShot (`telemetry.oneshotagent.com`), which validates the payload against the whitelist above and stores one row per event. No third-party analytics SDK is bundled in the CLI — it's a plain `fetch` POST, so there's no vendor phoning home from your machine. Aggregated and used to prioritize the public roadmap. Never sold, never shared with third parties.
 
+`oneshot-gtm measure benchmark` reads those aggregates only when telemetry sharing is enabled. It sends the existing anonymous install UUID as a query parameter so the service can return that install's command count, success rate, and median duration beside the opt-in cohort. No additional telemetry fields are collected. Set `ONESHOT_GTM_BENCHMARK_URL` to override the aggregate endpoint in development.
+
 This file is the authoritative spec. If telemetry is ever extended, this file is updated in the same PR — the client (`packages/core/src/telemetry.ts`) and the first-party receiver carry the same field whitelist deliberately, and must move together. (This is a maintainer convention; it is not yet enforced by CI.)
 
 ## Local development log (separate from telemetry)

--- a/apps/cli/__tests__/measure-benchmark.test.ts
+++ b/apps/cli/__tests__/measure-benchmark.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+let telemetryEnabled = true;
+let clientId: string | null = "install-123";
+
+vi.mock("@oneshot-gtm/core", () => ({
+  loadConfig: () => ({ telemetryEnabled, clientId }),
+  shouldSendTelemetry: (cfg: { telemetryEnabled: boolean }, env: NodeJS.ProcessEnv) =>
+    cfg.telemetryEnabled && env["ONESHOT_GTM_TELEMETRY"] !== "0",
+  telemetryUrl: () => "https://telemetry.oneshotagent.com/v1/cli",
+}));
+
+const { commandMeasureBenchmark } = await import("../src/commands/measure.ts");
+const { setJsonMode } = await import("../src/output.ts");
+
+const aggregate = {
+  cohortSize: 42,
+  local: { commandsRun: 18, successRate: 0.75, medianDurationMs: 980 },
+  cohort: { commandsRun: 12, successRate: 0.625, medianDurationMs: 1200 },
+};
+
+let stdout: string[];
+let stdoutSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  telemetryEnabled = true;
+  clientId = "install-123";
+  stdout = [];
+  stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    stdout.push(String(chunk));
+    return true;
+  });
+});
+
+afterEach(() => {
+  stdoutSpy.mockRestore();
+  setJsonMode(false);
+  vi.unstubAllGlobals();
+});
+
+describe("measure benchmark", () => {
+  it("renders the opted-in install against the cohort", async () => {
+    const fetchMock = vi.fn(
+      async (_input: URL) =>
+        new Response(JSON.stringify(aggregate), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await commandMeasureBenchmark({}, {});
+
+    const output = stdout.join("");
+    expect(output).toContain("Your install vs 42 opted-in installs");
+    expect(output).toContain("commands run");
+    expect(output).toContain("18");
+    expect(output).toContain("75.0%");
+    expect(output).toContain("980 ms");
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(String(fetchMock.mock.calls[0]![0])).toContain("anonymous_machine_id=install-123");
+  });
+
+  it("does not read aggregates and clearly explains when telemetry is opted out", async () => {
+    telemetryEnabled = false;
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+
+    await commandMeasureBenchmark({}, {});
+
+    expect(stdout.join("")).toContain("Telemetry sharing is disabled");
+    expect(stdout.join("")).toContain("config telemetry on");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["empty", {}],
+    ["malformed", { cohortSize: 3, local: null, cohort: { successRate: "lots" } }],
+  ])("handles an %s aggregate response", async (_name, body) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify(body), { status: 200 })),
+    );
+
+    await commandMeasureBenchmark({}, {});
+
+    expect(stdout.join("")).toContain("Benchmark data is unavailable");
+  });
+
+  it("emits the stable JSON shape", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(JSON.stringify(aggregate), { status: 200 })),
+    );
+
+    await commandMeasureBenchmark({ json: true }, {});
+
+    expect(JSON.parse(stdout.join(""))).toEqual({
+      schemaVersion: 1,
+      command: "measure benchmark",
+      status: "ok",
+      ...aggregate,
+    });
+  });
+});

--- a/apps/cli/src/commands/measure.ts
+++ b/apps/cli/src/commands/measure.ts
@@ -121,8 +121,17 @@ export async function commandMeasureBenchmark(
     if (endpoint && cfg.clientId) {
       const url = new URL(endpoint);
       url.searchParams.set("anonymous_machine_id", cfg.clientId);
-      const response = await fetch(url, { headers: { accept: "application/json" } });
-      if (response.ok) aggregate = parseBenchmarkAggregate(await response.json());
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 10000);
+      try {
+        const response = await fetch(url, {
+          headers: { accept: "application/json" },
+          signal: controller.signal,
+        });
+        if (response.ok) aggregate = parseBenchmarkAggregate(await response.json());
+      } finally {
+        clearTimeout(timeoutId);
+      }
     }
   } catch {
     // The comparison is informational; a bad aggregate must not crash the CLI.

--- a/apps/cli/src/commands/measure.ts
+++ b/apps/cli/src/commands/measure.ts
@@ -1,0 +1,142 @@
+import { loadConfig, shouldSendTelemetry, telemetryUrl } from "@oneshot-gtm/core";
+import { emitJson, header, note, setJsonMode, warn } from "../output.ts";
+
+export interface BenchmarkMetrics {
+  commandsRun: number;
+  successRate: number;
+  medianDurationMs: number;
+}
+
+export interface BenchmarkAggregate {
+  cohortSize: number;
+  local: BenchmarkMetrics;
+  cohort: BenchmarkMetrics;
+}
+
+type BenchmarkStatus = "ok" | "opted-out" | "unavailable";
+
+/** The aggregate reader lives beside the telemetry ingest route. */
+export function benchmarkUrl(env: NodeJS.ProcessEnv = process.env): string {
+  const override = env["ONESHOT_GTM_BENCHMARK_URL"];
+  if (override !== undefined) return override.trim();
+  const ingest = telemetryUrl(env);
+  if (!ingest) return "";
+  try {
+    const url = new URL(ingest);
+    url.pathname = url.pathname.replace(/\/cli\/?$/, "/benchmark");
+    url.search = "";
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return "";
+  }
+}
+
+function finiteNonNegative(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0;
+}
+
+function metrics(value: unknown): BenchmarkMetrics | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const row = value as Record<string, unknown>;
+  if (
+    !finiteNonNegative(row["commandsRun"]) ||
+    !finiteNonNegative(row["successRate"]) ||
+    row["successRate"] > 1 ||
+    !finiteNonNegative(row["medianDurationMs"])
+  ) {
+    return null;
+  }
+  return {
+    commandsRun: row["commandsRun"],
+    successRate: row["successRate"],
+    medianDurationMs: row["medianDurationMs"],
+  };
+}
+
+/** Validate the public aggregate response before using it in terminal output. */
+export function parseBenchmarkAggregate(value: unknown): BenchmarkAggregate | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const row = value as Record<string, unknown>;
+  const local = metrics(row["local"]);
+  const cohort = metrics(row["cohort"]);
+  if (!Number.isInteger(row["cohortSize"]) || !finiteNonNegative(row["cohortSize"])) return null;
+  if (!local || !cohort || row["cohortSize"] === 0) return null;
+  return { cohortSize: row["cohortSize"], local, cohort };
+}
+
+function renderMetric(label: string, local: string, cohort: string): void {
+  note(`  ${label.padEnd(20)} ${local.padStart(10)}   cohort ${cohort.padStart(10)}`);
+}
+
+function renderBenchmark(aggregate: BenchmarkAggregate): void {
+  header("measure · benchmark");
+  note(`Your install vs ${aggregate.cohortSize.toLocaleString()} opted-in installs\n`);
+  renderMetric(
+    "commands run",
+    aggregate.local.commandsRun.toLocaleString(),
+    aggregate.cohort.commandsRun.toLocaleString(),
+  );
+  renderMetric(
+    "success rate",
+    `${(aggregate.local.successRate * 100).toFixed(1)}%`,
+    `${(aggregate.cohort.successRate * 100).toFixed(1)}%`,
+  );
+  renderMetric(
+    "median duration",
+    `${Math.round(aggregate.local.medianDurationMs)} ms`,
+    `${Math.round(aggregate.cohort.medianDurationMs)} ms`,
+  );
+}
+
+function emitBenchmarkJson(status: BenchmarkStatus, aggregate?: BenchmarkAggregate): void {
+  emitJson({
+    command: "measure benchmark",
+    status,
+    ...(aggregate ? aggregate : {}),
+  });
+}
+
+export async function commandMeasureBenchmark(
+  opts: { json?: boolean } = {},
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  if (opts.json) setJsonMode(true);
+  const cfg = loadConfig();
+
+  if (!shouldSendTelemetry(cfg, env)) {
+    if (opts.json) emitBenchmarkJson("opted-out");
+    else {
+      header("measure · benchmark");
+      note(
+        "Telemetry sharing is disabled, so this install is not included in the opt-in cohort. Enable it with `oneshot-gtm config telemetry on` to view benchmarks.",
+      );
+    }
+    return;
+  }
+
+  const endpoint = benchmarkUrl(env);
+  let aggregate: BenchmarkAggregate | null = null;
+  try {
+    if (endpoint && cfg.clientId) {
+      const url = new URL(endpoint);
+      url.searchParams.set("anonymous_machine_id", cfg.clientId);
+      const response = await fetch(url, { headers: { accept: "application/json" } });
+      if (response.ok) aggregate = parseBenchmarkAggregate(await response.json());
+    }
+  } catch {
+    // The comparison is informational; a bad aggregate must not crash the CLI.
+  }
+
+  if (!aggregate) {
+    if (opts.json) emitBenchmarkJson("unavailable");
+    else {
+      header("measure · benchmark");
+      warn("Benchmark data is unavailable. The cohort may still be warming up; try again later.");
+    }
+    return;
+  }
+
+  if (opts.json) emitBenchmarkJson("ok", aggregate);
+  else renderBenchmark(aggregate);
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -66,6 +66,7 @@ import { commandEnrichLinkedIn } from "./commands/enrich-linkedin.ts";
 import { commandResearchProspects } from "./commands/research-prospects.ts";
 import { commandFindDrain, commandFindImport, commandFindWatch } from "./commands/find.ts";
 import { commandInstallService } from "./commands/install-service.ts";
+import { commandMeasureBenchmark } from "./commands/measure.ts";
 import {
   commandMotionBreakupRevive,
   commandMotionCompetitorSwitch,
@@ -719,6 +720,13 @@ pmf
   .option("-o, --out <path>", "write analysis markdown to this file")
   .description("Collect inbound replies and synthesize a Sean Ellis report")
   .action(runOrFail(commandPmfSurveyCollect));
+
+const measure = program.command("measure").description("Compare local GTM performance");
+measure
+  .command("benchmark")
+  .description("Compare this install with the opt-in telemetry cohort")
+  .option("--json", "output as JSON")
+  .action(runOrFail((opts: { json?: boolean }) => commandMeasureBenchmark(opts)));
 
 // Intel: interactive coaching + reply triage + personalize (no UI yet)
 const intel = program.command("intel").description("LLM-powered intelligence layer");

--- a/review-prompt.txt
+++ b/review-prompt.txt
@@ -1,0 +1,1 @@
+Review the diff against main. Report defects by file and line: logic errors, unhandled error paths, tests that assert nothing, unrequested scope, secrets or credentials, unbounded loops or retries. State whether each of the implementer's own numeric claims holds. Do not edit anything.

--- a/review.patch
+++ b/review.patch
@@ -1,0 +1,348 @@
+diff --git a/README.md b/README.md
+index e81b3c0..e9b6d5b 100644
+--- a/README.md
++++ b/README.md
+@@ -80,7 +80,7 @@ bun run cli -- find drain podcast-guest --dry-run  # preview approved /queue row
+ bun run cli -- cadence advance                     # daily tick: poll inbox, fire follow-ups
+ ```
+ 
+-51 commands — thirteen groups, plus `init`, `doctor` and `ui` at the top level. `bun run cli -- --help` (or `oneshot-gtm --help` once linked) is the reference:
++52 commands — fourteen groups, plus `init`, `doctor` and `ui` at the top level. `bun run cli -- --help` (or `oneshot-gtm --help` once linked) is the reference:
+ 
+ | Group                    | Commands                                                                                                                                                                                                                                    |
+ | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+@@ -94,12 +94,13 @@ bun run cli -- cadence advance                     # daily tick: poll inbox, fir
+ | `motion`                 | `post-funding` `concierge` `demo-no-show` `competitor-switch` `hiring-signal` `podcast-guest` — each takes `--target <file>`; `breakup-revive` reads the ledger                                                                             |
+ | `cadence`                | `advance` — poll inbound, fire due steps                                                                                                                                                                                                    |
+ | `discover`               | `icp interview-prep` · `icp synthesize` · `pmf classify` · `pmf survey` · `pmf survey-collect`                                                                                                                                              |
++| `measure`                | `benchmark` — compare this install's command activity with the opt-in telemetry cohort; supports `--json`                                                                                                                                   |
+ | `intel`                  | `advise` · `personalize` · `triage-replies` · `weekly-review`                                                                                                                                                                               |
+ | `handoff`                | `readiness` · `templatize` · `first-ae`                                                                                                                                                                                                     |
+ | `demo`                   | `seed` · `ui` · `reset` — a fictional install for screenshots and video                                                                                                                                                                     |
+ | `workspace`              | `list` · `create <name>` · `use <name>` · `current` · `path <name>` · `remove <name>` — one isolated install per product; `--workspace <name>` on any command                                                                               |
+ 
+-Spend, CAC, RoCS and outcome logging deliberately have no CLI group — they live on the dashboard's Measure and Cadences pages so there's one source of truth. The `/api/measure/*` routes are there if you'd rather script them, or add `--json` to a read-only command (`doctor`, `identities list`) for machine-readable output.
++Spend, CAC, RoCS and outcome logging remain in the dashboard's Measure and Cadences pages so there's one source of truth. The CLI's `measure benchmark` surface is limited to anonymous telemetry comparisons. The `/api/measure/*` routes are there if you'd rather script local ledger metrics, or add `--json` to a read-only command for machine-readable output.
+ 
+ ### Dashboard
+ 
+@@ -313,7 +314,7 @@ Add a OneShot domain and mailbox from `/setup` or `identities add` — pick a pr
+ 
+ ```
+ apps/
+-  cli/        51-command CLI (commander); src/demo/ seeds the demo install, src/main.ts picks the workspace
++  cli/        52-command CLI (commander); src/demo/ seeds the demo install, src/main.ts picks the workspace
+   server/     Bun.serve + SSE; tsdown bundle published as `oneshot-gtm-server`
+   web/        Vite + React 19 + TanStack + Base UI — 9 pages, run form, strategist dock, privacy mode
+ packages/
+diff --git a/ROADMAP.md b/ROADMAP.md
+index 8e27b17..0867845 100644
+--- a/ROADMAP.md
++++ b/ROADMAP.md
+@@ -57,7 +57,7 @@ The ICP filter currently judges each candidate cold — `icpFilter` in `packages
+ 
+ ## Measurement
+ 
+-- [ ] **`measure benchmark`** — opt-in cohort comparisons. Unblocked: the telemetry endpoint is live.
++- [x] **`measure benchmark`** — opt-in cohort comparisons, with human and versioned JSON output. The command does not contact the aggregate endpoint when telemetry sharing is disabled.
+ - [ ] **Public benchmarks page** reading aggregates from the telemetry table. The pipeline exists; this is the surface.
+ 
+ ## Integrations
+diff --git a/TELEMETRY.md b/TELEMETRY.md
+index 9938faf..71faee0 100644
+--- a/TELEMETRY.md
++++ b/TELEMETRY.md
+@@ -40,6 +40,8 @@ To point the CLI at a different ingest endpoint (e.g. a local receiver while dev
+ 
+ Sent to a single first-party endpoint owned by OneShot (`telemetry.oneshotagent.com`), which validates the payload against the whitelist above and stores one row per event. No third-party analytics SDK is bundled in the CLI — it's a plain `fetch` POST, so there's no vendor phoning home from your machine. Aggregated and used to prioritize the public roadmap. Never sold, never shared with third parties.
+ 
++`oneshot-gtm measure benchmark` reads those aggregates only when telemetry sharing is enabled. It sends the existing anonymous install UUID as a query parameter so the service can return that install's command count, success rate, and median duration beside the opt-in cohort. No additional telemetry fields are collected. Set `ONESHOT_GTM_BENCHMARK_URL` to override the aggregate endpoint in development.
++
+ This file is the authoritative spec. If telemetry is ever extended, this file is updated in the same PR — the client (`packages/core/src/telemetry.ts`) and the first-party receiver carry the same field whitelist deliberately, and must move together. (This is a maintainer convention; it is not yet enforced by CI.)
+ 
+ ## Local development log (separate from telemetry)
+diff --git a/apps/cli/__tests__/measure-benchmark.test.ts b/apps/cli/__tests__/measure-benchmark.test.ts
+new file mode 100644
+index 0000000..038616a
+--- /dev/null
++++ b/apps/cli/__tests__/measure-benchmark.test.ts
+@@ -0,0 +1,105 @@
++import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
++
++let telemetryEnabled = true;
++let clientId: string | null = "install-123";
++
++vi.mock("@oneshot-gtm/core", () => ({
++  loadConfig: () => ({ telemetryEnabled, clientId }),
++  shouldSendTelemetry: (cfg: { telemetryEnabled: boolean }, env: NodeJS.ProcessEnv) =>
++    cfg.telemetryEnabled && env["ONESHOT_GTM_TELEMETRY"] !== "0",
++  telemetryUrl: () => "https://telemetry.oneshotagent.com/v1/cli",
++}));
++
++const { commandMeasureBenchmark } = await import("../src/commands/measure.ts");
++const { setJsonMode } = await import("../src/output.ts");
++
++const aggregate = {
++  cohortSize: 42,
++  local: { commandsRun: 18, successRate: 0.75, medianDurationMs: 980 },
++  cohort: { commandsRun: 12, successRate: 0.625, medianDurationMs: 1200 },
++};
++
++let stdout: string[];
++let stdoutSpy: ReturnType<typeof vi.spyOn>;
++
++beforeEach(() => {
++  telemetryEnabled = true;
++  clientId = "install-123";
++  stdout = [];
++  stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
++    stdout.push(String(chunk));
++    return true;
++  });
++});
++
++afterEach(() => {
++  stdoutSpy.mockRestore();
++  setJsonMode(false);
++  vi.unstubAllGlobals();
++});
++
++describe("measure benchmark", () => {
++  it("renders the opted-in install against the cohort", async () => {
++    const fetchMock = vi.fn(
++      async (_input: URL) =>
++        new Response(JSON.stringify(aggregate), {
++          status: 200,
++          headers: { "content-type": "application/json" },
++        }),
++    );
++    vi.stubGlobal("fetch", fetchMock);
++
++    await commandMeasureBenchmark({}, {});
++
++    const output = stdout.join("");
++    expect(output).toContain("Your install vs 42 opted-in installs");
++    expect(output).toContain("commands run");
++    expect(output).toContain("18");
++    expect(output).toContain("75.0%");
++    expect(output).toContain("980 ms");
++    expect(fetchMock).toHaveBeenCalledOnce();
++    expect(String(fetchMock.mock.calls[0]![0])).toContain("anonymous_machine_id=install-123");
++  });
++
++  it("does not read aggregates and clearly explains when telemetry is opted out", async () => {
++    telemetryEnabled = false;
++    const fetchMock = vi.fn();
++    vi.stubGlobal("fetch", fetchMock);
++
++    await commandMeasureBenchmark({}, {});
++
++    expect(stdout.join("")).toContain("Telemetry sharing is disabled");
++    expect(stdout.join("")).toContain("config telemetry on");
++    expect(fetchMock).not.toHaveBeenCalled();
++  });
++
++  it.each([
++    ["empty", {}],
++    ["malformed", { cohortSize: 3, local: null, cohort: { successRate: "lots" } }],
++  ])("handles an %s aggregate response", async (_name, body) => {
++    vi.stubGlobal(
++      "fetch",
++      vi.fn(async () => new Response(JSON.stringify(body), { status: 200 })),
++    );
++
++    await commandMeasureBenchmark({}, {});
++
++    expect(stdout.join("")).toContain("Benchmark data is unavailable");
++  });
++
++  it("emits the stable JSON shape", async () => {
++    vi.stubGlobal(
++      "fetch",
++      vi.fn(async () => new Response(JSON.stringify(aggregate), { status: 200 })),
++    );
++
++    await commandMeasureBenchmark({ json: true }, {});
++
++    expect(JSON.parse(stdout.join(""))).toEqual({
++      schemaVersion: 1,
++      command: "measure benchmark",
++      status: "ok",
++      ...aggregate,
++    });
++  });
++});
+diff --git a/apps/cli/src/commands/measure.ts b/apps/cli/src/commands/measure.ts
+new file mode 100644
+index 0000000..f54c576
+--- /dev/null
++++ b/apps/cli/src/commands/measure.ts
+@@ -0,0 +1,142 @@
++import { loadConfig, shouldSendTelemetry, telemetryUrl } from "@oneshot-gtm/core";
++import { emitJson, header, note, setJsonMode, warn } from "../output.ts";
++
++export interface BenchmarkMetrics {
++  commandsRun: number;
++  successRate: number;
++  medianDurationMs: number;
++}
++
++export interface BenchmarkAggregate {
++  cohortSize: number;
++  local: BenchmarkMetrics;
++  cohort: BenchmarkMetrics;
++}
++
++type BenchmarkStatus = "ok" | "opted-out" | "unavailable";
++
++/** The aggregate reader lives beside the telemetry ingest route. */
++export function benchmarkUrl(env: NodeJS.ProcessEnv = process.env): string {
++  const override = env["ONESHOT_GTM_BENCHMARK_URL"];
++  if (override !== undefined) return override.trim();
++  const ingest = telemetryUrl(env);
++  if (!ingest) return "";
++  try {
++    const url = new URL(ingest);
++    url.pathname = url.pathname.replace(/\/cli\/?$/, "/benchmark");
++    url.search = "";
++    url.hash = "";
++    return url.toString();
++  } catch {
++    return "";
++  }
++}
++
++function finiteNonNegative(value: unknown): value is number {
++  return typeof value === "number" && Number.isFinite(value) && value >= 0;
++}
++
++function metrics(value: unknown): BenchmarkMetrics | null {
++  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
++  const row = value as Record<string, unknown>;
++  if (
++    !finiteNonNegative(row["commandsRun"]) ||
++    !finiteNonNegative(row["successRate"]) ||
++    row["successRate"] > 1 ||
++    !finiteNonNegative(row["medianDurationMs"])
++  ) {
++    return null;
++  }
++  return {
++    commandsRun: row["commandsRun"],
++    successRate: row["successRate"],
++    medianDurationMs: row["medianDurationMs"],
++  };
++}
++
++/** Validate the public aggregate response before using it in terminal output. */
++export function parseBenchmarkAggregate(value: unknown): BenchmarkAggregate | null {
++  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
++  const row = value as Record<string, unknown>;
++  const local = metrics(row["local"]);
++  const cohort = metrics(row["cohort"]);
++  if (!Number.isInteger(row["cohortSize"]) || !finiteNonNegative(row["cohortSize"])) return null;
++  if (!local || !cohort || row["cohortSize"] === 0) return null;
++  return { cohortSize: row["cohortSize"], local, cohort };
++}
++
++function renderMetric(label: string, local: string, cohort: string): void {
++  note(`  ${label.padEnd(20)} ${local.padStart(10)}   cohort ${cohort.padStart(10)}`);
++}
++
++function renderBenchmark(aggregate: BenchmarkAggregate): void {
++  header("measure · benchmark");
++  note(`Your install vs ${aggregate.cohortSize.toLocaleString()} opted-in installs\n`);
++  renderMetric(
++    "commands run",
++    aggregate.local.commandsRun.toLocaleString(),
++    aggregate.cohort.commandsRun.toLocaleString(),
++  );
++  renderMetric(
++    "success rate",
++    `${(aggregate.local.successRate * 100).toFixed(1)}%`,
++    `${(aggregate.cohort.successRate * 100).toFixed(1)}%`,
++  );
++  renderMetric(
++    "median duration",
++    `${Math.round(aggregate.local.medianDurationMs)} ms`,
++    `${Math.round(aggregate.cohort.medianDurationMs)} ms`,
++  );
++}
++
++function emitBenchmarkJson(status: BenchmarkStatus, aggregate?: BenchmarkAggregate): void {
++  emitJson({
++    command: "measure benchmark",
++    status,
++    ...(aggregate ? aggregate : {}),
++  });
++}
++
++export async function commandMeasureBenchmark(
++  opts: { json?: boolean } = {},
++  env: NodeJS.ProcessEnv = process.env,
++): Promise<void> {
++  if (opts.json) setJsonMode(true);
++  const cfg = loadConfig();
++
++  if (!shouldSendTelemetry(cfg, env)) {
++    if (opts.json) emitBenchmarkJson("opted-out");
++    else {
++      header("measure · benchmark");
++      note(
++        "Telemetry sharing is disabled, so this install is not included in the opt-in cohort. Enable it with `oneshot-gtm config telemetry on` to view benchmarks.",
++      );
++    }
++    return;
++  }
++
++  const endpoint = benchmarkUrl(env);
++  let aggregate: BenchmarkAggregate | null = null;
++  try {
++    if (endpoint && cfg.clientId) {
++      const url = new URL(endpoint);
++      url.searchParams.set("anonymous_machine_id", cfg.clientId);
++      const response = await fetch(url, { headers: { accept: "application/json" } });
++      if (response.ok) aggregate = parseBenchmarkAggregate(await response.json());
++    }
++  } catch {
++    // The comparison is informational; a bad aggregate must not crash the CLI.
++  }
++
++  if (!aggregate) {
++    if (opts.json) emitBenchmarkJson("unavailable");
++    else {
++      header("measure · benchmark");
++      warn("Benchmark data is unavailable. The cohort may still be warming up; try again later.");
++    }
++    return;
++  }
++
++  if (opts.json) emitBenchmarkJson("ok", aggregate);
++  else renderBenchmark(aggregate);
++}
+diff --git a/apps/cli/src/index.ts b/apps/cli/src/index.ts
+index 369bd5b..6fc22d8 100644
+--- a/apps/cli/src/index.ts
++++ b/apps/cli/src/index.ts
+@@ -66,6 +66,7 @@ import { commandEnrichLinkedIn } from "./commands/enrich-linkedin.ts";
+ import { commandResearchProspects } from "./commands/research-prospects.ts";
+ import { commandFindDrain, commandFindImport, commandFindWatch } from "./commands/find.ts";
+ import { commandInstallService } from "./commands/install-service.ts";
++import { commandMeasureBenchmark } from "./commands/measure.ts";
+ import {
+   commandMotionBreakupRevive,
+   commandMotionCompetitorSwitch,
+@@ -713,6 +714,13 @@ pmf
+   .description("Collect inbound replies and synthesize a Sean Ellis report")
+   .action(runOrFail(commandPmfSurveyCollect));
+ 
++const measure = program.command("measure").description("Compare local GTM performance");
++measure
++  .command("benchmark")
++  .description("Compare this install with the opt-in telemetry cohort")
++  .option("--json", "output as JSON")
++  .action(runOrFail((opts: { json?: boolean }) => commandMeasureBenchmark(opts)));
++
+ // Intel: interactive coaching + reply triage + personalize (no UI yet)
+ const intel = program.command("intel").description("LLM-powered intelligence layer");
+ intel


### PR DESCRIPTION
Closes #360.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 371b3a65c496 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `measure benchmark` CLI command for opt-in cohort comparison
> - Introduces a new `measure` command group with a `benchmark` subcommand that compares local GTM performance against the anonymous telemetry cohort
> - When telemetry sharing is enabled, fetches aggregate metrics from a benchmark endpoint (overridable via `ONESHOT_GTM_BENCHMARK_URL`) with a 10s timeout, sending the anonymous install UUID as a query parameter
> - Strictly validates aggregate responses via `parseBenchmarkAggregate`; renders human-readable output via `renderBenchmark` or stable JSON with `schemaVersion: 1` when `--json` is passed
> - Emits `opted-out` status with an explanatory note when telemetry is disabled; emits `unavailable` status when no valid aggregate is retrieved
> - Updates README, ROADMAP, and TELEMETRY docs to describe the new command and its privacy behavior
> - Risk: `benchmarkUrl` derives the endpoint by replacing a `/cli` suffix on the telemetry ingest URL with `/benchmark`; if the ingest URL does not end in `/cli`, the builder returns an empty string and the command reports `unavailable`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 271e2a1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->