### PR TITLE
fix: issue #403: Fix 1 shipped review finding(s) from merged PR #396

### DIFF
--- a/apps/cli/__tests__/json-output.test.ts
+++ b/apps/cli/__tests__/json-output.test.ts
@@ -659,7 +659,7 @@ describe("domains list --json", () => {
       dailySent: 0,
       dailyLimit: 20,
     });
-    // Clean pool: no domainsError flag if using the old shape, but we now always emit it.
+    // Always emit the boolean so consumers can distinguish this schema from the old shape.
     expect(parsed.domainsError).toBe(false);
   });
 

--- a/apps/cli/src/commands/identities.ts
+++ b/apps/cli/src/commands/identities.ts
@@ -208,7 +208,6 @@ export async function commandDomainsList(opts: { json?: boolean } = {}): Promise
         dailySent: d.daily_sent_count,
         dailyLimit: d.daily_send_limit,
       })),
-      ...(domainsError ? { domainsError: true } : {}),
     });
   }
 }


### PR DESCRIPTION
Closes #403.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: ba504f2ce8f8 (merge-base with origin base)
✓ bun run typecheck: worktree FAIL (1 errs) vs base fail (1 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Always emit `domainsError` in `commandDomainsList` JSON output
> Removes the conditional spread that added `{ domainsError: true }` only when the flag was set, replacing it with a single unconditional `domainsError` property in the JSON payload. This lets consumers rely on the field always being present. A test comment in the JSON output tests is updated to reflect this. Risk: existing consumers that assumed `domainsError` would be absent when false now receive the key with a `false` value.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 17e8cb1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->