### PR TITLE
feat(cadences): preserve manual stop dispositions

### DIFF
--- a/apps/server/__tests__/cadence-stop-route.test.ts
+++ b/apps/server/__tests__/cadence-stop-route.test.ts
@@ -49,6 +49,12 @@ describe("stopCadence", () => {
     expect(stopCadenceMock).not.toHaveBeenCalled();
   });
 
+  it("rejects null and array JSON bodies as validation errors", async () => {
+    expect((await stopCadence(request(null), { id: "7" })).status).toBe(400);
+    expect((await stopCadence(request([]), { id: "7" })).status).toBe(400);
+    expect(stopCadenceMock).not.toHaveBeenCalled();
+  });
+
   it("requires a play so the stop remains cadence-scoped", async () => {
     expect((await stopCadence(request({ reason: "not_a_fit" }, ""), { id: "7" })).status).toBe(400);
   });

--- a/apps/server/__tests__/cadence-stop-route.test.ts
+++ b/apps/server/__tests__/cadence-stop-route.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const stopCadenceMock = vi.fn();
+const getCadenceMock = vi.fn();
+
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    getLedger: () => ({ stopCadence: stopCadenceMock, getCadence: getCadenceMock }),
+  };
+});
+
+const { stopCadence } = await import("../src/api/cadences.ts");
+
+function request(body: unknown, play = "show-hn"): Request {
+  return new Request(`http://localhost/api/cadences/7/stop?play=${play}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("stopCadence", () => {
+  beforeEach(() => {
+    stopCadenceMock.mockReset();
+    stopCadenceMock.mockReturnValue(true);
+    getCadenceMock.mockReset();
+    getCadenceMock.mockReturnValue({ status: "active", sending_started_at: null });
+  });
+
+  it("records a structured reason and trimmed note", async () => {
+    const response = await stopCadence(
+      request({ reason: "bad_timing", note: "  revisit after launch  " }),
+      { id: "7" },
+    );
+    expect(response.status).toBe(200);
+    expect(stopCadenceMock).toHaveBeenCalledWith({
+      prospectId: 7,
+      playName: "show-hn",
+      reason: "bad_timing",
+      note: "revisit after launch",
+    });
+  });
+
+  it("requires a valid reason and a note for other", async () => {
+    expect((await stopCadence(request({ reason: "unknown" }), { id: "7" })).status).toBe(400);
+    expect((await stopCadence(request({ reason: "other" }), { id: "7" })).status).toBe(400);
+    expect(stopCadenceMock).not.toHaveBeenCalled();
+  });
+
+  it("requires a play so the stop remains cadence-scoped", async () => {
+    expect((await stopCadence(request({ reason: "not_a_fit" }, ""), { id: "7" })).status).toBe(400);
+  });
+
+  it("refuses to race an in-flight send", async () => {
+    getCadenceMock.mockReturnValue({ status: "active", sending_started_at: "2026-09-01 10:00:00" });
+    const response = await stopCadence(request({ reason: "bad_timing" }), { id: "7" });
+    expect(response.status).toBe(409);
+    expect(stopCadenceMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/server/src/api/cadences.ts
+++ b/apps/server/src/api/cadences.ts
@@ -225,7 +225,11 @@ export async function stopCadence(req: Request, params: Record<string, string>):
   if (!playName) return jsonResponse({ error: "play query param required" }, 400, req);
   let body: { reason?: unknown; note?: unknown } = {};
   try {
-    body = (await req.json()) as { reason?: unknown; note?: unknown };
+    const parsed: unknown = await req.json();
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return jsonResponse({ error: "JSON object body required" }, 400, req);
+    }
+    body = parsed as { reason?: unknown; note?: unknown };
   } catch {
     return jsonResponse({ error: "JSON body required" }, 400, req);
   }

--- a/apps/server/src/api/cadences.ts
+++ b/apps/server/src/api/cadences.ts
@@ -14,6 +14,7 @@ import type {
   CadenceCounts,
   CadenceNextStepDraft,
   CadenceStatus,
+  CadenceStopReason,
   CadenceView,
   CadencesResult,
 } from "@oneshot-gtm/shared-types";
@@ -106,6 +107,9 @@ function toView(
     enrolledAt: row.enrolled_at,
     nextDueAt: row.next_due_at,
     lastPolledAt: row.last_polled_at,
+    stopReason: row.stop_reason as CadenceStopReason | null,
+    stopNote: row.stop_note,
+    stoppedAt: row.stopped_at,
     nextStepDraft,
     nextStepLabel: next?.label ?? null,
     nextStepIsBreakup: next?.isBreakup ?? false,
@@ -174,6 +178,7 @@ function tallyCounts(
     breakup: 0,
     completed: 0,
     paused: 0,
+    stopped: 0,
     bounced: 0,
     overdue: 0,
   };
@@ -184,6 +189,7 @@ function tallyCounts(
       r.status === "breakup" ||
       r.status === "completed" ||
       r.status === "paused" ||
+      r.status === "stopped" ||
       r.status === "bounced"
     ) {
       counts[r.status]++;
@@ -204,24 +210,56 @@ export function getCadence(req: Request, params: Record<string, string>): Respon
   return jsonResponse({ cadences: viewsForRows(all) }, 200, req);
 }
 
-export function stopCadence(req: Request, params: Record<string, string>): Response {
+const STOP_REASONS = new Set<CadenceStopReason>([
+  "bad_timing",
+  "other",
+  "not_a_fit",
+  "do_not_contact",
+]);
+
+export async function stopCadence(req: Request, params: Record<string, string>): Promise<Response> {
   const id = Number.parseInt(params["id"] ?? "", 10);
   if (!Number.isFinite(id)) return jsonResponse({ error: "bad id" }, 400, req);
   const url = new URL(req.url);
   const playName = url.searchParams.get("play");
-  const ledger = getLedger();
-  const cadences = ledger.listCadencesForProspect(id).filter((c) => {
-    if (playName && c.play_name !== playName) return false;
-    return c.status === "active";
-  });
-  for (const cad of cadences) {
-    ledger.setCadenceStatus({
-      prospectId: id,
-      playName: cad.play_name,
-      status: "completed",
-    });
+  if (!playName) return jsonResponse({ error: "play query param required" }, 400, req);
+  let body: { reason?: unknown; note?: unknown } = {};
+  try {
+    body = (await req.json()) as { reason?: unknown; note?: unknown };
+  } catch {
+    return jsonResponse({ error: "JSON body required" }, 400, req);
   }
-  return jsonResponse({ stopped: cadences.length }, 200, req);
+  if (typeof body.reason !== "string" || !STOP_REASONS.has(body.reason as CadenceStopReason)) {
+    return jsonResponse({ error: "valid stop reason required" }, 400, req);
+  }
+  const note = typeof body.note === "string" ? body.note.trim() : "";
+  if (body.reason === "other" && !note) {
+    return jsonResponse({ error: "note required for other" }, 400, req);
+  }
+  if (note.length > 500)
+    return jsonResponse({ error: "note must be 500 characters or less" }, 400, req);
+  const ledger = getLedger();
+  const cadence = ledger.getCadence(id, playName);
+  if (!cadence) return jsonResponse({ error: "cadence not found" }, 404, req);
+  if (cadence.status !== "active") {
+    return jsonResponse({ error: `cadence is already ${cadence.status}` }, 409, req);
+  }
+  if (cadence.sending_started_at) {
+    return jsonResponse(
+      { error: "cadence send is already in flight; wait for it to finish" },
+      409,
+      req,
+    );
+  }
+  const stopped = ledger.stopCadence({
+    prospectId: id,
+    playName,
+    reason: body.reason as CadenceStopReason,
+    ...(note ? { note } : {}),
+  });
+  if (!stopped)
+    return jsonResponse({ error: "cadence changed while stopping; refresh and retry" }, 409, req);
+  return jsonResponse({ stopped: stopped ? 1 : 0 }, 200, req);
 }
 
 function parseProspectAndPlay(

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -1,6 +1,7 @@
 import type {
   AddProspectResult,
   CadencesResult,
+  CadenceStopReason,
   CadenceView,
   CancelRunResponse,
   DoctorCheck,
@@ -84,10 +85,14 @@ export const api = {
   cancelRun: (id: number, reason?: string) =>
     postJson<CancelRunResponse>(`/run/${id}/cancel`, reason ? { reason } : {}),
   cadenceForProspect: (id: number) => getJson<{ cadences: CadenceView[] }>(`/cadences/${id}`),
-  stopCadence: (id: number, playName?: string) =>
+  stopCadence: (
+    id: number,
+    playName: string,
+    input: { reason: CadenceStopReason; note?: string },
+  ) =>
     postJson<{ stopped: number }>(
-      `/cadences/${id}/stop${playName ? `?play=${encodeURIComponent(playName)}` : ""}`,
-      {},
+      `/cadences/${id}/stop?play=${encodeURIComponent(playName)}`,
+      input,
     ),
   previewCadenceNext: (id: number, playName: string) =>
     postJson<{

--- a/apps/web/src/routes/cadences.tsx
+++ b/apps/web/src/routes/cadences.tsx
@@ -3,7 +3,12 @@ import { createFileRoute } from "@tanstack/react-router";
 import { ChevronDown, CircleStop, Eye, Loader2, RotateCw, Send, Trophy } from "lucide-react";
 import { Fragment, useMemo, useState } from "react";
 import { toast } from "sonner";
-import type { CadenceCounts, CadenceView, OutcomeRequest } from "@oneshot-gtm/shared-types";
+import type {
+  CadenceCounts,
+  CadenceStopReason,
+  CadenceView,
+  OutcomeRequest,
+} from "@oneshot-gtm/shared-types";
 import { api } from "../api/client.ts";
 import { Badge } from "../components/primitives/Badge.tsx";
 import { Button } from "../components/primitives/Button.tsx";
@@ -21,6 +26,7 @@ const TILE_GRID_COLS: Record<number, string> = {
   4: "md:grid-cols-4",
   5: "md:grid-cols-5",
   6: "md:grid-cols-6",
+  7: "md:grid-cols-7",
 };
 
 export const Route = createFileRoute("/cadences")({
@@ -59,6 +65,8 @@ function statusTone(status: string): "receipt" | "signal" | "spend" | "blocked" 
       return "spend";
     case "completed":
       return "neutral";
+    case "stopped":
+      return "blocked";
     case "bounced":
       return "blocked";
     case "off-icp":
@@ -76,6 +84,19 @@ interface OutcomeModalState {
   playName: string;
 }
 
+interface StopModalState {
+  prospectId: number;
+  prospectName: string | null;
+  playName: string;
+}
+
+const STOP_REASON_LABELS: Record<CadenceStopReason, string> = {
+  bad_timing: "Bad timing / revisit later",
+  other: "Other",
+  not_a_fit: "Not a fit",
+  do_not_contact: "Do not contact",
+};
+
 const rowKey = (c: CadenceView): string => `${c.prospectId}|${c.playName}`;
 
 function CadencesPage() {
@@ -85,6 +106,9 @@ function CadencesPage() {
   const [outcomeKind, setOutcomeKind] = useState<OutcomeRequest["outcome"]>("meeting_booked");
   const [outcomeAmount, setOutcomeAmount] = useState("");
   const [outcomeNotes, setOutcomeNotes] = useState("");
+  const [stopModal, setStopModal] = useState<StopModalState | null>(null);
+  const [stopReason, setStopReason] = useState<CadenceStopReason>("bad_timing");
+  const [stopNote, setStopNote] = useState("");
 
   const { sinceRun } = Route.useSearch();
   const cadences = useQuery({
@@ -100,10 +124,17 @@ function CadencesPage() {
   };
 
   const stop = useMutation({
-    mutationFn: (vars: { prospectId: number; playName: string }) =>
-      api.stopCadence(vars.prospectId, vars.playName),
+    mutationFn: (vars: {
+      prospectId: number;
+      playName: string;
+      reason: CadenceStopReason;
+      note?: string;
+    }) => api.stopCadence(vars.prospectId, vars.playName, { reason: vars.reason, note: vars.note }),
     onSuccess: (data, vars) => {
       void qc.invalidateQueries({ queryKey: ["cadences"] });
+      setStopModal(null);
+      setStopReason("bad_timing");
+      setStopNote("");
       toast.success(`stopped cadence · ${vars.playName}`);
     },
     onError: (err) => toast.error(`couldn't stop cadence: ${err.message}`),
@@ -352,7 +383,7 @@ function CadencesPage() {
       <section
         className={cn(
           "grid grid-cols-2 divide-x divide-ink-rule border-b border-ink-rule",
-          TILE_GRID_COLS[4 + (counts.bounced > 0 ? 1 : 0) + (cadences.data?.sendsToday ? 1 : 0)],
+          TILE_GRID_COLS[5 + (counts.bounced > 0 ? 1 : 0) + (cadences.data?.sendsToday ? 1 : 0)],
         )}
       >
         <CadenceSummary
@@ -374,6 +405,12 @@ function CadencesPage() {
           tone="spend"
         />
         <CadenceSummary label="Completed" value={counts.completed} caption="full cadence done" />
+        <CadenceSummary
+          label="Stopped"
+          value={counts.stopped}
+          caption="manually ended"
+          tone="blocked"
+        />
         {cadences.data?.sendsToday && (
           <CadenceSummary
             label="Sends today"
@@ -527,6 +564,7 @@ function CadencesPage() {
                 // prior sends, a persisted draft, or a remaining step to generate.
                 const hasExpandable =
                   c.priorSteps.length > 0 ||
+                  c.status === "stopped" ||
                   c.nextStepDraft != null ||
                   (c.status === "active" && c.nextStepLabel != null);
                 return (
@@ -606,7 +644,9 @@ function CadencesPage() {
                                 ? "signal"
                                 : c.status === "breakup"
                                   ? "spend"
-                                  : c.status === "bounced" || c.status === "unsubscribed"
+                                  : c.status === "bounced" ||
+                                      c.status === "unsubscribed" ||
+                                      c.status === "stopped"
                                     ? "blocked"
                                     : "receipt"
                             }
@@ -718,11 +758,16 @@ function CadencesPage() {
                                   <Button
                                     variant="ghost"
                                     size="sm"
-                                    title="stop cadence"
-                                    disabled={stop.isPending}
+                                    title={
+                                      c.isSending
+                                        ? "wait for the in-flight send to finish before stopping"
+                                        : "stop cadence"
+                                    }
+                                    disabled={stop.isPending || c.isSending}
                                     onClick={() =>
-                                      stop.mutate({
+                                      setStopModal({
                                         prospectId: c.prospectId,
+                                        prospectName: c.prospectName,
                                         playName: c.playName,
                                       })
                                     }
@@ -735,7 +780,7 @@ function CadencesPage() {
                           {/* Chevron for non-active rows with history — the active-status
                             block renders its own above. */}
                           {c.status !== "active" &&
-                            c.priorSteps.length > 0 &&
+                            (c.priorSteps.length > 0 || c.status === "stopped") &&
                             (() => {
                               const key = `${c.prospectId}|${c.playName}`;
                               return (
@@ -778,10 +823,26 @@ function CadencesPage() {
                         </div>
                       </td>
                     </tr>
-                    {(c.priorSteps.length > 0 || c.nextStepDraft) &&
+                    {(c.priorSteps.length > 0 || c.nextStepDraft || c.status === "stopped") &&
                       expandedKeys.has(rowKey(c)) && (
                         <tr className="border-b border-ink-rule/60 bg-ink-surface/30">
                           <td colSpan={8} className="px-6 py-3">
+                            {c.status === "stopped" && (
+                              <div className="mb-4 border-l-2 border-[color:var(--ink-blocked)] pl-3">
+                                <div className="ln-eyebrow">Stopped</div>
+                                <div className="mt-1 text-[12px] text-ink-cream-2">
+                                  {c.stopReason
+                                    ? STOP_REASON_LABELS[c.stopReason]
+                                    : "Reason unavailable"}
+                                  {c.stoppedAt ? ` · ${timeAgo(c.stoppedAt)}` : ""}
+                                </div>
+                                {c.stopNote && (
+                                  <div className="mt-1 whitespace-pre-wrap text-[12px] text-ink-muted">
+                                    {c.stopNote}
+                                  </div>
+                                )}
+                              </div>
+                            )}
                             {c.priorSteps.length > 0 && (
                               <>
                                 <div className="ln-eyebrow mb-1">
@@ -972,6 +1033,77 @@ function CadencesPage() {
       </Modal>
 
       <Modal
+        open={stopModal != null}
+        onClose={() => {
+          setStopModal(null);
+          setStopReason("bad_timing");
+          setStopNote("");
+        }}
+        title={`Stop cadence${stopModal?.prospectName ? ` — ${mask("name", stopModal.prospectName)}` : ""}`}
+        footer={
+          <>
+            <Button
+              variant="ghost"
+              onClick={() => {
+                setStopModal(null);
+                setStopReason("bad_timing");
+                setStopNote("");
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                if (!stopModal) return;
+                stop.mutate({
+                  prospectId: stopModal.prospectId,
+                  playName: stopModal.playName,
+                  reason: stopReason,
+                  ...(stopNote.trim() ? { note: stopNote.trim() } : {}),
+                });
+              }}
+              disabled={stop.isPending || (stopReason === "other" && !stopNote.trim())}
+            >
+              {stop.isPending ? "Stopping…" : "Stop cadence"}
+            </Button>
+          </>
+        }
+      >
+        <div className="flex flex-col gap-4">
+          <div className="text-[12px] text-ink-muted">
+            This stops only <code>{stopModal?.playName}</code>. The prospect will be excluded from
+            Expandi. Bad timing and Other may return through breakup-revive after 60–90 days;
+            permanent reasons will not.
+          </div>
+          <Field label="Reason">
+            <Select
+              value={stopReason}
+              onChange={(e) => setStopReason(e.target.value as CadenceStopReason)}
+            >
+              {(Object.entries(STOP_REASON_LABELS) as Array<[CadenceStopReason, string]>).map(
+                ([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ),
+              )}
+            </Select>
+          </Field>
+          <Field
+            label={stopReason === "other" ? "Notes (required)" : "Notes (optional)"}
+            hint="Stored with the cadence for future context."
+          >
+            <Textarea
+              value={stopNote}
+              maxLength={500}
+              onChange={(e) => setStopNote(e.target.value)}
+              placeholder="Why are you stopping this cadence?"
+            />
+          </Field>
+        </div>
+      </Modal>
+
+      <Modal
         open={sendConfirm != null}
         onClose={() => setSendConfirm(null)}
         title={
@@ -1139,6 +1271,7 @@ const EMPTY_COUNTS: CadenceCounts = {
   breakup: 0,
   completed: 0,
   paused: 0,
+  stopped: 0,
   bounced: 0,
   overdue: 0,
 };

--- a/packages/core/__tests__/ledger-extra.test.ts
+++ b/packages/core/__tests__/ledger-extra.test.ts
@@ -686,6 +686,27 @@ describe("manual cadence stops", () => {
         .map((p) => p.id),
     ).toEqual([timing]);
   });
+
+  it("can revive from a stop timestamp when no sequence event exists", () => {
+    const pid = ledger.upsertProspect({ name: "Stop Only", email: "stop-only@x.com", source: "t" });
+    ledger.enrollCadence({
+      prospectId: pid,
+      playName: "show-hn",
+      nextDueAt: new Date().toISOString(),
+    });
+    ledger.stopCadence({ prospectId: pid, playName: "show-hn", reason: "other", note: "later" });
+    const db = new Database(dbPath);
+    db.exec(
+      `UPDATE cadence_state SET stopped_at = datetime('now', '-75 days') WHERE prospect_id = ${pid};`,
+    );
+    db.close();
+
+    expect(
+      ledger
+        .listColdProspects({ minDaysSinceLastEvent: 60, maxDaysSinceLastEvent: 90 })
+        .map((p) => p.id),
+    ).toEqual([pid]);
+  });
 });
 
 describe("recordInterview", () => {

--- a/packages/core/__tests__/ledger-extra.test.ts
+++ b/packages/core/__tests__/ledger-extra.test.ts
@@ -3,6 +3,7 @@ import { rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { Ledger } from "../src/ledger.ts";
+import { Database } from "bun:sqlite";
 
 let dbPath: string;
 let ledger: Ledger;
@@ -567,6 +568,123 @@ describe("cadence next-step draft round-trip", () => {
       status: "replied",
     });
     expect(ledger.getCadenceDraft({ prospectId: pid, playName: "show-hn" })).toBeNull();
+  });
+});
+
+describe("manual cadence stops", () => {
+  it("stores the disposition, leaves sibling cadences active, and expires queued revives", () => {
+    const pid = ledger.upsertProspect({ name: "Stop Me", email: "stop@x.com", source: "t" });
+    ledger.enrollCadence({
+      prospectId: pid,
+      playName: "show-hn",
+      nextDueAt: new Date().toISOString(),
+    });
+    ledger.enrollCadence({
+      prospectId: pid,
+      playName: "repo-interest",
+      nextDueAt: new Date().toISOString(),
+    });
+    const queueId = ledger.enqueueTarget({
+      playName: "breakup-revive",
+      payload: { email: "stop@x.com" },
+      dedupeKey: `prospect:${pid}`,
+      source: "test",
+      initialStatus: "approved",
+    })!;
+    ledger.setQueueProspectId(queueId, pid);
+
+    expect(
+      ledger.stopCadence({
+        prospectId: pid,
+        playName: "show-hn",
+        reason: "not_a_fit",
+        note: "wrong role",
+      }),
+    ).toBe(true);
+
+    const stopped = ledger.getCadence(pid, "show-hn")!;
+    expect(stopped).toMatchObject({
+      status: "stopped",
+      stop_reason: "not_a_fit",
+      stop_note: "wrong role",
+      next_due_at: null,
+    });
+    expect(stopped.stopped_at).toBeTruthy();
+    expect(ledger.getCadence(pid, "repo-interest")?.status).toBe("active");
+    expect(ledger.getQueueRow(queueId)?.status).toBe("expired");
+    expect(ledger.breakupReviveHoldFor("stop@x.com")?.reason).toBe("not_a_fit");
+
+    // Generic enrollment cannot silently erase a deliberate stop disposition.
+    ledger.enrollCadence({
+      prospectId: pid,
+      playName: "show-hn",
+      nextDueAt: new Date(Date.now() + 86_400_000).toISOString(),
+    });
+    expect(ledger.getCadence(pid, "show-hn")).toMatchObject({
+      status: "stopped",
+      stop_reason: "not_a_fit",
+      stop_note: "wrong role",
+    });
+  });
+
+  it("does not claim a stop while a cadence send is in flight", () => {
+    const pid = ledger.upsertProspect({ name: "Sending", email: "sending@x.com", source: "t" });
+    ledger.enrollCadence({
+      prospectId: pid,
+      playName: "show-hn",
+      nextDueAt: new Date().toISOString(),
+    });
+    expect(
+      ledger.claimCadenceSendingMarker({
+        prospectId: pid,
+        playName: "show-hn",
+        startedAtIso: new Date().toISOString(),
+      }),
+    ).toBe(true);
+    expect(ledger.stopCadence({ prospectId: pid, playName: "show-hn", reason: "bad_timing" })).toBe(
+      false,
+    );
+    expect(ledger.getCadence(pid, "show-hn")?.status).toBe("active");
+  });
+
+  it("uses a revivable stop as the cold clock and permanently excludes blocking reasons", () => {
+    const timing = ledger.upsertProspect({ name: "Later", email: "later@x.com", source: "t" });
+    const blocked = ledger.upsertProspect({ name: "No Fit", email: "nofit@x.com", source: "t" });
+    for (const [id, reason] of [
+      [timing, "bad_timing"],
+      [blocked, "do_not_contact"],
+    ] as const) {
+      ledger.recordSequenceEvent({
+        prospectId: id,
+        playName: "show-hn",
+        stepIndex: 0,
+        channel: "email",
+        status: "sent",
+      });
+      ledger.enrollCadence({
+        prospectId: id,
+        playName: "show-hn",
+        nextDueAt: new Date().toISOString(),
+      });
+      ledger.stopCadence({ prospectId: id, playName: "show-hn", reason });
+    }
+    const db = new Database(dbPath);
+    db.exec(`UPDATE sequence_events SET created_at = datetime('now', '-75 days');`);
+
+    // A fresh timing stop resets the clock even though the email itself is old.
+    expect(
+      ledger.listColdProspects({ minDaysSinceLastEvent: 60, maxDaysSinceLastEvent: 90 }),
+    ).toEqual([]);
+    db.exec(
+      `UPDATE cadence_state SET stopped_at = datetime('now', '-75 days') WHERE prospect_id = ${timing};`,
+    );
+    db.close();
+
+    expect(
+      ledger
+        .listColdProspects({ minDaysSinceLastEvent: 60, maxDaysSinceLastEvent: 90 })
+        .map((p) => p.id),
+    ).toEqual([timing]);
   });
 });
 

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -115,6 +115,9 @@ export interface CadenceWithProspect {
   enrolled_at: string;
   next_due_at: string | null;
   last_polled_at: string | null;
+  stop_reason: string | null;
+  stop_note: string | null;
+  stopped_at: string | null;
   next_step_draft_json: string | null;
   next_step_drafted_at: string | null;
   /**
@@ -364,6 +367,11 @@ export class Ledger {
     // restart. CAS-claimed (claimCadenceSendingMarker); cleared on success and
     // failure; sweepStaleCadenceSends treats cold-boot markers as stranded.
     this.addColumnIfMissing("cadence_state", "sending_started_at", "TEXT");
+    // Manual stops are distinct from natural completion and carry a durable
+    // disposition used by Expandi and breakup-revive.
+    this.addColumnIfMissing("cadence_state", "stop_reason", "TEXT");
+    this.addColumnIfMissing("cadence_state", "stop_note", "TEXT");
+    this.addColumnIfMissing("cadence_state", "stopped_at", "TEXT");
     // v10: mirror of v9 for the queue Send-draft path (claimQueueSendingMarker
     // + sweepStaleQueueSends; cleared by setQueueStatus on terminal states).
     this.addColumnIfMissing("target_queue", "send_started_at", "TEXT");
@@ -702,8 +710,12 @@ export class Ledger {
            status = 'active',
            next_due_at = excluded.next_due_at,
            last_polled_at = NULL,
+           stop_reason = NULL,
+           stop_note = NULL,
+           stopped_at = NULL,
            last_send_error = NULL,
-           last_send_error_at = NULL`,
+           last_send_error_at = NULL
+         WHERE cadence_state.status != 'stopped'`,
       )
       .run(input.prospectId, input.playName, input.nextDueAt);
   }
@@ -833,6 +845,43 @@ export class Ledger {
         input.prospectId,
         input.playName,
       );
+  }
+
+  stopCadence(input: {
+    prospectId: number;
+    playName: string;
+    reason: "bad_timing" | "other" | "not_a_fit" | "do_not_contact";
+    note?: string;
+  }): boolean {
+    let changed = false;
+    this.db.transaction(() => {
+      const result = this.db
+        .prepare(
+          `UPDATE cadence_state
+           SET status = 'stopped', stop_reason = ?, stop_note = ?, stopped_at = datetime('now'),
+               next_due_at = NULL,
+               next_step_draft_json = NULL, next_step_drafted_at = NULL,
+               sending_started_at = NULL, last_send_error = NULL, last_send_error_at = NULL
+           WHERE prospect_id = ? AND play_name = ? AND status = 'active'
+             AND sending_started_at IS NULL`,
+        )
+        .run(input.reason, input.note?.trim() || null, input.prospectId, input.playName);
+      changed = result.changes > 0;
+      if (changed) {
+        this.db
+          .prepare(
+            `UPDATE target_queue
+             SET status = 'expired', send_started_at = NULL,
+                 notes = CASE WHEN notes IS NULL OR notes = '' THEN 'expired: cadence stopped'
+                              ELSE notes || ' · expired: cadence stopped' END
+             WHERE (prospect_id = ? OR dedupe_key = ?)
+               AND play_name = 'breakup-revive'
+               AND status IN ('pending', 'approved')`,
+          )
+          .run(input.prospectId, `prospect:${input.prospectId}`);
+      }
+    })();
+    return changed;
   }
 
   setCadenceDraft(input: {
@@ -1443,6 +1492,24 @@ export class Ledger {
     );
   }
 
+  /** Permanent manual-stop hold used only by breakup-revive's final send backstop. */
+  breakupReviveHoldFor(email: string): { reason: string; stopped_at: string } | null {
+    const prospect = this.findProspectByEmail(email);
+    if (!prospect) return null;
+    return (
+      (this.db
+        .query(
+          `SELECT stop_reason AS reason, stopped_at
+           FROM cadence_state
+           WHERE prospect_id = ? AND status = 'stopped'
+             AND stop_reason IN ('not_a_fit', 'do_not_contact')
+           ORDER BY stopped_at DESC
+           LIMIT 1`,
+        )
+        .get(prospect.id) as { reason: string; stopped_at: string }) ?? null
+    );
+  }
+
   /** Bounce counts per sending identity since `sinceIso` — the doctor check's numerator. */
   bounceStatsByIdentity(opts: {
     sinceIso: string;
@@ -1898,9 +1965,21 @@ export class Ledger {
     last_event_at: string | null;
   }> {
     const sql = `
-      SELECT p.id, p.name, p.email, p.company, p.linkedin_url, p.phone, MAX(s.created_at) AS last_event_at
+      SELECT p.id, p.name, p.email, p.company, p.linkedin_url, p.phone,
+             MAX(s.created_at) AS last_sequence_at,
+             MAX(CASE WHEN c.status = 'stopped' AND c.stop_reason IN ('bad_timing', 'other')
+                      THEN c.stopped_at END) AS last_revivable_stop_at,
+             MAX(MAX(s.created_at), COALESCE(MAX(CASE
+               WHEN c.status = 'stopped' AND c.stop_reason IN ('bad_timing', 'other')
+               THEN c.stopped_at END), '')) AS last_event_at
       FROM prospects p
       LEFT JOIN sequence_events s ON s.prospect_id = p.id
+      LEFT JOIN cadence_state c ON c.prospect_id = p.id
+      WHERE NOT EXISTS (
+        SELECT 1 FROM cadence_state blocked
+        WHERE blocked.prospect_id = p.id AND blocked.status = 'stopped'
+          AND blocked.stop_reason IN ('not_a_fit', 'do_not_contact')
+      )
       GROUP BY p.id
       HAVING last_event_at IS NOT NULL
         AND julianday('now') - julianday(last_event_at) BETWEEN ? AND ?

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -1969,7 +1969,7 @@ export class Ledger {
              MAX(s.created_at) AS last_sequence_at,
              MAX(CASE WHEN c.status = 'stopped' AND c.stop_reason IN ('bad_timing', 'other')
                       THEN c.stopped_at END) AS last_revivable_stop_at,
-             MAX(MAX(s.created_at), COALESCE(MAX(CASE
+             MAX(COALESCE(MAX(s.created_at), ''), COALESCE(MAX(CASE
                WHEN c.status = 'stopped' AND c.stop_reason IN ('bad_timing', 'other')
                THEN c.stopped_at END), '')) AS last_event_at
       FROM prospects p
@@ -1981,7 +1981,7 @@ export class Ledger {
           AND blocked.stop_reason IN ('not_a_fit', 'do_not_contact')
       )
       GROUP BY p.id
-      HAVING last_event_at IS NOT NULL
+      HAVING last_event_at != ''
         AND julianday('now') - julianday(last_event_at) BETWEEN ? AND ?
       ORDER BY last_event_at ASC
       LIMIT ?

--- a/packages/core/src/oneshot.ts
+++ b/packages/core/src/oneshot.ts
@@ -379,6 +379,14 @@ async function dispatchEmail(input: SendEmailInput, ctx: CallContext) {
       `${input.to} ${why} (${contactStop.kind} reply on ${contactStop.received_at.slice(0, 10)}) — not sending`,
     );
   }
+  if (ctx.playName === "breakup-revive") {
+    const manualHold = getLedger().breakupReviveHoldFor(input.to);
+    if (manualHold) {
+      throw new SuppressedRecipientError(
+        `${input.to} has a ${manualHold.reason} manual stop from ${manualHold.stopped_at.slice(0, 10)} — not reviving`,
+      );
+    }
+  }
   // Sender rotation: resolve the sticky per-prospect identity BEFORE any
   // network call. Throws SendDeferredError when every identity is at its
   // daily cap — callers leave the work queued for tomorrow.

--- a/packages/plays/__tests__/cadence-deferral.test.ts
+++ b/packages/plays/__tests__/cadence-deferral.test.ts
@@ -215,7 +215,9 @@ describe("advanceCadence — daily-cap deferral", () => {
     cadenceClaimable = false;
     const result = await advanceCadence({ dryRun: false });
     expect(result.stepsExecuted).toBe(0);
-    expect(result.details).toEqual([]);
+    expect(result.details).toMatchObject([
+      { action: "skipped", note: "cadence changed or is already sending" },
+    ]);
     expect(calls.llm).toBe(0);
     expect(calls.sendEmail).toBe(0);
   });

--- a/packages/plays/__tests__/cadence-deferral.test.ts
+++ b/packages/plays/__tests__/cadence-deferral.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const calls = { sendEmail: 0, llm: 0 };
 let capacityAvailable = true;
 let sendEmailDefers = false;
+let cadenceClaimable = true;
 
 let cadenceRows: Array<{
   prospect_id: number;
@@ -68,6 +69,8 @@ vi.mock("@oneshot-gtm/core", async () => {
       contactSuppressionFor: () => null,
       listAllCadences: () => cadenceRows,
       listActiveCadences: () => cadenceRows.filter((c) => c.status === "active"),
+      claimCadenceSendingMarker: () => cadenceClaimable,
+      clearCadenceSendingMarker: () => {},
       listCadencesForProspect: (prospectId: number) =>
         cadenceRows.filter((c) => c.prospect_id === prospectId),
       getCadence: (prospectId: number, playName: string) =>
@@ -166,6 +169,7 @@ beforeEach(() => {
   calls.llm = 0;
   capacityAvailable = true;
   sendEmailDefers = false;
+  cadenceClaimable = true;
   advanceCalls.length = 0;
   seedOverdueCadence();
 });
@@ -204,6 +208,15 @@ describe("advanceCadence — daily-cap deferral", () => {
     const detail = result.details.find((d) => d.playName === "stack-consolidation");
     expect(detail).toBeDefined();
     expect(detail?.note ?? "").not.toMatch(/deferred/);
+    expect(calls.sendEmail).toBe(0);
+  });
+
+  it("does not draft or send when Stop wins the scheduler claim race", async () => {
+    cadenceClaimable = false;
+    const result = await advanceCadence({ dryRun: false });
+    expect(result.stepsExecuted).toBe(0);
+    expect(result.details).toEqual([]);
+    expect(calls.llm).toBe(0);
     expect(calls.sendEmail).toBe(0);
   });
 });

--- a/packages/plays/src/_cadence.ts
+++ b/packages/plays/src/_cadence.ts
@@ -648,7 +648,20 @@ export async function advanceCadence(
     return result;
   }
 
-  const outs = await parallelMap(due, 3, async (cad): Promise<RunCadenceStepResult> => {
+  // Claim every due row synchronously before any builder awaits. This closes
+  // the scheduler/Stop race: once claimed, stopCadence returns 409; if Stop
+  // won first, the runner re-reads the terminal status and skips the row.
+  const runnable = opts.dryRun
+    ? due
+    : due.filter((cad) =>
+        ledger.claimCadenceSendingMarker({
+          prospectId: cad.prospect_id,
+          playName: cad.play_name,
+          startedAtIso: nowIso,
+        }),
+      );
+
+  const outs = await parallelMap(runnable, 3, async (cad): Promise<RunCadenceStepResult> => {
     try {
       return await runCadenceStepForProspect({
         prospectId: cad.prospect_id,
@@ -668,11 +681,20 @@ export async function advanceCadence(
         };
       }
       throw err;
+    } finally {
+      if (!opts.dryRun) {
+        // Success usually clears through advanceCadence; skips, deferrals and
+        // failures land here. Clearing twice is harmless.
+        ledger.clearCadenceSendingMarker({
+          prospectId: cad.prospect_id,
+          playName: cad.play_name,
+        });
+      }
     }
   });
 
-  for (let i = 0; i < due.length; i++) {
-    const cad = due[i]!;
+  for (let i = 0; i < runnable.length; i++) {
+    const cad = runnable[i]!;
     const out = outs[i]!;
     result.details.push({
       prospectEmail: cad.prospect_email,

--- a/packages/plays/src/_cadence.ts
+++ b/packages/plays/src/_cadence.ts
@@ -648,20 +648,26 @@ export async function advanceCadence(
     return result;
   }
 
-  // Claim every due row synchronously before any builder awaits. This closes
-  // the scheduler/Stop race: once claimed, stopCadence returns 409; if Stop
-  // won first, the runner re-reads the terminal status and skips the row.
-  const runnable = opts.dryRun
-    ? due
-    : due.filter((cad) =>
-        ledger.claimCadenceSendingMarker({
-          prospectId: cad.prospect_id,
-          playName: cad.play_name,
-          startedAtIso: nowIso,
-        }),
-      );
-
-  const outs = await parallelMap(runnable, 3, async (cad): Promise<RunCadenceStepResult> => {
+  const outs = await parallelMap(due, 3, async (cad): Promise<RunCadenceStepResult> => {
+    // The claim is the worker's first synchronous operation, before any await.
+    // Rows waiting for a concurrency slot remain stoppable; once a worker
+    // starts, Stop and dispatch serialize through this marker. If Stop won,
+    // the runner re-reads the terminal status and skips.
+    const claimed =
+      !opts.dryRun &&
+      ledger.claimCadenceSendingMarker({
+        prospectId: cad.prospect_id,
+        playName: cad.play_name,
+        startedAtIso: nowIso,
+      });
+    if (!opts.dryRun && !claimed) {
+      return {
+        action: "skipped",
+        payload: null,
+        receiptIds: [],
+        note: "cadence changed or is already sending",
+      };
+    }
     try {
       return await runCadenceStepForProspect({
         prospectId: cad.prospect_id,
@@ -682,7 +688,7 @@ export async function advanceCadence(
       }
       throw err;
     } finally {
-      if (!opts.dryRun) {
+      if (claimed) {
         // Success usually clears through advanceCadence; skips, deferrals and
         // failures land here. Clearing twice is harmless.
         ledger.clearCadenceSendingMarker({
@@ -693,8 +699,8 @@ export async function advanceCadence(
     }
   });
 
-  for (let i = 0; i < runnable.length; i++) {
-    const cad = runnable[i]!;
+  for (let i = 0; i < due.length; i++) {
+    const cad = due[i]!;
     const out = outs[i]!;
     result.details.push({
       prospectEmail: cad.prospect_email,

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -9,10 +9,14 @@ export type CadenceStatus =
   | "breakup"
   | "completed"
   | "paused"
+  /** Explicitly stopped by the founder before the cadence naturally finished. */
+  | "stopped"
   /** Stopped by a hard bounce — the address is dead and is suppressed from further sends. */
   | "bounced"
   /** Stopped by an explicit do-not-contact reply — the prospect is suppressed from further sends. */
   | "unsubscribed";
+
+export type CadenceStopReason = "bad_timing" | "other" | "not_a_fit" | "do_not_contact";
 
 export interface CadenceNextStepDraft {
   subject: string;
@@ -45,6 +49,9 @@ export interface CadenceView {
   enrolledAt: string;
   nextDueAt: string | null;
   lastPolledAt: string | null;
+  stopReason: CadenceStopReason | null;
+  stopNote: string | null;
+  stoppedAt: string | null;
   /** Persisted next-step preview (set by Preview, cleared on advance). */
   nextStepDraft: CadenceNextStepDraft | null;
   /** Label of the next step ("value follow-up", "breakup", …). Null when
@@ -85,6 +92,7 @@ export interface CadenceCounts {
   breakup: number;
   completed: number;
   paused: number;
+  stopped: number;
   bounced: number;
   overdue: number;
 }


### PR DESCRIPTION
## Summary
- record manual cadence stops as a distinct terminal status with structured reasons and notes
- keep stop dispositions cadence-scoped while preventing accidental re-enrollment and in-flight send races
- exclude permanent stop reasons from breakup-revive and anchor revivable reasons to the stop date
- expose stopped status, counts, reason details, and a stop dialog in the dashboard

## Downstream behavior
- `not_a_fit` and `do_not_contact` never enter breakup-revive
- `bad_timing` and `other` use the configured revive window starting at `stopped_at`
- pending/approved breakup-revive queue rows expire when a cadence is stopped
- the maintainer-local, gitignored `ops/expandi-sync` selector was updated locally to exclude stopped prospects from outreach and friendship campaigns; it is intentionally not part of this tracked PR

## Validation
- `bun run typecheck`
- `bun run test` (2,301 tests)
- `bun run build`
- `cd ops/expandi-sync && bun test` (57 tests)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add manual stop dispositions with structured reasons to cadences
> - Introduces `stopCadence` in [ledger.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/409/files#diff-717d28717ccfb3e17791019e23031dc0feeec16ff1e3b3462975264e3734098e) to atomically set active, non-sending cadences to 'stopped' with a structured reason and note. Adds schema columns for `stop_reason`, `stop_note`, and `stopped_at`.
> - Updates `POST /cadences/:id/stop` in [cadences.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/409/files#diff-3f069de7e6754133fd555f7cc8a3646ce9eca79fef46fc57d3d109d7010e010a) to require a `play` query parameter and a valid reason from `STOP_REASONS`, rejecting non-object bodies and in-flight sends.
> - Adds a Stop modal to [cadences.tsx](https://github.com/oneshot-agent/oneshot-gtm/pull/409/files#diff-83e4a5cacb45599c76a5c02d1f79983074ad017b801b8e3acbacb03e74cb2c12) with reason selection and note limits, plus a 'Stopped' summary tile and expanded row details showing stop metadata.
> - Excludes permanent stops (`not_a_fit`, `do_not_contact`) from cold-prospect selection in `listColdProspects`, and suppresses 'breakup-revive' emails for these recipients in [oneshot.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/409/files#diff-a75653098eb1094047ae1458ce831158ed4abd7e08122279a6827b46c0c2e9db).
> - Risk: `enrollCadence` in [ledger.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/409/files#diff-717d28717ccfb3e17791019e23031dc0feeec16ff1e3b3462975264e3734098e) skips updates for stopped cadences and clears prior stop metadata for non-stopped rows. `advanceCadence` uses `claimCadenceSendingMarker` to serialize stop and send operations, skipping if unclaimable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b772a76.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->