### PR TITLE
fix: issue #439: Deferred review findings from ai/gtm/issue-434

### DIFF
--- a/apps/cli/__tests__/init-config.test.ts
+++ b/apps/cli/__tests__/init-config.test.ts
@@ -42,4 +42,21 @@ describe("init config writer", () => {
       clientId: "client-1",
     });
   });
+
+  it("normalizes an explicitly cleared optional field to null, not an empty string", () => {
+    const withIcp = { ...current, icpOneLiner: "Series A infra founders" } satisfies OneShotConfig;
+
+    const next = mergeInitConfig(withIcp, { icpOneLiner: "" });
+
+    expect(next.icpOneLiner).toBeNull();
+    expect(next.icpOneLiner).not.toBe("");
+  });
+
+  it("leaves an optional field untouched when the wizard answer key is omitted entirely", () => {
+    const withIcp = { ...current, icpOneLiner: "Series A infra founders" } satisfies OneShotConfig;
+
+    const next = mergeInitConfig(withIcp, { founderName: "New Name" });
+
+    expect(next.icpOneLiner).toBe("Series A infra founders");
+  });
 });

--- a/apps/cli/src/commands/init.ts
+++ b/apps/cli/src/commands/init.ts
@@ -200,6 +200,22 @@ export async function runInit(): Promise<void> {
   );
 }
 
+/**
+ * Merge a wizard answer for an optional text field onto the existing config
+ * value. An omitted key (the field wasn't part of this wizard run) falls
+ * back to whatever was already stored. An explicitly supplied empty string
+ * (the user cleared the field) normalizes to null rather than persisting
+ * "" — downstream fallbacks like `cfg.icpOneLiner ?? "(not set)"` only work
+ * against null, not an empty string.
+ */
+function normalizeOptionalAnswer(
+  answer: string | undefined,
+  existing: string | null,
+): string | null {
+  if (answer === undefined) return existing ?? null;
+  return answer === "" ? null : answer;
+}
+
 export function mergeInitConfig(
   cfg: OneShotConfig,
   answers: Record<string, unknown>,
@@ -211,20 +227,43 @@ export function mergeInitConfig(
     llmProvider: provider,
     llmModel: (answers["llmModel"] as string | undefined) ?? cfg.llmModel,
     telemetryEnabled: (answers["telemetryEnabled"] as boolean | undefined) ?? cfg.telemetryEnabled,
-    founderName: (answers["founderName"] as string | undefined) ?? cfg.founderName ?? null,
-    founderEmail: (answers["founderEmail"] as string | undefined) ?? cfg.founderEmail ?? null,
-    productOneLiner:
-      (answers["productOneLiner"] as string | undefined) ?? cfg.productOneLiner ?? null,
-    productDomain: (answers["productDomain"] as string | undefined) ?? cfg.productDomain ?? null,
-    sendingDomain: (answers["sendingDomain"] as string | undefined) ?? cfg.sendingDomain ?? null,
-    icpOneLiner: (answers["icpOneLiner"] as string | undefined) ?? cfg.icpOneLiner ?? null,
-    founderCredentials:
-      (answers["founderCredentials"] as string | undefined) ?? cfg.founderCredentials ?? null,
-    productPortfolio:
-      (answers["productPortfolio"] as string | undefined) ?? cfg.productPortfolio ?? null,
-    partners: (answers["partners"] as string | undefined) ?? cfg.partners ?? null,
-    founderAdmission:
-      (answers["founderAdmission"] as string | undefined) ?? cfg.founderAdmission ?? null,
+    founderName: normalizeOptionalAnswer(
+      answers["founderName"] as string | undefined,
+      cfg.founderName,
+    ),
+    founderEmail: normalizeOptionalAnswer(
+      answers["founderEmail"] as string | undefined,
+      cfg.founderEmail,
+    ),
+    productOneLiner: normalizeOptionalAnswer(
+      answers["productOneLiner"] as string | undefined,
+      cfg.productOneLiner,
+    ),
+    productDomain: normalizeOptionalAnswer(
+      answers["productDomain"] as string | undefined,
+      cfg.productDomain,
+    ),
+    sendingDomain: normalizeOptionalAnswer(
+      answers["sendingDomain"] as string | undefined,
+      cfg.sendingDomain,
+    ),
+    icpOneLiner: normalizeOptionalAnswer(
+      answers["icpOneLiner"] as string | undefined,
+      cfg.icpOneLiner,
+    ),
+    founderCredentials: normalizeOptionalAnswer(
+      answers["founderCredentials"] as string | undefined,
+      cfg.founderCredentials,
+    ),
+    productPortfolio: normalizeOptionalAnswer(
+      answers["productPortfolio"] as string | undefined,
+      cfg.productPortfolio,
+    ),
+    partners: normalizeOptionalAnswer(answers["partners"] as string | undefined, cfg.partners),
+    founderAdmission: normalizeOptionalAnswer(
+      answers["founderAdmission"] as string | undefined,
+      cfg.founderAdmission,
+    ),
   };
 }
 


### PR DESCRIPTION
Closes #439.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: d88580a5101f (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (1 errs) vs base ok (1 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `mergeInitConfig` to distinguish omitted optional fields from explicitly cleared ones
> - Adds `normalizeOptionalAnswer` helper to [init.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/453/files#diff-967f92d283af04a1204717c38b440c55f3e8ae14b528f2581a85b9f07857cc08): returns the existing value when the answer key is absent, converts an empty string to `null`, and otherwise returns the supplied answer.
> - Replaces nullish-coalescing assignments for `founder`, `product`, `sending-domain`, `ICP`, `credentials`, `portfolio`, `partner`, and `admission` text fields with calls to the new helper; `provider`, `model`, and `telemetry` remain unchanged.
> - Adds tests in [init-config.test.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/453/files#diff-4e4f50ec11ef1884e900b13d33982cb4d42d1c559cd1e44b6d3122591109ad6b) covering both the cleared-field and omitted-field merge paths.
> - Behavioral Change: omitted optional answer keys now preserve stored config values instead of being overwritten; explicitly empty answers are stored as `null` rather than an empty string.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be3d70b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved setup wizard handling for optional profile fields.
  * Leaving an optional field unanswered now preserves its existing value.
  * Clearing an optional text field now correctly removes its value instead of saving an empty string.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->