### PR TITLE
feat(plays): cap how much of a step's mail one opener may hold

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 51 CLI commands, 17 plays, 11 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-02** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2516 tests / 197 files** · typecheck + oxlint + oxfmt clean.
+Last verified **2026-09-02** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2532 tests / 197 files** · typecheck + oxlint + oxfmt clean.
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 51 CLI commands, 17 plays, 11 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-02** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2532 tests / 197 files** · typecheck + oxlint + oxfmt clean.
+Last verified **2026-09-02** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2534 tests / 197 files** · typecheck + oxlint + oxfmt clean.
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/packages/core/__tests__/ledger-extra.test.ts
+++ b/packages/core/__tests__/ledger-extra.test.ts
@@ -1031,3 +1031,70 @@ describe("receipt annotation (memo / decisionContext / value_tag)", () => {
     expect(ledger.goalLabels([]).size).toBe(0);
   });
 });
+
+describe("recentSentEmailBodies", () => {
+  const write = (
+    prospectId: number,
+    stepIndex: number,
+    body: string | null,
+    status: "sent" | "replied" | "failed" = "sent",
+  ): void => {
+    ledger.recordSequenceEvent({
+      prospectId,
+      playName: "repo-interest",
+      stepIndex,
+      channel: "email",
+      status,
+      metadata: body == null ? { subject: "s" } : { subject: "s", body },
+    });
+  };
+
+  it("returns bodies for one play + step, newest first", () => {
+    const pid = ledger.upsertProspect({ name: "A", email: "a@x.com", source: "t" });
+    write(pid, 1, "first");
+    write(pid, 1, "second");
+    expect(ledger.recentSentEmailBodies({ playName: "repo-interest", stepIndex: 1 })).toEqual([
+      "second",
+      "first",
+    ]);
+  });
+
+  it("counts replied rows — they are sends that were answered, not non-sends", () => {
+    const pid = ledger.upsertProspect({ name: "B", email: "b@x.com", source: "t" });
+    write(pid, 1, "answered", "replied");
+    expect(ledger.recentSentEmailBodies({ playName: "repo-interest", stepIndex: 1 })).toEqual([
+      "answered",
+    ]);
+  });
+
+  it("excludes other steps, other plays, failures, and bodyless rows", () => {
+    const pid = ledger.upsertProspect({ name: "C", email: "c@x.com", source: "t" });
+    write(pid, 0, "intro");
+    write(pid, 1, "kept");
+    write(pid, 1, null);
+    write(pid, 1, "   ");
+    write(pid, 1, "dropped", "failed");
+    ledger.recordSequenceEvent({
+      prospectId: pid,
+      playName: "stack-consolidation",
+      stepIndex: 1,
+      channel: "email",
+      status: "sent",
+      metadata: { subject: "s", body: "other play" },
+    });
+    expect(ledger.recentSentEmailBodies({ playName: "repo-interest", stepIndex: 1 })).toEqual([
+      "kept",
+    ]);
+  });
+
+  it("honours the limit and clamps it", () => {
+    const pid = ledger.upsertProspect({ name: "D", email: "d@x.com", source: "t" });
+    for (let i = 0; i < 5; i++) write(pid, 1, `body ${i}`);
+    expect(
+      ledger.recentSentEmailBodies({ playName: "repo-interest", stepIndex: 1, limit: 2 }),
+    ).toHaveLength(2);
+    expect(
+      ledger.recentSentEmailBodies({ playName: "repo-interest", stepIndex: 1, limit: 0 }),
+    ).toHaveLength(1);
+  });
+});

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -1889,6 +1889,42 @@ export class Ledger {
     return null;
   }
 
