### PR TITLE
fix(luma): sample configured cities fairly

### DIFF
--- a/packages/find/__tests__/luma.test.ts
+++ b/packages/find/__tests__/luma.test.ts
@@ -53,25 +53,39 @@ const sdkCalls = {
 // City-page discovery. Default: null → finder falls back to webSearch (so the
 // existing webSearch-driven cases below are unaffected). Discovery cases set
 // `discoveredEvents`. cityToSlug maps the baseConfig city so discovery is tried.
-let discoveredEvents: Array<{
+type DiscoveredEventFixture = {
   slug: string;
   name: string;
   startAtIso: string;
   city: string | null;
-}> | null = null;
+};
+let discoveredEvents: DiscoveredEventFixture[] | null = null;
+let discoveredEventsBySlug: Record<string, DiscoveredEventFixture[]> = {};
 // Per-event structured details (api.lu.ma/url). Default: null → finder falls
 // back to the webRead + LLM extract path the existing cases below exercise.
-let eventDetails: {
+type EventDetailsFixture = {
   eventTitle: string | null;
   eventDateIso: string | null;
   eventTimezone?: string | null;
   eventCity: string | null;
   attendees: Array<Record<string, unknown>>;
-} | null = null;
+};
+let eventDetails: EventDetailsFixture | null = null;
+let eventDetailsBySlug: Record<string, EventDetailsFixture> = {};
+const fetchedCitySlugs: string[] = [];
+const fetchedDetailSlugs: string[] = [];
 vi.mock("../src/_luma-discover.ts", () => ({
-  cityToSlug: (city: string) => (city.trim().toLowerCase() === "san francisco" ? "sf" : null),
-  fetchCityEvents: async () => discoveredEvents,
-  fetchEventDetails: async () => eventDetails,
+  cityToSlug: (city: string) =>
+    ({ "san francisco": "sf", "new york": "nyc", london: "london" })[city.trim().toLowerCase()] ??
+    null,
+  fetchCityEvents: async (slug: string) => {
+    fetchedCitySlugs.push(slug);
+    return discoveredEventsBySlug[slug] ?? discoveredEvents;
+  },
+  fetchEventDetails: async (slug: string) => {
+    fetchedDetailSlugs.push(slug);
+    return eventDetailsBySlug[slug] ?? eventDetails;
+  },
   // Keyword pre-filter is unit-tested in luma-discover.test.ts; let it pass here
   // so these integration cases exercise the event-level ICP gate + extract.
   eventNameMatchesTopics: () => true,
@@ -210,7 +224,11 @@ beforeEach(() => {
   verifyDeliverable = true;
   shouldSkipFindEmailResult = { ok: true };
   discoveredEvents = null;
+  discoveredEventsBySlug = {};
   eventDetails = null;
+  eventDetailsBySlug = {};
+  fetchedCitySlugs.length = 0;
+  fetchedDetailSlugs.length = 0;
   for (const k of Object.keys(sdkCalls)) {
     (sdkCalls as Record<string, number>)[k] = 0;
   }
@@ -345,6 +363,117 @@ describe("runLumaFinder — city-page discovery", () => {
     const out = await runLumaFinder(baseConfig);
     expect(sdkCalls.webSearch).toBe(1);
     expect(out.enqueued).toBe(2);
+  });
+
+  it("round-robins events and attendees so a high-volume first city cannot crowd out later cities", async () => {
+    const sfEvents = Array.from({ length: 20 }, (_, i) => ({
+      slug: `sf-${i}`,
+      name: `AI SF ${i}`,
+      startAtIso: futureIso(3),
+      city: "San Francisco",
+    }));
+    discoveredEventsBySlug = {
+      sf: sfEvents,
+      nyc: [{ slug: "ny-1", name: "AI NY", startAtIso: futureIso(3), city: "New York" }],
+      london: [{ slug: "ldn-1", name: "AI London", startAtIso: futureIso(3), city: "London" }],
+    };
+    const details = (city: string, prefix: string): EventDetailsFixture => ({
+      eventTitle: `${city} AI Meetup`,
+      eventDateIso: futureIso(3),
+      eventCity: city,
+      attendees: [
+        { name: `${prefix} One`, websiteUrl: `https://${prefix.toLowerCase()}1.dev`, role: "Host" },
+        {
+          name: `${prefix} Two`,
+          websiteUrl: `https://${prefix.toLowerCase()}2.dev`,
+          role: "Guest",
+        },
+      ],
+    });
+    eventDetailsBySlug = {
+      ...Object.fromEntries(
+        sfEvents.map((event) => [event.slug, details("San Francisco", event.slug)]),
+      ),
+      "ny-1": details("New York", "NY"),
+      "ldn-1": details("London", "LDN"),
+    };
+
+    const out = await runLumaFinder({
+      ...baseConfig,
+      cities: ["San Francisco", "New York", "London"],
+      limit: 6,
+    });
+
+    expect(out.candidates).toBe(18);
+    expect(fetchedDetailSlugs.slice(0, 3)).toEqual(["sf-0", "ny-1", "ldn-1"]);
+    expect(enqueued).toHaveLength(6);
+    const byCity = enqueued.reduce<Record<string, number>>((counts, row) => {
+      const city = String(row.payload["eventCity"]);
+      counts[city] = (counts[city] ?? 0) + 1;
+      return counts;
+    }, {});
+    expect(byCity).toEqual({ "San Francisco": 2, "New York": 2, London: 2 });
+  });
+
+  it("redistributes sparse-city capacity, dedupes configured cities, and reads cross-listed events once", async () => {
+    const sfEvents = Array.from({ length: 12 }, (_, i) => ({
+      slug: `shared-${i}`,
+      name: `AI SF ${i}`,
+      startAtIso: futureIso(3),
+      city: "San Francisco",
+    }));
+    discoveredEventsBySlug = {
+      sf: sfEvents,
+      nyc: [sfEvents[0]!],
+      london: [{ slug: "ldn-only", name: "AI London", startAtIso: futureIso(3), city: "London" }],
+    };
+    const details = (city: string): EventDetailsFixture => ({
+      eventTitle: `${city} AI Meetup`,
+      eventDateIso: futureIso(3),
+      eventCity: city,
+      attendees: [
+        { name: `${city} One`, websiteUrl: "https://one.dev" },
+        { name: `${city} Two`, websiteUrl: "https://two.dev" },
+      ],
+    });
+    eventDetails = details("San Francisco");
+    eventDetailsBySlug["ldn-only"] = details("London");
+
+    const out = await runLumaFinder({
+      ...baseConfig,
+      cities: [" San Francisco ", "san francisco", "New York", "London"],
+      limit: 3,
+    });
+
+    expect(fetchedCitySlugs).toEqual(["sf", "nyc", "london"]);
+    expect(out.candidates).toBe(9);
+    expect(fetchedDetailSlugs.filter((slug) => slug === "shared-0")).toHaveLength(1);
+    expect(enqueued.filter((row) => row.payload["eventCity"] === "London")).toHaveLength(1);
+  });
+
+  it("round-robins attendees across events within the same city", async () => {
+    discoveredEventsBySlug.sf = [
+      { slug: "large", name: "AI Large", startAtIso: futureIso(3), city: "San Francisco" },
+      { slug: "small", name: "AI Small", startAtIso: futureIso(3), city: "San Francisco" },
+    ];
+    const details = (title: string, count: number): EventDetailsFixture => ({
+      eventTitle: title,
+      eventDateIso: futureIso(3),
+      eventCity: "San Francisco",
+      attendees: Array.from({ length: count }, (_, i) => ({
+        name: `${title} ${i}`,
+        websiteUrl: `https://${title.toLowerCase()}-${i}.dev`,
+      })),
+    });
+    eventDetailsBySlug = {
+      large: details("Large", 10),
+      small: details("Small", 2),
+    };
+
+    await runLumaFinder({ ...baseConfig, limit: 4 });
+
+    expect(enqueued.filter((row) => row.payload["eventTitle"] === "Large")).toHaveLength(2);
+    expect(enqueued.filter((row) => row.payload["eventTitle"] === "Small")).toHaveLength(2);
   });
 });
 

--- a/packages/find/src/luma.ts
+++ b/packages/find/src/luma.ts
@@ -52,8 +52,13 @@ interface SearchHit {
   description: string;
 }
 
+interface CitySearchHit extends SearchHit {
+  discoveryCity: string;
+}
+
 interface AttendeeWithEvent {
   attendee: LumaPublicAttendee;
+  discoveryCity: string;
   event: {
     url: string;
     title: string;
@@ -63,6 +68,26 @@ interface AttendeeWithEvent {
     city: string;
     description: string;
   };
+}
+
+/** Fairly interleave buckets; sparse buckets surrender unused capacity. */
+function roundRobin<T>(buckets: ReadonlyMap<string, readonly T[]>, cap: number): T[] {
+  const out: T[] = [];
+  const cursors = new Map<string, number>();
+  let added = true;
+  while (out.length < cap && added) {
+    added = false;
+    for (const [key, items] of buckets) {
+      if (out.length >= cap) break;
+      const cursor = cursors.get(key) ?? 0;
+      const item = items[cursor];
+      if (item === undefined) continue;
+      out.push(item);
+      cursors.set(key, cursor + 1);
+      added = true;
+    }
+  }
+  return out;
 }
 
 /**
@@ -163,7 +188,15 @@ export async function runLumaFinder(opts: LumaFinderOpts): Promise<{
   const limit = opts.limit ?? 25;
   const sinceDays = opts.sinceDays ?? 14;
   const topics = (opts.topics ?? []).filter((t) => t.trim().length > 0);
-  const cities = (opts.cities ?? []).filter((c) => c.trim().length > 0);
+  const seenCities = new Set<string>();
+  const cities = (opts.cities ?? [])
+    .map((raw) => raw.trim())
+    .filter((city) => {
+      const key = city.toLocaleLowerCase();
+      if (!city || seenCities.has(key)) return false;
+      seenCities.add(key);
+      return true;
+    });
   const yourEdge = (opts.yourEdge ?? "").trim();
   const icp = resolveIcp(opts.icpOverride);
   const ledger = getLedger();
@@ -200,16 +233,22 @@ export async function runLumaFinder(opts: LumaFinderOpts): Promise<{
   // after extract still enforces the exact window.
   const windowMonths = upcomingMonths(sinceDays);
   const seenUrls = new Set<string>();
-  const hits: SearchHit[] = [];
+  const cityHits = new Map<string, CitySearchHit[]>(cities.map((city) => [city, []]));
+  const discoveryStats = new Map(cities.map((city) => [city, { discovered: 0, inWindow: 0 }]));
   const cap = limit * 3;
   const windowStart = Date.now() - 24 * 3600 * 1000;
   const windowEnd = Date.now() + sinceDays * 24 * 3600 * 1000;
 
-  const pushHit = (url: string, title: string, description: string): void => {
+  const pushHit = (city: string, url: string, title: string, description: string): boolean => {
     const canonical = url.split("?")[0]!.replace(/\/$/, "");
-    if (seenUrls.has(canonical)) return;
+    if (seenUrls.has(canonical)) return false;
+    if (topics.length > 0 && !eventNameMatchesTopics(title, topics)) {
+      logEvent("finder.skipped_off_topic", { name: PLAY_NAME, url: canonical, title, city });
+      return false;
+    }
     seenUrls.add(canonical);
-    hits.push({ url: canonical, title, description });
+    cityHits.get(city)!.push({ url: canonical, title, description, discoveryCity: city });
+    return true;
   };
 
   // webSearch fallback for a single city — used when the city isn't a mapped
@@ -217,7 +256,7 @@ export async function runLumaFinder(opts: LumaFinderOpts): Promise<{
   // (older) pages, which is why the date defense downstream still matters.
   const webSearchCity = async (city: string): Promise<void> => {
     for (const topic of topics) {
-      if (hits.length >= cap) return;
+      if (opts.maxCostUsd != null && result.costUsd >= opts.maxCostUsd) return;
       const query = `site:luma.com "${topic}" "${city}" upcoming event ${windowMonths}`;
       try {
         const search = await webSearch(
@@ -231,7 +270,8 @@ export async function runLumaFinder(opts: LumaFinderOpts): Promise<{
           // query string (`?k=t` / `?k=c` mark Luma's category + calendar
           // pages); canonicalizing first would strip those markers.
           if (!looksLikeLumaEventUrl(hit.url)) continue;
-          pushHit(hit.url, hit.title, hit.description);
+          discoveryStats.get(city)!.discovered++;
+          pushHit(city, hit.url, hit.title, hit.description);
         }
       } catch (err) {
         logEvent(
@@ -254,28 +294,57 @@ export async function runLumaFinder(opts: LumaFinderOpts): Promise<{
   // genuinely-upcoming events. Fall back to webSearch per city when the city
   // isn't a mapped hub, the page won't parse, or nothing lands in the window.
   for (const city of cities) {
-    if (hits.length >= cap) break;
     const slug = cityToSlug(city);
     const discovered = slug ? await fetchCityEvents(slug) : null;
     if (discovered && discovered.length > 0) {
-      let kept = 0;
+      const stats = discoveryStats.get(city)!;
+      stats.discovered += discovered.length;
+      let eligible = 0;
       for (const ev of discovered) {
-        if (hits.length >= cap) break;
         const ms = new Date(ev.startAtIso).getTime();
         if (!Number.isFinite(ms) || ms < windowStart || ms > windowEnd) continue;
-        pushHit(`https://luma.com/${ev.slug}`, ev.name, "");
-        kept++;
+        stats.inWindow++;
+        if (pushHit(city, `https://luma.com/${ev.slug}`, ev.name, "")) eligible++;
       }
       logEvent(
         "luma-events.discover_ok",
-        { name: PLAY_NAME, city, slug, found: discovered.length, in_window: kept },
+        {
+          name: PLAY_NAME,
+          city,
+          slug,
+          found: discovered.length,
+          in_window: stats.inWindow,
+          eligible,
+        },
         "info",
       );
-      if (kept > 0) continue;
+      if (eligible > 0) continue;
     }
     await webSearchCity(city);
   }
+  const hits = roundRobin(cityHits, cap);
   result.candidates = hits.length;
+
+  logEvent(
+    "luma-events.discovery_sampled",
+    {
+      name: PLAY_NAME,
+      cap,
+      total_selected: hits.length,
+      by_city: Object.fromEntries(
+        cities.map((city) => [
+          city,
+          {
+            discovered: discoveryStats.get(city)?.discovered ?? 0,
+            in_window: discoveryStats.get(city)?.inWindow ?? 0,
+            eligible: cityHits.get(city)?.length ?? 0,
+            selected: hits.filter((hit) => hit.discoveryCity === city).length,
+          },
+        ]),
+      ),
+    },
+    "info",
+  );
 
   // Event-level relevance criterion: one LLM call (below) weighs the founder's
   // ICP AND topics, on the event NAME, BEFORE any webRead — so we never pay to
@@ -292,15 +361,9 @@ export async function runLumaFinder(opts: LumaFinderOpts): Promise<{
   // Phase 2: topic/ICP gate → webRead + LLM extract per event, parallelized.
   // Each surviving event yields 0..N attendees; flatten into one work list.
   const concurrency = 3;
-  const eventExtracts: Array<{ hit: SearchHit; extract: LumaEventExtract } | null> =
+  const eventExtracts: Array<{ hit: CitySearchHit; extract: LumaEventExtract } | null> =
     await parallelMap(hits.slice(0, limit * 2), concurrency, async (hit) => {
       if (opts.maxCostUsd != null && result.costUsd >= opts.maxCostUsd) return null;
-
-      // Free keyword pre-filter: skip the LLM call for obvious off-topic names.
-      if (topics.length > 0 && !eventNameMatchesTopics(hit.title, topics)) {
-        logEvent("finder.skipped_off_topic", { name: PLAY_NAME, url: hit.url, title: hit.title });
-        return null;
-      }
       // Event-level relevance gate (topic + ICP in one call), on the name only.
       if (relevanceCriteria) {
         const ev = await icpFilter({
@@ -484,7 +547,9 @@ export async function runLumaFinder(opts: LumaFinderOpts): Promise<{
       }
     });
 
-  const attendeesWork: AttendeeWithEvent[] = [];
+  const attendeeEventBuckets = new Map(
+    cities.map((city) => [city, new Map<string, AttendeeWithEvent[]>()]),
+  );
   for (const item of eventExtracts) {
     if (!item) continue;
     const { hit, extract } = item;
@@ -496,11 +561,40 @@ export async function runLumaFinder(opts: LumaFinderOpts): Promise<{
       city: extract.eventCity ?? "",
       description: extract.eventDescription ?? "",
     };
+    const eventAttendees: AttendeeWithEvent[] = [];
     for (const attendee of extract.publicAttendees.slice(0, MAX_ATTENDEES_PER_EVENT)) {
       if (!attendee.name || attendee.name.trim().length === 0) continue;
-      attendeesWork.push({ attendee, event: eventCtx });
+      eventAttendees.push({
+        attendee,
+        discoveryCity: hit.discoveryCity,
+        event: eventCtx,
+      });
     }
+    attendeeEventBuckets.get(hit.discoveryCity)!.set(hit.url, eventAttendees);
   }
+  const attendeeBuckets = new Map(
+    cities.map((city) => {
+      const eventBuckets = attendeeEventBuckets.get(city)!;
+      const count = [...eventBuckets.values()].reduce((sum, bucket) => sum + bucket.length, 0);
+      return [city, roundRobin(eventBuckets, count)] as const;
+    }),
+  );
+  const attendeeCount = [...attendeeBuckets.values()].reduce(
+    (sum, bucket) => sum + bucket.length,
+    0,
+  );
+  const attendeesWork = roundRobin(attendeeBuckets, attendeeCount);
+  logEvent(
+    "luma-events.attendees_sampled",
+    {
+      name: PLAY_NAME,
+      total: attendeesWork.length,
+      by_city: Object.fromEntries(
+        cities.map((city) => [city, attendeeBuckets.get(city)?.length ?? 0]),
+      ),
+    },
+    "info",
+  );
 
   // Phase 3: per-attendee contact resolution, concurrency 3 to bound SDK
   // burst. Soft halt via boxed flag (same pattern as _repo-pipeline): workers
@@ -509,12 +603,14 @@ export async function runLumaFinder(opts: LumaFinderOpts): Promise<{
   // The enqueue count itself stays exact via the synchronous re-check right
   // before enqueueTarget below.
   const phase3Halted = { value: false };
+  const attemptsByCity = new Map(cities.map((city) => [city, 0]));
   await parallelMap(attendeesWork, 3, async (work) => {
     if (phase3Halted.value) return;
     if (result.enqueued >= limit) {
       phase3Halted.value = true;
       return;
     }
+    attemptsByCity.set(work.discoveryCity, (attemptsByCity.get(work.discoveryCity) ?? 0) + 1);
     if (opts.maxCostUsd != null && result.costUsd >= opts.maxCostUsd) {
       result.halted = `max-cost cap (${opts.maxCostUsd})`;
       phase3Halted.value = true;
@@ -618,6 +714,15 @@ export async function runLumaFinder(opts: LumaFinderOpts): Promise<{
       result.droppedEnrichment++;
     } else result.droppedEnrichment++;
   });
+  logEvent(
+    "luma-events.attendees_attempted",
+    {
+      name: PLAY_NAME,
+      total: [...attemptsByCity.values()].reduce((sum, count) => sum + count, 0),
+      by_city: Object.fromEntries(attemptsByCity),
+    },
+    "info",
+  );
 
   return result;
 }


### PR DESCRIPTION
## Summary
- bucket eligible Luma events by configured city and select them round-robin
- round-robin attendee attempts so high-volume events cannot consume the global queue limit
- normalize duplicate cities, dedupe cross-listed events, preserve global caps, and add per-city diagnostics
- stop fallback searches once the configured cost cap is reached

## Verification
- `bun run typecheck`
- `bun run test` (176 files, 2293 tests)
- `bun run lint` (0 errors; existing warnings only)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fairly sample configured cities in `runLumaFinder` via round-robin selection
> - Adds generic `roundRobin(buckets, cap)` to interleave items across keyed buckets, surrendering capacity when a bucket runs dry
> - `runLumaFinder` now trims and case-insensitively dedupes configured cities, filters off-topic events at discovery/search time via `pushHit`, and round-robins event selection across cities up to the cap
> - Attendee selection is now fairly interleaved both across events within a city and across cities, replacing previous global accumulation
> - Adds per-city discovery, sampling, and attempt metrics logs (`luma-events.discovery_sampled`, `luma-events.attendees_sampled`, `luma-events.attendees_attempted`)
> - Behavioral Change: event and attendee processing order and which items are selected under caps now differ from prior behavior; removes the Phase 2 free keyword pre-filter since topic gating moved into `pushHit` during discovery
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized df7e056.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->