### PR TITLE
feat(find): score full queue history with --all-statuses + methodology gauge

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 50 CLI commands, 17 plays, 11 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-01** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2396 tests / 183 files** · typecheck + oxlint + oxfmt clean.
+Last verified **2026-09-01** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2398 tests / 183 files** · typecheck + oxlint + oxfmt clean.
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/apps/cli/__tests__/score-prospects.test.ts
+++ b/apps/cli/__tests__/score-prospects.test.ts
@@ -247,6 +247,41 @@ describe("--report", () => {
   });
 });
 
+describe("--all-statuses methodology evaluation", () => {
+  it("scores historical rows and gauges score vs human call, auto-rejections excluded", () => {
+    // Human-approved-and-sent strong candidate vs human-rejected weak one.
+    const sent = enqueue("post-funding", FUNDING_PAYLOAD);
+    ledger.setQueueStatus({ id: sent, status: "sent" });
+    const weak = enqueue("post-funding", { name: "Bo", email: "bo@x.dev" });
+    ledger.setQueueStatus({ id: weak, status: "rejected", notes: "not a fit" });
+    const auto = enqueue(
+      "post-funding",
+      { name: "Zed", email: "z@x.dev" },
+      { initialStatus: "rejected", notes: "auto: ICP — no" },
+    );
+
+    // Default scope skips all three (none is pending/approved)…
+    commandScoreProspects({ refresh: false, dryRun: false, report: false });
+    expect(ledger.getQueueRow(sent)!.priority_json).toBeNull();
+    // …and --all-statuses scores them.
+    commandScoreProspects({ refresh: false, dryRun: false, report: false, allStatuses: true });
+    expect(ledger.getQueueRow(sent)!.priority_json).not.toBeNull();
+    expect(ledger.getQueueRow(weak)!.priority_json).not.toBeNull();
+    expect(ledger.getQueueRow(auto)!.priority_json).not.toBeNull();
+
+    const report = buildShadowReport(ledger.listQueue({ limit: 1000 }));
+    const funding = report.find((r) => r.finder === "post-funding")!;
+    // Gauge covers only human calls: 1 approved-and-sent, 1 human-rejected.
+    expect(funding.approvedScored.n).toBe(1);
+    expect(funding.rejectedScored.n).toBe(1);
+    expect(funding.approvedScored.mean).toBeGreaterThan(funding.rejectedScored.mean!);
+    // The scored auto-rejection influences neither side.
+    expect(funding.humanReviewed).toBe(2);
+    // Buckets still describe the live queue only — nothing pending/approved here.
+    expect(funding.scored).toBe(0);
+  });
+});
+
 describe("buildShadowReport — human-vs-auto provenance", () => {
   it("excludes auto: rejections from human labels and rates", () => {
     const approved = enqueue("post-funding", FUNDING_PAYLOAD);

--- a/apps/cli/src/commands/score-prospects.ts
+++ b/apps/cli/src/commands/score-prospects.ts
@@ -31,6 +31,13 @@ export interface ScoreProspectsOpts {
   dryRun: boolean;
   /** Print the per-finder shadow report (works with --dry-run). */
   report: boolean;
+  /**
+   * Widen the backfill from the live queue (pending/approved) to EVERY row —
+   * sent, rejected, expired — so historical scores can be compared against
+   * the dispositions humans already made. Evaluation only: nothing anywhere
+   * acts on a score, and auto-rejections stay separated from human labels.
+   */
+  allStatuses?: boolean;
 }
 
 /**
@@ -108,6 +115,13 @@ export interface FinderShadowReport {
   humanReviewed: number;
   /** approved+sent over humanReviewed, or null when no human labels exist. */
   humanApprovalRate: number | null;
+  /**
+   * Methodology gauge: mean score among scored human-approved (incl. sent)
+   * vs scored human-rejected rows. If the heuristic carries signal, approved
+   * should average higher than rejected. Auto-rejections never count.
+   */
+  approvedScored: { n: number; mean: number | null };
+  rejectedScored: { n: number; mean: number | null };
 }
 
 /**
@@ -118,6 +132,7 @@ export interface FinderShadowReport {
 export function buildShadowReport(rows: QueueRow[]): FinderShadowReport[] {
   const byFinder = new Map<string, FinderShadowReport>();
   const humanApproved = new Map<string, number>();
+  const scoreSums = new Map<string, { approved: number; rejected: number }>();
   for (const row of rows) {
     let entry = byFinder.get(row.play_name);
     if (!entry) {
@@ -128,33 +143,53 @@ export function buildShadowReport(rows: QueueRow[]): FinderShadowReport[] {
         buckets: { "0-19": 0, "20-39": 0, "40-59": 0, "60-79": 0, "80-100": 0 },
         humanReviewed: 0,
         humanApprovalRate: null,
+        approvedScored: { n: 0, mean: null },
+        rejectedScored: { n: 0, mean: null },
       };
       byFinder.set(row.play_name, entry);
     }
     entry.rows++;
+    const priority = parseProspectPriority(row.priority_json);
     // Buckets describe the live queue only — a dispatched (sent) or dropped
     // row keeps its historical priority_json, and counting it here would make
     // the distribution misrepresent the claimed pending/approved population.
-    if (row.status === "pending" || row.status === "approved") {
-      const priority = parseProspectPriority(row.priority_json);
-      if (priority !== null) {
-        entry.scored++;
-        entry.buckets[bucketOf(priority.total)]++;
-      }
+    if (priority !== null && (row.status === "pending" || row.status === "approved")) {
+      entry.scored++;
+      entry.buckets[bucketOf(priority.total)]++;
     }
     if (row.reviewed_at !== null && !isAutoRejected(row)) {
       entry.humanReviewed++;
+      const sums = scoreSums.get(row.play_name) ?? { approved: 0, rejected: 0 };
       if (row.status === "approved" || row.status === "sent") {
         humanApproved.set(row.play_name, (humanApproved.get(row.play_name) ?? 0) + 1);
+        if (priority !== null) {
+          entry.approvedScored.n++;
+          sums.approved += priority.total;
+        }
+      } else if (row.status === "rejected" && priority !== null) {
+        entry.rejectedScored.n++;
+        sums.rejected += priority.total;
       }
+      scoreSums.set(row.play_name, sums);
     }
   }
   for (const entry of byFinder.values()) {
     if (entry.humanReviewed > 0) {
       entry.humanApprovalRate = (humanApproved.get(entry.finder) ?? 0) / entry.humanReviewed;
     }
+    const sums = scoreSums.get(entry.finder);
+    if (sums && entry.approvedScored.n > 0) {
+      entry.approvedScored.mean = sums.approved / entry.approvedScored.n;
+    }
+    if (sums && entry.rejectedScored.n > 0) {
+      entry.rejectedScored.mean = sums.rejected / entry.rejectedScored.n;
+    }
   }
   return [...byFinder.values()].toSorted((a, b) => a.finder.localeCompare(b.finder));
+}
+
+function gaugeSide(label: string, s: { n: number; mean: number | null }): string {
+  return s.mean === null ? `${label}: n/a` : `${label}: avg ${s.mean.toFixed(0)} (n=${s.n})`;
 }
 
 function printDistribution(label: string, counts: Map<string, Record<string, number>>): void {
@@ -173,14 +208,17 @@ export function commandScoreProspects(opts: ScoreProspectsOpts): void {
 
   // Read the backlog, then cap in memory after the skip filter — `--limit N`
   // means "score N rows", not "consider N rows".
-  const rows = ledger.listQueueRowsForScoring(scope === "all" ? {} : { playName: scope });
+  const rows = ledger.listQueueRowsForScoring({
+    ...(scope === "all" ? {} : { playName: scope }),
+    ...(opts.allStatuses ? { allStatuses: true } : {}),
+  });
   const todo = rows.filter((r) => !shouldSkipRow(r, opts.refresh));
   const cap = resolveCap(opts.limit);
   const candidates = cap === undefined ? todo : todo.slice(0, cap);
 
   process.stdout.write(
     `${c.dim("scope:")} ${scope}` +
-      `  ${c.dim("pending/approved rows:")} ${rows.length}` +
+      `  ${c.dim(opts.allStatuses ? "rows (all statuses):" : "pending/approved rows:")} ${rows.length}` +
       `  ${c.dim("already scored:")} ${rows.length - todo.length}` +
       `  ${c.dim("to score:")} ${candidates.length}` +
       (cap !== undefined && todo.length > candidates.length
@@ -246,6 +284,15 @@ export function commandScoreProspects(opts: ScoreProspectsOpts): void {
           `${c.dim("scored:")} ${String(r.scored).padEnd(5)} ${cells}` +
           `  ${c.dim("human approval (shadow):")} ${rate}\n`,
       );
+      // The methodology gauge: does the heuristic rank what humans approved
+      // above what they rejected? Needs scored rows on both sides to mean
+      // anything, so print whatever exists and let the reader judge n.
+      if (r.approvedScored.n > 0 || r.rejectedScored.n > 0) {
+        process.stdout.write(
+          `  ${"".padEnd(22)} ${c.dim("score vs human call —")} ` +
+            `${gaugeSide("approved", r.approvedScored)}  ${gaugeSide("rejected", r.rejectedScored)}\n`,
+        );
+      }
     }
     process.stdout.write("\n");
   }

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -513,6 +513,11 @@ find
     "print the per-finder shadow report (score buckets + human approval rate)",
     false,
   )
+  .option(
+    "--all-statuses",
+    "widen from pending/approved to every row (sent/rejected/expired) — evaluation only",
+    false,
+  )
   .description(
     "Backfill shadow-mode priority scores from stored payloads (free, resumable, no network)",
   )
@@ -524,11 +529,13 @@ find
         refresh: boolean;
         dryRun: boolean;
         report: boolean;
+        allStatuses: boolean;
       }) => {
         commandScoreProspects({
           refresh: opts.refresh,
           dryRun: opts.dryRun,
           report: opts.report,
+          allStatuses: opts.allStatuses,
           ...(opts.scope ? { scope: opts.scope } : {}),
           ...(opts.limit !== undefined ? { limit: opts.limit } : {}),
         });

--- a/packages/core/__tests__/ledger-priority.test.ts
+++ b/packages/core/__tests__/ledger-priority.test.ts
@@ -112,6 +112,15 @@ describe("listQueueRowsForScoring", () => {
     expect(rows.map((r) => r.id)).not.toContain(expired);
   });
 
+  it("allStatuses widens to the full history for methodology evaluation", () => {
+    const pending = enqueue();
+    const rejected = enqueue({ initialStatus: "rejected", notes: "auto: ICP — no" });
+    const sent = enqueue();
+    ledger.setQueueStatus({ id: sent, status: "sent" });
+    const ids = ledger.listQueueRowsForScoring({ allStatuses: true }).map((r) => r.id);
+    expect(ids).toEqual([pending, rejected, sent]);
+  });
+
   it("honors playName and limit", () => {
     enqueue();
     const other = ledger.enqueueTarget({

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -3434,9 +3434,14 @@ export class Ledger {
    * implies unsent — a dispatched row moves to status 'sent'. id-ascending so
    * an interrupted run resumes deterministically.
    */
-  listQueueRowsForScoring(opts: { playName?: string; limit?: number } = {}): QueueRow[] {
+  listQueueRowsForScoring(
+    opts: { playName?: string; limit?: number; allStatuses?: boolean } = {},
+  ): QueueRow[] {
     const args: unknown[] = [];
-    let where = `status IN ('pending','approved')`;
+    // Default scope is the live queue; `allStatuses` widens to full history so
+    // scores can be compared against dispositions already made (methodology
+    // evaluation) — it never changes what any consumer DOES with a score.
+    let where = opts.allStatuses ? `1=1` : `status IN ('pending','approved')`;
     if (opts.playName) {
       where += ` AND play_name = ?`;
       args.push(opts.playName);


### PR DESCRIPTION
Follow-up to #412 (issue #410 Phase 1). The shadow backfill only covered pending/approved rows, so scores couldn't be checked against the dispositions humans already made.

- `find score-prospects --all-statuses` widens the backfill to the full history (sent/rejected/expired). Stored payloads only, still $0/no-network, resumable; default scope unchanged.
- The `--report` gains a per-finder **score vs human call** line: mean score of scored human-approved (incl. sent) vs human-rejected rows. `auto:` rejections are excluded from both sides per the #410 provenance rule. If heuristic-v1 carries signal, approved should average above rejected.
- Evaluation only: nothing anywhere acts on a score; buckets still describe the live queue.

Verify: fmt:check + typecheck + lint clean, **2398 tests / 183 files** (new: ledger allStatuses scope, end-to-end all-statuses scoring + gauge with auto-rejection exclusion). STATUS.md updated.

https://claude.ai/code/session_019XJ5qAUV9NDrRrbqdTLebU

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `--all-statuses` flag to `score-prospects` and add methodology gauge to `buildShadowReport`
> - Adds `--all-statuses` CLI option that widens `Ledger.listQueueRowsForScoring` to return all queue rows (`1=1`) instead of only pending/approved, for evaluation purposes
> - Extends `FinderShadowReport` with `approvedScored` and `rejectedScored` gauge fields (`{ n, mean }`) computed from human-reviewed rows only, excluding auto-rejections
> - Prints a 'score vs human call' gauge line in the report when either gauge side has observations
> - Risk: `listQueueRowsForScoring` now accepts an optional `allStatuses` param; default behavior is unchanged but callers passing `allStatuses: true` will receive rows in all statuses including expired/sent/rejected
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9e825a0.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->