+  /**
+   * Bodies of the most recent email sends for one play + step, newest first.
+   * Feeds the opener-frequency lint: a follow-up step that keeps reaching for
+   * the same opening words is a fingerprint, and only the ledger knows what
+   * the last N sends actually opened with.
+   *
+   * Same status set as `latestSentEmailCopy` — 'sent' rows are UPDATEd in
+   * place to 'replied', so matching only 'sent' would silently drop every
+   * prospect who answered and skew the share.
+   */
+  recentSentEmailBodies(opts: { playName: string; stepIndex: number; limit?: number }): string[] {
+    const limit = Math.max(1, Math.min(opts.limit ?? 40, 200));
+    const rows = this.db
+      .query(
+        `SELECT metadata_json FROM sequence_events
+         WHERE play_name = ? AND step_index = ?
+           AND status IN ('sent', 'delivered', 'replied')
+           AND channel = 'email' AND metadata_json IS NOT NULL
+           AND json_valid(metadata_json)
+           AND trim(coalesce(json_extract(metadata_json, '$.body'), '')) != ''
+         ORDER BY created_at DESC, id DESC LIMIT ?`,
+      )
+      .all(opts.playName, opts.stepIndex, limit) as Array<{ metadata_json: string }>;
+    const out: string[] = [];
+    for (const row of rows) {
+      let body: unknown;
+      try {
+        body = (JSON.parse(row.metadata_json) as { body?: unknown }).body;
+      } catch {
+        continue;
+      }
+      if (typeof body === "string" && body.trim()) out.push(body);
+    }
+    return out;
+  }
+
   getReceipt(id: number): ReceiptRecord | null {
     return (this.db.query("SELECT * FROM receipts WHERE id = ?").get(id) as ReceiptRecord) ?? null;
   }

