### PR TITLE
fix: post-#424 follow-ups — dossier merge race, trigger claim guard, sdk cost accounting

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 51 CLI commands, 17 plays, 11 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-02** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2459 tests / 189 files** · typecheck + oxlint + oxfmt clean.
+Last verified **2026-09-02** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2472 tests / 191 files** · typecheck + oxlint + oxfmt clean.
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/apps/cli/__tests__/__snapshots__/install-service.test.ts.snap
+++ b/apps/cli/__tests__/__snapshots__/install-service.test.ts.snap
@@ -38,24 +38,6 @@ exports[`renderLaunchdPlist > matches the template snapshot 1`] = `
 "
 `;
 
-exports[`renderSystemdUnit > matches the template snapshot 1`] = `
-"[Unit]
-Description=oneshot-gtm find watch — poll registered triggers and enqueue candidates
-After=network-online.target
-
-[Service]
-Type=simple
-ExecStart="/opt/homebrew/bin/bun" "/Users/jo/oneshot-gtm/apps/cli/src/main.ts" find watch --quiet
-Environment="ONESHOT_GTM_HOME=/Users/jo/.oneshot-gtm"
-Environment="PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
-Restart=on-failure
-RestartSec=30
-
-[Install]
-WantedBy=default.target
-"
-`;
-
 exports[`renderLaunchdPlist matches the template snapshot 1`] = `
 "<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -91,6 +73,24 @@ exports[`renderLaunchdPlist matches the template snapshot 1`] = `
   <string>/Users/jo/.oneshot-gtm/find-watch.log</string>
 </dict>
 </plist>
