### PR TITLE
feat(find): heuristic-v2 — label-mined priors, versioned artifacts (Phase 2 PR-2)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 50 CLI commands, 17 plays, 11 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-01** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2413 tests / 185 files** · typecheck + oxlint + oxfmt clean.
+Last verified **2026-09-01** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2425 tests / 186 files** · typecheck + oxlint + oxfmt clean.
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of
@@ -17,6 +17,8 @@ lines of `check.ts`, and `packages/intel` tests cover only `_parse.ts` and `prom
 The person-level ICP gate (#45) was calibrated against 84 real LinkedIn titles (all 13 known off-ICP prospects caught, zero false rejects among 44 builders) and the history audit ran live `enrichProfile` for 111 titles. The workspace switcher's auto-start was live-verified in both directions (default ↔ gtm).
 
 Reply detection was verified on 2026-08-23 against the real mailboxes: a sliced sweep of all four inboxes from the first send onward (4,833 inbound, every slice fully covered) found exactly the replies the live poll then recorded on restart. Since 2026-08-28 every inbound is also classified (#63) — out-of-office autoresponders, dead-mailbox notices and unsubscribes are recorded for the conversation history but never count as replies, and the latter two durably suppress the address at the send funnel.
+
+Shadow priority score (#410): heuristic-v2 measured 2026-09-01 on 794 clean human labels — luma-events AUC 0.59-0.63 (up from v1's inverted 0.36), mean gap +1. Under the Phase 2 acceptance bar (gap ≥ +5, AUC ≥ 0.60), so ranked review order ships config-gated with `queueReviewOrder` defaulting to `newest`; scores stay shadow/display-only until richer features clear the bar.
 
 Updated by hand after each dogfood run.
 

--- a/apps/cli/__tests__/score-prospects.test.ts
+++ b/apps/cli/__tests__/score-prospects.test.ts
@@ -61,6 +61,23 @@ function enqueue(
   })!;
 }
 
+const artifact = (version: string) =>
+  JSON.stringify({
+    version,
+    total: 50,
+    components: {
+      personFit: 50,
+      accountFit: 50,
+      intentStrength: 50,
+      timingFreshness: 50,
+      signalConfidence: 50,
+      contactability: 50,
+    },
+    reasons: [],
+    finder: "post-funding",
+    scoredAt: "2026-09-01T12:00:00.000Z",
+  });
+
 const FUNDING_PAYLOAD = {
   name: "Ada",
   email: "ada@acme.dev",
@@ -119,24 +136,24 @@ describe("pure helpers", () => {
     expect(
       hasCurrentScore({ priority_json: JSON.stringify({ version: "heuristic-v1", total: 50 }) }),
     ).toBe(false);
-    const current = JSON.stringify({
-      version: "heuristic-v1",
-      total: 50,
-      components: {
-        personFit: 50,
-        accountFit: 50,
-        intentStrength: 50,
-        timingFreshness: 50,
-        signalConfidence: 50,
-        contactability: 50,
-      },
-      reasons: [],
-      finder: "post-funding",
-      scoredAt: "2026-09-01T12:00:00.000Z",
-    });
+    // A complete v1 artifact still PARSES (keeps rendering) but is not
+    // CURRENT — a plain backfill run upgrades it to v2.
+    expect(hasCurrentScore({ priority_json: artifact("heuristic-v1") })).toBe(false);
+    const current = artifact("heuristic-v2");
     expect(hasCurrentScore({ priority_json: current })).toBe(true);
     expect(shouldSkipRow({ priority_json: current }, false)).toBe(true);
     expect(shouldSkipRow({ priority_json: current }, true)).toBe(false);
+  });
+
+  it("a valid v1 artifact is auto-upgraded to v2 by a plain backfill run", () => {
+    const id = enqueue("post-funding", FUNDING_PAYLOAD);
+    commandScoreProspects({ refresh: false, dryRun: false, report: false });
+    const v2 = JSON.parse(ledger.getQueueRow(id)!.priority_json!);
+    ledger.setQueuePriority(id, { ...v2, version: "heuristic-v1", total: 42 });
+    commandScoreProspects({ refresh: false, dryRun: false, report: false });
+    const upgraded = JSON.parse(ledger.getQueueRow(id)!.priority_json!);
+    expect(upgraded.version).toBe("heuristic-v2");
+    expect(upgraded).toEqual(v2);
   });
 
   it("a partial artifact is repaired by a plain backfill run, no --refresh needed", () => {
@@ -175,7 +192,7 @@ describe("commandScoreProspects", () => {
     const id = enqueue("post-funding", FUNDING_PAYLOAD);
     commandScoreProspects({ refresh: false, dryRun: false, report: false });
     const written = JSON.parse(ledger.getQueueRow(id)!.priority_json!);
-    expect(written.version).toBe("heuristic-v1");
+    expect(written.version).toBe("heuristic-v2");
     expect(written.finder).toBe("post-funding");
     // Deterministic: anchored to found_at, so a re-run reproduces it exactly…
     commandScoreProspects({ refresh: false, dryRun: false, report: false });

--- a/apps/cli/src/commands/score-prospects.ts
+++ b/apps/cli/src/commands/score-prospects.ts
@@ -7,7 +7,13 @@ import {
   type QueueRow,
   safeParseJsonRecord,
 } from "@oneshot-gtm/core";
-import { PRIORITY_ADAPTERS, mannWhitneyAuc, meanOf, safeScorePriority } from "@oneshot-gtm/find";
+import {
+  PRIORITY_ADAPTERS,
+  PRIORITY_VERSION,
+  mannWhitneyAuc,
+  meanOf,
+  safeScorePriority,
+} from "@oneshot-gtm/find";
 import { c, header, note, ok } from "../output.ts";
 
 /**
@@ -64,13 +70,15 @@ export function resolveCap(limit: number | undefined): number | undefined {
 }
 
 /**
- * True when the row already carries a valid current-version artifact. Uses
+ * True when the row already carries a valid CURRENT-version artifact. Uses
  * the same full-shape validator as the API projection — an artifact the API
  * would hide as `priority: null` (partial, corrupt, out-of-range) must read
  * as "not scored" here too, or a plain backfill run could never repair it.
+ * Older versions parse (they keep rendering) but are not current, so a plain
+ * run auto-rescores v1 → v2.
  */
 export function hasCurrentScore(row: Pick<QueueRow, "priority_json">): boolean {
-  return parseProspectPriority(row.priority_json) !== null;
+  return parseProspectPriority(row.priority_json)?.version === PRIORITY_VERSION;
 }
 
 export function shouldSkipRow(row: Pick<QueueRow, "priority_json">, refresh: boolean): boolean {

--- a/apps/web/__tests__/priorityChip.test.ts
+++ b/apps/web/__tests__/priorityChip.test.ts
@@ -68,3 +68,13 @@ describe("priorityBreakdown", () => {
     ]);
   });
 });
+
+describe("per-version rendering", () => {
+  it("a v2 artifact renders with v2's weight table", () => {
+    const v2 = { ...priority(61), version: "heuristic-v2" as const };
+    const rows = priorityBreakdown(v2);
+    expect(rows[0]).toEqual({ component: "person fit", score: 90, weightPct: 30 });
+    expect(rows.reduce((a, r) => a + r.weightPct, 0)).toBe(100);
+    expect(priorityChip(v2)!.label).toBe("61 · shadow");
+  });
+});

--- a/apps/web/src/lib/priorityChip.ts
+++ b/apps/web/src/lib/priorityChip.ts
@@ -1,4 +1,4 @@
-import type { ProspectPriorityView } from "@oneshot-gtm/shared-types";
+import { PRIORITY_WEIGHTS_BY_VERSION, type ProspectPriorityView } from "@oneshot-gtm/shared-types";
 
 /**
  * Display logic for the shadow-mode priority score (issue #410). Pure so it's
@@ -44,24 +44,25 @@ export interface PriorityBreakdownRow {
   weightPct: number;
 }
 
-/** Fixed weight-descending order, matching how the total is composed. */
-const BREAKDOWN: Array<{
-  key: keyof ProspectPriorityView["components"];
-  label: string;
-  weightPct: number;
-}> = [
-  { key: "personFit", label: "person fit", weightPct: 30 },
-  { key: "accountFit", label: "account fit", weightPct: 20 },
-  { key: "intentStrength", label: "intent", weightPct: 20 },
-  { key: "timingFreshness", label: "freshness", weightPct: 15 },
-  { key: "signalConfidence", label: "confidence", weightPct: 10 },
-  { key: "contactability", label: "contactability", weightPct: 5 },
+/**
+ * Display order and labels only — the weights come from the canonical
+ * per-version table in shared-types, so a v1 artifact renders v1's weights
+ * and a v2 artifact v2's, and nothing here can drift from the engine.
+ */
+const BREAKDOWN: Array<{ key: keyof ProspectPriorityView["components"]; label: string }> = [
+  { key: "personFit", label: "person fit" },
+  { key: "accountFit", label: "account fit" },
+  { key: "intentStrength", label: "intent" },
+  { key: "timingFreshness", label: "freshness" },
+  { key: "signalConfidence", label: "confidence" },
+  { key: "contactability", label: "contactability" },
 ];
 
 export function priorityBreakdown(p: ProspectPriorityView): PriorityBreakdownRow[] {
+  const weights = PRIORITY_WEIGHTS_BY_VERSION[p.version];
   return BREAKDOWN.map((b) => ({
     component: b.label,
     score: p.components[b.key],
-    weightPct: b.weightPct,
+    weightPct: weights[b.key],
   }));
 }

--- a/packages/core/__tests__/priority-parse.test.ts
+++ b/packages/core/__tests__/priority-parse.test.ts
@@ -23,13 +23,19 @@ describe("parseProspectPriority — the single validity authority", () => {
     expect(parseProspectPriority(JSON.stringify(VALID))).toEqual(VALID);
   });
 
-  it("rejects null, broken JSON, non-objects, and foreign versions", () => {
+  it("rejects null, broken JSON, non-objects, and unknown versions", () => {
     expect(parseProspectPriority(null)).toBeNull();
     expect(parseProspectPriority(undefined)).toBeNull();
     expect(parseProspectPriority("")).toBeNull();
     expect(parseProspectPriority("{broken")).toBeNull();
     expect(parseProspectPriority("[1,2]")).toBeNull();
-    expect(parseProspectPriority(JSON.stringify({ ...VALID, version: "heuristic-v2" }))).toBeNull();
+    expect(parseProspectPriority(JSON.stringify({ ...VALID, version: "heuristic-v3" }))).toBeNull();
+  });
+
+  it("accepts every shipped version and passes it through verbatim", () => {
+    const v2 = { ...VALID, version: "heuristic-v2" as const };
+    expect(parseProspectPriority(JSON.stringify(v2))).toEqual(v2);
+    expect(parseProspectPriority(JSON.stringify(VALID))!.version).toBe("heuristic-v1");
   });
 
   it("rejects partial artifacts — a bare version stamp is not a score", () => {

--- a/packages/core/src/priority.ts
+++ b/packages/core/src/priority.ts
@@ -9,6 +9,8 @@ const COMPONENT_KEYS: Array<keyof ProspectPriorityComponents> = [
   "contactability",
 ];
 
+const ACCEPTED_VERSIONS: Array<ProspectPriority["version"]> = ["heuristic-v1", "heuristic-v2"];
+
 /** A score under the contract: a finite integer in 0..100. */
 function isScore(value: unknown): value is number {
   return typeof value === "number" && Number.isInteger(value) && value >= 0 && value <= 100;
@@ -35,7 +37,11 @@ export function parseProspectPriority(raw: string | null | undefined): ProspectP
   }
   if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
   const p = parsed as Record<string, unknown>;
-  if (p["version"] !== "heuristic-v1") return null;
+  // Every version ever shipped stays parseable — old artifacts on terminal
+  // rows must keep rendering after an engine version bump. Only the backfill's
+  // resume-skip cares about "current"; it checks the version itself.
+  const version = ACCEPTED_VERSIONS.find((v) => v === p["version"]);
+  if (!version) return null;
   if (!isScore(p["total"])) return null;
   const rawComponents = p["components"];
   if (rawComponents === null || typeof rawComponents !== "object" || Array.isArray(rawComponents)) {
@@ -45,7 +51,7 @@ export function parseProspectPriority(raw: string | null | undefined): ProspectP
   if (COMPONENT_KEYS.some((k) => !isScore(c[k]))) return null;
   if (!Array.isArray(p["reasons"]) || typeof p["finder"] !== "string") return null;
   return {
-    version: "heuristic-v1",
+    version,
     total: p["total"],
     components: {
       personFit: c["personFit"] as number,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -304,7 +304,12 @@ export interface ProspectPriorityComponents {
  * deliverability) are never rescued by a score.
  */
 export interface ProspectPriority {
-  version: "heuristic-v1";
+  /**
+   * Mirrored union of shared-types' `PriorityVersion` (core can't import it —
+   * web depends on shared-types alone; the find version-sync test guards the
+   * two lists against drift).
+   */
+  version: "heuristic-v1" | "heuristic-v2";
   /** Weighted total, clamped integer 0..100. */
   total: number;
   components: ProspectPriorityComponents;

--- a/packages/find/__tests__/priority-adapters.test.ts
+++ b/packages/find/__tests__/priority-adapters.test.ts
@@ -195,7 +195,7 @@ describe("per-play adapters", () => {
     it(`${play}: fixture payload → valid heuristic-v1 artifact`, () => {
       const p = safeScorePriority(play, FIXTURES[play], NOW);
       expect(p).not.toBeNull();
-      expect(p!.version).toBe("heuristic-v1");
+      expect(p!.version).toBe("heuristic-v2");
       expect(p!.finder).toBe(play);
       expect(p!.scoredAt).toBe(NOW.toISOString());
       expect(Number.isInteger(p!.total)).toBe(true);
@@ -274,7 +274,7 @@ describe("enqueueScoredTarget", () => {
     });
     expect(id).toBe(42);
     const priority = calls[0]!["priority"] as Record<string, unknown>;
-    expect(priority["version"]).toBe("heuristic-v1");
+    expect(priority["version"]).toBe("heuristic-v2");
     expect(priority["finder"]).toBe("show-hn");
   });
 
@@ -317,5 +317,46 @@ describe("review-hardened evidence edges", () => {
       NOW,
     );
     expect(p!.components.timingFreshness).toBe(50);
+  });
+});
+
+describe("v2 label-mined adapter priors", () => {
+  it("luma: exec titles score DOWN, Host scores below Guest, bios no longer feed seniority", () => {
+    const exec = safeScorePriority(
+      "luma-events",
+      { ...FIXTURES["luma-events"], title: "CEO", attendeeBio: "AI enthusiast" },
+      NOW,
+    )!;
+    expect(exec.components.personFit).toBe(35);
+    const host = safeScorePriority("luma-events", FIXTURES["luma-events"], NOW)!;
+    const guest = safeScorePriority(
+      "luma-events",
+      { ...FIXTURES["luma-events"], role: "Guest" },
+      NOW,
+    )!;
+    expect(host.components.intentStrength).toBe(45);
+    expect(guest.components.intentStrength).toBe(65);
+    // A founder-looking bio alone no longer inflates personFit (measured flat).
+    const bioOnly = safeScorePriority(
+      "luma-events",
+      { ...FIXTURES["luma-events"], title: undefined },
+      NOW,
+    )!;
+    expect(bioOnly.components.personFit).toBe(50);
+  });
+
+  it("repo-interest: exec-title prior inverted, non-exec titles neutral", () => {
+    const exec = safeScorePriority(
+      "repo-interest",
+      { ...FIXTURES["repo-interest"], title: "CTO" },
+      NOW,
+    )!;
+    expect(exec.components.personFit).toBe(35);
+    const ic = safeScorePriority(
+      "repo-interest",
+      { ...FIXTURES["repo-interest"], title: "ML Engineer" },
+      NOW,
+    )!;
+    expect(ic.components.personFit).toBe(50);
   });
 });

--- a/packages/find/__tests__/priority-version-sync.test.ts
+++ b/packages/find/__tests__/priority-version-sync.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { parseProspectPriority } from "@oneshot-gtm/core";
+import {
+  PRIORITY_COMPONENT_KEYS,
+  PRIORITY_WEIGHTS_BY_VERSION,
+  type PriorityVersion,
+} from "@oneshot-gtm/shared-types";
+import { PRIORITY_VERSION, PRIORITY_WEIGHTS, computePriority } from "../src/_priority.ts";
+
+/**
+ * The version contract lives in three packages that can't all import each
+ * other (web ← shared-types; core is dependency-root; find sees everything).
+ * This suite is the drift guard the mirrored copies rely on.
+ */
+describe("priority version sync", () => {
+  const versions = Object.keys(PRIORITY_WEIGHTS_BY_VERSION) as PriorityVersion[];
+
+  it("every declared version round-trips core's validator", () => {
+    for (const version of versions) {
+      const artifact = {
+        version,
+        total: 50,
+        components: {
+          personFit: 50,
+          accountFit: 50,
+          intentStrength: 50,
+          timingFreshness: 50,
+          signalConfidence: 50,
+          contactability: 50,
+        },
+        reasons: [],
+        finder: "t",
+        scoredAt: "2026-09-01T12:00:00.000Z",
+      };
+      expect(parseProspectPriority(JSON.stringify(artifact)), version).toEqual(artifact);
+    }
+  });
+
+  it("every version's weights sum to exactly 100", () => {
+    for (const version of versions) {
+      const sum = Object.values(PRIORITY_WEIGHTS_BY_VERSION[version]).reduce((a, b) => a + b, 0);
+      expect(sum, version).toBe(100);
+    }
+  });
+
+  it("the engine's current version is declared, and its weights are the shared table's", () => {
+    expect(versions).toContain(PRIORITY_VERSION);
+    expect(PRIORITY_WEIGHTS).toBe(PRIORITY_WEIGHTS_BY_VERSION[PRIORITY_VERSION]);
+  });
+
+  it("component keys match the artifact the engine emits", () => {
+    const emitted = computePriority("t", {}, new Date("2026-09-01T12:00:00Z"));
+    expect(Object.keys(emitted.components).toSorted()).toEqual(
+      [...PRIORITY_COMPONENT_KEYS].toSorted(),
+    );
+  });
+});

--- a/packages/find/__tests__/priority.test.ts
+++ b/packages/find/__tests__/priority.test.ts
@@ -21,7 +21,7 @@ describe("priority engine — contract", () => {
 
   it("empty evidence is neutral everywhere, not zero", () => {
     const p = computePriority("show-hn", {}, NOW);
-    expect(p.version).toBe("heuristic-v1");
+    expect(p.version).toBe("heuristic-v2");
     expect(p.finder).toBe("show-hn");
     expect(p.scoredAt).toBe(NOW.toISOString());
     expect(p.total).toBe(NEUTRAL);
@@ -39,8 +39,8 @@ describe("priority engine — contract", () => {
       NOW,
     );
     expect(p.components.intentStrength).toBe(100);
-    // Negative strength loses to the neutral base, and nothing goes below 0.
-    expect(p.components.accountFit).toBe(NEUTRAL);
+    // Signals are authoritative in v2 (anti-signals allowed), clamped at 0.
+    expect(p.components.accountFit).toBe(0);
     expect(p.total).toBeGreaterThanOrEqual(0);
     expect(p.total).toBeLessThanOrEqual(100);
     expect(Number.isInteger(p.total)).toBe(true);
@@ -179,5 +179,39 @@ describe("clamp100", () => {
     expect(clamp100(78.5)).toBe(79);
     expect(clamp100(-3)).toBe(0);
     expect(clamp100(140)).toBe(100);
+  });
+});
+
+describe("v2 personSignals — label-mined priors", () => {
+  it("override title bands entirely, including below neutral", () => {
+    const p = computePriority(
+      "t",
+      {
+        title: "CEO", // band alone would score 90
+        personSignals: [{ kind: "title-prior", strength: 35, reason: "title: CEO" }],
+      },
+      NOW,
+    );
+    expect(p.components.personFit).toBe(35);
+    expect(p.reasons[0]).toBe("title: CEO");
+  });
+
+  it("strongest signal wins and reasons come out strongest-first", () => {
+    const p = computePriority(
+      "t",
+      {
+        personSignals: [
+          { kind: "weak", strength: 40, reason: "weak" },
+          { kind: "strong", strength: 62, reason: "strong" },
+        ],
+      },
+      NOW,
+    );
+    expect(p.components.personFit).toBe(62);
+    expect(p.reasons).toEqual(["strong", "weak"]);
+  });
+
+  it("absent personSignals leave v1 band behavior untouched", () => {
+    expect(computePriority("t", { title: "CTO" }, NOW).components.personFit).toBe(90);
   });
 });

--- a/packages/find/package.json
+++ b/packages/find/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@oneshot-gtm/core": "workspace:*",
     "@oneshot-gtm/intel": "workspace:*",
-    "@oneshot-gtm/plays": "workspace:*"
+    "@oneshot-gtm/plays": "workspace:*",
+    "@oneshot-gtm/shared-types": "workspace:*"
   }
 }

--- a/packages/find/src/_priority-adapters.ts
+++ b/packages/find/src/_priority-adapters.ts
@@ -1,5 +1,10 @@
 import { type Ledger, type ProspectPriority, logEvent } from "@oneshot-gtm/core";
-import { type PriorityEvidence, type PrioritySignal, computePriority } from "./_priority.ts";
+import {
+  type PriorityEvidence,
+  type PrioritySignal,
+  SENIORITY_BANDS,
+  computePriority,
+} from "./_priority.ts";
 
 /**
  * Per-play adapters: payload already persisted at enqueue time → normalized
@@ -25,6 +30,18 @@ function urlCount(...urls: unknown[]): number {
   return urls.filter((u) => str(u) !== null).length;
 }
 
+/**
+ * Label-mined title prior for the indie-builder finders (luma, github-stars):
+ * exec-band titles measured at 35–44% approval vs a 55–92% baseline — the
+ * classic seniority boost is an ANTI-signal for this ICP. Non-exec titles are
+ * plain neutral evidence; a missing title stays unknown (no signal at all).
+ */
+function minedTitleSignals(title: string | null): PrioritySignal[] {
+  if (!title) return [];
+  const exec = SENIORITY_BANDS[0]!.pattern.test(title);
+  return [{ kind: "title-prior", strength: exec ? 35 : 50, reason: `title: ${title}` }];
+}
+
 function fmtUsd(amount: number): string {
   if (amount >= 1_000_000) return `$${(amount / 1_000_000).toFixed(1)}M`;
   if (amount >= 1_000) return `$${Math.round(amount / 1_000)}k`;
@@ -41,7 +58,9 @@ function xEvidence(p: Record<string, unknown>): PriorityEvidence {
   const accountSignals: PrioritySignal[] = [];
   const followers = num(p["followers"]);
   if (followers !== null) {
-    const strength = followers >= 10_000 ? 70 : followers >= 1_000 ? 60 : 45;
+    // 50 = "weak but not negative": small reach is unknown-ish, and signals
+    // are authoritative in v2 (no neutral floor to lean on).
+    const strength = followers >= 10_000 ? 70 : followers >= 1_000 ? 60 : 50;
     accountSignals.push({
       kind: "reach",
       strength,
@@ -170,16 +189,19 @@ export const PRIORITY_ADAPTERS: Record<string, (p: Record<string, unknown>) => P
     ...contact(p),
   }),
 
+  // v2, label-mined (65 approved / 69 rejected individually-judged rows):
+  // exec titles 35% approval vs 55% title-missing → title prior inverted;
+  // bios no longer feed seniority (bioTitleBand measured flat-to-negative);
+  // Host 35% vs Guest 54% → Host now scores BELOW Guest, not above.
   "luma-events": (p) => {
     const role = str(p["role"]);
     return {
-      title: str(p["title"]),
-      seniorityHint: str(p["attendeeBio"]),
+      personSignals: minedTitleSignals(str(p["title"])),
       companyKnown: str(p["company"]) !== null,
       intentSignals: [
         {
           kind: "event",
-          strength: role === "Host" ? 75 : 65,
+          strength: role === "Host" ? 45 : 65,
           reason: `${role ?? "attendee"} at ${str(p["eventTitle"]) ?? "?"}`,
         },
       ],
@@ -220,8 +242,11 @@ export const PRIORITY_ADAPTERS: Record<string, (p: Record<string, unknown>) => P
     ...contact(p),
   }),
 
+  // v2: exec-title prior inverted here too (44% approval at n=9, matching
+  // luma's direction; repo-interest labels are direction-only — bulk-approve
+  // heavy — so only the title change is applied, candidateRepos left alone).
   "repo-interest": (p) => ({
-    title: str(p["title"]),
+    personSignals: minedTitleSignals(str(p["title"])),
     companyKnown: str(p["company"]) !== null,
     intentSignals: [
       {

--- a/packages/find/src/_priority.ts
+++ b/packages/find/src/_priority.ts
@@ -1,7 +1,12 @@
 import type { ProspectPriority, ProspectPriorityComponents } from "@oneshot-gtm/core";
+import { PRIORITY_WEIGHTS_BY_VERSION } from "@oneshot-gtm/shared-types";
 
 /**
- * Pure heuristic-v1 priority engine (issue #410, Phase 1 — shadow mode).
+ * Pure heuristic-v2 priority engine (issue #410, Phase 2 — still shadow
+ * mode). v2 is the label-mined correction of v1: on the finders with human
+ * labels, exec titles (35–44% approval vs 55–92% baseline) and Luma Host
+ * roles (35% vs Guest 54%) were ANTI-signals that v1 scored up — adapters
+ * now express those through `personSignals`, which can land below neutral.
  *
  * Turns the evidence a finder already holds at enqueue time into the
  * explainable `ProspectPriority` artifact. No LLM calls, no paid SDK calls,
@@ -10,17 +15,11 @@ import type { ProspectPriority, ProspectPriorityComponents } from "@oneshot-gtm/
  * rescues an off-ICP, duplicate, undeliverable, or role-rejected candidate.
  */
 
-export const PRIORITY_VERSION = "heuristic-v1" as const;
+export const PRIORITY_VERSION = "heuristic-v2" as const;
 
-/** v1 component weights, percent. Sum is 100 by construction. */
-export const PRIORITY_WEIGHTS: Record<keyof ProspectPriorityComponents, number> = {
-  personFit: 30,
-  accountFit: 20,
-  intentStrength: 20,
-  timingFreshness: 15,
-  signalConfidence: 10,
-  contactability: 5,
-};
+/** Current-version component weights — single-sourced from shared-types. */
+export const PRIORITY_WEIGHTS: Record<keyof ProspectPriorityComponents, number> =
+  PRIORITY_WEIGHTS_BY_VERSION[PRIORITY_VERSION];
 
 /** Missing evidence is unknown, not bad: it scores neutral, never zero. */
 export const NEUTRAL = 50;
@@ -44,6 +43,13 @@ export interface PriorityEvidence {
   title?: string | null;
   /** Stronger seniority evidence than `title` (e.g. job-change newRole, a Luma bio). */
   seniorityHint?: string | null;
+  /**
+   * Explicit personFit evidence that OVERRIDES title banding when present —
+   * the channel for label-mined per-finder priors, which may sit BELOW
+   * neutral (an exec title on luma/repo finders is measured as an
+   * anti-signal, something the band table can't express).
+   */
+  personSignals?: PrioritySignal[];
   /** True when the payload names the account/company. */
   companyKnown?: boolean;
   /** Company-level signals: funding, cohort, hiring, audience size… */
@@ -83,6 +89,12 @@ export const SENIORITY_BANDS: Array<{ score: number; pattern: RegExp }> = [
 ];
 
 function scorePersonFit(ev: PriorityEvidence): ComponentResult {
+  // Explicit signals win outright — no neutral floor, because a measured
+  // anti-signal must be allowed to pull the component below 50.
+  if (ev.personSignals && ev.personSignals.length > 0) {
+    const ordered = [...ev.personSignals].toSorted((a, b) => b.strength - a.strength);
+    return { score: ordered[0]!.strength, reasons: ordered.map((s) => s.reason) };
+  }
   // Hint first, but a band-matching title beats a hint that matches nothing —
   // a Luma bio like "AI enthusiast" must not mask an ICP-gate title of "CTO".
   for (const text of [ev.seniorityHint?.trim(), ev.title?.trim()]) {
@@ -100,12 +112,16 @@ function scorePersonFit(ev: PriorityEvidence): ComponentResult {
  * of evidence ("raised Seed") shouldn't be dragged down by a weak second one,
  * and max keeps the arithmetic trivially explainable. Reasons come out
  * strongest-first; ties break on input order, so output stays deterministic.
+ *
+ * v2: the strongest signal is AUTHORITATIVE — no neutral floor. Label mining
+ * found anti-signals (Luma Hosts approve at 35% vs Guests 54%) that a
+ * floored max could never express; adapters that mean "weak but not
+ * negative" say strength 50, not 45.
  */
 function scoreSignals(signals: PrioritySignal[] | undefined, base: number): ComponentResult {
   if (!signals || signals.length === 0) return { score: base, reasons: [] };
   const ordered = [...signals].toSorted((a, b) => b.strength - a.strength);
-  const top = ordered[0]!;
-  return { score: Math.max(base, top.strength), reasons: ordered.map((s) => s.reason) };
+  return { score: ordered[0]!.strength, reasons: ordered.map((s) => s.reason) };
 }
 
 function scoreAccountFit(ev: PriorityEvidence): ComponentResult {

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -399,6 +399,49 @@ export interface SenderIdentityView {
 
 export type QueueStatusView = "pending" | "approved" | "rejected" | "sent" | "expired";
 
+export const PRIORITY_COMPONENT_KEYS = [
+  "personFit",
+  "accountFit",
+  "intentStrength",
+  "timingFreshness",
+  "signalConfidence",
+  "contactability",
+] as const;
+export type PriorityComponentKey = (typeof PRIORITY_COMPONENT_KEYS)[number];
+
+/** Every priority-artifact version the system can parse and render. */
+export type PriorityVersion = "heuristic-v1" | "heuristic-v2";
+
+/**
+ * Canonical per-version component weights (percent, each row sums to 100).
+ * The scoring engine (packages/find) AND the web chip both read THIS table —
+ * never restate the numbers elsewhere; a hand-copied weight list drifted
+ * once already. v2 kept v1's weights on purpose: the label-mined fix was
+ * feature DIRECTION (exec titles and Host roles were anti-signals), not the
+ * weighting.
+ */
+export const PRIORITY_WEIGHTS_BY_VERSION: Record<
+  PriorityVersion,
+  Record<PriorityComponentKey, number>
+> = {
+  "heuristic-v1": {
+    personFit: 30,
+    accountFit: 20,
+    intentStrength: 20,
+    timingFreshness: 15,
+    signalConfidence: 10,
+    contactability: 5,
+  },
+  "heuristic-v2": {
+    personFit: 30,
+    accountFit: 20,
+    intentStrength: 20,
+    timingFreshness: 15,
+    signalConfidence: 10,
+    contactability: 5,
+  },
+};
+
 /**
  * Shadow-mode explainable priority score (issue #410, Phase 1). Mirrors
  * core's `ProspectPriority` — the API contract copy, like
@@ -406,17 +449,10 @@ export type QueueStatusView = "pending" | "approved" | "rejected" | "sent" | "ex
  * gates by it, and it is NOT a conversion probability.
  */
 export interface ProspectPriorityView {
-  version: "heuristic-v1";
+  version: PriorityVersion;
   /** Weighted total, clamped integer 0..100. */
   total: number;
-  components: {
-    personFit: number;
-    accountFit: number;
-    intentStrength: number;
-    timingFreshness: number;
-    signalConfidence: number;
-    contactability: number;
-  };
+  components: Record<PriorityComponentKey, number>;
   /** Concise evidence strings, fixed order. */
   reasons: string[];
   finder: string;


### PR DESCRIPTION
Phase 2 PR-2 (#410 follow-up). Still shadow-only — nothing orders, gates, or sends by a score.

The bulk-excluded feature gauge (#414/#415) showed v1's priors were **anti-signals** for this ICP: exec titles 35–44% approval vs 55–92% baseline; Luma Hosts 35% vs Guests 54%. v2 fixes feature **direction** (weights unchanged):

- `PriorityVersion` + `PRIORITY_WEIGHTS_BY_VERSION` live in shared-types — the engine and the web chip both read one table (the chip's hand-copied weights are gone); guarded by a version-sync test.
- `parseProspectPriority` accepts every shipped version (old artifacts keep rendering); `hasCurrentScore` requires the current one, so a plain `find score-prospects` run auto-upgrades v1 → v2.
- Engine: `personSignals` override title bands and may land below neutral; `scoreSignals` is authoritative (no neutral floor — an anti-signal must be expressible); X reach bands adjusted for parity.
- Adapters: luma drops bio-as-seniority + inverts the exec prior + Host < Guest; repo-interest inverts the exec prior; the other 12 byte-identical.

**Measured verdict (sdk, 8,360 rows re-scored, $0)**: luma AUC **0.36 → 0.63** (0.59 on bulk-excluded labels) — inversion fixed — but mean gap +1 is under the pre-agreed acceptance bar (gap ≥ +5 AND AUC ≥ 0.60). Per plan, PR-3's ranked review order ships config-gated with `queueReviewOrder` **defaulting to `newest`**; recorded in STATUS.md.

Verify: fmt/typecheck/lint clean, **2425 tests / 186 files** (version-sync, v1-auto-upgrade, per-version chip rendering, anti-signal engine + adapter behavior).

https://claude.ai/code/session_019XJ5qAUV9NDrRrbqdTLebU

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `heuristic-v2` label-mined priors and versioned artifacts to `find`
> - Upgrades the `find` engine to `heuristic-v2`, stamping new artifacts with the version. The core parser accepts both v1 and v2, and weight tables are centralized in `shared-types` for engine and web use.
> - Introduces label-mined priors via `personSignals` in `PriorityEvidence`. `scorePersonFit` and `scoreSignals` use these explicit signals, allowing scores below the neutral 50 baseline. `scoreSignals` switches to authoritative strongest-wins logic without a neutral floor.
> - Updates `luma-events` and `repo-interest` adapters to use `minedTitleSignals`, dropping exec title strength to 35 and making non-exec titles neutral. `luma-events` also reverses Host (45) and Guest (65) intent strengths.
> - Changes backfill logic in `hasCurrentScore` to only skip rows matching the current `PRIORITY_VERSION`. Previously scored v1 rows will now be re-scored.
> - Risk: `scoreSignals` removes the neutral floor in [_priority.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/416/files#diff-0068d693e26e71b298b4d2f623df8f517663cf143442ad6d0b4e7401d66d4411), allowing `accountFit` and `intentStrength` to drop to 0. Plain backfill runs will re-score all existing `heuristic-v1` artifacts.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 982d0b9. 8 files reviewed, 1 issue evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>STATUS.md — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 21](https://github.com/oneshot-agent/oneshot-gtm/blob/982d0b949c6d822c0ae019abadf72c33191381dd/STATUS.md#L21): `STATUS.md` states that ranked review order ships with a `queueReviewOrder` setting defaulting to `newest`, but the reviewed commit contains no `queueReviewOrder` configuration or ranked-review-order implementation (the only repository match is this status line). This documents a nonexistent control and can mislead operators into believing scores can be enabled/configured while the feature remains unavailable. <b>[ Out of scope (triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->