### PR TITLE
fix: issue #398: Fix 1 shipped review finding(s) from merged PR #394

### DIFF
--- a/apps/web/src/routes/run.$playName.tsx
+++ b/apps/web/src/routes/run.$playName.tsx
@@ -745,7 +745,7 @@ function RunPage() {
           </div>
           <div className="mt-1 font-mono text-[11px] text-ink-muted">
             {verifyEvent.dropped.map((d, idx) => (
-              <div key={`${d.email}::${d.reason}::${idx}`}>
+              <div key={`${d.email || d.reason}-${idx}`}>
                 {d.email ? mask("email", d.email) : "(missing)"} — {d.reason}
               </div>
             ))}


### PR DESCRIPTION
Closes #398.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: c459f44a9af0 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix React list key for `verifyEvent.dropped` entries in `RunPage`
> Adjusts the list item key for dropped verify entries to use `(d.email || d.reason)` plus index instead of combining both `d.email` and `d.reason`. This addresses a review finding from merged PR #394. Risk: changing reconciliation keys in [run.$playName.tsx](https://github.com/oneshot-agent/oneshot-gtm/pull/402/files#diff-a41369a17db72d666888d998125772e6cd6f1c02a49d20021a82722bafe6dd20) may cause React to remount existing dropped-entry list items on first render after deploy, though rendered content is unchanged.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 108416b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->