### PR TITLE
feat: show prospect context in cadences

### DIFF
--- a/apps/cli/__tests__/__snapshots__/install-service.test.ts.snap
+++ b/apps/cli/__tests__/__snapshots__/install-service.test.ts.snap
@@ -38,63 +38,7 @@ exports[`renderLaunchdPlist > matches the template snapshot 1`] = `
 "
 `;
 
-exports[`renderLaunchdPlist matches the template snapshot 1`] = `
-"<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>Label</key>
-  <string>com.oneshot-gtm.find-watch</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>/opt/homebrew/bin/bun</string>
-    <string>/Users/jo/oneshot-gtm/apps/cli/src/main.ts</string>
-    <string>find</string>
-    <string>watch</string>
-    <string>--quiet</string>
-  </array>
-  <key>EnvironmentVariables</key>
-  <dict>
-    <key>ONESHOT_GTM_HOME</key>
-    <string>/Users/jo/.oneshot-gtm</string>
-    <key>PATH</key>
-    <string>/opt/homebrew/bin:/usr/bin:/bin</string>
-  </dict>
-  <key>RunAtLoad</key>
-  <true/>
-  <key>KeepAlive</key>
-  <dict>
-    <key>SuccessfulExit</key>
-    <false/>
-  </dict>
-  <key>StandardOutPath</key>
-  <string>/Users/jo/.oneshot-gtm/find-watch.log</string>
-  <key>StandardErrorPath</key>
-  <string>/Users/jo/.oneshot-gtm/find-watch.log</string>
-</dict>
-</plist>
-"
-`;
-
 exports[`renderSystemdUnit > matches the template snapshot 1`] = `
-"[Unit]
-Description=oneshot-gtm find watch — poll registered triggers and enqueue candidates
-After=network-online.target
-
-[Service]
-Type=simple
-ExecStart="/opt/homebrew/bin/bun" "/Users/jo/oneshot-gtm/apps/cli/src/main.ts" find watch --quiet
-Environment="ONESHOT_GTM_HOME=/Users/jo/.oneshot-gtm"
-Environment="PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
-Restart=on-failure
-RestartSec=30
-
-[Install]
-WantedBy=default.target
-"
-`;
-
-exports[`renderSystemdUnit matches the template snapshot 1`] = `
 "[Unit]
 Description=oneshot-gtm find watch — poll registered triggers and enqueue candidates
 After=network-online.target

--- a/apps/server/src/api/cadences.ts
+++ b/apps/server/src/api/cadences.ts
@@ -1,4 +1,4 @@
-import { getLedger, isDraining, logEvent } from "@oneshot-gtm/core";
+import { canonicalLinkedInProfileKey, getLedger, isDraining, logEvent } from "@oneshot-gtm/core";
 import {
   getPriorStepsBulk,
   nextStepInfo,
@@ -101,6 +101,11 @@ function toView(
     prospectEmail: row.prospect_email,
     prospectName: row.prospect_name,
     prospectCompany: row.prospect_company,
+    prospectTitle: row.prospect_title,
+    prospectLinkedinUrl:
+      row.prospect_linkedin_url && canonicalLinkedInProfileKey(row.prospect_linkedin_url)
+        ? row.prospect_linkedin_url.trim()
+        : null,
     playName: row.play_name,
     status: row.status as CadenceStatus,
     currentStep: row.current_step,

--- a/apps/web/src/routes/cadences.tsx
+++ b/apps/web/src/routes/cadences.tsx
@@ -588,6 +588,10 @@ function CadencesPage() {
             <tbody>
               {list.map((c, i) => {
                 const totalSteps = c.followupCount + 1;
+                const knownCompany =
+                  c.prospectCompany && !/^\(?unknown\)?$/i.test(c.prospectCompany.trim())
+                    ? c.prospectCompany
+                    : null;
                 const isOverdue =
                   c.status === "active" && c.nextDueAt !== null && c.nextDueAt <= nowIso;
                 // Expandable when there's something to show OR something to do:
@@ -637,9 +641,36 @@ function CadencesPage() {
                         />
                       </td>
                       <td className="px-6 py-2">
-                        <div className="text-ink-cream">
-                          {c.prospectName ? <Pii kind="name">{c.prospectName}</Pii> : "(unknown)"}
+                        <div className="flex items-center gap-2 text-ink-cream">
+                          <span>
+                            {c.prospectName ? <Pii kind="name">{c.prospectName}</Pii> : "(unknown)"}
+                          </span>
+                          {c.prospectLinkedinUrl && (
+                            <a
+                              href={c.prospectLinkedinUrl}
+                              target="_blank"
+                              rel="noreferrer"
+                              className="font-mono text-[10px] text-ink-muted underline decoration-ink-rule underline-offset-2 hover:text-ink-cream-2"
+                              title="Open LinkedIn profile"
+                            >
+                              LinkedIn ↗
+                            </a>
+                          )}
                         </div>
+                        {(c.prospectTitle || knownCompany) && (
+                          <div className="max-w-[280px] truncate text-[11px] text-ink-muted">
+                            {c.prospectTitle ?? "Role unknown"}
+                            {knownCompany && (
+                              <>
+                                {" · "}
+                                <Pii kind="company">{knownCompany}</Pii>
+                              </>
+                            )}
+                          </div>
+                        )}
+                        {!c.prospectTitle && !knownCompany && c.prospectLinkedinUrl && (
+                          <div className="text-[11px] text-ink-faint">Role/company not enriched</div>
+                        )}
                         <div className="font-mono text-[11px] text-ink-faint">
                           {c.prospectEmail ? <Pii kind="email">{c.prospectEmail}</Pii> : "—"}
                         </div>

--- a/apps/web/src/routes/cadences.tsx
+++ b/apps/web/src/routes/cadences.tsx
@@ -669,7 +669,9 @@ function CadencesPage() {
                           </div>
                         )}
                         {!c.prospectTitle && !knownCompany && c.prospectLinkedinUrl && (
-                          <div className="text-[11px] text-ink-faint">Role/company not enriched</div>
+                          <div className="text-[11px] text-ink-faint">
+                            Role/company not enriched
+                          </div>
                         )}
                         <div className="font-mono text-[11px] text-ink-faint">
                           {c.prospectEmail ? <Pii kind="email">{c.prospectEmail}</Pii> : "—"}

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -123,7 +123,7 @@ function safeParseJsonArray(raw: string): unknown[] {
   }
 }
 
-/** A `cadence_state` row joined with its prospect's email/name/company. */
+/** A `cadence_state` row joined with the prospect details needed by cadence surfaces. */
 export interface CadenceWithProspect {
   prospect_id: number;
   play_name: string;
@@ -152,6 +152,8 @@ export interface CadenceWithProspect {
   prospect_email: string | null;
   prospect_name: string | null;
   prospect_company: string | null;
+  prospect_title: string | null;
+  prospect_linkedin_url: string | null;
   reply_channel: "email" | "linkedin" | null;
   replied_at: string | null;
 }
@@ -832,6 +834,7 @@ export class Ledger {
     }
     const sql = `
       SELECT c.*, p.email AS prospect_email, p.name AS prospect_name, p.company AS prospect_company,
