### PR TITLE
fix: issue #406: Fix main typecheck in json-output.test.ts write-callback types

### DIFF
--- a/apps/cli/__tests__/find-drain.test.ts
+++ b/apps/cli/__tests__/find-drain.test.ts
@@ -38,10 +38,20 @@ beforeEach(() => {
   nextThrow = null;
   stdout = [];
   stderr = [];
-  writeSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
-    stdout.push(String(chunk));
-    return true;
-  });
+  writeSpy = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation(
+      (
+        chunk: string | Uint8Array,
+        encodingOrCallback?: BufferEncoding | ((error?: Error | undefined) => void),
+        callback?: (error?: Error | undefined) => void,
+      ) => {
+        stdout.push(String(chunk));
+        if (typeof encodingOrCallback === "function") encodingOrCallback();
+        else callback?.();
+        return true;
+      },
+    );
   errSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
     stderr.push(String(chunk));
     return true;

--- a/apps/cli/__tests__/find-watch.test.ts
+++ b/apps/cli/__tests__/find-watch.test.ts
@@ -70,10 +70,20 @@ beforeEach(() => {
   nextOutcomes = [];
   stdout = [];
   stderr = [];
-  writeSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
-    stdout.push(String(chunk));
-    return true;
-  });
+  writeSpy = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation(
+      (
+        chunk: string | Uint8Array,
+        encodingOrCallback?: BufferEncoding | ((error?: Error | undefined) => void),
+        callback?: (error?: Error | undefined) => void,
+      ) => {
+        stdout.push(String(chunk));
+        if (typeof encodingOrCallback === "function") encodingOrCallback();
+        else callback?.();
+        return true;
+      },
+    );
   errSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk: unknown) => {
     stderr.push(String(chunk));
     return true;

--- a/apps/cli/__tests__/json-output.test.ts
+++ b/apps/cli/__tests__/json-output.test.ts
@@ -124,8 +124,8 @@ beforeEach(() => {
     .mockImplementation(
       (
         chunk: string | Uint8Array,
-        encodingOrCallback?: BufferEncoding | ((error?: Error | null) => void),
-        callback?: (error?: Error | null) => void,
+        encodingOrCallback?: BufferEncoding | ((error?: Error | undefined) => void),
+        callback?: (error?: Error | undefined) => void,
       ) => {
         stdoutChunks.push(String(chunk));
         if (typeof encodingOrCallback === "function") encodingOrCallback();

--- a/apps/cli/__tests__/measure-benchmark.test.ts
+++ b/apps/cli/__tests__/measure-benchmark.test.ts
@@ -26,10 +26,20 @@ beforeEach(() => {
   telemetryEnabled = true;
   clientId = "install-123";
   stdout = [];
-  stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
-    stdout.push(String(chunk));
-    return true;
-  });
+  stdoutSpy = vi
+    .spyOn(process.stdout, "write")
+    .mockImplementation(
+      (
+        chunk: string | Uint8Array,
+        encodingOrCallback?: BufferEncoding | ((error?: Error | undefined) => void),
+        callback?: (error?: Error | undefined) => void,
+      ) => {
+        stdout.push(String(chunk));
+        if (typeof encodingOrCallback === "function") encodingOrCallback();
+        else callback?.();
+        return true;
+      },
+    );
 });
 
 afterEach(() => {


### PR DESCRIPTION
Closes #406.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 486d2716ab7e (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base fail (1 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (0 errs) vs base ok (0 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stdout write mock signatures in CLI test files
> - Updates `process.stdout.write` mocks across multiple CLI test files to accept the full Node.js `Writable.write` signature `(chunk, encodingOrCallback?, callback?)` and invoke the provided callback when present
> - Adjusts callback parameter types in [json-output.test.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/407/files#diff-2d22f16c091d9cfd4348bdd34cc68e952ce405a4295b129699b89c445507f56d) from `Error | null` to `Error | undefined`
> - Files updated: [find-drain.test.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/407/files#diff-5137fa070529010a713edbe477a9daf116e3ccdb2695e14af9a3dab450781cff), [find-watch.test.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/407/files#diff-87baea33276d26abd7beecb2233fd2022de079f4e82da5c5b2deb44edecf814d), [measure-benchmark.test.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/407/files#diff-c2a0136dbb38f0d1f3f8d01f72d4d830c25418226c2d35d03aef9e588698c69d)
> - Behavioral Change: the stdout mock now calls any supplied callback (as second or third argument), matching real stream semantics; tests relying on callbacks never firing will observe different behavior
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f18ce0e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->