### PR TITLE
feat(core): decision provenance for queue rows — schema v26 (Phase 3 PR-A)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,8 @@
 # Status
 
-**Assume green.** The 50 CLI commands, 17 plays, 11 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
+**Assume green.** The 51 CLI commands, 17 plays, 11 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-01** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2437 tests / 187 files** · typecheck + oxlint + oxfmt clean.
+Last verified **2026-09-02** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2459 tests / 189 files** · typecheck + oxlint + oxfmt clean.
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/apps/cli/__tests__/score-prospects.test.ts
+++ b/apps/cli/__tests__/score-prospects.test.ts
@@ -268,9 +268,9 @@ describe("--all-statuses methodology evaluation", () => {
   it("scores historical rows and gauges score vs human call, auto-rejections excluded", () => {
     // Human-approved-and-sent strong candidate vs human-rejected weak one.
     const sent = enqueue("post-funding", FUNDING_PAYLOAD);
-    ledger.setQueueStatus({ id: sent, status: "sent" });
+    ledger.setQueueStatus({ id: sent, status: "sent", decidedBy: "human" });
     const weak = enqueue("post-funding", { name: "Bo", email: "bo@x.dev" });
-    ledger.setQueueStatus({ id: weak, status: "rejected", notes: "not a fit" });
+    ledger.setQueueStatus({ id: weak, status: "rejected", notes: "not a fit", decidedBy: "human" });
     const auto = enqueue(
       "post-funding",
       { name: "Zed", email: "z@x.dev" },
@@ -308,7 +308,12 @@ describe("buildShadowReport — human-vs-auto provenance", () => {
     const humanRejected = enqueue("post-funding", FUNDING_PAYLOAD, {
       notes: "wrong segment",
     });
-    ledger.setQueueStatus({ id: humanRejected, status: "rejected", notes: "wrong segment" });
+    ledger.setQueueStatus({
+      id: humanRejected,
+      status: "rejected",
+      notes: "wrong segment",
+      decidedBy: "human",
+    });
     enqueue("post-funding", { name: "x" }, { initialStatus: "rejected", notes: "auto: ICP — no" });
     commandScoreProspects({ refresh: false, dryRun: false, report: false });
 

--- a/apps/server/__tests__/mark-sent-route.test.ts
+++ b/apps/server/__tests__/mark-sent-route.test.ts
@@ -80,7 +80,7 @@ describe("markSentRoute", () => {
     expect(events[0]!.status).toBe("sent");
     expect(events[0]!.playName).toBe("x-amplify-dm");
     expect(events[0]!.metadata).toMatchObject({ body: "dm text", seedHandle: "iamdevloper" });
-    expect(statusCalls).toEqual([{ id: 1, status: "sent" }]);
+    expect(statusCalls).toEqual([{ id: 1, status: "sent", decidedBy: "human" }]);
     // Prospect keyed by the X profile, not an email.
     expect(upserts[0]).toMatchObject({
       email: null,

--- a/apps/server/src/api/queue.ts
+++ b/apps/server/src/api/queue.ts
@@ -153,7 +153,7 @@ export async function approveQueueRoute(
   const ledger = getLedger();
   const row = ledger.getQueueRow(id);
   if (!row) return jsonResponse({ error: `row #${id} not found` }, 404, req);
-  ledger.setQueueStatus({ id, status: "approved" });
+  ledger.setQueueStatus({ id, status: "approved", decidedBy: "human" });
   return jsonResponse({ ok: true }, 200, req);
 }
 
@@ -173,7 +173,9 @@ export async function rejectQueueRoute(
   const row = ledger.getQueueRow(id);
   if (!row) return jsonResponse({ error: `row #${id} not found` }, 404, req);
   ledger.setQueueStatus(
-    body.reason ? { id, status: "rejected", notes: body.reason } : { id, status: "rejected" },
+    body.reason
+      ? { id, status: "rejected", notes: body.reason, decidedBy: "human" }
+      : { id, status: "rejected", decidedBy: "human" },
   );
   return jsonResponse({ ok: true }, 200, req);
 }
@@ -392,7 +394,8 @@ export async function markSentRoute(
   } catch {
     // best-effort backfill — the marked send is already recorded
   }
-  ledger.setQueueStatus({ id: row.id, status: "sent" });
+  // A per-row human action (manually sent via another channel).
+  ledger.setQueueStatus({ id: row.id, status: "sent", decidedBy: "human" });
   return jsonResponse({ ok: true, prospectId }, 200, req);
 }
 
@@ -571,7 +574,8 @@ export async function sendDraftRoute(
 
   const prospect = ledger.findProspectByEmail(email);
   if (prospect) enrollInCadence({ prospectId: prospect.id, playName: row.play_name });
-  ledger.setQueueStatus({ id, status: "sent" });
+  // The human read this draft and clicked Send — a per-row judgment.
+  ledger.setQueueStatus({ id, status: "sent", decidedBy: "human" });
   ledger.setQueueDraft({
     id,
     draft: { subject, body, flags: [], sent: true, receiptIds: result.receiptIds, dryRun: false },

--- a/bun.lock
+++ b/bun.lock
@@ -101,6 +101,7 @@
       "version": "0.7.0",
       "dependencies": {
         "@oneshot-gtm/core": "workspace:*",
+        "@oneshot-gtm/find": "workspace:*",
       },
     },
     "packages/find": {
@@ -110,6 +111,7 @@
         "@oneshot-gtm/core": "workspace:*",
         "@oneshot-gtm/intel": "workspace:*",
         "@oneshot-gtm/plays": "workspace:*",
+        "@oneshot-gtm/shared-types": "workspace:*",
       },
     },
     "packages/intel": {

--- a/packages/core/__tests__/labels.test.ts
+++ b/packages/core/__tests__/labels.test.ts
@@ -1,50 +1,97 @@
 import { describe, expect, it } from "vitest";
 import { humanDecisionWhereSql, isHumanApproval, isHumanDecision } from "../src/labels.ts";
+import type { QueueRow } from "../src/types.ts";
 
 const at = "2026-09-01T12:00:00.000Z";
 
-describe("isHumanDecision — the shared label predicate", () => {
-  it("accepts human approve / send / reject", () => {
-    expect(isHumanDecision({ status: "approved", notes: null, reviewed_at: at })).toBe(true);
-    expect(isHumanDecision({ status: "sent", notes: null, reviewed_at: at })).toBe(true);
-    expect(isHumanDecision({ status: "rejected", notes: "wrong segment", reviewed_at: at })).toBe(
-      true,
-    );
+type LabelRow = Pick<QueueRow, "status" | "notes" | "reviewed_at" | "decision" | "decided_by">;
+
+/** Legacy-shaped row: NULL provenance → predicates fall back to status inference. */
+function legacy(input: Partial<LabelRow>): LabelRow {
+  return {
+    status: "pending",
+    notes: null,
+    reviewed_at: null,
+    decision: null,
+    decided_by: null,
+    ...input,
+  } as LabelRow;
+}
+
+describe("isHumanDecision — provenance-first (v26)", () => {
+  it("trusts the decision columns when present, regardless of current status", () => {
+    // The Phase 3 point: an approved row machinery later expired keeps its label.
+    expect(
+      isHumanDecision(
+        legacy({ status: "expired", decision: "approve", decided_by: "human", reviewed_at: at }),
+      ),
+    ).toBe(true);
+    expect(
+      isHumanDecision(legacy({ status: "rejected", decision: "reject", decided_by: "human" })),
+    ).toBe(true);
   });
 
-  it("rejects machine rejections, unreviewed rows, and expiry-machinery stamps", () => {
-    expect(isHumanDecision({ status: "rejected", notes: "auto: ICP — no", reviewed_at: at })).toBe(
-      false,
-    );
-    expect(isHumanDecision({ status: "approved", notes: null, reviewed_at: null })).toBe(false);
-    expect(isHumanDecision({ status: "pending", notes: null, reviewed_at: at })).toBe(false);
-    // Expired rows get reviewed_at from reservations/bulk stamps/cadence
-    // stops, never from a per-row judgment.
-    expect(isHumanDecision({ status: "expired", notes: null, reviewed_at: at })).toBe(false);
+  it("bulk approvals count as human; machine decisions never do", () => {
+    expect(
+      isHumanDecision(
+        legacy({ status: "approved", decision: "approve", decided_by: "human_bulk" }),
+      ),
+    ).toBe(true);
+    expect(
+      isHumanDecision(
+        legacy({ status: "rejected", decision: "auto_reject", decided_by: "machine" }),
+      ),
+    ).toBe(false);
+    // A machine-stamped approve (send on a never-decided row) is not a human label.
+    expect(
+      isHumanDecision(legacy({ status: "sent", decision: "approve", decided_by: "machine" })),
+    ).toBe(false);
+  });
+
+  it("falls back to status inference for NULL-provenance rows", () => {
+    expect(isHumanDecision(legacy({ status: "approved", reviewed_at: at }))).toBe(true);
+    expect(isHumanDecision(legacy({ status: "sent", reviewed_at: at }))).toBe(true);
+    expect(
+      isHumanDecision(legacy({ status: "rejected", notes: "wrong segment", reviewed_at: at })),
+    ).toBe(true);
+    expect(
+      isHumanDecision(legacy({ status: "rejected", notes: "auto: ICP — no", reviewed_at: at })),
+    ).toBe(false);
+    expect(isHumanDecision(legacy({ status: "approved", reviewed_at: null }))).toBe(false);
+    expect(isHumanDecision(legacy({ status: "pending", reviewed_at: at }))).toBe(false);
+    // Expiry machinery stamps reviewed_at without judgment.
+    expect(isHumanDecision(legacy({ status: "expired", reviewed_at: at }))).toBe(false);
   });
 });
 
 describe("isHumanApproval", () => {
-  it("is the positive subset of human decisions", () => {
-    expect(isHumanApproval({ status: "sent", notes: null, reviewed_at: at })).toBe(true);
-    expect(isHumanApproval({ status: "rejected", notes: "no", reviewed_at: at })).toBe(false);
-    expect(isHumanApproval({ status: "approved", notes: null, reviewed_at: null })).toBe(false);
+  it("is the positive subset in both provenance and fallback modes", () => {
+    expect(
+      isHumanApproval(legacy({ status: "expired", decision: "approve", decided_by: "human" })),
+    ).toBe(true);
+    expect(
+      isHumanApproval(legacy({ status: "rejected", decision: "reject", decided_by: "human" })),
+    ).toBe(false);
+    expect(isHumanApproval(legacy({ status: "sent", reviewed_at: at }))).toBe(true);
+    expect(isHumanApproval(legacy({ status: "rejected", notes: "no", reviewed_at: at }))).toBe(
+      false,
+    );
+    expect(isHumanApproval(legacy({ status: "approved", reviewed_at: null }))).toBe(false);
   });
 });
 
 describe("humanDecisionWhereSql", () => {
   it("prefixes every column reference for aliased queries", () => {
     const sql = humanDecisionWhereSql("q.");
-    expect(sql).toContain("q.reviewed_at");
-    expect(sql).toContain("q.status IN");
-    expect(sql).toContain("COALESCE(q.notes, '') LIKE 'auto:%'");
-    // Unprefixed form has no stray column-qualifying dots.
+    for (const col of ["q.decision", "q.decided_by", "q.reviewed_at", "q.status", "q.notes"]) {
+      expect(sql).toContain(col);
+    }
     expect(humanDecisionWhereSql()).not.toContain("q.");
   });
 
-  it("NULL notes never hides a human rejection (three-valued logic guard)", () => {
-    // The COALESCE is load-bearing: `NULL LIKE 'auto:%'` is NULL and
-    // `NOT (… AND NULL)` filters the row out.
-    expect(humanDecisionWhereSql()).toContain("COALESCE(notes, '')");
+  it("guards the legacy arm with decision IS NULL and keeps the 3VL COALESCE", () => {
+    const sql = humanDecisionWhereSql();
+    expect(sql).toContain("decision IS NULL");
+    expect(sql).toContain("COALESCE(notes, '')");
   });
 });

--- a/packages/core/__tests__/ledger-extra.test.ts
+++ b/packages/core/__tests__/ledger-extra.test.ts
@@ -29,13 +29,20 @@ afterEach(() => {
 
 describe("recentIcpDecisions", () => {
   it("returns the newest reviewed labels and keeps sent rows as approvals", () => {
+    // Human rejections happen post-enqueue via the /queue route (insert-time
+    // rejections are always machine gates and are excluded structurally
+    // since v26 — decision='auto_reject').
     const rejected = ledger.enqueueTarget({
       playName: "show-hn",
       payload: { title: "Wine meetup" },
       dedupeKey: "reject",
       source: "test",
-      initialStatus: "rejected",
+    });
+    ledger.setQueueStatus({
+      id: rejected!,
+      status: "rejected",
       notes: "wrong industry",
+      decidedBy: "human",
     });
     const approved = ledger.enqueueTarget({
       playName: "show-hn",
@@ -58,7 +65,12 @@ describe("recentIcpDecisions", () => {
       dedupeKey: "sent",
       source: "test",
     });
-    ledger.setQueueStatus({ id: sent!, status: "sent", notes: "founder approved" });
+    ledger.setQueueStatus({
+      id: sent!,
+      status: "sent",
+      notes: "founder approved",
+      decidedBy: "human",
+    });
     ledger.enqueueTarget({
       playName: "show-hn",
       payload: { title: "Not reviewed" },
@@ -121,8 +133,8 @@ describe("finderApprovalStats", () => {
     const rejected = add("c", "find:github-stars");
     add("pending", "find:github-stars");
     ledger.setQueueStatus({ id: approved, status: "approved" });
-    ledger.setQueueStatus({ id: sent, status: "sent" });
-    ledger.setQueueStatus({ id: rejected, status: "rejected" });
+    ledger.setQueueStatus({ id: sent, status: "sent", decidedBy: "human" });
+    ledger.setQueueStatus({ id: rejected, status: "rejected", decidedBy: "human" });
 
     expect(ledger.finderApprovalStats({ finder: "github-stars", sinceIso: "2000-01-01" })).toEqual({
       approved: 2,

--- a/packages/core/__tests__/ledger-provenance.test.ts
+++ b/packages/core/__tests__/ledger-provenance.test.ts
@@ -1,0 +1,248 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { Database } from "bun:sqlite";
+import { Ledger } from "../src/ledger.ts";
+import { isHumanApproval, isHumanDecision } from "../src/labels.ts";
+
+let dbPath: string;
+let ledger: Ledger;
+
+beforeEach(() => {
+  dbPath = join(
+    tmpdir(),
+    `oneshot-gtm-provenance-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`,
+  );
+  ledger = new Ledger(dbPath);
+});
+
+afterEach(() => {
+  ledger.close();
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      rmSync(`${dbPath}${suffix}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+function enqueue(overrides: Record<string, unknown> = {}): number {
+  return ledger.enqueueTarget({
+    playName: "post-funding",
+    payload: { name: "Ada", email: "ada@acme.dev" },
+    dedupeKey: `k-${Math.random().toString(36).slice(2)}`,
+    source: "find:post-funding",
+    ...overrides,
+  })!;
+}
+
+const rawDb = (): Database => (ledger as unknown as { db: Database }).db;
+
+describe("decision provenance writes (v26)", () => {
+  it("per-row human approve/reject stamp decision columns", () => {
+    const a = enqueue();
+    ledger.setQueueStatus({ id: a, status: "approved", decidedBy: "human" });
+    const row = ledger.getQueueRow(a)!;
+    expect(row.decision).toBe("approve");
+    expect(row.decided_by).toBe("human");
+    expect(row.decided_at).not.toBeNull();
+
+    const r = enqueue();
+    ledger.setQueueStatus({
+      id: r,
+      status: "rejected",
+      notes: "wrong segment",
+      decidedBy: "human",
+    });
+    expect(ledger.getQueueRow(r)!.decision).toBe("reject");
+    expect(ledger.getQueueRow(r)!.decided_by).toBe("human");
+  });
+
+  it("an unannotated rejection is a machine decision — callers can't mint human labels by default", () => {
+    const id = enqueue();
+    ledger.setQueueStatus({ id, status: "rejected", notes: "auto: dedup — not re-sent" });
+    const row = ledger.getQueueRow(id)!;
+    expect(row.decision).toBe("auto_reject");
+    expect(row.decided_by).toBe("machine");
+    expect(isHumanDecision(row)).toBe(false);
+  });
+
+  it("a machine send never overwrites the human approve (COALESCE)", () => {
+    const id = enqueue();
+    ledger.setQueueStatus({ id, status: "approved", decidedBy: "human" });
+    const decidedAt = ledger.getQueueRow(id)!.decided_at;
+    ledger.setQueueStatus({ id, status: "sent" }); // drain — machine default
+    const row = ledger.getQueueRow(id)!;
+    expect(row.status).toBe("sent");
+    expect(row.decision).toBe("approve");
+    expect(row.decided_by).toBe("human");
+    expect(row.decided_at).toBe(decidedAt);
+  });
+
+  it("a send on a never-decided row records an honest machine disposition", () => {
+    const id = enqueue();
+    ledger.setQueueStatus({ id, status: "sent" });
+    const row = ledger.getQueueRow(id)!;
+    expect(row.decision).toBe("approve");
+    expect(row.decided_by).toBe("machine");
+    expect(isHumanDecision(row)).toBe(false);
+  });
+
+  it("re-open to pending keeps the decision; a re-decide overwrites (latest wins)", () => {
+    const id = enqueue();
+    ledger.setQueueStatus({ id, status: "approved", decidedBy: "human" });
+    ledger.setQueueStatus({ id, status: "pending" });
+    let row = ledger.getQueueRow(id)!;
+    expect(row.reviewed_at).toBeNull();
+    expect(row.decision).toBe("approve");
+    ledger.setQueueStatus({ id, status: "rejected", notes: "second look", decidedBy: "human" });
+    row = ledger.getQueueRow(id)!;
+    expect(row.decision).toBe("reject");
+  });
+
+  it("enqueueTarget auto-rejection is structurally machine-decided", () => {
+    const id = enqueue({ initialStatus: "rejected", notes: "auto: ICP — no" });
+    const row = ledger.getQueueRow(id)!;
+    expect(row.decision).toBe("auto_reject");
+    expect(row.decided_by).toBe("machine");
+    expect(row.reviewed_at).not.toBeNull(); // existing behavior preserved
+  });
+
+  it("approveAllPending marks the batch human_bulk", () => {
+    const a = enqueue();
+    const b = enqueue();
+    ledger.approveAllPending();
+    for (const id of [a, b]) {
+      const row = ledger.getQueueRow(id)!;
+      expect(row.decision).toBe("approve");
+      expect(row.decided_by).toBe("human_bulk");
+      expect(isHumanApproval(row)).toBe(true); // bulk counts as human (parity)
+    }
+  });
+});
+
+describe("expiry never destroys a decision (the Phase 3 point)", () => {
+  it("a prospect replying expires the approved breakup-revive row but keeps the label", () => {
+    const prospectId = ledger.upsertProspect({ email: "rae@acme.dev", name: "Rae" });
+    const id = ledger.enqueueTarget({
+      playName: "breakup-revive",
+      payload: { email: "rae@acme.dev", daysCold: 14 },
+      dedupeKey: `prospect:${prospectId}`,
+      source: "find:breakup-revive",
+    })!;
+    ledger.setQueueStatus({ id, status: "approved", decidedBy: "human" });
+    ledger.recordProspectReply(prospectId); // used to destroy the approval
+    const row = ledger.getQueueRow(id)!;
+    expect(row.status).toBe("expired");
+    expect(row.notes).toContain("expired: prospect replied");
+    expect(row.decision).toBe("approve");
+    expect(row.decided_by).toBe("human");
+    expect(isHumanApproval(row)).toBe(true);
+  });
+
+  it("expirePendingOlderThan leaves undecided rows undecided", () => {
+    const id = enqueue();
+    rawDb()
+      .prepare(`UPDATE target_queue SET found_at = '2020-01-01 00:00:00' WHERE id = ?`)
+      .run(id);
+    ledger.expirePendingOlderThan(1);
+    const row = ledger.getQueueRow(id)!;
+    expect(row.status).toBe("expired");
+    expect(row.decision).toBeNull();
+    expect(isHumanDecision(row)).toBe(false);
+  });
+});
+
+describe("backfillDecisionProvenance", () => {
+  /** Insert a legacy-shaped row with NULL decision columns via raw SQL. */
+  function legacyRow(input: {
+    status: string;
+    reviewedAt: string | null;
+    notes?: string | null;
+    play?: string;
+  }): number {
+    const result = rawDb()
+      .prepare(
+        `INSERT INTO target_queue(play_name, payload_json, dedupe_key, source, status, reviewed_at, notes)
+         VALUES(?, '{}', ?, 'test', ?, ?, ?)`,
+      )
+      .run(
+        input.play ?? "post-funding",
+        `legacy-${Math.random().toString(36).slice(2)}`,
+        input.status,
+        input.reviewedAt,
+        input.notes ?? null,
+      );
+    return Number(result.lastInsertRowid);
+  }
+
+  function reopen(): void {
+    ledger.close();
+    ledger = new Ledger(dbPath); // backfill runs on boot
+  }
+
+  it("classifies legacy rows: single approvals, bulk clusters, human and auto rejections", () => {
+    const single = legacyRow({ status: "approved", reviewedAt: "2026-08-01T10:00:00.000Z" });
+    const bulkIds = Array.from({ length: 21 }, () =>
+      legacyRow({
+        status: "approved",
+        reviewedAt: "2026-08-02T10:00:00.000Z",
+        play: "luma-events",
+      }),
+    );
+    const humanReject = legacyRow({ status: "rejected", reviewedAt: "2026-08-01T11:00:00.000Z" }); // NULL notes
+    const autoReject = legacyRow({
+      status: "rejected",
+      reviewedAt: "2026-08-01T12:00:00.000Z",
+      notes: "auto: ICP — no",
+    });
+    const expired = legacyRow({ status: "expired", reviewedAt: "2026-08-01T13:00:00.000Z" });
+    reopen();
+
+    expect(ledger.getQueueRow(single)!.decision).toBe("approve");
+    expect(ledger.getQueueRow(single)!.decided_by).toBe("human");
+    expect(ledger.getQueueRow(bulkIds[0]!)!.decided_by).toBe("human_bulk");
+    const hr = ledger.getQueueRow(humanReject)!;
+    expect(hr.decision).toBe("reject"); // NULL notes must not read as auto (3VL guard)
+    expect(hr.decided_by).toBe("human");
+    expect(ledger.getQueueRow(autoReject)!.decision).toBe("auto_reject");
+    // Expired history is not fabricated.
+    expect(ledger.getQueueRow(expired)!.decision).toBeNull();
+  });
+
+  it("is idempotent across re-opens and never overwrites live-written provenance", () => {
+    const id = enqueue();
+    ledger.setQueueStatus({ id, status: "approved", decidedBy: "human" });
+    const before = ledger.getQueueRow(id)!;
+    reopen();
+    reopen();
+    expect(ledger.getQueueRow(id)).toEqual(before);
+  });
+
+  it("parity: label predicates agree before and after backfill", () => {
+    const rows = [
+      legacyRow({ status: "approved", reviewedAt: "2026-08-01T10:00:00.000Z" }),
+      legacyRow({ status: "sent", reviewedAt: "2026-08-01T10:00:01.000Z" }),
+      legacyRow({ status: "rejected", reviewedAt: "2026-08-01T10:00:02.000Z", notes: "meh" }),
+      legacyRow({
+        status: "rejected",
+        reviewedAt: "2026-08-01T10:00:03.000Z",
+        notes: "auto: role — no",
+      }),
+      legacyRow({ status: "expired", reviewedAt: "2026-08-01T10:00:04.000Z" }),
+      legacyRow({ status: "pending", reviewedAt: null }),
+    ];
+    const before = rows.map((id) => {
+      const row = ledger.getQueueRow(id)!;
+      return [isHumanDecision(row), isHumanApproval(row)];
+    });
+    reopen();
+    const after = rows.map((id) => {
+      const row = ledger.getQueueRow(id)!;
+      return [isHumanDecision(row), isHumanApproval(row)];
+    });
+    expect(after).toEqual(before);
+  });
+});

--- a/packages/core/src/labels.ts
+++ b/packages/core/src/labels.ts
@@ -1,29 +1,41 @@
 import type { QueueRow } from "./types.ts";
 
+type LabelRow = Pick<QueueRow, "status" | "notes" | "reviewed_at" | "decision" | "decided_by">;
+
 /**
  * THE single definition of "a human decided this queue row" — shared by the
  * shadow-score gauge, finder approval stats, and ICP few-shot selection so
  * they can never drift apart (each had hand-rolled copies before; one missed
  * the auto: clause, one counted expiry timeouts as rejections).
  *
- * A human decision is: reviewed, terminal-by-review status, and not a machine
- * rejection (`auto:` notes prefix — ICP/role gates, import classifiers).
+ * v26 makes this provenance-first: the `decision`/`decided_by` columns are
+ * written at decision time and survive expiry and re-open — a reply that
+ * expires an approved breakup-revive row no longer destroys the label. Rows
+ * with NULL provenance (pre-v26, or never backfillable) fall back to the
+ * status inference, same COALESCE-to-legacy pattern as `inbox_replies.kind`:
+ * reviewed + terminal-by-review status + not an `auto:` machine rejection;
+ * `expired` is never a human status there (reservation inserts, bulk stamps,
+ * and cadence-stop expiry all write reviewed_at without per-row judgment).
  *
- * `expired` is deliberately NOT a human status even when reviewed_at is set:
- * reservation inserts (csv-import), bulk stamps, and cadence-stop expiry all
- * write reviewed_at without any per-row judgment. Known lossy edge: a row a
- * human approved that machinery later expires (e.g. stopCadence on
- * breakup-revive) loses its label — current-status is a lossy record of the
- * decision history; a disposition-provenance column is the Phase 3 fix.
+ * `human_bulk` (approve-all batches) COUNTS as a human decision — parity
+ * with the status inference; evaluation code that wants per-row judgment
+ * only filters `decided_by === "human"` explicitly.
  */
-export function isHumanDecision(row: Pick<QueueRow, "status" | "notes" | "reviewed_at">): boolean {
+export function isHumanDecision(row: LabelRow): boolean {
+  if (row.decision != null) {
+    return (
+      (row.decision === "approve" || row.decision === "reject") &&
+      (row.decided_by === "human" || row.decided_by === "human_bulk")
+    );
+  }
   if (row.reviewed_at === null) return false;
   if (row.status === "approved" || row.status === "sent") return true;
   return row.status === "rejected" && !(row.notes ?? "").startsWith("auto:");
 }
 
 /** True when a human decision was a yes (approve, or approve-then-send). */
-export function isHumanApproval(row: Pick<QueueRow, "status" | "notes" | "reviewed_at">): boolean {
+export function isHumanApproval(row: LabelRow): boolean {
+  if (row.decision != null) return isHumanDecision(row) && row.decision === "approve";
   return isHumanDecision(row) && (row.status === "approved" || row.status === "sent");
 }
 
@@ -33,13 +45,17 @@ export function isHumanApproval(row: Pick<QueueRow, "status" | "notes" | "review
  */
 export function humanDecisionWhereSql(prefix = ""): string {
   const p = prefix;
-  // COALESCE matters: `NULL LIKE 'auto:%'` is NULL, and `NOT (… AND NULL)`
-  // is NULL too — without it a notes-less human rejection silently drops out
-  // of the result set (three-valued logic; this bug shipped in
-  // recentIcpDecisions before the predicate was unified here).
+  // Provenance arm first; the legacy arm is guarded by `decision IS NULL` so
+  // a machine-stamped row can never fall through to the status inference.
+  // COALESCE matters in the legacy arm: `NULL LIKE 'auto:%'` is NULL, and
+  // `NOT (… AND NULL)` is NULL too — without it a notes-less human rejection
+  // silently drops out of the result set (three-valued logic; this bug
+  // shipped in recentIcpDecisions before the predicate was unified here).
   return (
-    `${p}reviewed_at IS NOT NULL` +
+    `( (${p}decision IN ('approve','reject') AND ${p}decided_by IN ('human','human_bulk'))` +
+    ` OR (${p}decision IS NULL` +
+    ` AND ${p}reviewed_at IS NOT NULL` +
     ` AND ${p}status IN ('approved','rejected','sent')` +
-    ` AND NOT (${p}status = 'rejected' AND COALESCE(${p}notes, '') LIKE 'auto:%')`
+    ` AND NOT (${p}status = 'rejected' AND COALESCE(${p}notes, '') LIKE 'auto:%')) )`
   );
 }

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -605,6 +605,64 @@ export class Ledger {
     // manual/legacy rows, auto-rejections, and everything pre-v25. Read-only
     // metadata — nothing orders, gates, or drains by it in Phase 1.
     this.addColumnIfMissing("target_queue", "priority_json", "TEXT");
+    // v26: decision provenance (issue #410 Phase 3). `status` is a lossy
+    // record of the decision HISTORY — expiry overwrites approvals (a reply
+    // used to destroy the approval label on its own breakup-revive row),
+    // re-open nulls reviewed_at, and bulk approves share one timestamp.
+    // These columns record the decision itself and are never touched by
+    // expiry or re-open.
+    this.addColumnIfMissing("target_queue", "decision", "TEXT"); // 'approve'|'reject'|'auto_reject'
+    this.addColumnIfMissing("target_queue", "decided_at", "TEXT");
+    this.addColumnIfMissing("target_queue", "decided_by", "TEXT"); // 'human'|'human_bulk'|'machine'
+    this.backfillDecisionProvenance();
+  }
+
+  /**
+   * One-time (guard-idempotent, boot-run) inference of decision provenance
+   * for pre-v26 rows, reproducing the status-based `isHumanDecision`
+   * predicate exactly so every existing metric is unchanged by the migration.
+   * Pending/expired rows stay NULL — labels machinery already destroyed are
+   * not fabricated. Safe under concurrent boots: the `decision IS NULL`
+   * guard makes the loser's UPDATE a no-op.
+   */
+  private backfillDecisionProvenance(): void {
+    // Approvals. A human cannot hand-approve 20 rows in one millisecond, so
+    // >=20 rows sharing (play_name, reviewed_at) is an approveAllPending
+    // batch (the gauge measured a single 108-row millisecond) → human_bulk.
+    this.db.exec(`
+      UPDATE target_queue SET
+        decision = 'approve',
+        decided_at = reviewed_at,
+        decided_by = CASE WHEN (
+          SELECT COUNT(*) FROM target_queue t2
+          WHERE t2.play_name = target_queue.play_name
+            AND t2.reviewed_at = target_queue.reviewed_at
+            AND t2.status IN ('approved','sent')
+        ) >= 20 THEN 'human_bulk' ELSE 'human' END
+      WHERE decision IS NULL
+        AND status IN ('approved','sent')
+        AND reviewed_at IS NOT NULL
+    `);
+    // Human rejections (COALESCE: NULL notes is a human rejection, the
+    // three-valued-logic trap documented in labels.ts).
+    this.db.exec(`
+      UPDATE target_queue SET
+        decision = 'reject', decided_at = reviewed_at, decided_by = 'human'
+      WHERE decision IS NULL
+        AND status = 'rejected'
+        AND reviewed_at IS NOT NULL
+        AND COALESCE(notes, '') NOT LIKE 'auto:%'
+    `);
+    // Machine rejections (ICP/role gates, import classifiers).
+    this.db.exec(`
+      UPDATE target_queue SET
+        decision = 'auto_reject',
+        decided_at = COALESCE(reviewed_at, found_at),
+        decided_by = 'machine'
+      WHERE decision IS NULL
+        AND status = 'rejected'
+        AND COALESCE(notes, '') LIKE 'auto:%'
+    `);
   }
 
   /**
@@ -2656,8 +2714,8 @@ export class Ledger {
       const reviewedAt = status === "pending" ? null : new Date().toISOString();
       const result = this.db
         .prepare(
-          `INSERT INTO target_queue(play_name, payload_json, dedupe_key, source, status, reviewed_at, notes, priority_json)
-           VALUES(?, ?, ?, ?, ?, ?, ?, ?)`,
+          `INSERT INTO target_queue(play_name, payload_json, dedupe_key, source, status, reviewed_at, notes, priority_json, decision, decided_at, decided_by)
+           VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         )
         .run(
           input.playName,
@@ -2668,6 +2726,12 @@ export class Ledger {
           reviewedAt,
           input.notes ?? null,
           input.priority ? JSON.stringify(input.priority) : null,
+          // An insert-time rejection is a gate's verdict, never a human's —
+          // structural provenance replaces the `auto:` notes-sniffing (the
+          // notes convention stays for humans and pre-v26 fallback).
+          status === "rejected" ? "auto_reject" : null,
+          status === "rejected" ? reviewedAt : null,
+          status === "rejected" ? "machine" : null,
         );
       return Number(result.lastInsertRowid);
     } catch (err) {
@@ -2893,31 +2957,53 @@ export class Ledger {
     return result.changes > 0;
   }
 
-  setQueueStatus(input: { id: number; status: QueueStatus; notes?: string }): void {
+  setQueueStatus(input: {
+    id: number;
+    status: QueueStatus;
+    notes?: string;
+    /**
+     * Who made this transition. Defaults are per-status, chosen so every
+     * existing unannotated caller stays correctly classified:
+     * - approved → "human": approving IS the review act; no machine path
+     *   approves single rows today (bulk goes through approveAllPending).
+     * - rejected/sent → "machine": auto-reject gates and drain sends call
+     *   this unannotated, and an unannotated caller must never mint a human
+     *   REJECTION label (a mislabeled negative poisons any future fit) —
+     *   the per-row UI routes pass "human" explicitly.
+     */
+    decidedBy?: "human" | "machine";
+  }): void {
     const now = new Date().toISOString();
+    const decidedBy = input.decidedBy ?? (input.status === "approved" ? "human" : "machine");
     // Every status transition clears `send_started_at` — a deliberate status
     // change means the previous "sending" attempt (if any) is settled. Terminal
     // states (sent/rejected/expired) clear naturally. Approved → approved
     // doesn't need to preserve a marker (caller re-claims on the next send).
     if (input.status === "sent") {
+      // COALESCE on the decision columns: a drain/run send must never
+      // overwrite the human approve that put the row here; a send on a
+      // never-decided row records an honest machine disposition.
       this.db
         .prepare(
-          `UPDATE target_queue SET status = ?, sent_at = ?, reviewed_at = COALESCE(reviewed_at, ?), send_started_at = NULL ${input.notes ? ", notes = ?" : ""} WHERE id = ?`,
+          `UPDATE target_queue SET status = ?, sent_at = ?, reviewed_at = COALESCE(reviewed_at, ?), decision = COALESCE(decision, 'approve'), decided_at = COALESCE(decided_at, ?), decided_by = COALESCE(decided_by, ?), send_started_at = NULL ${input.notes ? ", notes = ?" : ""} WHERE id = ?`,
         )
         .run(
           ...(input.notes
-            ? [input.status, now, now, input.notes, input.id]
-            : [input.status, now, now, input.id]),
+            ? [input.status, now, now, now, decidedBy, input.notes, input.id]
+            : [input.status, now, now, now, decidedBy, input.id]),
         );
     } else if (input.status === "approved" || input.status === "rejected") {
+      // Always overwrites: the latest decision wins on a re-decide.
+      const decision =
+        input.status === "approved" ? "approve" : decidedBy === "human" ? "reject" : "auto_reject";
       this.db
         .prepare(
-          `UPDATE target_queue SET status = ?, reviewed_at = ?, send_started_at = NULL ${input.notes ? ", notes = ?" : ""} WHERE id = ?`,
+          `UPDATE target_queue SET status = ?, reviewed_at = ?, decision = ?, decided_at = ?, decided_by = ?, send_started_at = NULL ${input.notes ? ", notes = ?" : ""} WHERE id = ?`,
         )
         .run(
           ...(input.notes
-            ? [input.status, now, input.notes, input.id]
-            : [input.status, now, input.id]),
+            ? [input.status, now, decision, now, decidedBy, input.notes, input.id]
+            : [input.status, now, decision, now, decidedBy, input.id]),
         );
     } else if (input.status === "pending") {
       this.db
@@ -3019,11 +3105,15 @@ export class Ledger {
       where.push("play_name = ?");
       args.push(opts.playName);
     }
+    // decided_by='human_bulk': a human sanctioned the batch, but no per-row
+    // judgment happened — evaluation code can include or exclude these
+    // explicitly instead of reverse-engineering shared timestamps.
+    const now = new Date().toISOString();
     const result = this.db
       .prepare(
-        `UPDATE target_queue SET status = 'approved', reviewed_at = ? WHERE ${where.join(" AND ")}`,
+        `UPDATE target_queue SET status = 'approved', reviewed_at = ?, decision = 'approve', decided_at = ?, decided_by = 'human_bulk' WHERE ${where.join(" AND ")}`,
       )
-      .run(...([new Date().toISOString(), ...args] as never[]));
+      .run(...([now, now, ...args] as never[]));
     return Number(result.changes);
   }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -384,6 +384,15 @@ export interface QueueRow {
    * from manual/legacy producers, auto-rejections, and pre-v25 rows.
    */
   priority_json: string | null;
+  /**
+   * Decision provenance (v26): the decision itself, durable against expiry
+   * and re-open — `status` alone is lossy history. NULL on undecided and
+   * pre-v26-unbackfillable rows. See core/labels.ts.
+   */
+  decision: "approve" | "reject" | "auto_reject" | null;
+  decided_at: string | null;
+  /** 'human' (per-row click) | 'human_bulk' (approve-all batch) | 'machine'. */
+  decided_by: "human" | "human_bulk" | "machine" | null;
 }
 
 export interface TriggerRow {

--- a/packages/find/__tests__/drain.test.ts
+++ b/packages/find/__tests__/drain.test.ts
@@ -25,6 +25,9 @@ function row(id: number, payload: Record<string, unknown> = {}): QueueRow {
     last_drafted_at: null,
     send_started_at: null,
     priority_json: null,
+    decision: null,
+    decided_at: null,
+    decided_by: null,
   };
 }
 


### PR DESCRIPTION
Phase 3 PR-A of prospect prioritization (#410) — durable label capture, the prerequisite for ever calibrating on outcomes. Measurement-neutral by construction: every number the shadow report, `finderApprovalStats`, and `recentIcpDecisions` produce is identical before and after (property-tested parity).

**The bug this kills**: `status` is a lossy record of decision *history*. A prospect replying ran `expireBreakupReviveQueue` and flipped their human-approved breakup-revive row to `expired` — the strongest positive outcome destroyed the very label it should pair with. Re-open nulls `reviewed_at`; `approveAllPending` smears one timestamp across a whole batch (the measured 108-row millisecond).

- **v26**: `target_queue.decision` (`approve|reject|auto_reject`), `decided_at`, `decided_by` (`human|human_bulk|machine`) + a boot-run, guard-idempotent backfill that reproduces the status-based predicate exactly (≥20-row shared-timestamp clusters → `human_bulk`; destroyed expired history is not fabricated).
- **`setQueueStatus`** gains `decidedBy` with per-status defaults chosen so every existing unannotated caller stays correct: approve → human (approving IS the review act; no machine path approves single rows), reject/sent → machine (gates and drains call unannotated, and an unannotated caller must never mint a label). The four per-row `/queue` routes pass `"human"`; the sent branch COALESCEs so a drain send can't overwrite the human approve.
- **`enqueueTarget`** insert-time rejections stamp `auto_reject`/`machine` — the issue's "never train automatic rejections" now structural, not notes-sniffed (the `auto:` convention stays for humans + pre-v26 fallback).
- **`labels.ts`** predicates are provenance-first with status-inference fallback (`decision IS NULL` guarded — same COALESCE-to-legacy pattern as `inbox_replies.kind`). Expiry writers untouched — regression tests prove an approved-then-expired row keeps its label through both `stopCadence` and `recordProspectReply`.

Verify: fmt/typecheck/lint clean, **2459 tests / 189 files** (new provenance suite: write paths, defaults, COALESCE, re-open/re-decide, backfill classification incl. bulk clusters + NULL-notes 3VL, idempotence across re-opens, pre/post parity). STATUS.md counts corrected (50→51 commands — research-products had landed uncounted).

PR-B (outcome labels + shadow outcome report) and PR-C (fit math + threshold-gated `find calibrate`) follow per the approved Phase 3 plan.

https://claude.ai/code/session_019XJ5qAUV9NDrRrbqdTLebU

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add decision provenance to queue row transitions and migrate to schema v26
> - Adds nullable `decision`, `decision_timestamp`, and `decision_maker` columns to `QueueRow`, upgrading the ledger schema to v26.
> - `migrate` in [ledger.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/425/files#diff-717d28717ccfb3e17791019e23031dc0feeec16ff1e3b3462975264e3734098e) runs a boot-time `backfillDecisionProvenance` step that infers labels for legacy rows using bulk-approval thresholds and auto-note matching, leaving pending or expired rows untouched.
> - Label predicates in [labels.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/425/files#diff-0d8af163bde8537499dd6dc5b99141c5565ebec6f1f16cd1c70adf415ca4900f) now use explicit provenance as the primary signal, falling back to status and notes only for NULL-provenance rows.
> - Queue routes in [queue.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/425/files#diff-82603c88c0a618245651db800cb8da95025555c3c6992b82d689dd5b2b34bcd9) pass explicit human provenance during approve, reject, manual-send, and draft-send transitions.
> - Behavioral Change: `Ledger.setQueueStatus` defaults to machine provenance when no actor is passed and coalesces on send to avoid overwriting existing approvals. Insert-time rejections are structurally recorded as machine auto-rejections. The expanded `QueueRow` type requires TypeScript consumers to handle the new nullable provenance fields.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a23284f. 5 files reviewed, 3 issues evaluated, 1 issue filtered, 2 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>STATUS.md — 0 comments posted, 1 evaluated, 1 filtered</summary>
>
> - [line 3](https://github.com/oneshot-agent/oneshot-gtm/blob/a23284f733dd0b3f104e597fd4ec9554beb2fcee/STATUS.md#L3): `STATUS.md` now says the CLI has 51 commands, but the repository's code-derived README count is 53 commands (and the README count guard derives it from the Commander command tree). This leaves the newly updated status claim stale and misstates the shipped CLI surface. <b>[ Out of scope (post-validation triage) ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->