+"
+`;
+
+exports[`renderSystemdUnit > matches the template snapshot 1`] = `
+"[Unit]
+Description=oneshot-gtm find watch — poll registered triggers and enqueue candidates
+After=network-online.target
+
+[Service]
+Type=simple
+ExecStart="/opt/homebrew/bin/bun" "/Users/jo/oneshot-gtm/apps/cli/src/main.ts" find watch --quiet
+Environment="ONESHOT_GTM_HOME=/Users/jo/.oneshot-gtm"
+Environment="PATH=/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"
+Restart=on-failure
+RestartSec=30
+
+[Install]
+WantedBy=default.target
 "
 `;
 

--- a/apps/cli/src/commands/research-products.ts
+++ b/apps/cli/src/commands/research-products.ts
@@ -115,7 +115,8 @@ export async function commandResearchProducts(opts: ResearchProductsOpts): Promi
         return;
       }
       if (researched.dossier.status === "unavailable") unavailable++;
-      ledger.setProspectDossier(row.id, mergeProductDossier(row.dossier_json, researched.dossier));
+      const latestDossier = ledger.getProspectById(row.id)?.dossier_json ?? row.dossier_json;
+      ledger.setProspectDossier(row.id, mergeProductDossier(latestDossier, researched.dossier));
       written++;
       return;
     }

--- a/packages/find/__tests__/trigger-claim.test.ts
+++ b/packages/find/__tests__/trigger-claim.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { getLedger } from "@oneshot-gtm/core";
+import { MAX_RUN_AGE_MS, runTriggerNow } from "../src/registry.ts";
+
+/**
+ * Direct `runTriggerNow` calls must respect the running claim — the exported
+ * boundary cannot overlap same-trigger runs. Only the BLOCKED path is tested
+ * here: it returns before the finder is ever invoked, so no network/SDK is
+ * touched (the happy path necessarily runs a real finder and is covered by
+ * dogfood runs via fireTriggerNow, which claims before delegating).
+ */
+describe("runTriggerNow claim guard", () => {
+  it("refuses to run while another run holds the claim, leaving the claim intact", async () => {
+    const ledger = getLedger();
+    ledger.upsertTrigger({ name: "show-hn", configJson: "{}", enabled: true });
+    const heldSince = new Date().toISOString();
+    const claimed = ledger.markTriggerRunning(
+      "show-hn",
+      heldSince,
+      new Date(Date.now() - MAX_RUN_AGE_MS).toISOString(),
+    );
+    expect(claimed).toBe(true);
+
+    const outcome = await runTriggerNow("show-hn");
+    expect(outcome.fired).toBe(false);
+    expect(outcome.error).toMatch(/already running/);
+    // The holder's claim was not clobbered by the refused run.
+    expect(ledger.getTrigger("show-hn")?.running_started_at).toBe(heldSince);
+  });
+});

--- a/packages/find/src/registry.ts
+++ b/packages/find/src/registry.ts
@@ -796,7 +796,7 @@ export function fireTriggerNow(name: string): void {
   }
   // Explicit catch (not `void`): a rejection before runTriggerNow's own
   // try/catch must surface AND clear the stranded `running_started_at`.
-  runTriggerNow(name).catch((err) => {
+  runTriggerNow(name, { claimHeld: true }).catch((err) => {
     const message = (err as Error).message ?? "runTriggerNow rejected";
     logEvent("trigger.run.fire_failed", { name, message_120: message.slice(0, 120) }, "error");
     try {
@@ -815,7 +815,10 @@ export function fireTriggerNow(name: string): void {
  * (the founder explicitly asked). Persists last_polled_at + last_run_summary
  * so the watch loop respects the run.
  */
-export async function runTriggerNow(name: string): Promise<TriggerRunOutcome> {
+export async function runTriggerNow(
+  name: string,
+  options: { claimHeld?: boolean } = {},
+): Promise<TriggerRunOutcome> {
   startRun();
   const spec = TRIGGERS.find((t) => t.name === name);
   if (!spec) throw new Error(`unknown trigger '${name}'`);
@@ -841,6 +844,16 @@ export async function runTriggerNow(name: string): Promise<TriggerRunOutcome> {
     });
     logEvent("trigger.run.skipped", { name, source: "ad_hoc", reason: readiness.reason });
     return { name, fired: false, error: message, nextDueInMs: intervalMs };
+  }
+  // fireTriggerNow claims before detaching its promise. Direct callers must
+  // claim here so this exported boundary cannot overlap same-trigger runs.
+  if (!options.claimHeld) {
+    const claimNowIso = new Date().toISOString();
+    const staleCutoffIso = new Date(Date.now() - MAX_RUN_AGE_MS).toISOString();
+    if (!ledger.markTriggerRunning(name, claimNowIso, staleCutoffIso)) {
+      const message = `trigger '${name}' is already running`;
+      return { name, fired: false, error: message, nextDueInMs: intervalMs };
+    }
   }
   const startedAt = Date.now();
   logEvent("trigger.run.start", { name, source: "ad_hoc" });

--- a/packages/find/src/x-reposters.ts
+++ b/packages/find/src/x-reposters.ts
@@ -250,6 +250,7 @@ export async function runXRepostersFinder(opts: XRepostersFinderOpts): Promise<F
 
   if (picks.length === 0) {
     result.costUsd = meter.total;
+    result.sdkCostUsd = 0;
     if (!result.halted) {
       result.halted =
         result.candidates === 0


### PR DESCRIPTION
Ships three small fixes that were sitting uncommitted in the checkout after #424 landed — each verified against its call sites before shipping:

1. **research-products dossier merge race**: the write path merged onto the `dossier_json` snapshot read at run start; a dossier written concurrently (reply-research, another pass) got clobbered. Now re-reads the latest via `getProspectById` before merging.
2. **`runTriggerNow` claim guard**: the exported boundary could overlap a same-trigger run when called directly. It now claims `running_started_at` (same atomic claim + stale-cutoff as `fireTriggerNow`, which passes `claimHeld: true` since it claims before detaching). Both completion paths already clear via `updateTriggerLastPoll` — verified symmetric. Added a guard test for the blocked path (returns before any finder/network runs; the happy path necessarily runs a real finder and stays dogfood-covered).
3. **x-reposters `sdkCostUsd` on the zero-picks path**: `registry.ts` computes `priorSdkCostUsd: result.sdkCostUsd ?? result.costUsd` for the product-research budget — an unset field on this path made harvest spend count as SDK spend. The two other early returns spend nothing, so the `?? costUsd` fallback is already correct there.

Verify: fmt/typecheck/lint clean, **2472 tests / 191 files**.

https://claude.ai/code/session_019XJ5qAUV9NDrRrbqdTLebU

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix dossier merge race, trigger claim guard, and SDK cost accounting in `runXRepostersFinder`
> - `research-products` command now reads the prospect's latest dossier from the ledger before merging research results, falling back to the original snapshot when no current row exists
> - `runTriggerNow` adds an atomic running-claim guard for direct callers; if a non-stale claim already exists, the call returns a non-fired already-running outcome without invoking the finder. `fireTriggerNow` passes a claim-held flag so its delegated run is not rejected by the new guard
> - `runXRepostersFinder` explicitly sets the finder result's SDK cost to zero in the no-picks path alongside the existing total cost assignment
> - Risk: direct `runTriggerNow` callers that previously overlapped an existing run will now be refused with an already-running error instead of proceeding; verify no external callers depend on concurrent execution
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 0a6252a. 4 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->