--- a/packages/plays/__tests__/_lib.test.ts
+++ b/packages/plays/__tests__/_lib.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { lintEmail } from "../src/_lib.ts";
+import { lintEmail, lintOpenerFrequency, openerStem, overusedOpeners } from "../src/_lib.ts";
 
 describe("lintEmail — humanizer canon", () => {
   it("returns no flags for a clean founder-to-founder email", () => {
@@ -103,5 +103,95 @@ describe("lintEmail — meeting asks dressed as small ones", () => {
 
   it("leaves a one-line question answerable from their own experience alone", () => {
     expect(lintEmail("ping", "the keys or the billing, which one actually bites? Sam")).toEqual([]);
+  });
+});
+
+describe("openerStem", () => {
+  it("drops a generated greeting so the stem is the actual opener", () => {
+    expect(openerStem("Hey Akhilesh,\n\nStill curious if the keys bit you.\n\nJ.")).toBe(
+      "still curious",
+    );
+    expect(openerStem("Hi Dr. Chen -\nthe keys or the billing?")).toBe("the keys");
+  });
+
+  it("keeps a first line that only looks like a greeting", () => {
+    expect(openerStem("Heya the ramp stalled?")).toBe("heya the");
+  });
+
+  it("normalizes case and punctuation, and survives an empty body", () => {
+    expect(openerStem("  STILL, curious...  whether\n")).toBe("still curious");
+    expect(openerStem("\n\n")).toBe("");
+  });
+});
+
+/** `n` bodies that all open with `stem`, each otherwise distinct. */
+const withStem = (stem: string, n: number): string[] =>
+  Array.from({ length: n }, (_, i) => `Hey Sam,\n\n${stem} thing number ${i}.\n\nJ.`);
+
+describe("lintOpenerFrequency — cap, not ban", () => {
+  it("flags an opener that holds more than a quarter of recent sends", () => {
+    const recent = [...withStem("still curious", 12), ...withStem("the keys", 8)];
+    expect(lintOpenerFrequency("Hey Ada,\n\nstill curious about it.", recent)).toEqual([
+      "opener-overused",
+    ]);
+  });
+
+  it("allows the same opener while it is still a minority", () => {
+    const recent = [...withStem("still curious", 4), ...withStem("the keys", 16)];
+    expect(lintOpenerFrequency("Hey Ada,\n\nstill curious about it.", recent)).toEqual([]);
+  });
+
+  it("stays quiet below the minimum sample rather than guessing", () => {
+    expect(
+      lintOpenerFrequency("Hey Ada,\n\nstill curious about it.", withStem("still curious", 7)),
+    ).toEqual([]);
+    expect(lintOpenerFrequency("Hey Ada,\n\nstill curious about it.", [])).toEqual([]);
+  });
+
+  it("does not flag a body with no opener at all", () => {
+    expect(lintOpenerFrequency("\n\n", withStem("still curious", 20))).toEqual([]);
+  });
+
+  it("measures the real shape: a six-word stem would have missed this", () => {
+    // "still curious how you handle the" held 18% of 411 real follow-ups while
+    // "still curious" held 55% — the cap has to compare the short stem.
+    const recent = [
+      ...withStem("still curious how you handle the", 8),
+      ...withStem("still curious whether the keys are", 8),
+      ...withStem("the migration", 4),
+    ];
+    expect(lintOpenerFrequency("Hey Ada,\n\nstill curious if it bit you.", recent)).toEqual([
+      "opener-overused",
+    ]);
+  });
+});
+
+describe("overusedOpeners", () => {
+  it("names every stem over the cap, worst first", () => {
+    const recent = [
+      ...withStem("still curious", 10),
+      ...withStem("still open", 6),
+      ...withStem("the keys", 4),
+    ];
+    expect(overusedOpeners(recent)).toEqual(["still curious", "still open"]);
+  });
+
+  it("names nothing when the window is short or evenly spread", () => {
+    expect(overusedOpeners(withStem("still curious", 7))).toEqual([]);
+    const spread = ["a x", "b x", "c x", "d x", "e x", "f x", "g x", "h x"];
+    expect(overusedOpeners(spread)).toEqual([]);
+  });
+
+  it("agrees with the flag it steers away from", () => {
+    // 12 of 20 on one stem; the rest spread thin enough to stay under the cap.
+    const spread = ["alpha one", "bravo two", "charlie three", "delta four"].flatMap((s) =>
+      withStem(s, 2),
+    );
+    const recent = [...withStem("still curious", 12), ...spread];
+    expect(overusedOpeners(recent)).toEqual(["still curious"]);
+    expect(lintOpenerFrequency("Hey Ada,\n\nstill curious about it.", recent)).toEqual([
+      "opener-overused",
+    ]);
+    expect(lintOpenerFrequency("Hey Ada,\n\nalpha one thing.", recent)).toEqual([]);
   });
 });

--- a/packages/plays/__tests__/cadence-batch.test.ts
+++ b/packages/plays/__tests__/cadence-batch.test.ts
@@ -50,6 +50,8 @@ vi.mock("@oneshot-gtm/core", async () => {
     },
     listInbox: async () => ({ emails: [], has_more: false }),
     getLedger: () => ({
+      // Opener-frequency cap: no send history in these fakes, so nothing is worn out.
+      recentSentEmailBodies: () => [],
       // Reply-poll plumbing: no watermark, nothing to record (inbox is stubbed empty).
       getPollWatermark: () => null,
       setPollWatermark: () => {},

--- a/packages/plays/__tests__/cadence-batch.test.ts
+++ b/packages/plays/__tests__/cadence-batch.test.ts
@@ -212,6 +212,36 @@ afterEach(() => {
 });
 
 describe("previewCadenceStepBatch", () => {
+  it("counts drafts accepted earlier in the same batch, so a batch cannot agree on one opener", async () => {
+    // Every mocked draft opens the same way. With an empty ledger the cap has
+    // no history to measure, so without carrying accepted drafts forward the
+    // whole batch would pass and ship one identical opener.
+    for (let id = 4; id <= 15; id++) {
+      cadenceRows.push({
+        prospect_id: id,
+        play_name: "stack-consolidation",
+        current_step: 0,
+        status: "active",
+        enrolled_at: new Date().toISOString(),
+        next_due_at: new Date(Date.now() - 1000).toISOString(),
+        last_polled_at: null,
+        next_step_draft_json: null,
+        next_step_drafted_at: null,
+        prospect_email: `p${id}@x.dev`,
+        prospect_name: `P${id}`,
+        prospect_company: "PC",
+      });
+    }
+    const out = await previewCadenceStepBatch(
+      cadenceRows
+        .filter((c) => c.status === "active")
+        .map((c) => ({ prospectId: c.prospect_id, playName: c.play_name })),
+    );
+    const flagged = out.filter((r) => r.preview?.flags.includes("opener-overused"));
+    expect(out[0]?.preview?.flags ?? []).not.toContain("opener-overused");
+    expect(flagged.length).toBeGreaterThan(0);
+  });
+
   it("processes all items; a non-active row records ok:false but the rest succeed", async () => {
     const out = await previewCadenceStepBatch([
       { prospectId: 1, playName: "stack-consolidation" },

--- a/packages/plays/__tests__/cadence-deferral.test.ts
+++ b/packages/plays/__tests__/cadence-deferral.test.ts
@@ -60,6 +60,8 @@ vi.mock("@oneshot-gtm/core", async () => {
     },
     listInbox: async () => ({ emails: [], has_more: false }),
     getLedger: () => ({
+      // Opener-frequency cap: no send history in these fakes, so nothing is worn out.
+      recentSentEmailBodies: () => [],
       // Reply-poll plumbing: no watermark, nothing to record (inbox is stubbed empty).
       getPollWatermark: () => null,
       setPollWatermark: () => {},

--- a/packages/plays/__tests__/cadence-prior-emails.test.ts
+++ b/packages/plays/__tests__/cadence-prior-emails.test.ts
@@ -31,6 +31,9 @@ vi.mock("@oneshot-gtm/core", async () => {
       clientId: null,
     }),
     getLedger: () => ({
+      // Opener-frequency cap: no send history in these fakes, so nothing is worn out.
+      recentSentEmailBodies: () => [],
+      getCadence: () => ({ current_step: 0, status: "active" }),
       listSequenceEventsForProspectPlay: (_pid: number, _play: string) => storedRows,
     }),
     receiptUrlForId: (id: number) => `local://receipt/${id}`,

--- a/packages/plays/__tests__/cadence-step-runner.test.ts
+++ b/packages/plays/__tests__/cadence-step-runner.test.ts
@@ -315,6 +315,15 @@ describe("sendCadenceStep", () => {
     ).rejects.toThrow(/no persisted preview/);
   });
 
+  it("refuses to send a draft the lint held, so the API matches the disabled button", async () => {
+    await previewCadenceStep({ prospectId: 1, playName: "stack-consolidation" });
+    persistedDraft = { ...persistedDraft!, flags: ["opener-overused"] };
+    await expect(
+      sendCadenceStep({ prospectId: 1, playName: "stack-consolidation" }),
+    ).rejects.toThrow(/held by lint \(opener-overused\)/);
+    expect(calls.sendEmail).toBe(0);
+  });
+
   it("attaches audit context (memo + decisionContext.source='cadence') to the SDK call", async () => {
     await previewCadenceStep({ prospectId: 1, playName: "stack-consolidation" });
     await sendCadenceStep({ prospectId: 1, playName: "stack-consolidation" });

--- a/packages/plays/__tests__/cadence-step-runner.test.ts
+++ b/packages/plays/__tests__/cadence-step-runner.test.ts
@@ -93,6 +93,8 @@ vi.mock("@oneshot-gtm/core", async () => {
     },
     listInbox: async () => ({ emails: [], has_more: false }),
     getLedger: () => ({
+      // Opener-frequency cap: no send history in these fakes, so nothing is worn out.
+      recentSentEmailBodies: () => [],
       // Reply-poll plumbing: no watermark, nothing to record (inbox is stubbed empty).
       getPollWatermark: () => null,
       setPollWatermark: () => {},

--- a/packages/plays/__tests__/humanizer-coverage.test.ts
+++ b/packages/plays/__tests__/humanizer-coverage.test.ts
@@ -61,6 +61,9 @@ const PROBES: RuleProbe[] = [
   { flag: "subject-shouty", marker: "lowercase the whole subject" },
   { flag: "body-too-long", marker: "≤80 words" },
   { flag: "calendar-link", marker: "calendly" },
+  // Not a SLOP_PHRASES regex — lintOpenerFrequency reads the ledger — but the
+  // humanizer must still document the rule it enforces.
+  { flag: "opener-overused", marker: "opener-overused" },
 ];
 
 describe("_humanizer.md covers every lintEmail rule (drift guard)", () => {

--- a/packages/plays/src/_cadence.ts
+++ b/packages/plays/src/_cadence.ts
@@ -1028,6 +1028,10 @@ export interface CadenceStepPreview {
 export async function previewCadenceStep(input: {
   prospectId: number;
   playName: string;
+  /** Bodies accepted earlier in the same batch — they are not in the ledger
+   *  yet, and without them a batch can agree on one brand-new opener and every
+   *  row passes the cap individually. */
+  extraRecentBodies?: readonly string[];
 }): Promise<CadenceStepPreview> {
   const ledger = getLedger();
   const cfg = loadConfig();
@@ -1067,10 +1071,10 @@ export async function previewCadenceStep(input: {
     built.kind === "email"
       ? [
           ...lintEmail(subject, body, 100),
-          ...lintOpenerFrequency(
-            body,
-            ledger.recentSentEmailBodies({ playName: input.playName, stepIndex: nextIndex }),
-          ),
+          ...lintOpenerFrequency(body, [
+            ...(input.extraRecentBodies ?? []),
+            ...ledger.recentSentEmailBodies({ playName: input.playName, stepIndex: nextIndex }),
+          ]),
         ]
       : [];
   ledger.setCadenceDraft({
@@ -1106,6 +1110,11 @@ export async function sendCadenceStep(input: {
   const ledger = getLedger();
   const draft = ledger.getCadenceDraft(input);
   if (!draft) throw new Error("no persisted preview — click Preview first");
+  // The UI disables Send on a flagged draft; enforce the same rule here so a
+  // direct API call cannot dispatch copy the lint held back.
+  if (draft.flags.length > 0) {
+    throw new Error(`draft held by lint (${draft.flags.join(", ")}) — re-preview first`);
+  }
   return runCadenceStepForProspect({
     prospectId: input.prospectId,
     playName: input.playName,
@@ -1142,9 +1151,20 @@ export interface BatchSendResult {
  * preserves input order so the result matches `items` 1:1.
  */
 export async function previewCadenceStepBatch(items: BatchItem[]): Promise<BatchPreviewResult[]> {
+  // Drafts this batch has already accepted, keyed by play (the step is fixed
+  // per prospect but the play is what the cap is scoped to). Concurrency 3
+  // means the last couple of rows may not see each other; that still closes
+  // the batch-wide agreement this exists to catch.
+  const accepted = new Map<string, string[]>();
   return parallelMap(items, 3, async (item) => {
     try {
-      const preview = await previewCadenceStep(item);
+      const preview = await previewCadenceStep({
+        ...item,
+        extraRecentBodies: accepted.get(item.playName) ?? [],
+      });
+      if (preview.flags.length === 0) {
+        accepted.set(item.playName, [...(accepted.get(item.playName) ?? []), preview.body]);
+      }
       return { prospectId: item.prospectId, playName: item.playName, ok: true, preview };
     } catch (err) {
       return {

--- a/packages/plays/src/_cadence.ts
+++ b/packages/plays/src/_cadence.ts
@@ -25,6 +25,8 @@ import {
   firstNameFrom,
   humanizeDraft,
   lintEmail,
+  lintOpenerFrequency,
+  overusedOpeners,
   signatureDirective,
   socialProofBlock,
 } from "./_lib.ts";
@@ -1057,7 +1059,20 @@ export async function previewCadenceStep(input: {
         : built.kind === "voice"
           ? built.objective
           : "";
-  const flags = built.kind === "email" ? lintEmail(subject, body, 100) : [];
+  // Opener-frequency cap on top of the phrase lint: the phrase rules cannot
+  // see that this play's last 40 sends all opened the same way. Scoped to the
+  // same play + step because that is the population a reader would ever
+  // compare — an intro and a day-3 ping are allowed to sound different.
+  const flags =
+    built.kind === "email"
+      ? [
+          ...lintEmail(subject, body, 100),
+          ...lintOpenerFrequency(
+            body,
+            ledger.recentSentEmailBodies({ playName: input.playName, stepIndex: nextIndex }),
+          ),
+        ]
+      : [];
   ledger.setCadenceDraft({
     prospectId: input.prospectId,
     playName: input.playName,
@@ -1316,6 +1331,31 @@ function loadProspect(id: number): ProspectRecord | null {
   return getLedger().getProspectById(id);
 }
 
+/**
+ * The OPENERS ALREADY WORN OUT block, or "" when nothing is over the cap.
+ *
+ * Scoped to this prospect's next step on this play — the same population the
+ * `opener-overused` lint measures, so the guidance and the gate cannot
+ * disagree. Returns "" on any missing cadence rather than throwing: steering
+ * copy is a nicety, and a follow-up must still draft without it.
+ */
+function overusedOpenersBlock(prospectId: number, playName: string): string {
+  const ledger = getLedger();
+  const cadence = ledger.getCadence(prospectId, playName);
+  if (!cadence) return "";
+  const recent = ledger.recentSentEmailBodies({
+    playName,
+    stepIndex: cadence.current_step + 1,
+  });
+  const worn = overusedOpeners(recent);
+  if (worn.length === 0) return "";
+  return [
+    "OPENERS ALREADY WORN OUT ON THIS STEP — do not open the body with these words:",
+    ...worn.map((stem) => `- "${stem}"`),
+    "Pick a different shape from the ones the prompt lists.",
+  ].join("\n");
+}
+
 export function buildFollowUpEmail(opts: {
   playName: string;
   promptName: string;
@@ -1328,6 +1368,10 @@ export function buildFollowUpEmail(opts: {
     // Optional first-name field: prompt rule lets the LLM occasionally open
     // with "Hey {firstName},". Absent when name is null / (unknown) / handle.
     const firstName = firstNameFrom(ctx.prospect.name);
+    // Steer the draft away from openers this step has already worn out, rather
+    // than only rejecting them afterwards: a rejected draft costs another paid
+    // completion, and the model cannot see the last 40 sends on its own.
+    const avoidBlock = overusedOpenersBlock(ctx.prospect.id, opts.playName);
     const user = [
       `FOUNDER: ${ctx.cfg.founderName}`,
       `PRODUCT: ${ctx.cfg.productOneLiner}`,
@@ -1338,6 +1382,7 @@ export function buildFollowUpEmail(opts: {
       ...(priorBlock ? ["", priorBlock] : []),
       ...(proofBlock ? ["", proofBlock] : []),
       ...(firstName ? ["", `PROSPECT_FIRST_NAME: ${firstName}`] : []),
+      ...(avoidBlock ? ["", avoidBlock] : []),
     ].join("\n");
     const res = await complete({
       messages: [

--- a/packages/plays/src/_lib.ts
+++ b/packages/plays/src/_lib.ts
@@ -184,6 +184,90 @@ export function bodyWordsForLint(body: string, sigLines?: string[]): number {
   return trimmed.split(/\s+/).filter(Boolean).length;
 }
 
+/**
+ * Words of the body that make up an opener fingerprint. Two, measured: across
+ * 411 sent follow-ups the opener "still curious" held 55% at two words but
+ * fragmented to 18% by six, so a longer stem slips under any usable cap while
+ * the mail still reads identically to anyone who sees two of them.
+ */
+const OPENER_STEM_WORDS = 2;
+
+/** Below this many prior sends the share is noise, so the cap never fires. */
+const OPENER_MIN_SAMPLE = 8;
+
+/** Share of recent sends one stem may hold before it counts as a fingerprint. */
+const OPENER_MAX_SHARE = 0.25;
+
+/**
+ * The body's first `words` words, minus a greeting line, lowercased and
+ * stripped of punctuation — the unit the opener-frequency cap compares.
+ *
+ * The greeting goes because it is generated from the prospect's name: leaving
+ * "Hey Sam," in would make every stem unique and the cap would never fire.
+ */
+export function openerStem(body: string, words = OPENER_STEM_WORDS): string {
+  const lines = body
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0);
+  const first = lines[0] ?? "";
+  const rest =
+    lines.length > 1 &&
+    /^(?:hey|hi|hello|good (?:morning|afternoon))\b[^,]{0,40}[,\-–—]?$/i.test(first)
+      ? lines.slice(1)
+      : lines;
+  const normalized = rest
+    .join(" ")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ");
+  return normalized.split(" ").filter(Boolean).slice(0, words).join(" ");
+}
+
+/**
+ * Flags a draft whose opening words already carry more than their share of
+ * this play + step's recent sends.
+ *
+ * A frequency cap rather than a ban: the goal is not that every opener be
+ * unique, it is that no single opener speaks for the majority of a domain's
+ * touches. Prompt text alone did not hold this — the prompts advertise four
+ * shapes and the model still reached for the same one — so it is gated here,
+ * where a rule cannot be talked out of.
+ *
+ * `recentBodies` is the caller's window (newest first); an empty or short
+ * window returns no flags rather than guessing.
+ *
+ * Paired with `overusedOpeners`, which the follow-up builder feeds to the
+ * model BEFORE it drafts — the flag alone would only reject, and every
+ * rejection costs another paid draft.
+ */
+export function overusedOpeners(
+  recentBodies: readonly string[],
+  opts: { minSample?: number; maxShare?: number } = {},
+): string[] {
+  const minSample = opts.minSample ?? OPENER_MIN_SAMPLE;
+  const maxShare = opts.maxShare ?? OPENER_MAX_SHARE;
+  if (recentBodies.length < minSample) return [];
+  const counts = new Map<string, number>();
+  for (const prior of recentBodies) {
+    const stem = openerStem(prior);
+    if (stem.length > 0) counts.set(stem, (counts.get(stem) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .filter(([, n]) => n / recentBodies.length >= maxShare)
+    .toSorted((a, b) => b[1] - a[1])
+    .map(([stem]) => stem);
+}
+
+export function lintOpenerFrequency(
+  body: string,
+  recentBodies: readonly string[],
+  opts: { minSample?: number; maxShare?: number } = {},
+): string[] {
+  const stem = openerStem(body);
+  if (stem.length === 0) return [];
+  return overusedOpeners(recentBodies, opts).includes(stem) ? ["opener-overused"] : [];
+}
+
 export function lintEmail(subject: string, body: string, maxBodyWords = 110): string[] {
   const flags: string[] = [];
   if (subject.length === 0) flags.push("empty-subject");

--- a/packages/prompts/_humanizer.md
+++ b/packages/prompts/_humanizer.md
@@ -143,6 +143,8 @@ A follow-up body is ANCHORED to the concrete thing the first email named — the
 
 Requiring every body to literally begin with the noun would just trade one uniform shape for another. Vary the sentence, keep the anchor.
 
+This one is measured, not trusted: a draft whose first two words already open more than a quarter of that play + step's recent sends is flagged `opener-overused` and held until it is rewritten.
+
 The example lines in each play prompt are SHAPES, not strings. They show how long the sentence is and what it is allowed to reference. Copying one verbatim, or reusing the same first three words every send, is a failure of this rule even when the copied line breaks no other ban.
 
 ## Banned CTAs


### PR DESCRIPTION
The prompt-side fix in #447 did not hold. Two live previews immediately after it merged:

> **Still curious** if the credential-injection part bit you on agent-peek too…
> the keys or the billing, **still curious** which half of that is the actual tax…

Better anchored — that part of #447 worked — but the same stem, 2 for 2. Which is what that PR's own review warned ("the output lint has no check for this rule") and what the meeting-ask ban had already demonstrated: a rule the lint cannot see is a rule the model drifts past.

## Two layers, one threshold

- **`overusedOpeners()`** names every opener holding ≥25% of the last 40 sends on this play + step. `buildFollowUpEmail` feeds them to the model as an `OPENERS ALREADY WORN OUT` block *before* it drafts.
- **`lintOpenerFrequency()`** flags a draft whose opener is on that list — `opener-overused`, which disables Send until it's rewritten.

Prevention first on purpose: a draft that is only rejected costs another paid completion.

## Why two words

Measured on 411 real follow-ups:

| stem length | top opener | share |
|---|---|---|
| 2 | `still curious` | **55%** |
| 3 | `still curious how` | 37% |
| 4 | `still curious how you` | 37% |
| 6 | `still curious how you handle the` | 18% |

A six-word stem slips under any usable cap while the mail still reads identically to anyone who sees two of them. The greeting is stripped first — it's generated from the prospect's name, so leaving it in makes every stem unique and the cap never fires.

## A cap, not a ban

No opener is forbidden; no single one may speak for the majority. Below 8 prior sends it stays quiet rather than guessing.

Replaying the real corpus chronologically holds **293 of 411 (71%)**. That is the size of the existing concentration, not the steady state — each hold forces a re-roll the model is now steered away from, so the share decays toward the cap. Scoped to play + step because that's the population a reader could ever compare; intros are untouched (top opener already 2.5% of 689).

## Verify

- `npx vitest run`: **2532 passed / 197 files**, 0 fail (STATUS.md updated 2516 → 2532)
- 16 new tests: stem extraction incl. greeting stripping, cap/min-sample/empty-window behaviour, `overusedOpeners` agreeing with the flag it steers away from, and ledger-side filtering (step, play, failed rows, bodyless rows, limit clamp)
- `bun run typecheck` clean · `bun run lint` 0 errors, back to the 24 pre-existing warnings · `bun run fmt:check` clean

Ledger test fakes gained the two methods the new path calls.

https://claude.ai/code/session_01CPweATEtibYbHW7CUBqbig

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Cap opener reuse in cadence step emails with `opener-overused` lint and steering
> - Adds `Ledger.recentSentEmailBodies` to fetch up to 200 recent nonblank email bodies for a play and step, ordered newest first.
> - Adds `openerStem`, `overusedOpeners`, and `lintOpenerFrequency` in [_lib.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/448/files#diff-586f14829195e8211d573a99c431e65ccfd7eb1e14b4243a03745b16145e90cb). A draft is flagged `opener-overused` when its first two-word opener stem appears in at least 25% of a history of at least 8 same-play, same-step bodies.
> - `previewCadenceStep` and `previewCadenceStepBatch` now run `lintOpenerFrequency` alongside `lintEmail`; accepted unflagged bodies within a batch feed later previews so reuse is caught before ledger persistence.
> - `buildFollowUpEmail` now includes an avoidance block listing over-cap opener stems for the prospect's next cadence step.
> - Behavioral Change: `sendCadenceStep` now rejects any persisted draft with a nonempty `flags` array, throwing a lint-hold error instead of dispatching; previously it sent persisted drafts unconditionally. Reviewers should check `sendCadenceStep` in [_cadence.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/448/files#diff-b5886e0754b63449da688aa771e8634838f3d95383ef926ba4b22ef67bd5adbc) for callers that relied on direct send.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2676152.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->