### PR TITLE
fix: issue #367: Deferred review findings from ai/gtm/issue-360

### DIFF
--- a/apps/cli/__tests__/measure-benchmark.test.ts
+++ b/apps/cli/__tests__/measure-benchmark.test.ts
@@ -46,6 +46,7 @@ afterEach(() => {
   stdoutSpy.mockRestore();
   setJsonMode(false);
   vi.unstubAllGlobals();
+  vi.useRealTimers();
 });
 
 describe("measure benchmark", () => {
@@ -111,5 +112,89 @@ describe("measure benchmark", () => {
       status: "ok",
       ...aggregate,
     });
+  });
+
+  it("stops reading benchmark responses larger than 512KB", async () => {
+    let cancelled = false;
+    let pulls = 0;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulls += 1;
+        controller.enqueue(new Uint8Array(256 * 1024));
+      },
+      cancel() {
+        cancelled = true;
+      },
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(body, { status: 200 })),
+    );
+
+    await commandMeasureBenchmark({}, {});
+
+    expect(stdout.join("")).toContain("Benchmark data is unavailable");
+    expect(pulls).toBeLessThanOrEqual(4);
+    expect(cancelled).toBe(true);
+  });
+
+  it("accepts a benchmark response exactly 512KB long", async () => {
+    const json = JSON.stringify(aggregate);
+    const body = `${json}${" ".repeat(512 * 1024 - Buffer.byteLength(json))}`;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(body, { status: 200 })),
+    );
+
+    await commandMeasureBenchmark({ json: true }, {});
+
+    expect(JSON.parse(stdout.join(""))).toMatchObject({ status: "ok", ...aggregate });
+  });
+
+  it("times out a benchmark request after 10 seconds", async () => {
+    vi.useFakeTimers();
+    let signal: AbortSignal | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn((_input: URL, init?: RequestInit) => {
+        signal = init?.signal ?? undefined;
+        return new Promise<Response>((_resolve, reject) => {
+          signal?.addEventListener("abort", () => reject(signal?.reason), { once: true });
+        });
+      }),
+    );
+
+    const benchmark = commandMeasureBenchmark({}, {});
+    await vi.advanceTimersByTimeAsync(10000);
+    await benchmark;
+
+    expect(signal?.aborted).toBe(true);
+    expect(stdout.join("")).toContain("Benchmark data is unavailable");
+  });
+
+  it("times out while reading a stalled benchmark response", async () => {
+    vi.useFakeTimers();
+    let signal: AbortSignal | undefined;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_input: URL, init?: RequestInit) => {
+        signal = init?.signal ?? undefined;
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            signal?.addEventListener("abort", () => controller.error(signal?.reason), {
+              once: true,
+            });
+          },
+        });
+        return new Response(body, { status: 200 });
+      }),
+    );
+
+    const benchmark = commandMeasureBenchmark({}, {});
+    await vi.advanceTimersByTimeAsync(10000);
+    await benchmark;
+
+    expect(signal?.aborted).toBe(true);
+    expect(stdout.join("")).toContain("Benchmark data is unavailable");
   });
 });

--- a/apps/cli/src/commands/measure.ts
+++ b/apps/cli/src/commands/measure.ts
@@ -15,6 +15,9 @@ export interface BenchmarkAggregate {
 
 type BenchmarkStatus = "ok" | "opted-out" | "unavailable";
 
+const MAX_BENCHMARK_RESPONSE_BYTES = 512 * 1024;
+const BENCHMARK_TIMEOUT_MS = 10000;
+
 /** The aggregate reader lives beside the telemetry ingest route. */
 export function benchmarkUrl(env: NodeJS.ProcessEnv = process.env): string {
   const override = env["ONESHOT_GTM_BENCHMARK_URL"];
@@ -63,6 +66,35 @@ export function parseBenchmarkAggregate(value: unknown): BenchmarkAggregate | nu
   if (!Number.isInteger(row["cohortSize"]) || !finiteNonNegative(row["cohortSize"])) return null;
   if (!local || !cohort || row["cohortSize"] === 0) return null;
   return { cohortSize: row["cohortSize"], local, cohort };
+}
+
+async function readBenchmarkJson(response: Response): Promise<unknown> {
+  const reader = response.body?.getReader();
+  if (!reader) return null;
+
+  const chunks: Uint8Array[] = [];
+  let bytesRead = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      bytesRead += value.byteLength;
+      if (bytesRead > MAX_BENCHMARK_RESPONSE_BYTES) {
+        await reader.cancel();
+        return null;
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const decoder = new TextDecoder();
+  let json = "";
+  for (const chunk of chunks) json += decoder.decode(chunk, { stream: true });
+  json += decoder.decode();
+  return JSON.parse(json);
 }
 
 function renderMetric(label: string, local: string, cohort: string): void {
@@ -122,13 +154,13 @@ export async function commandMeasureBenchmark(
       const url = new URL(endpoint);
       url.searchParams.set("anonymous_machine_id", cfg.clientId);
       const controller = new AbortController();
-      const timeoutId = setTimeout(() => controller.abort(), 10000);
+      const timeoutId = setTimeout(() => controller.abort(), BENCHMARK_TIMEOUT_MS);
       try {
         const response = await fetch(url, {
           headers: { accept: "application/json" },
           signal: controller.signal,
         });
-        if (response.ok) aggregate = parseBenchmarkAggregate(await response.json());
+        if (response.ok) aggregate = parseBenchmarkAggregate(await readBenchmarkJson(response));
       } finally {
         clearTimeout(timeoutId);
       }


### PR DESCRIPTION
Closes #367.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 4427e5025835 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (1 errs) vs base ok (1 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `readBenchmarkJson` streaming reader with 512 KiB limit and 10s timeout to `commandMeasureBenchmark`
> - Adds a streaming body reader `readBenchmarkJson` in [measure.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/436/files#diff-6258eba852aaa5547850a146cf3880fe34f40486d2fa95eab1e65e468965ef6c) that consumes the response via a `ReadableStreamDefaultReader`, tracks cumulative bytes, cancels the stream when the body exceeds 512 KiB, decodes UTF-8 chunks, and parses the JSON
> - Introduces constants for the 512 KiB max response size and the 10 second request timeout, and swaps the direct JSON read in `commandMeasureBenchmark` to use the new reader
> - Adds fake-timer tests for request timeout and stalled response (both verify abort after 10s and unavailable output), plus an oversized-response test (256 KiB chunks, ≤4 pulls, stream cancelled) and an exact-512-KiB test that still produces a valid result
> - Restores real timers in the `afterEach` cleanup hook in [measure-benchmark.test.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/436/files#diff-c2a0136dbb38f0d1f3f8d01f72d4d830c25418226c2d35d03aef9e588698c69d)
> - Behavioral Change: benchmark responses larger than 512 KiB are now cancelled and reported as unavailable instead of being fully read and parsed
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ccda4bf.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->