### PR TITLE
fix: issue #393: Deferred review findings from ai/gtm/issue-384

### DIFF
--- a/apps/web/src/lib/pruneSentRows.ts
+++ b/apps/web/src/lib/pruneSentRows.ts
@@ -59,13 +59,18 @@ export function remapFilteredEventIndexes(
     }
   }
 
-  return events.map((event) => {
-    if (event.kind === "draft" || event.kind === "send" || event.kind === "error") {
-      const originalIndex = postDropToOriginal.get(event.index);
-      if (originalIndex !== undefined) return { ...event, index: originalIndex };
-    }
-    return event;
-  });
+  return events
+    .map((event) => {
+      if (event.kind === "draft" || event.kind === "send" || event.kind === "error") {
+        const originalIndex = postDropToOriginal.get(event.index);
+        if (originalIndex !== undefined) return { ...event, index: originalIndex };
+        // Drop unmappable indexed events instead of returning them unchanged
+        // with a filtered index that pruneSentRows will misinterpret.
+        return null;
+      }
+      return event;
+    })
+    .filter((event): event is RunPlayEvent => event !== null);
 }
 
 /**


### PR DESCRIPTION
Closes #393.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 09b3e0d6ba85 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (1 errs) vs base ok (1 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop unmappable `draft`/`send`/`error` events in `remapFilteredEventIndexes`
> Changes the final event transformation in `remapFilteredEventIndexes` to set unmappable indexed events to `null` and filter them out. Previously these events were returned unchanged with their filtered indexes.
> - Risk: callers in [pruneSentRows.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/420/files#diff-8849dc9155e99159e893b67b42138e9097dbd6397c7b20d695845529119a7eeb) now receive a shorter array — draft/send/error events without a resolvable original index are silently removed, so any consumer counting array length will see different values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bbc2c3a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->