### PR TITLE
fix(find): require 100 reviews before approval gating

### DIFF
--- a/apps/server/src/api/triggers.ts
+++ b/apps/server/src/api/triggers.ts
@@ -1,6 +1,8 @@
 import { getLedger, type TriggerRow } from "@oneshot-gtm/core";
 import {
   checkReadiness,
+  DEFAULT_APPROVAL_RATE_MIN_SAMPLES,
+  DEFAULT_APPROVAL_RATE_THRESHOLD,
   effectiveIntervalMs,
   fireTriggerNow,
   finderApprovalHealth,
@@ -50,8 +52,8 @@ export function toView(
     : {
         rate: null,
         reviewed: 0,
-        minSamples: 10,
-        threshold: 0.2,
+        minSamples: DEFAULT_APPROVAL_RATE_MIN_SAMPLES,
+        threshold: DEFAULT_APPROVAL_RATE_THRESHOLD,
         windowDays: 30,
         deprioritized: false,
         reason: null,

--- a/packages/find/__tests__/registry.test.ts
+++ b/packages/find/__tests__/registry.test.ts
@@ -14,6 +14,15 @@ import {
 } from "../src/registry.ts";
 
 describe("finder approval health", () => {
+  it("defaults to a 10% threshold after 100 reviewed prospects", () => {
+    const insufficient = evaluateFinderApprovalHealth({ approved: 0, reviewed: 99 });
+    expect(insufficient.sufficientData).toBe(false);
+    expect(insufficient.deprioritized).toBe(false);
+
+    expect(evaluateFinderApprovalHealth({ approved: 10, reviewed: 100 }).deprioritized).toBe(false);
+    expect(evaluateFinderApprovalHealth({ approved: 9, reviewed: 100 }).deprioritized).toBe(true);
+  });
+
   it("does not deprioritize at the threshold boundary, only below it", () => {
     expect(
       evaluateFinderApprovalHealth({ approved: 2, reviewed: 10, threshold: 0.2, minSamples: 10 })

--- a/packages/find/src/registry.ts
+++ b/packages/find/src/registry.ts
@@ -606,9 +606,9 @@ export interface TriggerRunOutcome {
   skippedReason?: string;
 }
 
-export const DEFAULT_APPROVAL_RATE_THRESHOLD = 0.2;
+export const DEFAULT_APPROVAL_RATE_THRESHOLD = 0.1;
 export const DEFAULT_APPROVAL_RATE_WINDOW_DAYS = 30;
-export const DEFAULT_APPROVAL_RATE_MIN_SAMPLES = 10;
+export const DEFAULT_APPROVAL_RATE_MIN_SAMPLES = 100;
 
 export interface FinderApprovalHealth {
   approved: number;


### PR DESCRIPTION
## Summary
- lower the default finder approval-rate threshold from 20% to 10%
- raise the default minimum reviewed sample from 10 to 100
- reuse shared defaults in the trigger API fallback and test the boundary

## Verification
- `bun run fmt:check`
- `bun run typecheck`
- focused registry and trigger-view tests
- `bun run lint` (0 errors; existing warnings only)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Require 100 reviews before applying approval-rate gating in `find` registry
> - Changes `DEFAULT_APPROVAL_RATE_MIN_SAMPLES` from 10 to 100 and `DEFAULT_APPROVAL_RATE_THRESHOLD` from 0.2 to 0.1 in [registry.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/411/files#diff-bcee29f6661eb8b7924d1a73f646e38164b2cca444d2816330057b68b3e8b83d)
> - Updates the no-spec fallback in [triggers.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/411/files#diff-621a7f6a5d695811c987d260cb3619f3c5fbdd45f1a012c65ecbab035cff5fcd) to import these constants instead of using hardcoded 10 and 0.2
> - Adds tests in [registry.test.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/411/files#diff-264190a11ecf8333b4e9f17a1bd506e7251e3c228d0546d594fed65e009858b8) verifying 99 reviews is insufficient, 10/100 is not deprioritized, and 9/100 is deprioritized
> - Risk: callers relying on the old defaults (10 samples, 20% threshold) without explicit overrides will now need 100 reviews and a 10% threshold before approval penalties apply
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8a62032.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->