### PR TITLE
feat(queue): ranked review order — config-gated, review-only (Phase 2 PR-3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ bun run cli -- ui [--dev] [--port 4000] [--no-browser]
 Nine pages plus a run form:
 
 - **Home** — spend, reply-rate trend, in-flight cadences, and a scheduler strip showing each trigger's state, last run and next due
-- **Queue** — triggers table (enable, edit config, fire) plus the target queue with bulk approve and per-play **Drain**
+- **Queue** — triggers table (enable, edit config, fire) plus the target queue with bulk approve and per-play **Drain**; the pending review list can be ordered `newest` or `ranked` (finder-interleaved priority score with exploration slots — a toggle on the page, defaulted by `queueReviewOrder` in config)
 - **Add Prospect** — paste a LinkedIn / X / GitHub URL; `deepResearchPerson` builds a dossier, the LLM picks an angle against your ICP and drafts an intro, and the row lands in the queue
 - **Replies** — every reply matched to its prospect, play and cadence status across all sender identities; answer in place, by hand or LLM-drafted. Drafting is research-grounded: known prospects reuse their stored dossier, unknown senders get enriched + their site read (~$0.06, cached 30 days, receipted under `inbox-reply`), and replies may cite links from your product brief — never invented ones
 - **Cadences** — stop, log outcome, preview the next step, batch send

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 50 CLI commands, 17 plays, 11 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-01** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2425 tests / 186 files** · typecheck + oxlint + oxfmt clean.
+Last verified **2026-09-01** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2437 tests / 187 files** · typecheck + oxlint + oxfmt clean.
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of
@@ -18,7 +18,7 @@ The person-level ICP gate (#45) was calibrated against 84 real LinkedIn titles (
 
 Reply detection was verified on 2026-08-23 against the real mailboxes: a sliced sweep of all four inboxes from the first send onward (4,833 inbound, every slice fully covered) found exactly the replies the live poll then recorded on restart. Since 2026-08-28 every inbound is also classified (#63) — out-of-office autoresponders, dead-mailbox notices and unsubscribes are recorded for the conversation history but never count as replies, and the latter two durably suppress the address at the send funnel.
 
-Shadow priority score (#410): heuristic-v2 measured 2026-09-01 on 794 clean human labels — luma-events AUC 0.59-0.63 (up from v1's inverted 0.36), mean gap +1. Under the Phase 2 acceptance bar (gap ≥ +5, AUC ≥ 0.60), so ranked review order ships config-gated with `queueReviewOrder` defaulting to `newest`; scores stay shadow/display-only until richer features clear the bar.
+Shadow priority score (#410): heuristic-v2 measured 2026-09-01 on 794 clean human labels — luma-events AUC 0.59-0.63 (up from v1's inverted 0.36), mean gap +1. Under the Phase 2 acceptance bar (gap ≥ +5, AUC ≥ 0.60), so the ranked review order shipped config-gated with `queueReviewOrder` defaulting to `newest` (a toggle on /queue; scores drive nothing else until richer features clear the bar).
 
 Updated by hand after each dogfood run.
 

--- a/apps/server/__tests__/queue-list-route.test.ts
+++ b/apps/server/__tests__/queue-list-route.test.ts
@@ -7,11 +7,13 @@ import { describe, expect, it, vi } from "vitest";
 
 const listQueueCalls: Array<Record<string, unknown>> = [];
 let nextRows: unknown[] = [];
+let configOrder: "ranked" | "newest" = "newest";
 
 vi.mock("@oneshot-gtm/core", async () => {
   const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
   return {
     ...actual,
+    loadConfig: () => ({ ...actual.loadConfig(), queueReviewOrder: configOrder }),
     getLedger: () => ({
       listQueue: (args: Record<string, unknown>) => {
         listQueueCalls.push(args);
@@ -168,5 +170,81 @@ describe("listQueueRoute — priority projection", () => {
       JSON.stringify({ ...VALID_PRIORITY, reasons: ["ok", 42, null] }),
     )) as { reasons: string[] };
     expect(got.reasons).toEqual(["ok"]);
+  });
+});
+
+// Ranked review order (Phase 2 PR-3): ranked applies ONLY to the pending
+// review view, is config-defaulted, param-overridable, and echoed back.
+
+function pendingRow(id: number, play: string, total: number | null): Record<string, unknown> {
+  return {
+    ...queueRow(
+      total === null
+        ? null
+        : JSON.stringify({
+            ...VALID_PRIORITY,
+            total,
+            components: { ...VALID_PRIORITY.components },
+          }),
+    ),
+    id,
+    play_name: play,
+    dedupe_key: `k${id}`,
+    found_at: `2026-09-01 10:00:${String(id).padStart(2, "0")}`,
+  };
+}
+
+describe("listQueueRoute — ranked review order", () => {
+  async function idsOf(url: string): Promise<{ ids: number[]; order: unknown }> {
+    const out = await body(url);
+    return {
+      ids: (out["rows"] as Array<{ id: number }>).map((r) => r.id),
+      order: out["order"],
+    };
+  }
+
+  it("?order=ranked interleaves finders on the pending view and echoes the mode", async () => {
+    listQueueCalls.length = 0;
+    nextRows = [pendingRow(1, "aaa", 90), pendingRow(2, "aaa", 80), pendingRow(3, "zzz", 85)];
+    try {
+      const { ids, order } = await idsOf("http://x/api/queue?status=pending&order=ranked");
+      expect(order).toBe("ranked");
+      // zzz interleaves at slot 2 despite the lower (incomparable) total;
+      // aaa's 80 is the bottom decile here and rotates to the exploration tail.
+      expect(ids).toEqual([1, 3, 2]);
+      // Ranked mode reads the wider window, not the page limit.
+      expect(listQueueCalls[0]).toMatchObject({ status: "pending", limit: 1000 });
+    } finally {
+      nextRows = [];
+    }
+  });
+
+  it("the configured default applies when no param is given", async () => {
+    configOrder = "ranked";
+    nextRows = [pendingRow(1, "aaa", 10), pendingRow(2, "zzz", 90)];
+    try {
+      const ranked = await idsOf("http://x/api/queue?status=pending");
+      expect(ranked.order).toBe("ranked");
+      const overridden = await idsOf("http://x/api/queue?status=pending&order=newest");
+      expect(overridden.order).toBe("newest");
+      expect(overridden.ids).toEqual([1, 2]);
+    } finally {
+      configOrder = "newest";
+      nextRows = [];
+    }
+  });
+
+  it("never ranks other statuses or explicit id picks", async () => {
+    nextRows = [pendingRow(1, "aaa", 10), pendingRow(2, "zzz", 90)];
+    try {
+      const approved = await idsOf("http://x/api/queue?status=approved&order=ranked");
+      expect(approved.order).toBe("newest");
+      expect(approved.ids).toEqual([1, 2]);
+      const picked = await idsOf("http://x/api/queue?status=pending&order=ranked&ids=1,2");
+      expect(picked.order).toBe("newest");
+      expect(picked.ids).toEqual([1, 2]);
+    } finally {
+      nextRows = [];
+    }
   });
 });

--- a/apps/server/src/api/queue.ts
+++ b/apps/server/src/api/queue.ts
@@ -1,6 +1,7 @@
 import {
   getLedger,
   isDraining,
+  loadConfig,
   isRecentlyContacted,
   isSendDeferred,
   parseProspectPriority,
@@ -8,7 +9,7 @@ import {
   type QueueStatus,
   type TelemetryOutcome,
 } from "@oneshot-gtm/core";
-import { drainQueue } from "@oneshot-gtm/find";
+import { drainQueue, rankPendingRows } from "@oneshot-gtm/find";
 import {
   MANUAL_PLAYS,
   enrollInCadence,
@@ -91,6 +92,15 @@ function toView(row: QueueRow): QueueRowView {
   };
 }
 
+/**
+ * Ranked mode reads a wider pending window than the page, ranks it in memory
+ * (interleave + score-within-finder + exploration — see find/_rank.ts), then
+ * slices. Product logic stays in the tested pure function; listQueue SQL is
+ * untouched. Rows past the window never enter the ranking — the same
+ * truncation class as the 200-row page itself.
+ */
+const RANK_WINDOW = 1000;
+
 export function listQueueRoute(req: Request): Response {
   const url = new URL(req.url);
   const playName = url.searchParams.get("play") ?? undefined;
@@ -101,23 +111,33 @@ export function listQueueRoute(req: Request): Response {
   const ids = parseQueueIds(url.searchParams.get("ids"));
   const limit = Math.min(500, Number.parseInt(url.searchParams.get("limit") ?? "200", 10) || 200);
   const ledger = getLedger();
+  const orderParam = url.searchParams.get("order");
+  const requestedOrder =
+    orderParam === "ranked" || orderParam === "newest"
+      ? orderParam
+      : (loadConfig().queueReviewOrder ?? "newest");
+  // Ranked order exists for ONE surface: the pending review list. Explicit id
+  // picks and every other status keep chronological order.
+  const ranked = requestedOrder === "ranked" && status === "pending" && !ids;
   const filterArgs: {
     playName?: string;
     status?: QueueStatus;
     limit?: number;
     ids?: number[];
-  } = { limit: ids ? Math.max(limit, ids.length) : limit };
+  } = { limit: ranked ? RANK_WINDOW : ids ? Math.max(limit, ids.length) : limit };
   if (playName) filterArgs.playName = playName;
   if (status) filterArgs.status = status;
   if (ids) filterArgs.ids = ids;
   const rows = ledger.listQueue(filterArgs);
+  const ordered = ranked ? rankPendingRows(rows).slice(0, limit) : rows;
   const counts: QueueCounts = ledger.queueCounts();
   // Unfiltered on purpose — the drain button needs per-play approved counts
   // regardless of the page's current filter.
   const body: QueueListResponse = {
-    rows: rows.map(toView),
+    rows: ordered.map(toView),
     counts,
     approvedByPlay: ledger.approvedCountsByPlay(),
+    order: ranked ? "ranked" : "newest",
   };
   const capacity = sendsToday();
   if (capacity) body.sendsToday = capacity;

--- a/apps/web/__tests__/priorityChip.test.ts
+++ b/apps/web/__tests__/priorityChip.test.ts
@@ -78,3 +78,10 @@ describe("per-version rendering", () => {
     expect(priorityChip(v2)!.label).toBe("61 · shadow");
   });
 });
+
+describe("shadow suffix under ranked order", () => {
+  it("drops the suffix once the score drives ordering", () => {
+    expect(priorityChip(priority(72), false, { shadow: false })!.label).toBe("72");
+    expect(priorityChip(priority(72), false, { shadow: true })!.label).toBe("72 · shadow");
+  });
+});

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -204,6 +204,8 @@ export const api = {
     play?: string;
     status?: QueueStatusView;
     limit?: number;
+    /** Review-order override; omit to use the configured default. */
+    order?: "ranked" | "newest";
     /** Explicit row pick — the "drain selected" path. */
     ids?: number[];
   }) => {
@@ -211,6 +213,7 @@ export const api = {
     if (opts?.play) q.set("play", opts.play);
     if (opts?.status) q.set("status", opts.status);
     if (opts?.limit != null) q.set("limit", String(opts.limit));
+    if (opts?.order) q.set("order", opts.order);
     // Note the `!= null`, not a length check: an empty array is an explicit
     // "nothing picked" and must reach the server as `ids=`, or the server would
     // read it as absent and return the unscoped batch instead of no rows.

--- a/apps/web/src/lib/priorityChip.ts
+++ b/apps/web/src/lib/priorityChip.ts
@@ -24,14 +24,21 @@ const MAX_TITLE_REASONS = 4;
  * and companies the structured `<Pii>` masking can't reach, so under the mask
  * they are suppressed entirely (the numeric score is not identifying).
  */
-export function priorityChip(p: ProspectPriorityView | null, masked = false): PriorityChip | null {
+export function priorityChip(
+  p: ProspectPriorityView | null,
+  masked = false,
+  opts: { shadow?: boolean } = {},
+): PriorityChip | null {
   if (!p) return null;
   const tone: PriorityTone = p.total >= 70 ? "signal" : p.total >= 40 ? "neutral" : "receipt";
   const reasons = masked
     ? []
     : p.reasons.filter((r) => r.trim() !== "").slice(0, MAX_TITLE_REASONS);
+  // "· shadow" says the score is informational-only; once the ranked review
+  // order is live on the page the score IS driving the order, so drop it.
+  const shadow = opts.shadow ?? true;
   return {
-    label: `${p.total} · shadow`,
+    label: shadow ? `${p.total} · shadow` : `${p.total}`,
     tone,
     title: reasons.length > 0 ? reasons.join(" · ") : `experimental priority score (${p.finder})`,
   };

--- a/apps/web/src/routes/queue.tsx
+++ b/apps/web/src/routes/queue.tsx
@@ -127,17 +127,21 @@ function QueuePage() {
   const [drainSenderCohort, setDrainSenderCohort] = useState("");
   const [drainOffer, setDrainOffer] = useState("");
   const [drainDryRun, setDrainDryRun] = useState(true);
+  // null = follow the configured default; the server echoes what it used.
+  const [orderOverride, setOrderOverride] = useState<"ranked" | "newest" | null>(null);
 
   const queueQuery = useQuery({
-    queryKey: ["queue", statusFilter, playFilter],
+    queryKey: ["queue", statusFilter, playFilter, orderOverride],
     queryFn: () =>
       api.queue({
         ...(statusFilter !== "all" ? { status: statusFilter } : {}),
         ...(playFilter !== "all" ? { play: playFilter } : {}),
+        ...(orderOverride ? { order: orderOverride } : {}),
         limit: 200,
       }),
     refetchInterval: 20_000,
   });
+  const effectiveOrder = queueQuery.data?.order ?? "newest";
 
   const invalidate = (): void => {
     void qc.invalidateQueries({ queryKey: ["queue"] });
@@ -344,6 +348,22 @@ function QueuePage() {
               {s}
             </Button>
           ))}
+          {statusFilter === "pending" && (
+            <>
+              <span className="mx-2 h-4 w-px bg-ink-rule" />
+              <span className="ln-eyebrow">order</span>
+              {(["newest", "ranked"] as const).map((o) => (
+                <Button
+                  key={o}
+                  variant={effectiveOrder === o ? "primary" : "ghost"}
+                  size="sm"
+                  onClick={() => setOrderOverride(o)}
+                >
+                  {o}
+                </Button>
+              ))}
+            </>
+          )}
           <span className="mx-2 h-4 w-px bg-ink-rule" />
           <span className="ln-eyebrow">play</span>
           <Button
@@ -390,7 +410,7 @@ function QueuePage() {
         </div>
 
         {/* 7-day signal strip — enqueues per day from the rows in memory. */}
-        {rows.length > 0 && <SignalStrip rows={rows} />}
+        {rows.length > 0 && <SignalStrip rows={rows} ranked={effectiveOrder === "ranked"} />}
 
         {queueQuery.isLoading ? (
           Array.from({ length: 5 }, (_, i) => <SkeletonRow key={i} />)
@@ -429,6 +449,7 @@ function QueuePage() {
                 <QueueRow
                   key={row.id}
                   row={row}
+                  ranked={effectiveOrder === "ranked"}
                   zebra={i % 2 === 1}
                   expanded={expanded === row.id}
                   selected={selected.has(row.id)}
@@ -619,6 +640,7 @@ function QueuePage() {
 
 function QueueRow({
   row,
+  ranked,
   zebra,
   expanded,
   selected,
@@ -631,6 +653,7 @@ function QueueRow({
   busy,
 }: {
   row: QueueRowView;
+  ranked: boolean;
   zebra: boolean;
   expanded: boolean;
   selected: boolean;
@@ -657,7 +680,7 @@ function QueueRow({
   // Privacy mode suppresses reason text — freeform reasons can embed names
   // and companies the structured <Pii> masking can't reach.
   const { masked } = usePrivacy();
-  const prio = priorityChip(row.priority, masked);
+  const prio = priorityChip(row.priority, masked, { shadow: !ranked });
   return (
     <>
       <tr
@@ -1191,7 +1214,7 @@ function DraftSection({
  * rows currently in memory) but gives a quick visual pulse without any
  * new API.
  */
-function SignalStrip({ rows }: { rows: QueueRowView[] }) {
+function SignalStrip({ rows, ranked = false }: { rows: QueueRowView[]; ranked?: boolean }) {
   const days = buildSignalDays(rows);
   const max = Math.max(1, ...days.map((d) => d.count));
   const total = days.reduce((a, d) => a + d.count, 0);
@@ -1199,7 +1222,9 @@ function SignalStrip({ rows }: { rows: QueueRowView[] }) {
   return (
     <div className="flex items-center gap-4 border-b border-ink-rule/60 bg-ink-bg-deep/40 px-6 py-2.5">
       <div className="ln-eyebrow" style={{ fontSize: 10 }}>
-        last 7d
+        {/* A ranked page is no longer "the newest N", so the histogram only
+            describes the rows shown — make the existing approximation visible. */}
+        {ranked ? "last 7d · shown rows" : "last 7d"}
       </div>
       <div className="flex items-end gap-1" aria-hidden="true">
         {days.map((d) => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -42,6 +42,7 @@ const DEFAULTS: OneShotConfig = {
   emailIdentities: null,
   icpOneLiner: null,
   cadenceOverrides: null,
+  queueReviewOrder: "newest",
   founderCredentials: null,
   productPortfolio: null,
   partners: null,

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -238,6 +238,16 @@ export interface OneShotConfig {
    * breakup position) is NOT overridable — timing only.
    */
   cadenceOverrides: Record<string, number[]> | null;
+  /**
+   * Default order of the /queue pending review list. "ranked" interleaves
+   * finders with score-within-finder + exploration slots (see find/_rank.ts);
+   * "newest" is the classic found_at DESC. Defaults to "newest": the
+   * 2026-09-01 heuristic-v2 measurement (luma AUC 0.59-0.63, gap +1) is under
+   * the Phase 2 acceptance bar for ranked-by-default. Per-request override:
+   * GET /api/queue?order=. Optional so pre-existing config literals and older
+   * config files stay valid; readers treat absent as "newest".
+   */
+  queueReviewOrder?: "ranked" | "newest";
   /** Founder's résumé / credentials — the founder-trust social-proof beat. */
   founderCredentials: string | null;
   /** Products you've shipped — the peer-founder social-proof beat. */

--- a/packages/find/__tests__/rank.test.ts
+++ b/packages/find/__tests__/rank.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from "vitest";
+import { rankPendingRows, roundRobin } from "../src/_rank.ts";
+
+function artifact(total: number): string {
+  return JSON.stringify({
+    version: "heuristic-v2",
+    total,
+    components: {
+      personFit: total,
+      accountFit: total,
+      intentStrength: total,
+      timingFreshness: total,
+      signalConfidence: total,
+      contactability: total,
+    },
+    reasons: [],
+    finder: "t",
+    scoredAt: "2026-09-01T12:00:00.000Z",
+  });
+}
+
+let nextId = 1;
+function row(play: string, total: number | null, extra: Record<string, unknown> = {}) {
+  const id = nextId++;
+  return {
+    id,
+    play_name: play,
+    dedupe_key: `k${id}`,
+    found_at: `2026-09-01 10:00:${String(id % 60).padStart(2, "0")}`,
+    priority_json: total === null ? null : artifact(total),
+    payload_json: JSON.stringify({ name: "x", ...extra }),
+  };
+}
+
+describe("roundRobin (moved from luma.ts)", () => {
+  it("interleaves fairly and sparse buckets surrender capacity", () => {
+    const out = roundRobin(
+      new Map([
+        ["a", [1, 2, 3]],
+        ["b", [10]],
+      ]),
+      4,
+    );
+    expect(out).toEqual([1, 10, 2, 3]);
+  });
+});
+
+describe("rankPendingRows", () => {
+  it("returns a permutation — nothing dropped, nothing duplicated", () => {
+    const rows = [
+      ...Array.from({ length: 10 }, (_, i) => row("show-hn", 40 + i)),
+      ...Array.from({ length: 10 }, (_, i) => row("post-funding", 50 + i)),
+      row("show-hn", null),
+    ];
+    const ranked = rankPendingRows(rows);
+    expect(ranked.map((r) => r.id).toSorted((a, b) => a - b)).toEqual(
+      rows.map((r) => r.id).toSorted((a, b) => a - b),
+    );
+  });
+
+  it("is deterministic", () => {
+    const rows = [row("a", 70), row("b", 30), row("a", null), row("b", 90), row("a", 55)];
+    expect(rankPendingRows(rows)).toEqual(rankPendingRows(rows));
+  });
+
+  it("interleaves finders instead of sorting one flat list", () => {
+    const rows = [row("aaa", 90), row("aaa", 89), row("aaa", 88), row("zzz", 10), row("zzz", 9)];
+    const plays = rankPendingRows(rows, { explorationInterval: 100 }).map((r) => r.play_name);
+    // zzz's low totals must not banish it to the tail — the second slot is zzz.
+    expect(plays[1]).toBe("zzz");
+  });
+
+  it("orders by score within a finder; pool rows (bottom decile + unscored) trail", () => {
+    const low = row("solo", 40);
+    const high = row("solo", 90);
+    const unscored = row("solo", null);
+    const mid = row("solo", 60);
+    const ranked = rankPendingRows([low, high, unscored, mid], { explorationInterval: 100 });
+    // Main stream is score-desc; the bottom-decile row (40) and the unscored
+    // row live in the exploration pool (hash-ordered) at the tail here.
+    expect(ranked.slice(0, 2).map((r) => r.id)).toEqual([high.id, mid.id]);
+    expect(new Set(ranked.slice(2).map((r) => r.id))).toEqual(new Set([low.id, unscored.id]));
+  });
+
+  it("sub-buckets luma rows by eventCity so city diversity survives ranking", () => {
+    const sf1 = row("luma-events", 80, { eventCity: "San Francisco" });
+    const sf2 = row("luma-events", 79, { eventCity: "San Francisco" });
+    const ny = row("luma-events", 78, { eventCity: "New York" });
+    const junk = row("luma-events", 10, { eventCity: "San Francisco" }); // → exploration pool
+    const ranked = rankPendingRows([sf1, sf2, ny, junk], { explorationInterval: 100 });
+    // NY interleaves at slot 1 (key order) despite the lower score.
+    expect(ranked.map((r) => r.id)).toEqual([ny.id, sf1.id, sf2.id, junk.id]);
+  });
+
+  it("hands every Kth slot to the exploration pool (unscored rows get eyes)", () => {
+    const rows = [
+      ...Array.from({ length: 8 }, (_, i) => row("solo", 60 + i)),
+      row("solo", null),
+      row("solo", null),
+    ];
+    const ranked = rankPendingRows(rows, { explorationInterval: 3 });
+    // Pool = the two unscored rows plus the bottom-decile scored row (60).
+    // Slots 3 and 6 (1-indexed multiples of 3) must come from that pool.
+    const poolTotals = new Set([null, 60]);
+    const totalAt = (i: number) => {
+      const raw = ranked[i]!.priority_json;
+      return raw === null ? null : (JSON.parse(raw) as { total: number }).total;
+    };
+    expect(poolTotals.has(totalAt(2))).toBe(true);
+    expect(poolTotals.has(totalAt(5))).toBe(true);
+    expect(ranked).toHaveLength(10);
+  });
+
+  it("survives empty input, all-unscored input, and malformed payloads", () => {
+    expect(rankPendingRows([])).toEqual([]);
+    const unscored = [row("a", null), row("b", null), row("a", null)];
+    expect(rankPendingRows(unscored)).toHaveLength(3);
+    const malformed = { ...row("luma-events", 70), payload_json: "{broken" };
+    expect(rankPendingRows([malformed])).toHaveLength(1);
+  });
+});

--- a/packages/find/src/_rank.ts
+++ b/packages/find/src/_rank.ts
@@ -1,0 +1,144 @@
+import { parseProspectPriority } from "@oneshot-gtm/core";
+
+/**
+ * Constrained ranking for the /queue REVIEW surface (Phase 2 of #410, PR-3).
+ * Pure and deterministic — zero I/O, no RNG, output is a permutation of the
+ * input. Review order only: drains, approvals, cadences, and sends never
+ * touch this.
+ *
+ * Cross-finder totals are NOT comparable (different adapters produce
+ * different achievable ranges — the same argument `_x-lanes.ts` makes for
+ * lanes), so ranking never sorts one flat list. Finders are interleaved
+ * round-robin; the score only orders rows WITHIN a finder.
+ */
+
+/** Fairly interleave buckets; sparse buckets surrender unused capacity.
+ *  (Moved verbatim from luma.ts, which now imports it — the same primitive
+ *  drives Luma's city/event sampling and the ranked review order.) */
+export function roundRobin<T>(buckets: ReadonlyMap<string, readonly T[]>, cap: number): T[] {
+  const out: T[] = [];
+  const cursors = new Map<string, number>();
+  let added = true;
+  while (out.length < cap && added) {
+    added = false;
+    for (const [key, items] of buckets) {
+      if (out.length >= cap) break;
+      const cursor = cursors.get(key) ?? 0;
+      const item = items[cursor];
+      if (item === undefined) continue;
+      out.push(item);
+      cursors.set(key, cursor + 1);
+      added = true;
+    }
+  }
+  return out;
+}
+
+export interface RankableRow {
+  id: number;
+  play_name: string;
+  dedupe_key: string;
+  found_at: string;
+  priority_json: string | null;
+  payload_json: string;
+}
+
+export interface RankOptions {
+  /** Every Kth slot goes to the exploration pool (unscored ∪ bottom decile). Default 5. */
+  explorationInterval?: number;
+}
+
+/** Same stable hash as plays' admissionSlot: decisions must not flap across refetches. */
+function stableHash(key: string): number {
+  let h = 0;
+  for (const ch of key) h = (h * 31 + ch.charCodeAt(0)) >>> 0;
+  return h;
+}
+
+function totalOf(row: RankableRow): number | null {
+  return parseProspectPriority(row.priority_json)?.total ?? null;
+}
+
+/** Luma rows sub-bucket by city so review order preserves the finder's city diversity. */
+function bucketKeyOf(row: RankableRow): string {
+  if (row.play_name !== "luma-events") return row.play_name;
+  let city = "";
+  try {
+    const payload = JSON.parse(row.payload_json) as Record<string, unknown>;
+    if (typeof payload["eventCity"] === "string") city = payload["eventCity"];
+  } catch {
+    // malformed payload → default bucket
+  }
+  return `luma-events::${city}`;
+}
+
+/**
+ * Rank pending rows for review: bucket by finder (luma by city), score-desc
+ * within a bucket (unscored rows sink to the bucket tail), interleave buckets
+ * in key order, and hand every Kth slot to an exploration pool so rows the
+ * heuristic dislikes still get human eyes (the labels Phase 3 learns from
+ * must not collapse into the heuristic's own blind spot).
+ */
+export function rankPendingRows<T extends RankableRow>(rows: T[], opts: RankOptions = {}): T[] {
+  const interval = Math.max(2, opts.explorationInterval ?? 5);
+  if (rows.length === 0) return [];
+
+  const totals = new Map<number, number | null>(rows.map((r) => [r.id, totalOf(r)]));
+
+  // Exploration pool: unscored rows plus the bottom decile of scored ones,
+  // ordered by the stable hash so the rotation is deterministic per row set.
+  const scoredTotals = [...totals.values()]
+    .filter((t): t is number => t !== null)
+    .toSorted((a, b) => a - b);
+  const decileCut =
+    scoredTotals.length > 0 ? scoredTotals[Math.floor(scoredTotals.length / 10)]! : null;
+  const inPool = (r: T): boolean => {
+    const t = totals.get(r.id) ?? null;
+    return t === null || (decileCut !== null && t <= decileCut);
+  };
+  const pool = rows
+    .filter(inPool)
+    .toSorted((a, b) => stableHash(a.dedupe_key) - stableHash(b.dedupe_key) || a.id - b.id);
+  const poolIds = new Set(pool.map((r) => r.id));
+
+  // Main stream: per-bucket score desc → found_at desc → id desc, buckets
+  // interleaved in KEY order — deliberately not by top score, because
+  // cross-finder totals aren't comparable; interleaving is the fairness.
+  const buckets = new Map<string, T[]>();
+  for (const row of rows) {
+    if (poolIds.has(row.id)) continue;
+    const key = bucketKeyOf(row);
+    buckets.set(key, [...(buckets.get(key) ?? []), row]);
+  }
+  const orderedBuckets = new Map(
+    [...buckets.entries()]
+      .toSorted(([a], [b]) => a.localeCompare(b))
+      .map(([key, items]) => [
+        key,
+        items.toSorted((a, b) => {
+          const ta = totals.get(a.id) ?? -1;
+          const tb = totals.get(b.id) ?? -1;
+          if (tb !== ta) return tb - ta;
+          if (a.found_at !== b.found_at) return a.found_at < b.found_at ? 1 : -1;
+          return b.id - a.id;
+        }),
+      ]),
+  );
+  const stream = roundRobin(orderedBuckets, rows.length);
+
+  // Weave: every `interval`-th slot pulls from the exploration pool; when one
+  // side runs dry the other fills the remainder.
+  const out: T[] = [];
+  let s = 0;
+  let e = 0;
+  for (let slot = 0; out.length < rows.length; slot++) {
+    const wantExploration = (slot + 1) % interval === 0;
+    if ((wantExploration && e < pool.length) || s >= stream.length) {
+      if (e < pool.length) out.push(pool[e++]!);
+      else out.push(stream[s++]!);
+    } else {
+      out.push(stream[s++]!);
+    }
+  }
+  return out;
+}

--- a/packages/find/src/index.ts
+++ b/packages/find/src/index.ts
@@ -30,6 +30,7 @@ export * from "./_pending.ts";
 export * from "./_priority.ts";
 export * from "./_priority-adapters.ts";
 export * from "./_gauge.ts";
+export * from "./_rank.ts";
 // Exported for the `find enrich-linkedin` backfill, which reuses the finders'
 // resolver so results are cached and billed identically.
 export * from "./_linkedin.ts";

--- a/packages/find/src/luma.ts
+++ b/packages/find/src/luma.ts
@@ -13,6 +13,7 @@ import type { LumaEventsTarget } from "@oneshot-gtm/plays";
 import { isDuplicate, urlDomain } from "./_dedupe.ts";
 import { resolveVerifyEnrichQualify } from "./_contact.ts";
 import { enqueueScoredTarget } from "./_priority-adapters.ts";
+import { roundRobin } from "./_rank.ts";
 import { icpFilter, resolveIcp } from "./_filter.ts";
 import { qualifyPreSpend } from "./_qualify.ts";
 import { findLinkedInUrl, isLinkedInProfileUrl } from "./_linkedin.ts";
@@ -71,25 +72,8 @@ interface AttendeeWithEvent {
   };
 }
 
-/** Fairly interleave buckets; sparse buckets surrender unused capacity. */
-function roundRobin<T>(buckets: ReadonlyMap<string, readonly T[]>, cap: number): T[] {
-  const out: T[] = [];
-  const cursors = new Map<string, number>();
-  let added = true;
-  while (out.length < cap && added) {
-    added = false;
-    for (const [key, items] of buckets) {
-      if (out.length >= cap) break;
-      const cursor = cursors.get(key) ?? 0;
-      const item = items[cursor];
-      if (item === undefined) continue;
-      out.push(item);
-      cursors.set(key, cursor + 1);
-      added = true;
-    }
-  }
-  return out;
-}
+// roundRobin moved to _rank.ts (shared with the ranked review order);
+// behavior is byte-identical.
 
 /**
  * Extract the single-segment slug from a Luma event URL. Returns null when

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -818,6 +818,12 @@ export interface QueueListResponse {
   approvedByPlay: Record<string, number>;
   /** Absent when the capacity computation failed — pages skip the figure. */
   sendsToday?: SendsToday;
+  /**
+   * The order `rows` actually came back in — `?order=` param, else the
+   * configured `queueReviewOrder`. "ranked" only ever applies to the pending
+   * review view; every other view is "newest" (found_at DESC).
+   */
+  order: "ranked" | "newest";
 }
 
 export interface DrainRequest {


### PR DESCRIPTION
Phase 2 PR-3 (#410 follow-up) — the only behavior-changing PR of the phase, shipped exactly per the measured verdict: heuristic-v2's luma AUC 0.59–0.63 / gap +1 is **under** the pre-agreed acceptance bar, so `queueReviewOrder` **defaults to `newest`** and ranked order is opt-in (a toggle on /queue, `?order=` on the API, or the config key).

- **`packages/find/src/_rank.ts`** — pure, deterministic `rankPendingRows`: bucket by finder (luma sub-bucketed by `eventCity` so the finder's city diversity survives into review order), score-desc within a bucket, buckets interleaved via `roundRobin` (extracted verbatim from luma.ts — cross-finder totals aren't comparable, so interleaving is the fairness, per `_x-lanes.ts`'s argument), and every 5th slot reserved for an exploration pool (unscored ∪ bottom decile, `admissionSlot`-style stable hash) so future labels don't collapse into the heuristic's own blind spot. Output is always a permutation of the input.
- **Server** — `?order=ranked|newest`; effective order = param ?? config (optional key, absent = newest). Ranks only the pending review view with no explicit id picks, over a 1000-row window, sliced to the page; response echoes `order`. `listQueue` SQL untouched.
- **Web** — order toggle on the pending view; SignalStrip eyebrow reads "shown rows" under ranked; the priority chip drops its `· shadow` suffix only when the score actually drives the order.
- **Untouched**: drains, `dequeueApproved`, `approveAllPending`, cadences, send paths.

Verify: fmt/typecheck/lint clean, **2437 tests / 187 files** (rank permutation/determinism/interleave/city-diversity/exploration, route param+config+scope tests, luma green after the roundRobin extraction, chip suffix). README + STATUS updated with the toggle and the recorded verdict.

https://claude.ai/code/session_019XJ5qAUV9NDrRrbqdTLebU

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add ranked review order for pending queue, gated by `queueReviewOrder` config
> - Adds `rankPendingRows` in [_rank.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/417/files#diff-0b4b57953bd3595d3ee62e911a3d7267bf7086860409166909b94e6624b4769e): a pure, deterministic function that buckets rows by finder (sub-bucketing luma-events by `eventCity`), sorts within bucket by score, interleaves buckets via `roundRobin`, and weaves in an exploration pool (unscored + bottom decile) every 5th slot.
> - Server route [queue.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/417/files#diff-82603c88c0a618245651db800cb8da95025555c3c6992b82d689dd5b2b34bcd9) reads `?order=ranked|newest`, defaults to `loadConfig().queueReviewOrder`, and applies ranking only to the pending status without explicit `ids`; ranked mode fetches up to `RANK_WINDOW=1000` rows, ranks in-memory, then slices to the original page limit.
> - [QueuePage](https://github.com/oneshot-agent/oneshot-gtm/pull/417/files#diff-ab2702847c8e5daaf53d7f5b91f4e059c734f2980e49449733dd4111103f308a) shows an order toggle when `statusFilter` is pending; ranked mode hides the ` · shadow` suffix on priority chips and relabels the signal strip.
> - [config.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/417/files#diff-4114b8f08217be27efd35a3891857cfabc6eb75aee8ab39ba304e4d1b1095323) and [types.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/417/files#diff-4c2458380e50c967c70d7afe819dc7412180f9f817043f27441de3498e4d0479) add optional `queueReviewOrder?: "ranked" | "newest"` defaulting to `"newest"`.
> - Behavioral Change: `QueueListResponse` in [shared-types](https://github.com/oneshot-agent/oneshot-gtm/pull/417/files#diff-8bfc1c4b53bda948594b3bcdeaead8e4c4130ad092154633bf858b7447c5d62f) gains a required `order: "ranked" | "newest"` field; any consumer not updated will fail type-checks. Ranked mode increases the SQL fetch limit to 1000 rows for the pending view.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 04fd9c4. 11 files reviewed, 4 issues evaluated, 1 issue filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>packages/find/src/_rank.ts — 1 comment posted, 3 evaluated, 1 filtered</summary>
>
> - [line 28](https://github.com/oneshot-agent/oneshot-gtm/blob/04fd9c46b6e5453016dba43d605763dfe78f3bcf/packages/find/src/_rank.ts#L28): `roundRobin` treats an `undefined` element as an exhausted bucket without advancing its cursor. Because `T` is unconstrained, a caller can supply `T = number | undefined`; for example `new Map([['a', [undefined, 1]]])` returns no elements and never reaches `1`, so the exported primitive is not a permutation of its input bucket contents. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->