### PR TITLE
fix: issue #435: feat: strategist-led onboarding — deterministic first-send status + concierge handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ bun run cli -- find drain podcast-guest --dry-run  # preview approved /queue row
 bun run cli -- cadence advance                     # daily tick: poll inbox, fire follow-ups
 ```
 
-54 commands — fourteen groups, plus `init`, `doctor` and `ui` at the top level. `bun run cli -- --help` (or `oneshot-gtm --help` once linked) is the reference:
+55 commands — fourteen groups, plus `init`, `doctor` and `ui` at the top level. `bun run cli -- --help` (or `oneshot-gtm --help` once linked) is the reference:
 
 | Group                    | Commands                                                                                                                                                                                                                                                                                            |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -350,7 +350,7 @@ Successful responses include `duplicate`, `prospectId`, `cadencesStopped`, and `
 
 ```
 apps/
-  cli/        54-command CLI (commander); src/demo/ seeds the demo install, src/main.ts picks the workspace
+  cli/        55-command CLI (commander); src/demo/ seeds the demo install, src/main.ts picks the workspace
   server/     Bun.serve + SSE; tsdown bundle published as `oneshot-gtm-server`
   web/        Vite + React 19 + TanStack + Base UI — 9 pages, run form, strategist dock, privacy mode
 packages/

--- a/apps/server/__tests__/home-route.test.ts
+++ b/apps/server/__tests__/home-route.test.ts
@@ -5,20 +5,22 @@ const listReceiptsMock = vi.fn();
 const eventsByPlayMock = vi.fn();
 const listActiveCadencesMock = vi.fn();
 const totalSpendUsdMock = vi.fn();
+const countSendsMock = vi.fn();
 
-vi.mock("@oneshot-gtm/core", async () => {
-  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
-  return {
-    ...actual,
-    getLedger: () => ({
-      listReceipts: listReceiptsMock,
-      eventsByPlay: eventsByPlayMock,
-      listActiveCadences: listActiveCadencesMock,
-      totalSpendUsd: totalSpendUsdMock,
-      listRuns: listRunsMock,
-    }),
-  };
-});
+vi.mock("@oneshot-gtm/core", () => ({
+  getLedger: () => ({
+    listReceipts: listReceiptsMock,
+    eventsByPlay: eventsByPlayMock,
+    listActiveCadences: listActiveCadencesMock,
+    totalSpendUsd: totalSpendUsdMock,
+    listRuns: listRunsMock,
+    countSends: countSendsMock,
+  }),
+  // Home capacity is best-effort and unrelated to this route contract test.
+  poolSendCapacity: () => {
+    throw new Error("not configured in test");
+  },
+}));
 
 const { homeMetrics } = await import("../src/api/home.ts");
 
@@ -48,16 +50,19 @@ describe("homeMetrics — currentRuns surfacing", () => {
         errorCount: 0,
       },
     ]);
+    countSendsMock.mockReturnValue(1);
     const res = homeMetrics(req());
     const body = (await res.json()) as {
       currentRuns: Array<{ id: number; playName: string; status: string }>;
       callsLast7d: number;
       sentLast7d: number;
       activeCadences: number;
+      hasFirstSend: boolean;
     };
     expect(body.callsLast7d).toBe(3);
     expect(body.sentLast7d).toBe(8); // 5 + 3
     expect(body.activeCadences).toBe(2);
+    expect(body.hasFirstSend).toBe(true);
     expect(body.currentRuns).toHaveLength(1);
     expect(body.currentRuns[0]).toMatchObject({
       id: 7,
@@ -73,8 +78,10 @@ describe("homeMetrics — currentRuns surfacing", () => {
     listActiveCadencesMock.mockReturnValue([]);
     totalSpendUsdMock.mockReturnValue(0);
     listRunsMock.mockReturnValue([]);
+    countSendsMock.mockReturnValue(0);
     const res = homeMetrics(req());
-    const body = (await res.json()) as { currentRuns: unknown[] };
+    const body = (await res.json()) as { currentRuns: unknown[]; hasFirstSend: boolean };
     expect(body.currentRuns).toEqual([]);
+    expect(body.hasFirstSend).toBe(false);
   });
 });

--- a/apps/server/__tests__/home-route.test.ts
+++ b/apps/server/__tests__/home-route.test.ts
@@ -7,20 +7,24 @@ const listActiveCadencesMock = vi.fn();
 const totalSpendUsdMock = vi.fn();
 const countSendsMock = vi.fn();
 
-vi.mock("@oneshot-gtm/core", () => ({
-  getLedger: () => ({
-    listReceipts: listReceiptsMock,
-    eventsByPlay: eventsByPlayMock,
-    listActiveCadences: listActiveCadencesMock,
-    totalSpendUsd: totalSpendUsdMock,
-    listRuns: listRunsMock,
-    countSends: countSendsMock,
-  }),
-  // Home capacity is best-effort and unrelated to this route contract test.
-  poolSendCapacity: () => {
-    throw new Error("not configured in test");
-  },
-}));
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    getLedger: () => ({
+      listReceipts: listReceiptsMock,
+      eventsByPlay: eventsByPlayMock,
+      listActiveCadences: listActiveCadencesMock,
+      totalSpendUsd: totalSpendUsdMock,
+      listRuns: listRunsMock,
+      countSends: countSendsMock,
+    }),
+    // Home capacity is best-effort and unrelated to this route contract test.
+    poolSendCapacity: () => {
+      throw new Error("not configured in test");
+    },
+  };
+});
 
 const { homeMetrics } = await import("../src/api/home.ts");
 

--- a/apps/server/src/api/home.ts
+++ b/apps/server/src/api/home.ts
@@ -21,6 +21,10 @@ export function homeMetrics(req: Request): Response {
     sentLast7d: sent7d,
     repliedLast7d: replied7d,
     activeCadences: active.length,
+    // Onboarding must not infer this from a filtered/paginated queue response:
+    // queue rows can be removed or change status after a real send. Sequence
+    // events are the durable record of transport success.
+    hasFirstSend: ledger.countSends() > 0,
     // In-flight /run dispatches — surfaces a "Resume" link on the home dashboard
     // so the founder can hop back to a running batch without remembering the URL.
     // Capped at 5 (the widget hides itself when empty).

--- a/apps/web/src/components/home/NextStep.tsx
+++ b/apps/web/src/components/home/NextStep.tsx
@@ -4,13 +4,15 @@ import { ArrowRight } from "lucide-react";
 import { api } from "../../api/client.ts";
 import { Button } from "../primitives/Button.tsx";
 import { useLocalStorage } from "../../lib/useLocalStorage.ts";
+import { openStrategist } from "../../lib/openStrategist.ts";
 
 interface Step {
-  id: "icp" | "find" | "drain";
+  id: "icp" | "strategy" | "send";
   title: string;
   lede: string;
   cta: string;
-  href: "/setup" | "/queue";
+  href?: "/setup" | "/queue";
+  opensStrategist?: boolean;
 }
 
 const STEPS: Step[] = [
@@ -22,17 +24,17 @@ const STEPS: Step[] = [
     href: "/setup",
   },
   {
-    id: "find",
-    title: "Run your first finder",
-    lede: "Pick a trigger (Show HN is cheapest) and click Run now. Results land in the queue for your review before anything sends.",
-    cta: "Open the queue",
-    href: "/queue",
+    id: "strategy",
+    title: "Plan your first motion",
+    lede: "Your strategist knows your product and ICP. It will recommend a signal, propose the exact config, and ask before applying it.",
+    cta: "Open strategist",
+    opensStrategist: true,
   },
   {
-    id: "drain",
-    title: "Approve a target and drain",
-    lede: "Approve a queued row, then click drain to send. The cadence engine takes over from there.",
-    cta: "Open the queue",
+    id: "send",
+    title: "Review and send",
+    lede: "The strategist has handed candidates to your queue. Review the evidence and draft, approve one, then send it.",
+    cta: "Review the queue",
     href: "/queue",
   },
 ];
@@ -44,6 +46,7 @@ export function NextStep() {
 
   const setup = useQuery({ queryKey: ["setup"], queryFn: api.setupStatus });
   const triggers = useQuery({ queryKey: ["triggers"], queryFn: api.triggers });
+  const home = useQuery({ queryKey: ["home"], queryFn: api.home });
   // Reuses the cache key from index.tsx's home queue query.
   const queue = useQuery({
     queryKey: ["queue", "recent", "home"],
@@ -51,15 +54,19 @@ export function NextStep() {
   });
 
   if (skipped) return null;
-  if (setup.isLoading || triggers.isLoading || queue.isLoading) return null;
+  if (setup.isLoading || triggers.isLoading || queue.isLoading || home.isLoading) return null;
 
   const icpDone = (setup.data?.cfg.icpOneLiner ?? "").trim().length > 0;
-  const findDone =
+  const strategyDone =
     (triggers.data?.triggers ?? []).some((t) => t.lastPolledAt !== null) ||
-    (queue.data?.counts.pending ?? 0) + (queue.data?.counts.sent ?? 0) > 0;
-  const drainDone = (queue.data?.counts.sent ?? 0) > 0;
+    (queue.data?.counts.pending ?? 0) + (queue.data?.counts.approved ?? 0) > 0;
+  const sendDone = home.data?.hasFirstSend === true;
 
-  const done: Record<Step["id"], boolean> = { icp: icpDone, find: findDone, drain: drainDone };
+  const done: Record<Step["id"], boolean> = {
+    icp: icpDone,
+    strategy: strategyDone,
+    send: sendDone,
+  };
   const ix = STEPS.findIndex((s) => !done[s.id]);
   if (ix === -1) return null;
 
@@ -87,11 +94,17 @@ export function NextStep() {
           <p className="mt-1.5 max-w-2xl text-sm leading-relaxed text-ink-cream-2">{step.lede}</p>
         </div>
         <div className="flex flex-col items-end gap-2">
-          <Link to={step.href}>
-            <Button size="sm" variant="primary">
+          {step.opensStrategist ? (
+            <Button size="sm" variant="primary" onClick={openStrategist}>
               {step.cta} <ArrowRight size={12} />
             </Button>
-          </Link>
+          ) : (
+            <Link to={step.href!}>
+              <Button size="sm" variant="primary">
+                {step.cta} <ArrowRight size={12} />
+              </Button>
+            </Link>
+          )}
           <button
             type="button"
             onClick={() => setSkipped(true)}

--- a/apps/web/src/components/home/NextStep.tsx
+++ b/apps/web/src/components/home/NextStep.tsx
@@ -58,6 +58,7 @@ export function NextStep() {
 
   const icpDone = (setup.data?.cfg.icpOneLiner ?? "").trim().length > 0;
   const strategyDone =
+    home.data?.hasFirstSend === true ||
     (triggers.data?.triggers ?? []).some((t) => t.lastPolledAt !== null) ||
     (queue.data?.counts.pending ?? 0) + (queue.data?.counts.approved ?? 0) > 0;
   const sendDone = home.data?.hasFirstSend === true;

--- a/apps/web/src/components/shell/StrategistDock.tsx
+++ b/apps/web/src/components/shell/StrategistDock.tsx
@@ -1,5 +1,6 @@
 import { Sparkles } from "lucide-react";
-import { lazy, Suspense, useState } from "react";
+import { lazy, Suspense, useEffect, useState } from "react";
+import { OPEN_STRATEGIST_EVENT } from "../../lib/openStrategist.ts";
 
 // Heavy half (assistant-ui runtime + drawer) is lazy-loaded on first open so
 // @assistant-ui/react stays out of the main bundle.
@@ -14,6 +15,15 @@ const StrategistPanel = lazy(() => import("./StrategistPanel.tsx"));
 export function StrategistDock() {
   const [open, setOpen] = useState(false);
   const [everOpened, setEverOpened] = useState(false);
+
+  useEffect(() => {
+    const openFromCta = () => {
+      setEverOpened(true);
+      setOpen(true);
+    };
+    window.addEventListener(OPEN_STRATEGIST_EVENT, openFromCta);
+    return () => window.removeEventListener(OPEN_STRATEGIST_EVENT, openFromCta);
+  }, []);
 
   return (
     <>

--- a/apps/web/src/components/shell/StrategistPanel.tsx
+++ b/apps/web/src/components/shell/StrategistPanel.tsx
@@ -22,10 +22,10 @@ import {
 // them concrete + outcome-oriented (not vague "tune everything"). Each one
 // should map cleanly to a single proactive proposal the strategist can make.
 const SUGGESTIONS = [
+  "Guide me through my first send",
   "Which triggers fit my ICP?",
   "Propose github-topics topics + vendors",
   "Pick an accelerator-batch cohort for my ICP",
-  "Audit my current trigger config",
 ];
 
 /**
@@ -89,8 +89,8 @@ function ChatBody() {
       <ThreadPrimitive.Empty>
         <div className="border-b border-ink-rule/60 px-5 py-4">
           <p className="text-sm text-ink-cream-2">
-            Tell me what to set up. I'll propose configs anchored in your ICP + product and ask
-            before applying anything. Try a chip below or ask anything.
+            I can guide your first motion from signal choice to a review-ready queue. I'll propose
+            configs anchored in your ICP + product and ask before applying anything.
           </p>
         </div>
       </ThreadPrimitive.Empty>

--- a/apps/web/src/lib/openStrategist.ts
+++ b/apps/web/src/lib/openStrategist.ts
@@ -1,0 +1,6 @@
+export const OPEN_STRATEGIST_EVENT = "oneshot-gtm:open-strategist";
+
+/** Open the global strategist drawer from onboarding or any future CTA. */
+export function openStrategist(): void {
+  window.dispatchEvent(new Event(OPEN_STRATEGIST_EVENT));
+}

--- a/apps/web/src/routes/queue.tsx
+++ b/apps/web/src/routes/queue.tsx
@@ -984,6 +984,7 @@ function DraftSection({
     mutationFn: () => api.sendDraft(id),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ["queue"] });
+      void qc.invalidateQueries({ queryKey: ["home"] });
       toast.success("sent · the reviewed draft went out as-is");
     },
     onError: (err) => {
@@ -1032,6 +1033,7 @@ function DraftSection({
     mutationFn: () => api.markSent(id),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ["queue"] });
+      void qc.invalidateQueries({ queryKey: ["home"] });
       toast.success("recorded · hand-send logged on channel x");
     },
     onError: (err) => {

--- a/packages/prompts/strategist-trigger.md
+++ b/packages/prompts/strategist-trigger.md
@@ -25,6 +25,7 @@ ICP: {{icpOneLiner}}
    - **`job-change.personas`**, **`hiring-signal.roles`**, **`podcast-guest.podcasts`** — same proactive treatment when the founder describes their buyer / ICP.
 6. **Show your work briefly.** When you propose a config, give one sentence of reasoning so the founder can sanity-check.
 7. **Don't propose without context.** If the ICP is too thin to anchor a config, say so and suggest the founder refine /setup first.
+8. **Own first-send onboarding.** When the founder asks for first-send guidance, lead them one decision at a time through choosing and configuring a trigger. After its config is applied, tell them to run it and make the handoff explicit: candidates go to `/queue`, where they review evidence and the draft before approving the first send. Never claim a trigger run or send happened merely because config was applied.
 
 ## Action markers
 

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -226,6 +226,8 @@ export interface HomeMetrics {
   sentLast7d: number;
   repliedLast7d: number;
   activeCadences: number;
+  /** Durable, all-time first-send milestone derived from sent sequence events. */
+  hasFirstSend: boolean;
   /** Absent when the capacity computation failed — pages skip the figure. */
   sendsToday?: SendsToday;
   /**


### PR DESCRIPTION
Closes #435.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 4b019a123f99 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (1 errs) vs base fail (6 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `hasFirstSend` to `HomeMetrics` and redesign onboarding to strategist-led flow
> - Adds `hasFirstSend` boolean to the `HomeMetrics` response, derived from the ledger's all-time `countSends` result being greater than zero
> - Replaces the three-step onboarding card with ICP setup → strategist planning → review/send steps, using `hasFirstSend` along with trigger and queue state to hide completed steps
> - Adds an `OPEN_STRATEGIST_EVENT` window event helper so the global `StrategistDock` drawer opens from the onboarding planning CTA
> - Updates the strategist trigger prompt to guide signal/trigger configuration one decision at a time and direct users to `/queue` after config, distinguishing configuration from an actual send
> - Invalidates the home query after successful queue sends and manual hand-send records so the onboarding card reflects the milestone immediately
> - Risk: `hasFirstSend` is a new required field on `HomeMetrics` in [index.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/437/files#diff-8bfc1c4b53bda948594b3bcdeaead8e4c4130ad092154633bf858b7447c5d62f); any out-of-tree consumers of this type must be updated
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 02d9cec.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->