### PR TITLE
feat: stop cadences on LinkedIn replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ Seventeen of them. Ten have a **Run** page in the dashboard and drain from the q
 
 Five more drain from the queue without a Run form — `profile-intro` (what Add Prospect enqueues), `breakup-revive`, and the three the `x-reposters` finder feeds: `x-repost-intro` (founder-lane email + cadence), `x-amplify` (one-touch launch-day repost ask), and `x-amplify-dm` — the one play that never auto-sends: it drafts X DM/reply text you copy and send by hand from the X app, then **Mark sent** records it as a channel-`x` touch. The last two, `concierge` and `demo-no-show`, are CLI-only because they open with a voice call and an SMS respectively.
 
-Most carry a cadence — a value follow-up, then a breakup, spread over roughly three to nine days and editable per play from `/plays`. Any reply stops the sequence — and is recorded whether the sequence is still running, already finished, or never existed (one-touch plays like `luma-events`), credited to the play whose subject it threads on.
+Most carry a cadence — a value follow-up, then a breakup, spread over roughly three to nine days and editable per play from `/plays`. Any email reply stops every live cadence for that prospect — and is recorded whether the sequence is still running, already finished, or never existed (one-touch plays like `luma-events`), credited to the play whose subject it threads on. You can also stop one cadence deliberately from `/cadences`, with a reason and note: bad-timing/other stops become breakup-revive candidates after the configured 60–90 day cold window, while not-a-fit/do-not-contact remain excluded.
 
 ---
 
@@ -275,6 +275,7 @@ Outbound ships through a **sender identity pool** — any mix of OneShot wallet-
 - **Defer, never exceed.** When every identity is at cap, cadence steps stay due and queue rows stay approved until midnight. Nothing sends over cap.
 - **Two products, one founder, one inbox.** A workspace (see Workspaces) never first-touches someone another workspace emailed in the last 7 days: the draft is held with a `contacted-elsewhere` flag that you can override on a manual send, and auto paths (drain, cadence steps) wait the window out. Touches and the paid lookup caches live in one shared SQLite (`~/.oneshot-gtm-shared/`), so the same person is never researched twice across products.
 - **Replies follow the pool.** The inbox poll merges the OneShot inbox with every authorized Gmail account, so stop-on-reply works whichever identity sent. It walks everything since its last clean poll — a persisted watermark with an hour of overlap, paged newest-first, parking anything beyond one poll's page budget as a backlog the next ticks drain — so a reply is delayed by an outage, never lost to it. A reply you've already read and archived still counts. Answering from `/inbox` records the reply too, replies from the receiving identity, and threads on both transports — Gmail via `In-Reply-To`/`References`, OneShot via `reply_to_email_id`. Sends carry an idempotency key, so a retry after a timeout can't double-send.
+- **LinkedIn replies stop email too.** On `/cadences`, **Mark LinkedIn reply** records the cross-channel reply and stops every active or paused cadence for that prospect. Automation tools can call the authenticated webhook below. Connection acceptance alone does nothing, message text is not retained, and an email already handed to a sender cannot be recalled. A LinkedIn reply resets breakup-revive's cold clock just like an email reply; it does not receive fake email-play attribution.
 
 Add a OneShot domain and mailbox from `/setup` or `identities add` — pick a provisioned domain or type a new one to auto-provision on first send. Add a Gmail account with `gmail auth` (one-time OAuth; needs a Google Cloud _Desktop_ client with the Gmail API on). Add Smartlead mailboxes with `smartlead connect` (paste the workspace API key, pick from your connected accounts) or from `/setup` — Smartlead does the warmup and hosts the inboxes; the default ramp ceiling clamps to each mailbox's own Smartlead limit. **Send-only for now**: replies to Smartlead-sent mail appear in Smartlead's inbox, not `/inbox`, and its bounces aren't harvested — like OneShot identities, `doctor` reports them as not bounce-covered. With no pool configured, behavior is the classic single OneShot identity.
 
@@ -310,7 +311,40 @@ Add a OneShot domain and mailbox from `/setup` or `identities add` — pick a pr
 
 **Secrets** — `~/.oneshot-gtm/.env`, chmod 600, auto-loaded on first import.
 
