### PR TITLE
fix: shared human-label predicate + bulk-approval exclusion (#414 review round)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 50 CLI commands, 17 plays, 11 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-01** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2408 tests / 184 files** · typecheck + oxlint + oxfmt clean.
+Last verified **2026-09-01** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2413 tests / 185 files** · typecheck + oxlint + oxfmt clean.
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/apps/cli/src/commands/score-prospects.ts
+++ b/apps/cli/src/commands/score-prospects.ts
@@ -1,5 +1,7 @@
 import {
   getLedger,
+  isHumanApproval,
+  isHumanDecision,
   parseProspectPriority,
   type ProspectPriority,
   type QueueRow,
@@ -136,63 +138,70 @@ export interface FinderShadowReport {
  * probability — no calibration has been measured.
  */
 export function buildShadowReport(rows: QueueRow[]): FinderShadowReport[] {
-  const byFinder = new Map<string, FinderShadowReport>();
-  const humanApproved = new Map<string, number>();
-  const scores = new Map<string, { approved: number[]; rejected: number[] }>();
+  // One accumulator per finder; the report objects are constructed once at
+  // the end so no field ever depends on a placeholder being overwritten.
+  interface Acc {
+    rows: number;
+    scored: number;
+    buckets: Record<(typeof SCORE_BUCKETS)[number], number>;
+    humanReviewed: number;
+    /** Human approvals INCLUDING unscored rows — not derivable from approved.length. */
+    approvedCount: number;
+    approved: number[];
+    rejected: number[];
+  }
+  const byFinder = new Map<string, Acc>();
   for (const row of rows) {
-    let entry = byFinder.get(row.play_name);
-    if (!entry) {
-      entry = {
-        finder: row.play_name,
+    let acc = byFinder.get(row.play_name);
+    if (!acc) {
+      acc = {
         rows: 0,
         scored: 0,
         buckets: { "0-19": 0, "20-39": 0, "40-59": 0, "60-79": 0, "80-100": 0 },
         humanReviewed: 0,
-        humanApprovalRate: null,
-        approvedScored: { n: 0, mean: null },
-        rejectedScored: { n: 0, mean: null },
-        auc: null,
+        approvedCount: 0,
+        approved: [],
+        rejected: [],
       };
-      byFinder.set(row.play_name, entry);
+      byFinder.set(row.play_name, acc);
     }
-    entry.rows++;
+    acc.rows++;
     const priority = parseProspectPriority(row.priority_json);
     // Buckets describe the live queue only — a dispatched (sent) or dropped
     // row keeps its historical priority_json, and counting it here would make
     // the distribution misrepresent the claimed pending/approved population.
     if (priority !== null && (row.status === "pending" || row.status === "approved")) {
-      entry.scored++;
-      entry.buckets[bucketOf(priority.total)]++;
+      acc.scored++;
+      acc.buckets[bucketOf(priority.total)]++;
     }
-    // Human label = a person decided. Expired rows carry reviewed_at from the
-    // reservation/expiry machinery, not from a review — counting them as
-    // non-approvals deflated approval rates (measured: luma 38% vs true 65%).
-    const humanDecided =
-      row.reviewed_at !== null &&
-      (row.status === "approved" || row.status === "sent" || row.status === "rejected") &&
-      !isAutoRejected(row);
-    if (humanDecided) {
-      entry.humanReviewed++;
-      const sides = scores.get(row.play_name) ?? { approved: [], rejected: [] };
-      if (row.status === "approved" || row.status === "sent") {
-        humanApproved.set(row.play_name, (humanApproved.get(row.play_name) ?? 0) + 1);
-        if (priority !== null) sides.approved.push(priority.total);
-      } else if (row.status === "rejected" && priority !== null) {
-        sides.rejected.push(priority.total);
+    // Human label = a person decided (shared predicate — expiry machinery
+    // stamps reviewed_at without judgment; counting those as non-approvals
+    // deflated approval rates: measured luma 38% vs true 65%).
+    if (isHumanDecision(row)) {
+      acc.humanReviewed++;
+      if (isHumanApproval(row)) {
+        acc.approvedCount++;
+        if (priority !== null) acc.approved.push(priority.total);
+      } else if (priority !== null) {
+        acc.rejected.push(priority.total);
       }
-      scores.set(row.play_name, sides);
     }
   }
-  for (const entry of byFinder.values()) {
-    if (entry.humanReviewed > 0) {
-      entry.humanApprovalRate = (humanApproved.get(entry.finder) ?? 0) / entry.humanReviewed;
-    }
-    const sides = scores.get(entry.finder) ?? { approved: [], rejected: [] };
-    entry.approvedScored = { n: sides.approved.length, mean: meanOf(sides.approved) };
-    entry.rejectedScored = { n: sides.rejected.length, mean: meanOf(sides.rejected) };
-    entry.auc = mannWhitneyAuc(sides.approved, sides.rejected);
-  }
-  return [...byFinder.values()].toSorted((a, b) => a.finder.localeCompare(b.finder));
+  return [...byFinder.entries()]
+    .map(
+      ([finder, acc]): FinderShadowReport => ({
+        finder,
+        rows: acc.rows,
+        scored: acc.scored,
+        buckets: acc.buckets,
+        humanReviewed: acc.humanReviewed,
+        humanApprovalRate: acc.humanReviewed > 0 ? acc.approvedCount / acc.humanReviewed : null,
+        approvedScored: { n: acc.approved.length, mean: meanOf(acc.approved) },
+        rejectedScored: { n: acc.rejected.length, mean: meanOf(acc.rejected) },
+        auc: mannWhitneyAuc(acc.approved, acc.rejected),
+      }),
+    )
+    .toSorted((a, b) => a.finder.localeCompare(b.finder));
 }
 
 function gaugeSide(label: string, s: { n: number; mean: number | null }): string {

--- a/packages/core/__tests__/labels.test.ts
+++ b/packages/core/__tests__/labels.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { humanDecisionWhereSql, isHumanApproval, isHumanDecision } from "../src/labels.ts";
+
+const at = "2026-09-01T12:00:00.000Z";
+
+describe("isHumanDecision — the shared label predicate", () => {
+  it("accepts human approve / send / reject", () => {
+    expect(isHumanDecision({ status: "approved", notes: null, reviewed_at: at })).toBe(true);
+    expect(isHumanDecision({ status: "sent", notes: null, reviewed_at: at })).toBe(true);
+    expect(isHumanDecision({ status: "rejected", notes: "wrong segment", reviewed_at: at })).toBe(
+      true,
+    );
+  });
+
+  it("rejects machine rejections, unreviewed rows, and expiry-machinery stamps", () => {
+    expect(isHumanDecision({ status: "rejected", notes: "auto: ICP — no", reviewed_at: at })).toBe(
+      false,
+    );
+    expect(isHumanDecision({ status: "approved", notes: null, reviewed_at: null })).toBe(false);
+    expect(isHumanDecision({ status: "pending", notes: null, reviewed_at: at })).toBe(false);
+    // Expired rows get reviewed_at from reservations/bulk stamps/cadence
+    // stops, never from a per-row judgment.
+    expect(isHumanDecision({ status: "expired", notes: null, reviewed_at: at })).toBe(false);
+  });
+});
+
+describe("isHumanApproval", () => {
+  it("is the positive subset of human decisions", () => {
+    expect(isHumanApproval({ status: "sent", notes: null, reviewed_at: at })).toBe(true);
+    expect(isHumanApproval({ status: "rejected", notes: "no", reviewed_at: at })).toBe(false);
+    expect(isHumanApproval({ status: "approved", notes: null, reviewed_at: null })).toBe(false);
+  });
+});
+
+describe("humanDecisionWhereSql", () => {
+  it("prefixes every column reference for aliased queries", () => {
+    const sql = humanDecisionWhereSql("q.");
+    expect(sql).toContain("q.reviewed_at");
+    expect(sql).toContain("q.status IN");
+    expect(sql).toContain("COALESCE(q.notes, '') LIKE 'auto:%'");
+    // Unprefixed form has no stray column-qualifying dots.
+    expect(humanDecisionWhereSql()).not.toContain("q.");
+  });
+
+  it("NULL notes never hides a human rejection (three-valued logic guard)", () => {
+    // The COALESCE is load-bearing: `NULL LIKE 'auto:%'` is NULL and
+    // `NOT (… AND NULL)` filters the row out.
+    expect(humanDecisionWhereSql()).toContain("COALESCE(notes, '')");
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export * from "./telemetry.ts";
 export * from "./version.ts";
 export * from "./json.ts";
 export * from "./priority.ts";
+export * from "./labels.ts";
 export * from "./gmail.ts";
 export * from "./smartlead.ts";
 export * from "./canary.ts";

--- a/packages/core/src/labels.ts
+++ b/packages/core/src/labels.ts
@@ -1,0 +1,45 @@
+import type { QueueRow } from "./types.ts";
+
+/**
+ * THE single definition of "a human decided this queue row" — shared by the
+ * shadow-score gauge, finder approval stats, and ICP few-shot selection so
+ * they can never drift apart (each had hand-rolled copies before; one missed
+ * the auto: clause, one counted expiry timeouts as rejections).
+ *
+ * A human decision is: reviewed, terminal-by-review status, and not a machine
+ * rejection (`auto:` notes prefix — ICP/role gates, import classifiers).
+ *
+ * `expired` is deliberately NOT a human status even when reviewed_at is set:
+ * reservation inserts (csv-import), bulk stamps, and cadence-stop expiry all
+ * write reviewed_at without any per-row judgment. Known lossy edge: a row a
+ * human approved that machinery later expires (e.g. stopCadence on
+ * breakup-revive) loses its label — current-status is a lossy record of the
+ * decision history; a disposition-provenance column is the Phase 3 fix.
+ */
+export function isHumanDecision(row: Pick<QueueRow, "status" | "notes" | "reviewed_at">): boolean {
+  if (row.reviewed_at === null) return false;
+  if (row.status === "approved" || row.status === "sent") return true;
+  return row.status === "rejected" && !(row.notes ?? "").startsWith("auto:");
+}
+
+/** True when a human decision was a yes (approve, or approve-then-send). */
+export function isHumanApproval(row: Pick<QueueRow, "status" | "notes" | "reviewed_at">): boolean {
+  return isHumanDecision(row) && (row.status === "approved" || row.status === "sent");
+}
+
+/**
+ * The same predicate as SQL, for queries that must filter in the database.
+ * `prefix` qualifies columns when the query aliases target_queue (e.g. "q.").
+ */
+export function humanDecisionWhereSql(prefix = ""): string {
+  const p = prefix;
+  // COALESCE matters: `NULL LIKE 'auto:%'` is NULL, and `NOT (… AND NULL)`
+  // is NULL too — without it a notes-less human rejection silently drops out
+  // of the result set (three-valued logic; this bug shipped in
+  // recentIcpDecisions before the predicate was unified here).
+  return (
+    `${p}reviewed_at IS NOT NULL` +
+    ` AND ${p}status IN ('approved','rejected','sent')` +
+    ` AND NOT (${p}status = 'rejected' AND COALESCE(${p}notes, '') LIKE 'auto:%')`
+  );
+}

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -2,6 +2,7 @@ import { Database } from "bun:sqlite";
 import { existsSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { configDir } from "./config.ts";
+import { humanDecisionWhereSql } from "./labels.ts";
 import { getSharedDb } from "./shared-db.ts";
 import type { ReplyKind } from "./reply-classify.ts";
 import type {
@@ -2413,10 +2414,8 @@ export class Ledger {
       .query(
         `SELECT payload_json, status, notes
          FROM target_queue
-         WHERE reviewed_at IS NOT NULL
+         WHERE ${humanDecisionWhereSql()}
            AND json_valid(payload_json)
-           AND status IN ('approved', 'rejected', 'sent')
-           AND NOT (status = 'rejected' AND notes LIKE 'auto:%')
          ORDER BY reviewed_at DESC, id DESC
          LIMIT ?`,
       )
@@ -2934,7 +2933,7 @@ export class Ledger {
            COUNT(*) AS reviewed
          FROM target_queue
          WHERE (source = ? OR source LIKE ?)
-           AND status IN ('approved','rejected','sent')
+           AND ${humanDecisionWhereSql()}
            AND reviewed_at >= ?`,
       )
       .get(source, `${source}:%`, input.sinceIso) as {

--- a/packages/find/src/_gauge.ts
+++ b/packages/find/src/_gauge.ts
@@ -44,6 +44,11 @@ export function mannWhitneyAuc(positives: number[], negatives: number[]): number
  * Wilson 95% confidence interval for a proportion. Preferred over the normal
  * approximation at the small n this workspace's labels actually have. n = 0
  * returns the uninformative full interval.
+ *
+ * NOT dead code: consumed by ops/gauge-priority-features.ts, which is
+ * maintainer-local tooling kept out of the public tree (/ops/ is gitignored)
+ * — a caller grep will find only the tests. Same situation as
+ * SENIORITY_BANDS in _priority.ts.
  */
 export function wilson95(successes: number, n: number): { lo: number; hi: number } {
   if (n === 0) return { lo: 0, hi: 1 };


### PR DESCRIPTION
Review-round fixes for the just-merged #414 (the merge raced the review; these landed minutes late).

- `isHumanDecision`/`isHumanApproval`/`humanDecisionWhereSql` in core — the single definition of "a human decided this row", now shared by the shadow gauge, `finderApprovalStats`, and `recentIcpDecisions` (each had a drifted hand-rolled copy).
- `finderApprovalStats` gains the missing `auto:` exclusion — machine rejections no longer deflate the approval rate that gates finder deprioritization (#411's input).
- Unification exposed a pre-existing three-valued-logic bug: `NOT (status='rejected' AND notes LIKE 'auto:%')` is NULL for NULL notes, silently dropping notes-less **human** rejections (shipped in `recentIcpDecisions`); `COALESCE` fixes it, regression-tested.
- `buildShadowReport` refactored to one accumulator per finder, report constructed once (no dead-vs-load-bearing placeholder inits).
- `wilson95` docstring names its out-of-tree consumer (ops/ is gitignored maintainer tooling — dead-code-cleanup guard, same as SENIORITY_BANDS).
- Ops gauge (local): bulk `approveAllPending` clusters (≥20 rows sharing one `reviewed_at`; measured a 108-row millisecond) excluded from feature tables — only per-row judgments tune heuristic-v2.

Corrected sdk-workspace numbers with bulk exclusion: luma 65/69 labels, exec-title 35% vs missing 55% approval, Host 35% vs Guest 54%; v1 AUC 0.36 (inverted). Verify: fmt/typecheck/lint clean, **2413 tests / 185 files**.

https://claude.ai/code/session_019XJ5qAUV9NDrRrbqdTLebU

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add shared `isHumanDecision`/`isHumanApproval` predicates and fix NULL-notes exclusion bug
> - Introduces `labels.ts` in `@oneshot-gtm/core` with `isHumanDecision`, `isHumanApproval`, and `humanDecisionWhereSql` (a SQL generator using `COALESCE(notes, '')` to avoid three-valued logic dropping rows with NULL notes).
> - Replaces ad-hoc predicates in `score-prospects.buildShadowReport` and two `Ledger` methods with the shared utilities.
> - `buildShadowReport` is refactored to accumulate into a single per-finder object before materializing reports, replacing intermediate Maps and placeholder objects.
> - Risk: `Ledger.recentIcpDecisions` and the finder-approval aggregation now include human rejections with NULL notes that were previously silently excluded; approval-rate denominators and reviewed counts will increase in those code paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b675334.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->