### PR TITLE
feat(find): priority feature-mining gauge + AUC in shadow report (Phase 2 PR-1)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 50 CLI commands, 17 plays, 11 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-01** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2398 tests / 183 files** · typecheck + oxlint + oxfmt clean.
+Last verified **2026-09-01** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2408 tests / 184 files** · typecheck + oxlint + oxfmt clean.
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/apps/cli/__tests__/score-prospects.test.ts
+++ b/apps/cli/__tests__/score-prospects.test.ts
@@ -275,6 +275,8 @@ describe("--all-statuses methodology evaluation", () => {
     expect(funding.approvedScored.n).toBe(1);
     expect(funding.rejectedScored.n).toBe(1);
     expect(funding.approvedScored.mean).toBeGreaterThan(funding.rejectedScored.mean!);
+    // One approved above one rejected = perfect separation on this tiny sample.
+    expect(funding.auc).toBe(1);
     // The scored auto-rejection influences neither side.
     expect(funding.humanReviewed).toBe(2);
     // Buckets still describe the live queue only — nothing pending/approved here.
@@ -303,10 +305,24 @@ describe("buildShadowReport — human-vs-auto provenance", () => {
     expect(funding.humanApprovalRate).toBeCloseTo(0.5);
   });
 
-  it("reports null approval rate when no human labels exist", () => {
+  it("reports null approval rate and null AUC when no human labels exist", () => {
     enqueue("post-funding", FUNDING_PAYLOAD);
     const report = buildShadowReport(ledger.listQueue({ limit: 1000 }));
     expect(report[0]!.humanApprovalRate).toBeNull();
+    expect(report[0]!.auc).toBeNull();
+  });
+
+  it("expired rows are never human labels, even when reviewed_at is set", () => {
+    // Reservation/expiry machinery stamps reviewed_at without any human
+    // decision — measured in prod: 137 expired luma rows deflated the
+    // approval rate from 65% to 38% before this guard.
+    const approved = enqueue("post-funding", FUNDING_PAYLOAD);
+    ledger.setQueueStatus({ id: approved, status: "approved" });
+    enqueue("post-funding", { name: "x" }, { initialStatus: "expired" });
+    const report = buildShadowReport(ledger.listQueue({ limit: 1000 }));
+    const funding = report.find((r) => r.finder === "post-funding")!;
+    expect(funding.humanReviewed).toBe(1);
+    expect(funding.humanApprovalRate).toBe(1);
   });
 
   it("excludes dispatched rows from the score buckets — they only describe the live queue", () => {

--- a/apps/cli/src/commands/score-prospects.ts
+++ b/apps/cli/src/commands/score-prospects.ts
@@ -5,7 +5,7 @@ import {
   type QueueRow,
   safeParseJsonRecord,
 } from "@oneshot-gtm/core";
-import { PRIORITY_ADAPTERS, safeScorePriority } from "@oneshot-gtm/find";
+import { PRIORITY_ADAPTERS, mannWhitneyAuc, meanOf, safeScorePriority } from "@oneshot-gtm/find";
 import { c, header, note, ok } from "../output.ts";
 
 /**
@@ -122,6 +122,12 @@ export interface FinderShadowReport {
    */
   approvedScored: { n: number; mean: number | null };
   rejectedScored: { n: number; mean: number | null };
+  /**
+   * Mann-Whitney AUC of score vs human call: P(random approved outranks a
+   * random rejected). 0.5 = no separation. Null until both sides have scored
+   * rows. The Phase 2 acceptance bar reads this number.
+   */
+  auc: number | null;
 }
 
 /**
@@ -132,7 +138,7 @@ export interface FinderShadowReport {
 export function buildShadowReport(rows: QueueRow[]): FinderShadowReport[] {
   const byFinder = new Map<string, FinderShadowReport>();
   const humanApproved = new Map<string, number>();
-  const scoreSums = new Map<string, { approved: number; rejected: number }>();
+  const scores = new Map<string, { approved: number[]; rejected: number[] }>();
   for (const row of rows) {
     let entry = byFinder.get(row.play_name);
     if (!entry) {
@@ -145,6 +151,7 @@ export function buildShadowReport(rows: QueueRow[]): FinderShadowReport[] {
         humanApprovalRate: null,
         approvedScored: { n: 0, mean: null },
         rejectedScored: { n: 0, mean: null },
+        auc: null,
       };
       byFinder.set(row.play_name, entry);
     }
@@ -157,33 +164,33 @@ export function buildShadowReport(rows: QueueRow[]): FinderShadowReport[] {
       entry.scored++;
       entry.buckets[bucketOf(priority.total)]++;
     }
-    if (row.reviewed_at !== null && !isAutoRejected(row)) {
+    // Human label = a person decided. Expired rows carry reviewed_at from the
+    // reservation/expiry machinery, not from a review — counting them as
+    // non-approvals deflated approval rates (measured: luma 38% vs true 65%).
+    const humanDecided =
+      row.reviewed_at !== null &&
+      (row.status === "approved" || row.status === "sent" || row.status === "rejected") &&
+      !isAutoRejected(row);
+    if (humanDecided) {
       entry.humanReviewed++;
-      const sums = scoreSums.get(row.play_name) ?? { approved: 0, rejected: 0 };
+      const sides = scores.get(row.play_name) ?? { approved: [], rejected: [] };
       if (row.status === "approved" || row.status === "sent") {
         humanApproved.set(row.play_name, (humanApproved.get(row.play_name) ?? 0) + 1);
-        if (priority !== null) {
-          entry.approvedScored.n++;
-          sums.approved += priority.total;
-        }
+        if (priority !== null) sides.approved.push(priority.total);
       } else if (row.status === "rejected" && priority !== null) {
-        entry.rejectedScored.n++;
-        sums.rejected += priority.total;
+        sides.rejected.push(priority.total);
       }
-      scoreSums.set(row.play_name, sums);
+      scores.set(row.play_name, sides);
     }
   }
   for (const entry of byFinder.values()) {
     if (entry.humanReviewed > 0) {
       entry.humanApprovalRate = (humanApproved.get(entry.finder) ?? 0) / entry.humanReviewed;
     }
-    const sums = scoreSums.get(entry.finder);
-    if (sums && entry.approvedScored.n > 0) {
-      entry.approvedScored.mean = sums.approved / entry.approvedScored.n;
-    }
-    if (sums && entry.rejectedScored.n > 0) {
-      entry.rejectedScored.mean = sums.rejected / entry.rejectedScored.n;
-    }
+    const sides = scores.get(entry.finder) ?? { approved: [], rejected: [] };
+    entry.approvedScored = { n: sides.approved.length, mean: meanOf(sides.approved) };
+    entry.rejectedScored = { n: sides.rejected.length, mean: meanOf(sides.rejected) };
+    entry.auc = mannWhitneyAuc(sides.approved, sides.rejected);
   }
   return [...byFinder.values()].toSorted((a, b) => a.finder.localeCompare(b.finder));
 }
@@ -290,7 +297,8 @@ export function commandScoreProspects(opts: ScoreProspectsOpts): void {
       if (r.approvedScored.n > 0 || r.rejectedScored.n > 0) {
         process.stdout.write(
           `  ${"".padEnd(22)} ${c.dim("score vs human call —")} ` +
-            `${gaugeSide("approved", r.approvedScored)}  ${gaugeSide("rejected", r.rejectedScored)}\n`,
+            `${gaugeSide("approved", r.approvedScored)}  ${gaugeSide("rejected", r.rejectedScored)}` +
+            `${r.auc === null ? "" : `  ${c.dim("AUC:")} ${r.auc.toFixed(2)}`}\n`,
         );
       }
     }

--- a/packages/find/__tests__/gauge.test.ts
+++ b/packages/find/__tests__/gauge.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { mannWhitneyAuc, meanOf, wilson95 } from "../src/_gauge.ts";
+
+describe("mannWhitneyAuc", () => {
+  it("is 1 for perfect separation and 0 when inverted", () => {
+    expect(mannWhitneyAuc([70, 80, 90], [10, 20, 30])).toBe(1);
+    expect(mannWhitneyAuc([10, 20, 30], [70, 80, 90])).toBe(0);
+  });
+
+  it("is 0.5 for identical distributions (all ties, midranked)", () => {
+    expect(mannWhitneyAuc([50, 50, 50], [50, 50])).toBe(0.5);
+  });
+
+  it("handles partial ties by midrank", () => {
+    // positives [1, 2], negatives [2, 3]: pairs → (1<2)=0, (1<3)=0, (2=2)=0.5, (2<3)=0 → 0.5/4
+    expect(mannWhitneyAuc([1, 2], [2, 3])).toBeCloseTo(0.125);
+  });
+
+  it("matches the pairwise definition on an unsorted mixed sample", () => {
+    const pos = [61, 55, 72];
+    const neg = [58, 61, 40, 66];
+    let wins = 0;
+    for (const p of pos) for (const n of neg) wins += p > n ? 1 : p === n ? 0.5 : 0;
+    expect(mannWhitneyAuc(pos, neg)).toBeCloseTo(wins / (pos.length * neg.length));
+  });
+
+  it("returns null when either side is empty — one-sided data is not evidence", () => {
+    expect(mannWhitneyAuc([], [1, 2])).toBeNull();
+    expect(mannWhitneyAuc([1, 2], [])).toBeNull();
+  });
+});
+
+describe("wilson95", () => {
+  it("is symmetric around 0.5 at p=0.5", () => {
+    const { lo, hi } = wilson95(50, 100);
+    expect(lo + hi).toBeCloseTo(1, 5);
+    expect(lo).toBeGreaterThan(0.39);
+    expect(hi).toBeLessThan(0.61);
+  });
+
+  it("stays within [0,1] at the extremes and widens at small n", () => {
+    const zero = wilson95(0, 5);
+    expect(zero.lo).toBe(0);
+    expect(zero.hi).toBeGreaterThan(0.3); // 0/5 is still compatible with a real rate
+    const full = wilson95(5, 5);
+    expect(full.hi).toBe(1);
+    expect(full.lo).toBeLessThan(0.7);
+  });
+
+  it("returns the uninformative interval for n=0", () => {
+    expect(wilson95(0, 0)).toEqual({ lo: 0, hi: 1 });
+  });
+});
+
+describe("meanOf", () => {
+  it("averages, and refuses an empty sample", () => {
+    expect(meanOf([1, 2, 3])).toBe(2);
+    expect(meanOf([])).toBeNull();
+  });
+});

--- a/packages/find/src/_gauge.ts
+++ b/packages/find/src/_gauge.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure statistics for evaluating the shadow priority score against human
+ * review labels (Phase 2 of #410). Lives in packages/find rather than ops/
+ * because ops/ is outside the vitest include globs and the score-prospects
+ * report reuses the AUC. No I/O, deterministic.
+ */
+
+export function meanOf(xs: number[]): number | null {
+  if (xs.length === 0) return null;
+  return xs.reduce((a, b) => a + b, 0) / xs.length;
+}
+
+/**
+ * Mann-Whitney AUC: the probability that a random positive outranks a random
+ * negative (ties count half). 0.5 = no separation, 1 = perfect, <0.5 =
+ * inverted. Midrank tie handling; null when either side is empty — a
+ * one-sided comparison is not evidence.
+ */
+export function mannWhitneyAuc(positives: number[], negatives: number[]): number | null {
+  if (positives.length === 0 || negatives.length === 0) return null;
+  const all = [
+    ...positives.map((v) => ({ v, pos: true })),
+    ...negatives.map((v) => ({ v, pos: false })),
+  ].toSorted((a, b) => a.v - b.v);
+  // Assign midranks: ties share the average of the ranks they span.
+  let posRankSum = 0;
+  let i = 0;
+  while (i < all.length) {
+    let j = i;
+    while (j + 1 < all.length && all[j + 1]!.v === all[i]!.v) j++;
+    const midrank = (i + 1 + (j + 1)) / 2;
+    for (let k = i; k <= j; k++) {
+      if (all[k]!.pos) posRankSum += midrank;
+    }
+    i = j + 1;
+  }
+  const nPos = positives.length;
+  const nNeg = negatives.length;
+  const u = posRankSum - (nPos * (nPos + 1)) / 2;
+  return u / (nPos * nNeg);
+}
+
+/**
+ * Wilson 95% confidence interval for a proportion. Preferred over the normal
+ * approximation at the small n this workspace's labels actually have. n = 0
+ * returns the uninformative full interval.
+ */
+export function wilson95(successes: number, n: number): { lo: number; hi: number } {
+  if (n === 0) return { lo: 0, hi: 1 };
+  const z = 1.959964; // 97.5th percentile of the standard normal
+  const p = successes / n;
+  const z2 = z * z;
+  const denom = 1 + z2 / n;
+  const center = (p + z2 / (2 * n)) / denom;
+  const margin = (z * Math.sqrt((p * (1 - p)) / n + z2 / (4 * n * n))) / denom;
+  return { lo: Math.max(0, center - margin), hi: Math.min(1, center + margin) };
+}

--- a/packages/find/src/_priority.ts
+++ b/packages/find/src/_priority.ts
@@ -75,7 +75,8 @@ export function clamp100(n: number): number {
   return Math.min(100, Math.max(0, Math.round(n)));
 }
 
-const SENIORITY_BANDS: Array<{ score: number; pattern: RegExp }> = [
+/** Exported for the ops feature gauge, so title banding matches the engine. */
+export const SENIORITY_BANDS: Array<{ score: number; pattern: RegExp }> = [
   { score: 90, pattern: /founder|co-?founder|\bceo\b|\bcto\b|\bcoo\b|chief|owner|president/i },
   { score: 75, pattern: /\bvp\b|vice president|head of|director/i },
   { score: 60, pattern: /senior|staff|principal|\blead\b/i },

--- a/packages/find/src/index.ts
+++ b/packages/find/src/index.ts
@@ -29,6 +29,7 @@ export * from "./_x-lanes.ts";
 export * from "./_pending.ts";
 export * from "./_priority.ts";
 export * from "./_priority-adapters.ts";
+export * from "./_gauge.ts";
 // Exported for the `find enrich-linkedin` backfill, which reuses the finders'
 // resolver so results are cached and billed identically.
 export * from "./_linkedin.ts";


### PR DESCRIPTION
Phase 2 PR-1 of prospect prioritization (#410 follow-up): instrument before intervention. Zero behavior change — pure measurement.

- `packages/find/src/_gauge.ts`: Mann-Whitney AUC (midrank ties, null on one-sided data), Wilson 95% interval, meanOf — tested; lives in a package (not ops/) because ops/ is outside vitest globs and the report reuses the AUC.
- `find score-prospects --report` now prints per-finder AUC next to the approved/rejected means.
- `ops/gauge-priority-features.ts`: read-only $0 pass over human-labeled rows; per-finder feature battery (title bands via the engine's own regexes, bio/role/city for luma, candidateRepos/repo for github-stars, vendor stack, contactability, email-domain type, prospects-join icp/dossier) with approval%+Wilson CIs, small-cell suppression, and a hard directional-only flag under 30 rejections. Feature #0 is the current stored score — the v1 baseline through the same instrument.
- **Provenance fix the instrument caught**: expired rows carry `reviewed_at` from the reservation/expiry machinery; the report was counting them as human non-approvals, deflating luma-events' approval rate from the true **65%** to the reported **38%** (137 phantom labels). Human labels now require status approved/sent/rejected. Regression-tested.

Measured on the sdk workspace (794 clean human labels), headline v1 baseline: within-finder AUC **0.38 (luma), 0.16 (repo-interest), 0.51 (stack)** — the current heuristic is *inverted*, chiefly because exec titles (35–44% approval) and Host roles (56%) are scored up while title-missing indie builders (74–95% approval) are scored neutral. Full tables in the PR-2 design discussion; verify: fmt/typecheck/lint clean, **2408 tests / 184 files**.

https://claude.ai/code/session_019XJ5qAUV9NDrRrbqdTLebU

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `mannWhitneyAuc` and gauge utilities to `find` shadow report
> - Adds `meanOf`, `mannWhitneyAuc`, and `wilson95` utility functions in [_gauge.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/414/files#diff-f177061de716e7c03d3f111db2b5496555dd61ad0f217696ea8ec091e1310197) and exports them from the `find` package public API
> - Integrates `mannWhitneyAuc` into the `buildShadowReport` function in [score-prospects.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/414/files#diff-ba59af067f3bc2a6eda6ddf494bb4715fdf6f067655fc5758ee89d311050b26f) to evaluate score quality against human labels
> - Tightens the definition of a human label in `buildShadowReport` to require `reviewed_at` plus a terminal status (`approved`, `sent`, or `rejected`), explicitly excluding auto rejections
> - Behavioral Change: `buildShadowReport` no longer counts expired rows (those lacking a terminal status) as human labels, which alters `humanReviewed` and `humanApprovalRate` outputs
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a1e5982.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->