-**Server** — single-user, local-first, binds `127.0.0.1` only, no auth.
+**Server** — single-user, local-first, binds `127.0.0.1` only. Dashboard routes rely on that local boundary. Keep unsigned intake endpoints private or protect them at your reverse proxy; the LinkedIn reply endpoint has its own bearer authentication.
+
+### Trigger webhooks
+
+Two JSON endpoints feed warm product signals through the normal ICP filter and review queue:
+
+- `POST /api/triggers/signup` requires `name`, `email`, and `phone`; optional fields are `signupContext`, `callWindow`, and `linkedinUrl`. Accepted ICP matches enqueue the `concierge` play.
+- `POST /api/triggers/cal-no-show` requires `name`, `email`, `company`, `missedAt`, and `rescheduleLink`; optional fields are `phone`, `whatTheyWanted`, and `linkedinUrl`. Accepted ICP matches enqueue `demo-no-show`.
+
+Valid matches return `202`; ICP rejections return `200` with `accepted: false`; malformed JSON or fields return `400`. Signup deliveries deduplicate by lowercase email, while no-shows deduplicate by lowercase `email + missedAt`. These two endpoints do **not** yet implement signing or replay protection—keep them on the local boundary or add authentication in front of them. The remaining work is tracked in [ROADMAP.md](./ROADMAP.md#L21).
+
+### LinkedIn reply webhook
+
+Public LinkedIn inbox APIs require partner approval, so OneShot exposes a provider-neutral intake that Expandi, Zapier, Make, n8n, or another automation can map into. Set a random bearer secret in `/setup` or `~/.oneshot-gtm/.env`:
+
+```bash
+LINKEDIN_REPLY_WEBHOOK_SECRET=<random-32+-character-secret>
+```
+
+Then send one stable event ID per actual reply. At least one of `linkedinUrl` or `email` is required; when both match different prospects the request is rejected.
+
+```bash
+curl -X POST http://127.0.0.1:3000/api/triggers/linkedin-reply \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <secret>' \
+  -d '{
+    "source": "expandi",
+    "eventId": "provider-event-123",
+    "occurredAt": "2026-09-01T12:00:00Z",
+    "linkedinUrl": "https://www.linkedin.com/in/example-person"
+  }'
+```
+
+Successful responses include `duplicate`, `prospectId`, `cadencesStopped`, and `inFlightSends`. Retries of the same `source + eventId` succeed without applying the event twice. The endpoint stops OneShot email; the source tool remains responsible for stopping its own LinkedIn automation.
 
 ```
 apps/

--- a/apps/server/__tests__/linkedin-replies-route.test.ts
+++ b/apps/server/__tests__/linkedin-replies-route.test.ts
@@ -32,6 +32,7 @@ function webhook(body: unknown, token = "test-secret-with-enough-entropy"): Requ
 
 describe("LinkedIn reply routes", () => {
   beforeEach(() => {
+    delete process.env["VITE_DEV_SERVER_URL"];
     process.env["LINKEDIN_REPLY_WEBHOOK_SECRET"] = "test-secret-with-enough-entropy";
     resolve.mockReset().mockReturnValue({ status: "matched", prospectId: 7 });
     record.mockReset().mockReturnValue({
@@ -102,5 +103,17 @@ describe("LinkedIn reply routes", () => {
     expect(record).toHaveBeenCalledWith(
       expect.objectContaining({ prospectId: 7, source: "manual" }),
     );
+  });
+
+  it("rejects a cross-origin dashboard mutation", () => {
+    const response = markLinkedInReplyRoute(
+      new Request("http://127.0.0.1:3030/api/prospects/7/linkedin-reply", {
+        method: "POST",
+        headers: { origin: "http://localhost.attacker.example" },
+      }),
+      { id: "7" },
+    );
+    expect(response.status).toBe(403);
+    expect(record).not.toHaveBeenCalled();
   });
 });

--- a/apps/server/__tests__/linkedin-replies-route.test.ts
+++ b/apps/server/__tests__/linkedin-replies-route.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const resolve = vi.fn();
+const record = vi.fn();
+const getProspectById = vi.fn();
+
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    getLedger: () => ({
+      resolveProspectForLinkedInReply: resolve,
+      recordLinkedInReply: record,
+      getProspectById,
+    }),
+  };
+});
+
+const { linkedinReplyWebhookRoute, markLinkedInReplyRoute } =
+  await import("../src/api/linkedin-replies.ts");
+
+function webhook(body: unknown, token = "test-secret-with-enough-entropy"): Request {
+  return new Request("http://localhost/api/triggers/linkedin-reply", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("LinkedIn reply routes", () => {
+  beforeEach(() => {
+    process.env["LINKEDIN_REPLY_WEBHOOK_SECRET"] = "test-secret-with-enough-entropy";
+    resolve.mockReset().mockReturnValue({ status: "matched", prospectId: 7 });
+    record.mockReset().mockReturnValue({
+      duplicate: false,
+      prospectId: 7,
+      cadencesStopped: 2,
+      inFlightSends: 0,
+    });
+    getProspectById.mockReset().mockReturnValue({ id: 7 });
+  });
+
+  it("authenticates and records a valid provider-neutral event", async () => {
+    const response = await linkedinReplyWebhookRoute(
+      webhook({
+        source: "expandi",
+        eventId: "evt-1",
+        occurredAt: "2026-08-01T10:00:00Z",
+        linkedinUrl: "https://www.linkedin.com/in/ada/",
+      }),
+    );
+    expect(response.status).toBe(200);
+    expect(await response.json()).toMatchObject({ accepted: true, cadencesStopped: 2 });
+    expect(record).toHaveBeenCalledWith({
+      prospectId: 7,
+      source: "expandi",
+      externalEventId: "evt-1",
+      occurredAt: "2026-08-01T10:00:00.000Z",
+    });
+  });
+
+  it("rejects bad auth, invalid input, missing prospects, and conflicting identities", async () => {
+    expect((await linkedinReplyWebhookRoute(webhook({}, "wrong"))).status).toBe(401);
+    expect((await linkedinReplyWebhookRoute(webhook({ source: "UPPER" }))).status).toBe(400);
+    resolve.mockReturnValueOnce({ status: "unmatched" });
+    expect(
+      (
+        await linkedinReplyWebhookRoute(
+          webhook({
+            source: "zapier",
+            eventId: "1",
+            occurredAt: "2026-08-01T10:00:00Z",
+            email: "a@example.com",
+          }),
+        )
+      ).status,
+    ).toBe(404);
+    resolve.mockReturnValueOnce({ status: "conflict" });
+    expect(
+      (
+        await linkedinReplyWebhookRoute(
+          webhook({
+            source: "zapier",
+            eventId: "2",
+            occurredAt: "2026-08-01T10:00:00Z",
+            email: "a@example.com",
+          }),
+        )
+      ).status,
+    ).toBe(409);
+  });
+
+  it("supports the dashboard's prospect-id action", async () => {
+    const response = markLinkedInReplyRoute(
+      new Request("http://localhost/api/prospects/7/linkedin-reply", { method: "POST" }),
+      { id: "7" },
+    );
+    expect(response.status).toBe(200);
+    expect(record).toHaveBeenCalledWith(
+      expect.objectContaining({ prospectId: 7, source: "manual" }),
+    );
+  });
+});

--- a/apps/server/src/api/cadences.ts
+++ b/apps/server/src/api/cadences.ts
@@ -110,6 +110,8 @@ function toView(
     stopReason: row.stop_reason as CadenceStopReason | null,
     stopNote: row.stop_note,
     stoppedAt: row.stopped_at,
+    replyChannel: row.reply_channel,
+    replyAt: row.replied_at,
     nextStepDraft,
     nextStepLabel: next?.label ?? null,
     nextStepIsBreakup: next?.isBreakup ?? false,

--- a/apps/server/src/api/linkedin-replies.ts
+++ b/apps/server/src/api/linkedin-replies.ts
@@ -1,0 +1,123 @@
+import { randomUUID, timingSafeEqual } from "node:crypto";
+import { canonicalLinkedInProfileKey, getLedger } from "@oneshot-gtm/core";
+import type { LinkedInReplyResult, LinkedInReplyWebhookRequest } from "@oneshot-gtm/shared-types";
+import { jsonResponse } from "../server.ts";
+
+const SOURCE_RX = /^[a-z0-9][a-z0-9._-]{0,63}$/;
+const EMAIL_RX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export async function linkedinReplyWebhookRoute(req: Request): Promise<Response> {
+  const configured = process.env["LINKEDIN_REPLY_WEBHOOK_SECRET"]?.trim() ?? "";
+  const supplied = (req.headers.get("authorization") ?? "").replace(/^Bearer\s+/i, "");
+  if (!configured || !safeEqual(configured, supplied)) {
+    return jsonResponse({ error: "unauthorized" }, 401, req);
+  }
+  if (!isJson(req))
+    return jsonResponse({ error: "content-type must be application/json" }, 400, req);
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return jsonResponse({ error: "invalid JSON body" }, 400, req);
+  }
+  const parsed = parseWebhook(raw);
+  if (typeof parsed === "string") return jsonResponse({ error: parsed }, 400, req);
+
+  const ledger = getLedger();
+  const matched = ledger.resolveProspectForLinkedInReply(parsed);
+  if (matched.status === "unmatched")
+    return jsonResponse({ error: "prospect not found" }, 404, req);
+  if (matched.status === "conflict") {
+    return jsonResponse({ error: "email and LinkedIn URL identify different prospects" }, 409, req);
+  }
+  return jsonResponse(
+    accepted(
+      ledger.recordLinkedInReply({
+        prospectId: matched.prospectId,
+        source: parsed.source,
+        externalEventId: parsed.eventId,
+        occurredAt: parsed.occurredAt,
+      }),
+    ),
+    200,
+    req,
+  );
+}
+
+export function markLinkedInReplyRoute(req: Request, params: Record<string, string>): Response {
+  const prospectId = Number.parseInt(params["id"] ?? "", 10);
+  if (!Number.isFinite(prospectId)) return jsonResponse({ error: "bad id" }, 400, req);
+  const ledger = getLedger();
+  if (!ledger.getProspectById(prospectId))
+    return jsonResponse({ error: "prospect not found" }, 404, req);
+  return jsonResponse(
+    accepted(
+      ledger.recordLinkedInReply({
+        prospectId,
+        source: "manual",
+        externalEventId: randomUUID(),
+        occurredAt: new Date().toISOString(),
+      }),
+    ),
+    200,
+    req,
+  );
+}
+
+function accepted(result: Omit<LinkedInReplyResult, "accepted">): LinkedInReplyResult {
+  return { accepted: true, ...result };
+}
+
+function parseWebhook(raw: unknown): LinkedInReplyWebhookRequest | string {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return "JSON object body required";
+  const value = raw as Record<string, unknown>;
+  if (value["email"] !== undefined && typeof value["email"] !== "string") {
+    return "email must be a string";
+  }
+  if (value["linkedinUrl"] !== undefined && typeof value["linkedinUrl"] !== "string") {
+    return "linkedinUrl must be a string";
+  }
+  const source = stringValue(value["source"]);
+  const eventId = stringValue(value["eventId"]);
+  const occurredAt = stringValue(value["occurredAt"]);
+  const email = optionalString(value["email"]);
+  const linkedinUrl = optionalString(value["linkedinUrl"]);
+  if (!source || !SOURCE_RX.test(source)) return "source must be a lowercase provider slug";
+  if (!eventId || eventId.length > 200) return "eventId must be 1–200 characters";
+  if (!occurredAt || !Number.isFinite(Date.parse(occurredAt)))
+    return "occurredAt must be an ISO timestamp";
+  if (Date.parse(occurredAt) > Date.now() + 5 * 60_000) return "occurredAt cannot be in the future";
+  if (!email && !linkedinUrl) return "email or linkedinUrl required";
+  if (email && !EMAIL_RX.test(email)) return "email must be valid";
+  if (linkedinUrl && !canonicalLinkedInProfileKey(linkedinUrl)) {
+    return "linkedinUrl must be a LinkedIn member profile URL";
+  }
+  return {
+    source,
+    eventId,
+    occurredAt: new Date(occurredAt).toISOString(),
+    ...(email ? { email } : {}),
+    ...(linkedinUrl ? { linkedinUrl } : {}),
+  };
+}
+
+function safeEqual(expected: string, actual: string): boolean {
+  const a = Buffer.from(expected);
+  const b = Buffer.from(actual);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+function stringValue(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+function optionalString(value: unknown): string | null {
+  return value === undefined ? null : stringValue(value);
+}
+
+function isJson(req: Request): boolean {
+  return (
+    (req.headers.get("content-type") ?? "").toLowerCase().split(";", 1)[0]?.trim() ===
+    "application/json"
+  );
+}

--- a/apps/server/src/api/linkedin-replies.ts
+++ b/apps/server/src/api/linkedin-replies.ts
@@ -45,6 +45,7 @@ export async function linkedinReplyWebhookRoute(req: Request): Promise<Response>
 }
 
 export function markLinkedInReplyRoute(req: Request, params: Record<string, string>): Response {
+  if (!isDashboardOrigin(req)) return jsonResponse({ error: "forbidden origin" }, 403, req);
   const prospectId = Number.parseInt(params["id"] ?? "", 10);
   if (!Number.isFinite(prospectId)) return jsonResponse({ error: "bad id" }, 400, req);
   const ledger = getLedger();
@@ -62,6 +63,21 @@ export function markLinkedInReplyRoute(req: Request, params: Record<string, stri
     200,
     req,
   );
+}
+
+function isDashboardOrigin(req: Request): boolean {
+  const origin = req.headers.get("origin");
+  if (!origin) return true;
+  const allowed = new Set([new URL(req.url).origin]);
+  const vite = process.env["VITE_DEV_SERVER_URL"];
+  if (vite) {
+    try {
+      allowed.add(new URL(vite).origin);
+    } catch {
+      // Invalid dev configuration grants no extra origin.
+    }
+  }
+  return allowed.has(origin);
 }
 
 function accepted(result: Omit<LinkedInReplyResult, "accepted">): LinkedInReplyResult {

--- a/apps/server/src/api/queue.ts
+++ b/apps/server/src/api/queue.ts
@@ -415,6 +415,9 @@ export async function sendDraftRoute(
   const row = ledger.getQueueRow(id);
   if (!row) return jsonResponse({ error: `row #${id} not found` }, 404, req);
   if (row.status === "sent") return jsonResponse({ error: "row already sent" }, 400, req);
+  if (row.status !== "approved") {
+    return jsonResponse({ error: `row is ${row.status}; approve it before sending` }, 409, req);
+  }
   if (!row.last_draft_json) {
     return jsonResponse({ error: "no draft to send — regenerate a draft first" }, 400, req);
   }
@@ -457,6 +460,13 @@ export async function sendDraftRoute(
       409,
       req,
     );
+  }
+  // The claim itself requires status='approved'. Re-read so an expiry that
+  // raced immediately after the claim is observed before provider dispatch.
+  const claimedRow = ledger.getQueueRow(id);
+  if (claimedRow?.status !== "approved") {
+    ledger.clearQueueSendingMarker(id);
+    return jsonResponse({ error: "row changed while sending; refresh and retry" }, 409, req);
   }
 
   let payload: Record<string, unknown> = {};

