### PR TITLE
fix: issue #363: Deferred review findings from ai/gtm/issue-344

### DIFF
--- a/packages/core/__tests__/timezone.test.ts
+++ b/packages/core/__tests__/timezone.test.ts
@@ -99,6 +99,16 @@ describe("formatLocalEventTime", () => {
     }
   });
 
+  it("rejects invalid calendar dates in zoned and offset timestamps", () => {
+    for (const invalid of [
+      "2026-02-29T19:30:00Z",
+      "2026-04-31T19:30:00+02:00",
+      "0001-02-29T19:30:00-08:00",
+    ]) {
+      expect(formatLocalEventTime(invalid, "UTC")).toBeNull();
+    }
+  });
+
   it("returns null (not 'Invalid Date') for a non-timestamp", () => {
     for (const junk of ["", "   ", "sometime next week", "TBD"]) {
       expect(formatLocalEventTime(junk, "America/Los_Angeles")).toBeNull();

--- a/packages/core/src/timezone.ts
+++ b/packages/core/src/timezone.ts
@@ -20,7 +20,7 @@ const DATE_ONLY = /^(\d{4})-(\d{2})-(\d{2})$/;
 /** `2026-08-26T19:30` / `2026-08-26 19:30:00` — a wall clock with no zone. */
 const NAIVE_DATETIME = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.\d+)?)?$/;
 /** Calendar fields at the start of an ISO timestamp with a zone or offset. */
-const ZONED_DATETIME_DATE = /^(\d{4})-(\d{2})-(\d{2})[T ]/;
+const ZONED_DATETIME_DATE = /^(\d{4})-(\d{2})-(\d{2})[Tt ]/;
 
 /**
  * City → IANA zone for the cities the luma-events finder can be configured

--- a/packages/core/src/timezone.ts
+++ b/packages/core/src/timezone.ts
@@ -19,6 +19,8 @@ import { loadConfig } from "./config.ts";
 const DATE_ONLY = /^(\d{4})-(\d{2})-(\d{2})$/;
 /** `2026-08-26T19:30` / `2026-08-26 19:30:00` — a wall clock with no zone. */
 const NAIVE_DATETIME = /^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2})(?:\.\d+)?)?$/;
+/** Calendar fields at the start of an ISO timestamp with a zone or offset. */
+const ZONED_DATETIME_DATE = /^(\d{4})-(\d{2})-(\d{2})[T ]/;
 
 /**
  * City → IANA zone for the cities the luma-events finder can be configured
@@ -260,6 +262,14 @@ function wallClock(isoInstant: string, zone: string): WallClock | null {
       time: twelveHour(h, min),
       tzAbbr: null,
     };
+  }
+
+  const zonedDate = ZONED_DATETIME_DATE.exec(raw);
+  if (zonedDate) {
+    const year = Number(zonedDate[1]);
+    const month = Number(zonedDate[2]);
+    const day = Number(zonedDate[3]);
+    if (!isValidDate(year, month, day)) return null;
   }
 
   const ms = Date.parse(raw);


### PR DESCRIPTION
Closes #363.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 4427e5025835 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (1 errs) vs base ok (1 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reject invalid calendar dates in `wallClock` zoned timestamp parser
> `wallClock` now extracts year, month, and day from timestamps with a UTC designator or numeric offset and rejects them when `isValidDate` reports an invalid calendar date (e.g. Feb 29 in non-leap years). Previously these strings went straight to `Date.parse`, which could silently normalize invalid dates.
> - Adds test coverage in `formatLocalEventTime` for non-leap Feb 29, April 31, and non-leap year-1 Feb 29.
> - Behavioral Change: `wallClock` returns `null` for zoned/offset timestamps whose calendar fields do not form a valid date; check [timezone.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/432/files#diff-94adc50ff0fda0971352ebe3126d036cb2263d8f35afc4a144bb0207cc9224b7) if consumers relied on prior normalization of such inputs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 0f534c3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->