### PR TITLE
fix: issue #381: Deferred review findings from ai/gtm/issue-374

### DIFF
--- a/apps/cli/__tests__/__snapshots__/install-service.test.ts.snap
+++ b/apps/cli/__tests__/__snapshots__/install-service.test.ts.snap
@@ -55,3 +55,59 @@ RestartSec=30
 WantedBy=default.target
 "
 `;
+
+exports[`renderLaunchdPlist matches the template snapshot 1`] = `
+"<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.oneshot-gtm.find-watch</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/opt/homebrew/bin/bun</string>
+    <string>/Users/jo/oneshot-gtm/apps/cli/src/main.ts</string>
+    <string>find</string>
+    <string>watch</string>
+    <string>--quiet</string>
+  </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>ONESHOT_GTM_HOME</key>
+    <string>/Users/jo/.oneshot-gtm</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/bin:/bin</string>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>/Users/jo/.oneshot-gtm/find-watch.log</string>
+  <key>StandardErrorPath</key>
+  <string>/Users/jo/.oneshot-gtm/find-watch.log</string>
+</dict>
+</plist>
+"
+`;
+
+exports[`renderSystemdUnit matches the template snapshot 1`] = `
+"[Unit]
+Description=oneshot-gtm find watch — poll registered triggers and enqueue candidates
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart="/opt/homebrew/bin/bun" "/Users/jo/oneshot-gtm/apps/cli/src/main.ts" find watch --quiet
+Environment="ONESHOT_GTM_HOME=/Users/jo/.oneshot-gtm"
+Environment="PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=default.target
+"
+`;

--- a/apps/server/src/api/_play-dispatch.ts
+++ b/apps/server/src/api/_play-dispatch.ts
@@ -8,6 +8,7 @@ export interface DraftedView {
   receiptIds: number[];
   sent: boolean;
   enrichmentFailed?: boolean;
+  originalTargetIndex?: number;
 }
 
 export function toDraftedView(d: {
@@ -17,6 +18,7 @@ export function toDraftedView(d: {
   receiptIds: number[];
   sent: boolean;
   enrichmentFailed?: boolean;
+  originalTargetIndex?: number;
 }): DraftedView {
   return {
     subject: d.subject,
@@ -25,6 +27,7 @@ export function toDraftedView(d: {
     receiptIds: d.receiptIds,
     sent: d.sent,
     ...(d.enrichmentFailed ? { enrichmentFailed: true } : {}),
+    ...(d.originalTargetIndex !== undefined ? { originalTargetIndex: d.originalTargetIndex } : {}),
   };
 }
 

--- a/apps/server/src/api/run.ts
+++ b/apps/server/src/api/run.ts
@@ -524,7 +524,8 @@ function persistDraftsToQueue(input: {
   for (let i = 0; i < input.drafted.length; i++) {
     const draft = input.drafted[i];
     if (!draft) continue;
-    const dedupeKey = input.indexToDedupeKey.get(i);
+    // The target index is now stored in originalTargetIndex to map back safely
+    const dedupeKey = input.indexToDedupeKey.get(draft.originalTargetIndex ?? i);
     if (!dedupeKey) continue;
     try {
       const row = ledger.getQueueRowByDedupe(input.playName, dedupeKey);

--- a/packages/plays/src/breakup-revive.ts
+++ b/packages/plays/src/breakup-revive.ts
@@ -56,6 +56,7 @@ export interface BreakupReviveDraft {
   receiptIds: number[];
   sent: boolean;
   flags: string[];
+  originalTargetIndex?: number;
 }
 
 export async function runBreakupRevive(
@@ -118,6 +119,7 @@ export async function runBreakupRevive(
         receiptIds: send.receiptIds,
         sent: send.sent,
         flags,
+        originalTargetIndex: index,
       };
     } catch (err) {
       // Daily-cap deferral is not a per-target failure — abort the run so the
@@ -136,6 +138,7 @@ export async function runBreakupRevive(
         receiptIds: stub.receiptIds,
         sent: stub.sent,
         flags: stub.flags,
+        originalTargetIndex: index,
       };
     }
     drafted.push(result);


### PR DESCRIPTION
Closes #381.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 09b3e0d6ba85 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (1 errs) vs base ok (1 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix queue row lookup in `persistDraftsToQueue` to use `originalTargetIndex`
> - Adds optional `originalTargetIndex` to the `DraftedView` and `BreakupReviveDraft` interfaces and forwards it through `toDraftedView`.
> - `runBreakupRevive` now sets `originalTargetIndex` to the current target's iteration index on both success and error draft paths.
> - `persistDraftsToQueue` uses `draft.originalTargetIndex` (falling back to loop index `i`) for the dedupeKey lookup, so the correct `target_queue` row is updated.
> - Behavioral Change: the `target_queue` row selected during draft persistence now depends on `originalTargetIndex` when present; queue rows indexed by the old loop-index assumption may map differently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f373348.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->