--- a/apps/server/src/api/setup.ts
+++ b/apps/server/src/api/setup.ts
@@ -106,6 +106,7 @@ export async function getSetupStatus(req: Request): Promise<Response> {
         GMAIL_CLIENT_SECRET: secretSource("GMAIL_CLIENT_SECRET"),
         GMAIL_REFRESH_TOKEN: secretSource("GMAIL_REFRESH_TOKEN"),
         SMARTLEAD_API_KEY: secretSource("SMARTLEAD_API_KEY"),
+        LINKEDIN_REPLY_WEBHOOK_SECRET: secretSource("LINKEDIN_REPLY_WEBHOOK_SECRET"),
         X_API_KEY: secretSource("X_API_KEY"),
         X_API_SECRET: secretSource("X_API_SECRET"),
         X_ACCESS_TOKEN: secretSource("X_ACCESS_TOKEN"),

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -265,11 +265,15 @@ export async function startServer(
 function isLoopbackOrigin(origin: string): boolean {
   // Empty origin = same-origin request (curl, server-side fetch); allow.
   if (origin === "") return true;
-  return (
-    origin.startsWith("http://127.0.0.1") ||
-    origin.startsWith("http://localhost") ||
-    origin.startsWith("http://[::1]")
-  );
+  try {
+    const url = new URL(origin);
+    return (
+      (url.protocol === "http:" || url.protocol === "https:") &&
+      (url.hostname === "127.0.0.1" || url.hostname === "localhost" || url.hostname === "[::1]")
+    );
+  } catch {
+    return false;
+  }
 }
 
 function isLoopbackHost(host: string | null): boolean {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -45,6 +45,7 @@ import {
 } from "./api/triggers.ts";
 import { addProspectRoute } from "./api/prospects.ts";
 import { calNoShowWebhookRoute, signupWebhookRoute } from "./api/webhook-triggers.ts";
+import { linkedinReplyWebhookRoute, markLinkedInReplyRoute } from "./api/linkedin-replies.ts";
 
 interface ServerOptions {
   port: number;
@@ -76,6 +77,7 @@ const routes: RouteEntry[] = [
   route("GET", "/api/cadences", listCadences),
   route("GET", "/api/cadences/:id", getCadence),
   route("POST", "/api/cadences/:id/stop", stopCadence),
+  route("POST", "/api/prospects/:id/linkedin-reply", markLinkedInReplyRoute),
   route("POST", "/api/cadences/:id/preview-next", previewCadenceStepRoute),
   route("POST", "/api/cadences/:id/send-next", sendCadenceStepRoute),
   route("POST", "/api/cadences/preview-batch", previewCadenceBatchRoute),
@@ -122,6 +124,7 @@ const routes: RouteEntry[] = [
   route("GET", "/api/triggers", listTriggersRoute),
   route("POST", "/api/triggers/cal-no-show", calNoShowWebhookRoute),
   route("POST", "/api/triggers/signup", signupWebhookRoute),
+  route("POST", "/api/triggers/linkedin-reply", linkedinReplyWebhookRoute),
   route("POST", "/api/triggers/:name/enabled", setTriggerEnabledRoute),
   route("POST", "/api/triggers/:name/config", setTriggerConfigRoute),
   route("POST", "/api/triggers/:name/run", runTriggerRoute),

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -12,6 +12,7 @@ import type {
   InboxDraftReplyRequest,
   InboxDraftReplyResult,
   InboxResult,
+  LinkedInReplyResult,
   InboxSaveDraftRequest,
   InboxSaveDraftResult,
   InboxSendReplyRequest,
@@ -94,6 +95,8 @@ export const api = {
       `/cadences/${id}/stop?play=${encodeURIComponent(playName)}`,
       input,
     ),
+  markLinkedInReply: (id: number) =>
+    postJson<LinkedInReplyResult>(`/prospects/${id}/linkedin-reply`, {}),
   previewCadenceNext: (id: number, playName: string) =>
     postJson<{
       subject: string;

--- a/apps/web/src/routes/cadences.tsx
+++ b/apps/web/src/routes/cadences.tsx
@@ -1,6 +1,15 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { ChevronDown, CircleStop, Eye, Loader2, RotateCw, Send, Trophy } from "lucide-react";
+import {
+  ChevronDown,
+  CircleStop,
+  Eye,
+  Loader2,
+  MessageCircle,
+  RotateCw,
+  Send,
+  Trophy,
+} from "lucide-react";
 import { Fragment, useMemo, useState } from "react";
 import { toast } from "sonner";
 import type {
@@ -90,6 +99,11 @@ interface StopModalState {
   playName: string;
 }
 
+interface LinkedInReplyModalState {
+  prospectId: number;
+  prospectName: string | null;
+}
+
 const STOP_REASON_LABELS: Record<CadenceStopReason, string> = {
   bad_timing: "Bad timing / revisit later",
   other: "Other",
@@ -107,6 +121,9 @@ function CadencesPage() {
   const [outcomeAmount, setOutcomeAmount] = useState("");
   const [outcomeNotes, setOutcomeNotes] = useState("");
   const [stopModal, setStopModal] = useState<StopModalState | null>(null);
+  const [linkedinReplyModal, setLinkedinReplyModal] = useState<LinkedInReplyModalState | null>(
+    null,
+  );
   const [stopReason, setStopReason] = useState<CadenceStopReason>("bad_timing");
   const [stopNote, setStopNote] = useState("");
 
@@ -138,6 +155,19 @@ function CadencesPage() {
       toast.success(`stopped cadence · ${vars.playName}`);
     },
     onError: (err) => toast.error(`couldn't stop cadence: ${err.message}`),
+  });
+
+  const markLinkedInReply = useMutation({
+    mutationFn: (prospectId: number) => api.markLinkedInReply(prospectId),
+    onSuccess: (data) => {
+      void qc.invalidateQueries({ queryKey: ["cadences"] });
+      setLinkedinReplyModal(null);
+      const warning = data.inFlightSends > 0 ? " · an in-flight email may still complete" : "";
+      toast.success(
+        `LinkedIn reply recorded · ${data.cadencesStopped} cadence(s) stopped${warning}`,
+      );
+    },
+    onError: (err) => toast.error(`couldn't record LinkedIn reply: ${err.message}`),
   });
 
   const previewNext = useMutation({
@@ -622,6 +652,12 @@ function CadencesPage() {
                             sending…
                           </Badge>
                         )}
+                        {c.status === "replied" && c.replyChannel && (
+                          <Badge tone="signal" className="ml-1.5">
+                            {c.replyChannel === "linkedin" ? "LinkedIn reply" : "email reply"}
+                            {c.replyAt ? ` · ${timeAgo(c.replyAt)}` : ""}
+                          </Badge>
+                        )}
                         {!c.isSending && c.status === "active" && c.lastSendError && (
                           <span
                             title={`${c.lastSendError}${
@@ -670,6 +706,21 @@ function CadencesPage() {
                       </td>
                       <td className="px-6 py-2 text-right">
                         <div className="flex items-center justify-end gap-1">
+                          {(c.status === "active" || c.status === "paused") && (
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              title="mark that this prospect replied on LinkedIn"
+                              onClick={() =>
+                                setLinkedinReplyModal({
+                                  prospectId: c.prospectId,
+                                  prospectName: c.prospectName,
+                                })
+                              }
+                            >
+                              <MessageCircle size={12} />
+                            </Button>
+                          )}
                           {c.status === "active" &&
                             (() => {
                               const key = `${c.prospectId}|${c.playName}`;
@@ -1029,6 +1080,32 @@ function CadencesPage() {
             Server processes serially; ~2 min per email. The UI refreshes every 15s and rows clear
             their preview as each completes.
           </div>
+        </div>
+      </Modal>
+
+      <Modal
+        open={linkedinReplyModal != null}
+        onClose={() => setLinkedinReplyModal(null)}
+        title={`Mark LinkedIn reply${linkedinReplyModal?.prospectName ? ` — ${mask("name", linkedinReplyModal.prospectName)}` : ""}`}
+        footer={
+          <>
+            <Button variant="ghost" onClick={() => setLinkedinReplyModal(null)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                if (linkedinReplyModal) markLinkedInReply.mutate(linkedinReplyModal.prospectId);
+              }}
+              disabled={markLinkedInReply.isPending}
+            >
+              {markLinkedInReply.isPending ? "Recording…" : "Mark replied"}
+            </Button>
+          </>
+        }
+      >
+        <div className="text-[12px] text-ink-muted">
+          This records a LinkedIn reply and stops every active or paused email cadence for this
+          prospect. An email already in flight cannot be recalled and may still complete.
         </div>
       </Modal>
 

--- a/apps/web/src/routes/setup.tsx
+++ b/apps/web/src/routes/setup.tsx
@@ -803,6 +803,24 @@ function SetupPage() {
         </LedgerSection>
 
         <LedgerSection
+          eyebrow="05.6 · LinkedIn replies"
+          lede="Let LinkedIn automation tools report a real prospect reply so OneShot stops every live email cadence. Connection acceptance alone does nothing."
+        >
+          <Field
+            label="LINKEDIN_REPLY_WEBHOOK_SECRET"
+            hint={`${hintFor(sources["LINKEDIN_REPLY_WEBHOOK_SECRET"])} Use a random 32+ character bearer secret.`}
+          >
+            <Input
+              type="password"
+              placeholder={sources["LINKEDIN_REPLY_WEBHOOK_SECRET"] ? "(unchanged)" : ""}
+              value={secrets["LINKEDIN_REPLY_WEBHOOK_SECRET"] ?? ""}
+              onChange={(e) => setSecret("LINKEDIN_REPLY_WEBHOOK_SECRET", e.target.value)}
+              autoComplete="new-password"
+            />
+          </Field>
+        </LedgerSection>
+
+        <LedgerSection
           eyebrow="06 · Email transport"
           lede="The sender rotation pool. Each prospect sticks to the identity that first emailed them; new prospects go to the identity with the most capacity left today."
         >

--- a/packages/core/__tests__/ledger-extra.test.ts
+++ b/packages/core/__tests__/ledger-extra.test.ts
@@ -709,6 +709,137 @@ describe("manual cadence stops", () => {
   });
 });
 
+describe("LinkedIn reply events", () => {
+  it("matches normalized identities, stops every live cadence, and is idempotent", () => {
+    const pid = ledger.upsertProspect({
+      name: "Lin Reply",
+      email: "Lin@Example.com",
+      linkedin_url: "https://www.linkedin.com/in/Lin-Reply/?trk=profile",
+      source: "test",
+    });
+    for (const playName of ["show-hn", "repo-interest"]) {
+      ledger.enrollCadence({ prospectId: pid, playName, nextDueAt: new Date().toISOString() });
+    }
+    ledger.recordSequenceEvent({
+      prospectId: pid,
+      playName: "show-hn",
+      stepIndex: 0,
+      channel: "email",
+      status: "sent",
+    });
+    const queueId = ledger.enqueueTarget({
+      playName: "breakup-revive",
+      payload: { email: "lin@example.com" },
+      dedupeKey: `prospect:${pid}`,
+      source: "test",
+      initialStatus: "approved",
+    })!;
+    ledger.setQueueProspectId(queueId, pid);
+
+    expect(
+      ledger.resolveProspectForLinkedInReply({
+        email: "lin@example.com",
+        linkedinUrl: "http://linkedin.com/in/lin-reply",
+      }),
+    ).toEqual({ status: "matched", prospectId: pid });
+    const first = ledger.recordLinkedInReply({
+      prospectId: pid,
+      source: "expandi",
+      externalEventId: "reply-1",
+      occurredAt: "2026-06-18T10:00:00.000Z",
+    });
+    expect(first).toMatchObject({ duplicate: false, cadencesStopped: 2, inFlightSends: 0 });
+    expect(ledger.listCadencesForProspect(pid).map((c) => c.status)).toEqual([
+      "replied",
+      "replied",
+    ]);
+    expect(ledger.getCadence(pid, "show-hn")).toMatchObject({
+      reply_channel: "linkedin",
+      replied_at: "2026-06-18T10:00:00.000Z",
+    });
+    expect(ledger.listSequenceEventsForProspect(pid)[0]?.status).toBe("sent");
+    expect(ledger.getQueueRow(queueId)?.status).toBe("expired");
+    expect(
+      ledger.recordLinkedInReply({
+        prospectId: pid,
+        source: "expandi",
+        externalEventId: "reply-1",
+        occurredAt: new Date().toISOString(),
+      }),
+    ).toMatchObject({ duplicate: true, cadencesStopped: 0 });
+  });
+
+  it("reports an already claimed send and leaves its marker for the worker", () => {
+    const pid = ledger.upsertProspect({ email: "race@example.com", source: "test" });
+    ledger.enrollCadence({
+      prospectId: pid,
+      playName: "show-hn",
+      nextDueAt: new Date().toISOString(),
+    });
+    ledger.claimCadenceSendingMarker({
+      prospectId: pid,
+      playName: "show-hn",
+      startedAtIso: new Date().toISOString(),
+    });
+    const result = ledger.recordLinkedInReply({
+      prospectId: pid,
+      source: "manual",
+      externalEventId: "race",
+      occurredAt: new Date().toISOString(),
+    });
+    expect(result).toMatchObject({ cadencesStopped: 1, inFlightSends: 1 });
+    expect(ledger.getCadence(pid, "show-hn")).toMatchObject({
+      status: "replied",
+      sending_started_at: expect.any(String),
+    });
+    expect(ledger.listActiveCadences()).toEqual([]);
+  });
+
+  it("rejects identifiers that resolve to different prospects", () => {
+    ledger.upsertProspect({ email: "one@example.com", source: "test" });
+    ledger.upsertProspect({
+      email: "two@example.com",
+      linkedin_url: "https://linkedin.com/in/two",
+      source: "test",
+    });
+    expect(
+      ledger.resolveProspectForLinkedInReply({
+        email: "one@example.com",
+        linkedinUrl: "https://www.linkedin.com/in/two/",
+      }),
+    ).toEqual({ status: "conflict" });
+  });
+
+  it("anchors breakup-revive to the LinkedIn reply time", () => {
+    const pid = ledger.upsertProspect({ email: "cold-reply@example.com", source: "test" });
+    ledger.recordSequenceEvent({
+      prospectId: pid,
+      playName: "show-hn",
+      stepIndex: 0,
+      channel: "email",
+      status: "sent",
+    });
+    ledger.recordLinkedInReply({
+      prospectId: pid,
+      source: "test",
+      externalEventId: "cold-clock",
+      occurredAt: new Date().toISOString(),
+    });
+    const db = new Database(dbPath);
+    db.exec(`UPDATE sequence_events SET created_at = datetime('now', '-100 days');`);
+    expect(
+      ledger.listColdProspects({ minDaysSinceLastEvent: 60, maxDaysSinceLastEvent: 90 }),
+    ).toEqual([]);
+    db.exec(`UPDATE channel_events SET occurred_at = datetime('now', '-75 days');`);
+    db.close();
+    expect(
+      ledger
+        .listColdProspects({ minDaysSinceLastEvent: 60, maxDaysSinceLastEvent: 90 })
+        .map((row) => row.id),
+    ).toEqual([pid]);
+  });
+});
+
 describe("recordInterview", () => {
   it("round-trips an interview record", () => {
     const id = ledger.recordInterview({

--- a/packages/core/__tests__/ledger.test.ts
+++ b/packages/core/__tests__/ledger.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { Database } from "bun:sqlite";
 import { Ledger } from "../src/ledger.ts";
 
 let dbPath: string;
@@ -618,6 +619,14 @@ describe("Ledger queue sending marker", () => {
     );
   });
 
+  it("claim fails after the row leaves approved status", () => {
+    const id = enqueue();
+    ledger.setQueueStatus({ id, status: "expired" });
+    expect(ledger.claimQueueSendingMarker({ id, startedAtIso: new Date().toISOString() })).toBe(
+      false,
+    );
+  });
+
   it("reclaim succeeds when previous marker is older than the stale cutoff", () => {
     const id = enqueue();
     ledger.claimQueueSendingMarker({
@@ -668,12 +677,13 @@ describe("Ledger queue sending marker", () => {
     // Simulate by writing the marker AFTER the status flip.
     const id = enqueue();
     ledger.setQueueStatus({ id, status: "sent" });
-    // setQueueStatus('sent') auto-clears the marker; re-claim to simulate the
-    // pre-clear stranded state.
-    ledger.claimQueueSendingMarker({
+    // The public claim now refuses terminal rows; write the legacy/crash state directly.
+    const db = new Database(dbPath);
+    db.prepare("UPDATE target_queue SET send_started_at = ? WHERE id = ?").run(
+      new Date(Date.now() - 1000).toISOString(),
       id,
-      startedAtIso: new Date(Date.now() - 1000).toISOString(),
-    });
+    );
+    db.close();
     const swept = ledger.sweepStaleQueueSends({ now: new Date(), maxAgeMs: 0 });
     expect(swept).toHaveLength(1);
     expect(swept[0]?.actuallySent).toBe(true);

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -25,6 +25,7 @@ export const SECRET_KEYS = [
   "GMAIL_CLIENT_SECRET",
   "GMAIL_REFRESH_TOKEN",
   "SMARTLEAD_API_KEY",
+  "LINKEDIN_REPLY_WEBHOOK_SECRET",
 ] as const;
 export type SecretKey = (typeof SECRET_KEYS)[number];
 

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -10,6 +10,7 @@ import type {
   BounceKind,
   BounceRecord,
   CanaryResultRecord,
+  ChannelEventRecord,
   GmailPlacement,
   InboxReplyRecord,
   IcpDecisionExample,
@@ -99,6 +100,20 @@ function canonEmail(email: string): string {
   return email.trim().toLowerCase();
 }
 
+/** Stable LinkedIn profile key across www/mobile hosts, schemes, query strings and trailing slashes. */
+export function canonicalLinkedInProfileKey(value: string): string | null {
+  try {
+    const url = new URL(value.trim());
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    if (!/(^|\.)linkedin\.com$/i.test(url.hostname)) return null;
+    const match = /^\/in\/([^/]+)\/?$/i.exec(url.pathname);
+    if (!match?.[1]) return null;
+    return `linkedin.com/in/${decodeURIComponent(match[1]).toLowerCase()}`;
+  } catch {
+    return null;
+  }
+}
+
 function safeParseJsonArray(raw: string): unknown[] {
   try {
     const parsed = JSON.parse(raw) as unknown;
@@ -137,6 +152,8 @@ export interface CadenceWithProspect {
   prospect_email: string | null;
   prospect_name: string | null;
   prospect_company: string | null;
+  reply_channel: "email" | "linkedin" | null;
+  replied_at: string | null;
 }
 
 /**
@@ -540,6 +557,21 @@ export class Ledger {
         ON inbox_replies(prospect_id, received_at);
       CREATE INDEX IF NOT EXISTS idx_inbox_replies_thread
         ON inbox_replies(thread_key, received_at);
+
+      CREATE TABLE IF NOT EXISTS channel_events (
+        id                INTEGER PRIMARY KEY AUTOINCREMENT,
+        source            TEXT NOT NULL,
+        external_event_id TEXT NOT NULL,
+        prospect_id       INTEGER NOT NULL,
+        channel           TEXT NOT NULL,
+        event_type        TEXT NOT NULL,
+        occurred_at       TEXT NOT NULL,
+        created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+        UNIQUE(source, external_event_id),
+        FOREIGN KEY(prospect_id) REFERENCES prospects(id)
+      );
+      CREATE INDEX IF NOT EXISTS idx_channel_events_prospect_time
+        ON channel_events(prospect_id, occurred_at);
     `);
     // v23: reply classification ('human' | 'auto' | 'auto_permanent' |
     // 'unsubscribe', see reply-classify.ts). NULL = row predates the
@@ -735,7 +767,17 @@ export class Ledger {
       args.push(opts.dueByIso);
     }
     const sql = `
-      SELECT c.*, p.email AS prospect_email, p.name AS prospect_name, p.company AS prospect_company
+      SELECT c.*, p.email AS prospect_email, p.name AS prospect_name, p.company AS prospect_company,
+             (SELECT channel FROM (
+                SELECT 'email' AS channel, received_at AS at FROM inbox_replies WHERE prospect_id = p.id AND coalesce(kind,'human') = 'human'
+                UNION ALL
+                SELECT channel, occurred_at AS at FROM channel_events WHERE prospect_id = p.id AND event_type = 'reply'
+              ) ORDER BY at DESC LIMIT 1) AS reply_channel,
+             (SELECT at FROM (
+                SELECT received_at AS at FROM inbox_replies WHERE prospect_id = p.id AND coalesce(kind,'human') = 'human'
+                UNION ALL
+                SELECT occurred_at AS at FROM channel_events WHERE prospect_id = p.id AND event_type = 'reply'
+              ) ORDER BY at DESC LIMIT 1) AS replied_at
       FROM cadence_state c
       JOIN prospects p ON p.id = c.prospect_id
       WHERE ${where.join(" AND ")}
@@ -746,7 +788,15 @@ export class Ledger {
 
   listAllCadences(): CadenceWithProspect[] {
     const sql = `
-      SELECT c.*, p.email AS prospect_email, p.name AS prospect_name, p.company AS prospect_company
+      SELECT c.*, p.email AS prospect_email, p.name AS prospect_name, p.company AS prospect_company,
+             (SELECT channel FROM (
+                SELECT 'email' AS channel, received_at AS at FROM inbox_replies WHERE prospect_id = p.id AND coalesce(kind,'human') = 'human'
+                UNION ALL SELECT channel, occurred_at AS at FROM channel_events WHERE prospect_id = p.id AND event_type = 'reply'
+              ) ORDER BY at DESC LIMIT 1) AS reply_channel,
+             (SELECT at FROM (
+                SELECT received_at AS at FROM inbox_replies WHERE prospect_id = p.id AND coalesce(kind,'human') = 'human'
+                UNION ALL SELECT occurred_at AS at FROM channel_events WHERE prospect_id = p.id AND event_type = 'reply'
+              ) ORDER BY at DESC LIMIT 1) AS replied_at
       FROM cadence_state c
       JOIN prospects p ON p.id = c.prospect_id
       ORDER BY c.status ASC, c.next_due_at ASC NULLS LAST
@@ -761,7 +811,15 @@ export class Ledger {
    */
   getCadence(prospectId: number, playName: string): CadenceWithProspect | null {
     const sql = `
-      SELECT c.*, p.email AS prospect_email, p.name AS prospect_name, p.company AS prospect_company
+      SELECT c.*, p.email AS prospect_email, p.name AS prospect_name, p.company AS prospect_company,
+             (SELECT channel FROM (
+                SELECT 'email' AS channel, received_at AS at FROM inbox_replies WHERE prospect_id = p.id AND coalesce(kind,'human') = 'human'
+                UNION ALL SELECT channel, occurred_at AS at FROM channel_events WHERE prospect_id = p.id AND event_type = 'reply'
+              ) ORDER BY at DESC LIMIT 1) AS reply_channel,
+             (SELECT at FROM (
+                SELECT received_at AS at FROM inbox_replies WHERE prospect_id = p.id AND coalesce(kind,'human') = 'human'
+                UNION ALL SELECT occurred_at AS at FROM channel_events WHERE prospect_id = p.id AND event_type = 'reply'
+              ) ORDER BY at DESC LIMIT 1) AS replied_at
       FROM cadence_state c
       JOIN prospects p ON p.id = c.prospect_id
       WHERE c.prospect_id = ? AND c.play_name = ?
@@ -772,7 +830,15 @@ export class Ledger {
   /** All cadences for one prospect — index seek on cadence_state.prospect_id (PK prefix). */
   listCadencesForProspect(prospectId: number): CadenceWithProspect[] {
     const sql = `
-      SELECT c.*, p.email AS prospect_email, p.name AS prospect_name, p.company AS prospect_company
+      SELECT c.*, p.email AS prospect_email, p.name AS prospect_name, p.company AS prospect_company,
+             (SELECT channel FROM (
+                SELECT 'email' AS channel, received_at AS at FROM inbox_replies WHERE prospect_id = p.id AND coalesce(kind,'human') = 'human'
+                UNION ALL SELECT channel, occurred_at AS at FROM channel_events WHERE prospect_id = p.id AND event_type = 'reply'
+              ) ORDER BY at DESC LIMIT 1) AS reply_channel,
+             (SELECT at FROM (
+                SELECT received_at AS at FROM inbox_replies WHERE prospect_id = p.id AND coalesce(kind,'human') = 'human'
+                UNION ALL SELECT occurred_at AS at FROM channel_events WHERE prospect_id = p.id AND event_type = 'reply'
+              ) ORDER BY at DESC LIMIT 1) AS replied_at
       FROM cadence_state c
       JOIN prospects p ON p.id = c.prospect_id
       WHERE c.prospect_id = ?
@@ -875,17 +941,7 @@ export class Ledger {
         .run(input.reason, input.note?.trim() || null, input.prospectId, input.playName);
       changed = result.changes > 0;
       if (changed) {
-        this.db
-          .prepare(
-            `UPDATE target_queue
-             SET status = 'expired', send_started_at = NULL,
-                 notes = CASE WHEN notes IS NULL OR notes = '' THEN 'expired: cadence stopped'
-                              ELSE notes || ' · expired: cadence stopped' END
-             WHERE (prospect_id = ? OR dedupe_key = ?)
-               AND play_name = 'breakup-revive'
-               AND status IN ('pending', 'approved')`,
-          )
-          .run(input.prospectId, `prospect:${input.prospectId}`);
+        this.expireBreakupReviveQueue(input.prospectId, "cadence stopped");
       }
     })();
     return changed;
@@ -1170,6 +1226,119 @@ export class Ledger {
         .query("SELECT * FROM prospects WHERE email = ?")
         .get(canonEmail(email)) as ProspectRecord) ?? null
     );
+  }
+
+  resolveProspectForLinkedInReply(input: {
+    email?: string;
+    linkedinUrl?: string;
+  }): { status: "matched"; prospectId: number } | { status: "unmatched" } | { status: "conflict" } {
+    const emailId = input.email ? (this.findProspectByEmail(input.email)?.id ?? null) : null;
+    let linkedinIds: number[] = [];
+    if (input.linkedinUrl) {
+      const key = canonicalLinkedInProfileKey(input.linkedinUrl);
+      if (key) {
+        const rows = this.db
+          .query(
+            `SELECT id, linkedin_url, source_profile_url FROM prospects
+             WHERE linkedin_url LIKE '%linkedin.com/in/%'
+                OR source_profile_url LIKE '%linkedin.com/in/%'`,
+          )
+          .all() as Array<{
+          id: number;
+          linkedin_url: string | null;
+          source_profile_url: string | null;
+        }>;
+        linkedinIds = rows
+          .filter(
+            (row) =>
+              (row.linkedin_url && canonicalLinkedInProfileKey(row.linkedin_url) === key) ||
+              (row.source_profile_url &&
+                canonicalLinkedInProfileKey(row.source_profile_url) === key),
+          )
+          .map((row) => row.id);
+      }
+    }
+    const uniqueLinkedIn = [...new Set(linkedinIds)];
+    if (uniqueLinkedIn.length > 1) return { status: "conflict" };
+    const linkedinId = uniqueLinkedIn[0] ?? null;
+    if (emailId && linkedinId && emailId !== linkedinId) return { status: "conflict" };
+    const prospectId = emailId ?? linkedinId;
+    return prospectId ? { status: "matched", prospectId } : { status: "unmatched" };
+  }
+
+  recordLinkedInReply(input: {
+    prospectId: number;
+    source: string;
+    externalEventId: string;
+    occurredAt: string;
+  }): {
+    duplicate: boolean;
+    prospectId: number;
+    cadencesStopped: number;
+    inFlightSends: number;
+  } {
+    return this.db.transaction(() => {
+      const existing = this.db
+        .query(`SELECT * FROM channel_events WHERE source = ? AND external_event_id = ?`)
+        .get(input.source, input.externalEventId) as ChannelEventRecord | null;
+      if (existing) {
+        const inFlight = this.db
+          .query(
+            `SELECT COUNT(*) AS n FROM cadence_state
+             WHERE prospect_id = ? AND sending_started_at IS NOT NULL`,
+          )
+          .get(existing.prospect_id) as { n: number };
+        return {
+          duplicate: true,
+          prospectId: existing.prospect_id,
+          cadencesStopped: 0,
+          inFlightSends: inFlight.n,
+        };
+      }
+      const live = this.db
+        .query(
+          `SELECT sending_started_at FROM cadence_state
+           WHERE prospect_id = ? AND status IN ('active','paused')`,
+        )
+        .all(input.prospectId) as Array<{ sending_started_at: string | null }>;
+      this.db
+        .prepare(
+          `INSERT INTO channel_events
+             (source, external_event_id, prospect_id, channel, event_type, occurred_at)
+           VALUES (?, ?, ?, 'linkedin', 'reply', ?)`,
+        )
+        .run(input.source, input.externalEventId, input.prospectId, input.occurredAt);
+      this.db
+        .prepare(
+          `UPDATE cadence_state
+           SET status = 'replied', next_due_at = NULL,
+               next_step_draft_json = NULL, next_step_drafted_at = NULL,
+               last_send_error = NULL, last_send_error_at = NULL
+           WHERE prospect_id = ? AND status IN ('active','paused')`,
+        )
+        .run(input.prospectId);
+      this.expireBreakupReviveQueue(input.prospectId, "prospect replied");
+      return {
+        duplicate: false,
+        prospectId: input.prospectId,
+        cadencesStopped: live.length,
+        inFlightSends: live.filter((row) => row.sending_started_at != null).length,
+      };
+    })();
+  }
+
+  private expireBreakupReviveQueue(prospectId: number, reason: string): void {
+    this.db
+      .prepare(
+        `UPDATE target_queue
+         SET status = 'expired', send_started_at = NULL,
+             notes = CASE WHEN notes IS NULL OR notes = '' THEN ?
+                          ELSE notes || ' · ' || ? END
+         WHERE (prospect_id = ? OR dedupe_key = ?)
+           AND play_name = 'breakup-revive'
+           AND status IN ('pending', 'approved')`,
+      )
+      .run(`expired: ${reason}`, `expired: ${reason}`, prospectId, `prospect:${prospectId}`);
   }
 
   /**
@@ -1976,9 +2145,15 @@ export class Ledger {
              MAX(s.created_at) AS last_sequence_at,
              MAX(CASE WHEN c.status = 'stopped' AND c.stop_reason IN ('bad_timing', 'other')
                       THEN c.stopped_at END) AS last_revivable_stop_at,
-             MAX(COALESCE(MAX(s.created_at), ''), COALESCE(MAX(CASE
-               WHEN c.status = 'stopped' AND c.stop_reason IN ('bad_timing', 'other')
-               THEN c.stopped_at END), '')) AS last_event_at
+             MAX(
+               COALESCE(MAX(s.created_at), ''),
+               COALESCE(MAX(CASE WHEN c.status = 'stopped' AND c.stop_reason IN ('bad_timing', 'other')
+                                 THEN c.stopped_at END), ''),
+               COALESCE((SELECT MAX(ir.received_at) FROM inbox_replies ir
+                         WHERE ir.prospect_id = p.id AND coalesce(ir.kind,'human') = 'human'), ''),
+               COALESCE((SELECT MAX(ce.occurred_at) FROM channel_events ce
+                         WHERE ce.prospect_id = p.id AND ce.event_type = 'reply'), '')
+             ) AS last_event_at
       FROM prospects p
       LEFT JOIN sequence_events s ON s.prospect_id = p.id
       LEFT JOIN cadence_state c ON c.prospect_id = p.id
@@ -2155,11 +2330,7 @@ export class Ledger {
       const cad = this.getCadence(input.prospectId, input.playName);
       const newlyReplied = cad?.status === "active" || cad?.status === "paused";
       if (newlyReplied) {
-        this.setCadenceStatus({
-          prospectId: input.prospectId,
-          playName: input.playName,
-          status: "replied",
-        });
+        this.markCadenceReplied(input.prospectId, input.playName);
       }
       const eventRecorded = this.markLatestStepReplied({
         prospectId: input.prospectId,
@@ -2186,7 +2357,7 @@ export class Ledger {
       for (const cad of this.listCadencesForProspect(prospectId)) {
         const live = cad.status === "active" || cad.status === "paused";
         if (live) {
-          this.setCadenceStatus({ prospectId, playName: cad.play_name, status: "replied" });
+          this.markCadenceReplied(prospectId, cad.play_name);
         }
         out.set(cad.play_name, { newlyReplied: live, eventRecorded: false });
       }
@@ -2197,12 +2368,26 @@ export class Ledger {
           eventRecorded,
         });
       }
+      this.expireBreakupReviveQueue(prospectId, "prospect replied");
       return [...out].map(([playName, r]) => ({
         playName,
         newlyReplied: r.newlyReplied,
         eventRecorded: r.eventRecorded,
       }));
     })();
+  }
+
+  /** Stop future work on one live cadence without hiding a send already handed to a provider. */
+  private markCadenceReplied(prospectId: number, playName: string): void {
+    this.db
+      .prepare(
+        `UPDATE cadence_state
+         SET status = 'replied', next_due_at = NULL,
+             next_step_draft_json = NULL, next_step_drafted_at = NULL,
+             last_send_error = NULL, last_send_error_at = NULL
+         WHERE prospect_id = ? AND play_name = ? AND status IN ('active','paused')`,
+      )
+      .run(prospectId, playName);
   }
 
   /**

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -1331,7 +1331,7 @@ export class Ledger {
     this.db
       .prepare(
         `UPDATE target_queue
-         SET status = 'expired', send_started_at = NULL,
+         SET status = 'expired',
              notes = CASE WHEN notes IS NULL OR notes = '' THEN ?
                           ELSE notes || ' · ' || ? END
          WHERE (prospect_id = ? OR dedupe_key = ?)
@@ -2948,14 +2948,18 @@ export class Ledger {
     startedAtIso: string;
     staleCutoffIso?: string;
   }): boolean {
-    return this.claimMarker({
-      table: "target_queue",
-      pkeyWhere: "id = ?",
-      column: "send_started_at",
-      pkeyValues: [input.id],
-      startedAtIso: input.startedAtIso,
-      ...(input.staleCutoffIso ? { staleCutoffIso: input.staleCutoffIso } : {}),
-    });
+    const markerWhere = input.staleCutoffIso
+      ? "(send_started_at IS NULL OR send_started_at < ?)"
+      : "send_started_at IS NULL";
+    const args: Array<string | number> = [input.startedAtIso, input.id];
+    if (input.staleCutoffIso) args.push(input.staleCutoffIso);
+    const result = this.db
+      .prepare(
+        `UPDATE target_queue SET send_started_at = ?
+         WHERE id = ? AND status = 'approved' AND ${markerWhere}`,
+      )
+      .run(...args);
+    return result.changes > 0;
   }
 
   clearQueueSendingMarker(id: number): void {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -68,6 +68,18 @@ export interface InboxReplyRecord {
   created_at: string;
 }
 
+/** Provider-neutral inbound engagement event. V1 records LinkedIn replies only. */
+export interface ChannelEventRecord {
+  id: number;
+  source: string;
+  external_event_id: string;
+  prospect_id: number;
+  channel: "linkedin";
+  event_type: "reply";
+  occurred_at: string;
+  created_at: string;
+}
+
 export interface ProspectRecord {
   id: number;
   name: string | null;

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -52,6 +52,9 @@ export interface CadenceView {
   stopReason: CadenceStopReason | null;
   stopNote: string | null;
   stoppedAt: string | null;
+  /** Most recent persisted human reply channel; null for legacy reply rows without an inbound event. */
+  replyChannel: "email" | "linkedin" | null;
+  replyAt: string | null;
   /** Persisted next-step preview (set by Preview, cleared on advance). */
   nextStepDraft: CadenceNextStepDraft | null;
   /** Label of the next step ("value follow-up", "breakup", …). Null when
@@ -102,6 +105,22 @@ export interface CadencesResult {
   counts: CadenceCounts;
   /** Absent when the capacity computation failed — pages skip the figure. */
   sendsToday?: SendsToday;
+}
+
+export interface LinkedInReplyWebhookRequest {
+  source: string;
+  eventId: string;
+  occurredAt: string;
+  linkedinUrl?: string;
+  email?: string;
+}
+
+export interface LinkedInReplyResult {
+  accepted: true;
+  duplicate: boolean;
+  prospectId: number;
+  cadencesStopped: number;
+  inFlightSends: number;
 }
 
 /** RoCS value tag attached to a receipt once its outcome is known. */
@@ -322,7 +341,8 @@ export interface SetupRequest {
       | "X_API_SECRET"
       | "X_ACCESS_TOKEN"
       | "X_ACCESS_SECRET"
-      | "TWITTERAPI_IO_KEY",
+      | "TWITTERAPI_IO_KEY"
+      | "LINKEDIN_REPLY_WEBHOOK_SECRET",
       string
     >
   >;


### PR DESCRIPTION
## Summary
- add authenticated, provider-neutral LinkedIn reply webhook plus manual cadence action
- record idempotent channel events, stop every live cadence without false email attribution, and anchor breakup-revive to reply time
- document cadence dispositions and all webhook intake; add setup secret and Expandi-safe behavior

## Verification
- bun run typecheck
- bun run lint (existing warnings only)
- bun run fmt:check
- bun run test (188 files, 2443 tests)
- bun run build
- local ops/expandi-sync: bun test (58 tests)

Closes #418

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add LinkedIn reply webhook and dashboard route to stop cadences
> - Adds `POST /api/triggers/linkedin-reply` (bearer-authed, idempotent) and a same-origin dashboard route `POST /api/prospects/:id/linkedin-reply` to record LinkedIn replies via [linkedin-replies.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/419/files#diff-b8e53ad4cd4ed009505617e9915d8c289740c028d80afb9a28a0fd70fcaf0b8f).
> - Introduces a new `channel_events` table and `recordLinkedInReply` in [ledger.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/419/files#diff-717d28717ccfb3e17791019e23031dc0feeec16ff1e3b3462975264e3734098e) that resolves the prospect by email/LinkedIn URL, stops all active/paused cadences, expires breakup-revive queue items, and returns idempotent results on duplicates.
> - Exposes `replyChannel` and `replyAt` on `CadenceView`; the cadences UI now shows a reply badge and lets users manually mark a LinkedIn reply.
> - Adds `LINKEDIN_REPLY_WEBHOOK_SECRET` to config, setup status, and the setup page.
> - Tightens `claimQueueSendingMarker` in [ledger.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/419/files#diff-717d28717ccfb3e17791019e23031dc0feeec16ff1e3b3462975264e3734098e) and `sendDraftRoute` in [queue.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/419/files#diff-82603c88c0a618245651db800cb8da95025555c3c6992b82d689dd5b2b34bcd9) to reject rows whose status is not `approved`, aborting sends that raced with expiry.
> - Behavioral Change: `claimQueueSendingMarker` now requires `status = 'approved'`; `isLoopbackOrigin` in [server.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/419/files#diff-a8f34e8f17024480f0ca046c8ea4a8af3b525fe68940b703ba496fa4aa4ddfbd) strictly validates protocol and hostname instead of using `startsWith`. New `channel_events` table is created via migration DDL in `ledger.ts`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f4d9e5f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->