### PR TITLE
fix(web): send cadence next step without a confirm modal

### DIFF
--- a/apps/web/src/routes/cadences.tsx
+++ b/apps/web/src/routes/cadences.tsx
@@ -198,7 +198,6 @@ function CadencesPage() {
         next.delete(`${vars.prospectId}|${vars.playName}`);
         return next;
       });
-      setSendConfirm(null);
       toast.success(`sending · ${vars.playName} — refreshes when complete`);
     },
     onError: (err) => toast.error(`send failed: ${err.message}`),
@@ -250,18 +249,6 @@ function CadencesPage() {
       else next.add(key);
       return next;
     });
-  const [sendConfirm, setSendConfirm] = useState<{
-    prospectId: number;
-    playName: string;
-    prospectEmail: string | null;
-    prospectName: string | null;
-    subject: string;
-    isBreakup: boolean;
-    /** ISO timestamp of the scheduled fire time; null when cadence has no schedule. */
-    nextDueAt: string | null;
-    /** True when next_due_at is in the future at the moment Send was clicked. */
-    isEarly: boolean;
-  } | null>(null);
   const pendingPreviewKey =
     previewNext.isPending && previewNext.variables
       ? `${previewNext.variables.prospectId}|${previewNext.variables.playName}`
@@ -764,6 +751,12 @@ function CadencesPage() {
                                 pendingSendKey != null ||
                                 pendingPreviewKey != null ||
                                 c.isSending;
+                              // Send fires immediately (no confirm modal), so the
+                              // early/breakup warnings live in the button tooltip.
+                              const earlyNote =
+                                c.nextDueAt != null && c.nextDueAt > new Date().toISOString()
+                                  ? ` · ${earlyByCopy(c.nextDueAt)} ahead of schedule — remaining steps recompute from today`
+                                  : "";
                               return (
                                 <>
                                   <Button
@@ -793,23 +786,15 @@ function CadencesPage() {
                                         : draft.flags.length > 0
                                           ? `draft held by lint (${draft.flags.length} flag(s)) — re-preview`
                                           : c.nextStepIsBreakup
-                                            ? "send breakup (final touch) — confirms first"
-                                            : "send next step — confirms first"
+                                            ? `send breakup (final touch) — sends now, no more emails after this${earlyNote}`
+                                            : `send next step — sends now${earlyNote}`
                                     }
                                     disabled={sendDisabled}
                                     onClick={() => {
                                       if (!draft) return;
-                                      setSendConfirm({
+                                      sendNext.mutate({
                                         prospectId: c.prospectId,
                                         playName: c.playName,
-                                        prospectEmail: c.prospectEmail,
-                                        prospectName: c.prospectName,
-                                        subject: draft.subject,
-                                        isBreakup: c.nextStepIsBreakup,
-                                        nextDueAt: c.nextDueAt,
-                                        isEarly:
-                                          c.nextDueAt != null &&
-                                          c.nextDueAt > new Date().toISOString(),
                                       });
                                     }}
                                   >
@@ -1210,73 +1195,6 @@ function CadencesPage() {
               placeholder="Why are you stopping this cadence?"
             />
           </Field>
-        </div>
-      </Modal>
-
-      <Modal
-        open={sendConfirm != null}
-        onClose={() => setSendConfirm(null)}
-        title={
-          sendConfirm?.isBreakup
-            ? `Send breakup — ${mask("auto", sendConfirm?.prospectName ?? sendConfirm?.prospectEmail ?? "(prospect)")}`
-            : `Send next step — ${mask("auto", sendConfirm?.prospectName ?? sendConfirm?.prospectEmail ?? "(prospect)")}`
-        }
-        footer={
-          <>
-            <Button variant="ghost" onClick={() => setSendConfirm(null)}>
-              Cancel
-            </Button>
-            <Button
-              onClick={() => {
-                if (!sendConfirm) return;
-                sendNext.mutate(
-                  { prospectId: sendConfirm.prospectId, playName: sendConfirm.playName },
-                  { onSettled: () => setSendConfirm(null) },
-                );
-              }}
-              disabled={sendNext.isPending}
-            >
-              {sendNext.isPending ? "Sending…" : sendConfirm?.isBreakup ? "Send breakup" : "Send"}
-            </Button>
-          </>
-        }
-      >
-        <div className="flex flex-col gap-3">
-          {sendConfirm?.isEarly && sendConfirm.nextDueAt && (
-            <div className="rounded border border-ink-rule bg-ink-surface/40 px-3 py-2 text-[12px] text-ink-cream-2">
-              Heads up: this step isn't scheduled to fire until{" "}
-              <span className="text-ink-cream">{timeAgo(sendConfirm.nextDueAt)}</span> (
-              {earlyByCopy(sendConfirm.nextDueAt)}). Sending now fires it ahead of schedule; the
-              remaining cadence steps will recompute their due dates from today, not the original
-              schedule.
-            </div>
-          )}
-          {sendConfirm?.isBreakup && (
-            <div className="rounded border border-ink-rule bg-ink-surface/40 px-3 py-2 text-[12px] text-[color:var(--ink-spend-2)]">
-              This is the breakup — the final touch in{" "}
-              <code className="font-mono text-[11px]">{sendConfirm.playName}</code>. After this, no
-              more emails will go to this prospect.
-            </div>
-          )}
-          <div className="font-mono text-[12px] text-ink-muted">
-            <div>
-              To:{" "}
-              <span className="text-ink-cream-2">
-                {sendConfirm?.prospectEmail
-                  ? mask("email", sendConfirm.prospectEmail)
-                  : "(no email)"}
-              </span>
-            </div>
-            <div>
-              Play: <span className="text-ink-cream-2">{sendConfirm?.playName}</span>
-            </div>
-            <div>
-              Subject: <span className="text-ink-cream-2">{sendConfirm?.subject}</span>
-            </div>
-          </div>
-          <div className="ln-eyebrow text-[10px] text-ink-faint">
-            sends the persisted preview verbatim — no LLM reroll.
-          </div>
         </div>
       </Modal>
 


### PR DESCRIPTION
The per-prospect **Send** button in the cadences view opened a confirm modal before dispatching. Send is already gated on a lint-clean persisted preview, so the modal was a second click on a decision already made.

## Changes
- `Send` fires `sendNext.mutate(...)` directly — no modal.
- Removed the `sendConfirm` state and the confirm modal (~90 lines).
- The two warnings that lived only in that modal moved into the button tooltip so they are still visible before the click:
  - breakup: "sends now, no more emails after this"
  - early send: "N ahead of schedule — remaining steps recompute from today"
- **Bulk send keeps its confirm** — that one dispatches many emails at once.

Unchanged guard: Send stays disabled until a lint-clean preview is persisted, so nothing goes out unpreviewed.

## Verify
- `bun run typecheck` (apps/web): clean
- `bun run lint`: 0 errors (24 pre-existing warnings elsewhere)
- `bun test` (apps/web): 146 pass, 6 fail — all in `__tests__/timeAgo.test.ts` (`vi.setSystemTime` undefined under `bun test`), pre-existing and untouched by this change

https://claude.ai/code/session_01CPweATEtibYbHW7CUBqbig

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Send cadence next step directly without confirm modal in `CadencesPage`
> Removes the send-confirmation state and confirmation `Modal` (recipient, subject, schedule, breakup, preview) from [cadences.tsx](https://github.com/oneshot-agent/oneshot-gtm/pull/445/files#diff-83e4a5cacb45599c76a5c02d1f79983074ad017b801b8e3acbacb03e74cb2c12). The active-cadence Send button now calls the send mutation immediately when a draft exists, with schedule and breakup warnings surfaced in the button tooltip instead.
> - Behavioral Change: clicking Send now dispatches the cadence next step with no modal prompt; users can no longer review recipient/subject/preview before sending.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a5810ac.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->