+             p.title AS prospect_title, p.linkedin_url AS prospect_linkedin_url,
              (SELECT channel FROM (
                 SELECT 'email' AS channel, received_at AS at FROM inbox_replies WHERE prospect_id = p.id AND coalesce(kind,'human') = 'human'
                 UNION ALL
@@ -853,6 +856,7 @@ export class Ledger {
   listAllCadences(): CadenceWithProspect[] {
     const sql = `
       SELECT c.*, p.email AS prospect_email, p.name AS prospect_name, p.company AS prospect_company,
+             p.title AS prospect_title, p.linkedin_url AS prospect_linkedin_url,
              (SELECT channel FROM (
                 SELECT 'email' AS channel, received_at AS at FROM inbox_replies WHERE prospect_id = p.id AND coalesce(kind,'human') = 'human'
                 UNION ALL SELECT channel, occurred_at AS at FROM channel_events WHERE prospect_id = p.id AND event_type = 'reply'
@@ -876,6 +880,7 @@ export class Ledger {
   getCadence(prospectId: number, playName: string): CadenceWithProspect | null {
     const sql = `
       SELECT c.*, p.email AS prospect_email, p.name AS prospect_name, p.company AS prospect_company,
+             p.title AS prospect_title, p.linkedin_url AS prospect_linkedin_url,
              (SELECT channel FROM (
                 SELECT 'email' AS channel, received_at AS at FROM inbox_replies WHERE prospect_id = p.id AND coalesce(kind,'human') = 'human'
                 UNION ALL SELECT channel, occurred_at AS at FROM channel_events WHERE prospect_id = p.id AND event_type = 'reply'
@@ -895,6 +900,7 @@ export class Ledger {
   listCadencesForProspect(prospectId: number): CadenceWithProspect[] {
     const sql = `
       SELECT c.*, p.email AS prospect_email, p.name AS prospect_name, p.company AS prospect_company,
+             p.title AS prospect_title, p.linkedin_url AS prospect_linkedin_url,
              (SELECT channel FROM (
                 SELECT 'email' AS channel, received_at AS at FROM inbox_replies WHERE prospect_id = p.id AND coalesce(kind,'human') = 'human'
                 UNION ALL SELECT channel, occurred_at AS at FROM channel_events WHERE prospect_id = p.id AND event_type = 'reply'

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -43,6 +43,9 @@ export interface CadenceView {
   prospectEmail: string | null;
   prospectName: string | null;
   prospectCompany: string | null;
+  prospectTitle: string | null;
+  /** Present only when the stored polymorphic profile field is a valid LinkedIn member URL. */
+  prospectLinkedinUrl: string | null;
   playName: string;
   status: CadenceStatus;
   currentStep: number;


### PR DESCRIPTION
## Summary
- include stored prospect title and validated LinkedIn member URL in cadence API views
- show role, company, and a LinkedIn profile link in each cadence prospect row
- clearly label profiles whose role/company have not been enriched

## Verification
- bun run typecheck
- bun run fmt:check
- targeted ledger/server tests (133 passing)
- bun run build

The checks were run in the primary workspace before isolating these four files from unrelated in-progress work.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show prospect title and LinkedIn URL in cadences
> - Extends `CadenceView` in [index.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/428/files#diff-8bfc1c4b53bda948594b3bcdeaead8e4c4130ad092154633bf858b7447c5d62f) with nullable `prospectTitle` and `prospectLinkedInUrl` fields
> - Adds prospect title and LinkedIn URL columns to all four cadence query methods in [ledger.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/428/files#diff-717d28717ccfb3e17791019e23031dc0feeec16ff1e3b3462975264e3734098e): `listActiveCadences`, `listAllCadences`, `getCadence`, and `listCadencesForProspect`
> - Maps the new fields in `toView` in [cadences.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/428/files#diff-3f069de7e6754133fd555f7cc8a3646ce9eca79fef46fc57d3d109d7010e010a); the LinkedIn URL is trimmed and only included when `canonicalLinkedInProfileKey` returns a valid key, otherwise `null`
> - Updates the cadences table in [cadences.tsx](https://github.com/oneshot-agent/oneshot-gtm/pull/428/files#diff-83e4a5cacb45599c76a5c02d1f79983074ad017b801b8e3acbacb03e74cb2c12) to render prospect title, company name with fallback enrichment message, and an external LinkedIn link when a valid URL is present
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec0ecdf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->