### PR TITLE
fix: issue #87: fix(intel): three deferred review findings in complete() retry logic

### DIFF
--- a/packages/intel/__tests__/retry.test.ts
+++ b/packages/intel/__tests__/retry.test.ts
@@ -65,9 +65,14 @@ describe("backoffDelayMs", () => {
     expect(backoffDelayMs(3, 9000, fixed)).toBe(9000);
   });
 
-  it("caps Retry-After at MAX_RETRY_AFTER_MS (60s)", () => {
-    expect(backoffDelayMs(1, 120_000)).toBe(60_000);
-    expect(backoffDelayMs(1, 900_000)).toBe(60_000);
+  it("no longer silently caps Retry-After — over-budget values are rejected by complete() before a delay is computed", () => {
+    // Finding 1 (#87): a Retry-After beyond MAX_RETRY_AFTER_MS used to be
+    // silently truncated here and then honoured as a real (guaranteed-failing)
+    // wait. Capping is now complete()'s job — see the "gives up immediately on
+    // an over-budget Retry-After" integration test below — so at this layer an
+    // over-budget hint is honoured like any other, same as a hint under budget.
+    expect(backoffDelayMs(1, 120_000)).toBe(120_000);
+    expect(backoffDelayMs(1, 900_000)).toBe(900_000);
   });
 
   it("uses exponential backoff without Retry-After", () => {
@@ -607,5 +612,136 @@ describe("complete() retry integration", () => {
     expect(error.message).toContain("INVALID_KEY");
     expect(error.status).toBeUndefined(); // Non-numeric code = no status
     expect(attemptCount).toBe(1); // No retry
+  });
+
+  it("gives up immediately on a Retry-After beyond the retry budget, instead of burning attempts", async () => {
+    const { complete } = await import("../src/client.ts");
+
+    // Finding 1 (#87): Retry-After: 300 used to be silently capped to 60s and
+    // then honoured as a real wait — two guaranteed-failing retries and ~120s
+    // of dead time. It must now fail on the FIRST attempt, with no sleep.
+    let attemptCount = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      attemptCount++;
+      return Promise.resolve({
+        ok: false,
+        status: 429,
+        headers: new Headers({ "retry-after": "300" }),
+        text: () => Promise.resolve("rate limited"),
+      });
+    }) as any;
+
+    const promise = complete({
+      messages: [{ role: "user", content: "test" }],
+      maxAttempts: 3,
+    });
+    const rejection = promise.catch((err) => err);
+
+    await vi.runAllTimersAsync();
+
+    const error = await rejection;
+    expect(error.message).toContain("300s");
+    expect(error.message).toContain("60s retry budget");
+    expect(attemptCount).toBe(1); // No retries burned on a guaranteed-failing wait
+  });
+
+  it("still retries a Retry-After within the budget, waiting the full hint", async () => {
+    const { complete } = await import("../src/client.ts");
+
+    // A hint under MAX_RETRY_AFTER_MS is still honoured in full — only
+    // over-budget hints are terminal.
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+
+    let attemptCount = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      attemptCount++;
+      if (attemptCount === 1) {
+        return Promise.resolve({
+          ok: false,
+          status: 429,
+          headers: new Headers({ "retry-after": "45" }),
+          text: () => Promise.resolve("rate limited"),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            choices: [{ message: { content: "ok" }, finish_reason: "stop" }],
+          }),
+      });
+    }) as any;
+
+    const promise = complete({
+      messages: [{ role: "user", content: "test" }],
+      maxAttempts: 3,
+    });
+
+    // Just under the 45s hint, the retry must not have fired yet.
+    await vi.advanceTimersByTimeAsync(44_000);
+    expect(attemptCount).toBe(1);
+
+    await vi.runAllTimersAsync();
+
+    const result = await promise;
+    expect(result.content).toBe("ok");
+    expect(attemptCount).toBe(2);
+  });
+
+  it("treats a 2xx JSON null body as a classified provider error, not a bare TypeError", async () => {
+    const { complete } = await import("../src/client.ts");
+
+    // Finding 2 (#87): postJson returned `unknown`, so a 2xx body that parses
+    // to JSON `null` used to reach `data.choices?.[0]` and throw a bare
+    // TypeError there instead of a named, classified LlmError.
+    let attemptCount = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      attemptCount++;
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(null) });
+    }) as any;
+
+    const promise = complete({
+      messages: [{ role: "user", content: "test" }],
+      maxAttempts: 3,
+    });
+    const rejection = promise.catch((err) => err);
+
+    await vi.runAllTimersAsync();
+
+    const error = await rejection;
+    expect(error.name).toBe("LlmError");
+    expect(error.message).toContain("non-object JSON body");
+    expect(attemptCount).toBe(1); // Terminal, not a TypeError worth retrying
+  });
+
+  it("clamps a non-positive timeoutMs instead of aborting every attempt instantly", async () => {
+    const { complete } = await import("../src/client.ts");
+
+    // Finding 3 (#87): timeoutMs: 0 survived `??` as "supplied", so the
+    // AbortController fired on the same tick, on every attempt, without ever
+    // reaching the provider. A clamp lets the request actually go out.
+    let attemptCount = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      attemptCount++;
+      return Promise.resolve({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            choices: [{ message: { content: "reached the provider" }, finish_reason: "stop" }],
+          }),
+      });
+    }) as any;
+
+    const promise = complete({
+      messages: [{ role: "user", content: "test" }],
+      timeoutMs: 0,
+      maxAttempts: 3,
+    });
+
+    await vi.runAllTimersAsync();
+
+    const result = await promise;
+    expect(result.content).toBe("reached the provider");
+    expect(attemptCount).toBe(1);
   });
 });

--- a/packages/intel/__tests__/retry.test.ts
+++ b/packages/intel/__tests__/retry.test.ts
@@ -645,6 +645,43 @@ describe("complete() retry integration", () => {
     expect(attemptCount).toBe(1); // No retries burned on a guaranteed-failing wait
   });
 
+  it("preserves the original error for a non-retryable status with an over-budget Retry-After", async () => {
+    const { complete } = await import("../src/client.ts");
+
+    // Correction round 1 (#87): overRetryBudget used to be derived only from
+    // retryAfterMs > MAX_RETRY_AFTER_MS, with no gate on isRetryableLlmError
+    // or attempt < maxAttempts. A non-retryable 401 (bad API key) that happens
+    // to carry a Retry-After over 60s would then be discarded and replaced
+    // with the generic "giving up instead of burning attempts" message, even
+    // though no retry was ever eligible for a 401. The real status + provider
+    // body must survive unchanged, and no retry budget message must appear.
+    let attemptCount = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      attemptCount++;
+      return Promise.resolve({
+        ok: false,
+        status: 401,
+        headers: new Headers({ "retry-after": "300" }),
+        text: () => Promise.resolve("Invalid API key"),
+      });
+    }) as any;
+
+    const promise = complete({
+      messages: [{ role: "user", content: "test" }],
+      maxAttempts: 3,
+    });
+    const rejection = promise.catch((err) => err);
+
+    await vi.runAllTimersAsync();
+
+    const error = await rejection;
+    expect(error.status).toBe(401);
+    expect(error.message).toContain("401");
+    expect(error.message).toContain("Invalid API key");
+    expect(error.message).not.toContain("retry budget");
+    expect(attemptCount).toBe(1); // Non-retryable: no retry was ever eligible
+  });
+
   it("still retries a Retry-After within the budget, waiting the full hint", async () => {
     const { complete } = await import("../src/client.ts");
 

--- a/packages/intel/src/client.ts
+++ b/packages/intel/src/client.ts
@@ -245,7 +245,16 @@ export async function complete(input: LlmCompleteInput): Promise<LlmCompleteOutp
       // it literally would burn the remaining attempts on ~120s+ of dead wait
       // in a sequential caller. Treat it as terminal instead, with a message
       // that names the wait so it reads as a deliberate give-up, not a bug.
-      const overRetryBudget = retryAfterMs !== undefined && retryAfterMs > MAX_RETRY_AFTER_MS;
+      // Only applies when a retry was actually still on the table — a
+      // non-retryable status (400/401/404) or an exhausted attempt count was
+      // never going to retry regardless of Retry-After, so there is nothing
+      // to "give up" on and the original error (status + provider body) must
+      // survive unchanged.
+      const overRetryBudget =
+        attempt < maxAttempts &&
+        isRetryableLlmError(err) &&
+        retryAfterMs !== undefined &&
+        retryAfterMs > MAX_RETRY_AFTER_MS;
       const ctx = {
         provider: cfg.llmProvider,
         model: cfg.llmModel,

--- a/packages/intel/src/client.ts
+++ b/packages/intel/src/client.ts
@@ -30,8 +30,20 @@ export interface LlmCompleteInput {
 const DEFAULT_MAX_ATTEMPTS = 3;
 const BASE_DELAY_MS = 500;
 const MAX_DELAY_MS = 20_000;
-/** Ceiling on a server-supplied Retry-After — a 15-minute hint is a give-up, not a wait. */
+/**
+ * Ceiling on a server-supplied Retry-After we are willing to wait out. Beyond
+ * this it is a give-up, not a wait — see the budget check in complete(),
+ * which fails fast instead of burning attempts on a guaranteed-failing retry.
+ */
 const MAX_RETRY_AFTER_MS = 60_000;
+/**
+ * Floor on an explicitly-supplied timeoutMs. `maxAttempts` is already clamped
+ * to >= 1; timeoutMs needs the same treatment — 0 (or a negative value) would
+ * abort the request before it ever reaches the provider, on every attempt.
+ * Leaving timeoutMs unset is unaffected: that still means no client-side
+ * timeout at all, not "use the floor".
+ */
+const MIN_TIMEOUT_MS = 1_000;
 
 export interface LlmCompleteOutput {
   content: string;
@@ -121,8 +133,11 @@ export function backoffDelayMs(
   // Retry-After raises the wait, it never lowers it. `Retry-After: 0` and an
   // HTTP-date already in the past (clock skew, second-rounding) are both common
   // and both parse to 0 — honouring them literally would fire every attempt
-  // within milliseconds, unpaced and unjittered.
-  return Math.max(Math.min(retryAfterMs, MAX_RETRY_AFTER_MS), backoff);
+  // within milliseconds, unpaced and unjittered. Anything past our retry
+  // budget (MAX_RETRY_AFTER_MS) never reaches here — complete() rejects it as
+  // terminal before computing a delay, rather than silently truncating a
+  // 300s hint down to a guaranteed-failing 60s wait.
+  return Math.max(retryAfterMs, backoff);
 }
 
 function sleep(ms: number): Promise<void> {
@@ -194,7 +209,11 @@ export async function complete(input: LlmCompleteInput): Promise<LlmCompleteOutp
 
   const expanded: LlmCompleteInput = { ...input, messages: injectHumanizer(input.messages) };
 
-  const timeoutMs = input.timeoutMs;
+  // `??` treats 0 as "supplied", and 0 (or a negative value) would abort every
+  // attempt before it reaches the provider. Only clamp when a value was
+  // actually given — leaving timeoutMs unset must keep meaning "no timeout".
+  const timeoutMs =
+    input.timeoutMs === undefined ? undefined : Math.max(MIN_TIMEOUT_MS, input.timeoutMs);
   const maxAttempts = Math.max(1, input.maxAttempts ?? DEFAULT_MAX_ATTEMPTS);
 
   const startedAt = Date.now();
@@ -221,6 +240,12 @@ export async function complete(input: LlmCompleteInput): Promise<LlmCompleteOutp
       break;
     } catch (err) {
       const status = err instanceof LlmError ? (err.status ?? null) : null;
+      const retryAfterMs = err instanceof LlmError ? err.retryAfterMs : undefined;
+      // A Retry-After past our budget is a guaranteed-failing retry: honouring
+      // it literally would burn the remaining attempts on ~120s+ of dead wait
+      // in a sequential caller. Treat it as terminal instead, with a message
+      // that names the wait so it reads as a deliberate give-up, not a bug.
+      const overRetryBudget = retryAfterMs !== undefined && retryAfterMs > MAX_RETRY_AFTER_MS;
       const ctx = {
         provider: cfg.llmProvider,
         model: cfg.llmModel,
@@ -231,14 +256,21 @@ export async function complete(input: LlmCompleteInput): Promise<LlmCompleteOutp
         attempt,
         max_attempts: maxAttempts,
       };
-      if (attempt < maxAttempts && isRetryableLlmError(err)) {
-        const delayMs = backoffDelayMs(
-          attempt,
-          err instanceof LlmError ? err.retryAfterMs : undefined,
-        );
+      if (attempt < maxAttempts && isRetryableLlmError(err) && !overRetryBudget) {
+        const delayMs = backoffDelayMs(attempt, retryAfterMs);
         logEvent("llm.retry", { ...ctx, delay_ms: delayMs }, "warn");
         await sleep(delayMs);
         continue;
+      }
+      if (overRetryBudget) {
+        logEvent("llm.error", { ...ctx, retry_after_ms: retryAfterMs }, "error");
+        throw new LlmError(
+          `${cfg.llmProvider} asked us to wait ${Math.round((retryAfterMs as number) / 1000)}s (Retry-After), ` +
+            `longer than the ${MAX_RETRY_AFTER_MS / 1000}s retry budget — giving up instead of ` +
+            `burning attempts on a guaranteed-failing retry.`,
+          status ?? undefined,
+          retryAfterMs,
+        );
       }
       logEvent("llm.error", ctx, "error");
       throw err;
@@ -302,7 +334,7 @@ async function postJson(args: {
   body: unknown;
   provider: string;
   timeoutMs: number | undefined;
-}): Promise<unknown> {
+}): Promise<Record<string, unknown>> {
   const controller = new AbortController();
   const timer = args.timeoutMs ? setTimeout(() => controller.abort(), args.timeoutMs) : undefined;
   const timedOut = () =>
@@ -341,8 +373,20 @@ async function postJson(args: {
     }
 
     try {
-      return await res.json();
+      const parsed: unknown = await res.json();
+      // A 2xx body that parses to JSON `null` (or any non-object shape) is the
+      // same "nothing usable" case as a body that never arrives — both provider
+      // paths immediately do `data.choices` / `data.content`, so an
+      // unclassified null here used to surface as a bare TypeError at the call
+      // site instead of a named, retry-classified error.
+      if (parsed === null || typeof parsed !== "object") {
+        throw new LlmError(
+          `${args.provider} returned a 2xx response with a non-object JSON body (${JSON.stringify(parsed)})`,
+        );
+      }
+      return parsed as Record<string, unknown>;
     } catch (err) {
+      if (err instanceof LlmError) throw err;
       // A 2xx whose body never arrives or is not JSON leaves us with nothing
       // usable, so this one genuinely is worth another attempt.
       if (controller.signal.aborted) throw timedOut();


### PR DESCRIPTION
Closes #87.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: d88580a5101f (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (1 errs) vs base ok (1 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix over-budget `Retry-After`, non-object JSON body, and non-positive timeout in intel `complete()`
> - `backoffDelayMs` no longer truncates `Retry-After` above 60s; `complete()` now detects over-budget retryable hints and fails immediately with a `LlmError` describing the requested wait and 60-second budget, instead of sleeping or retrying
> - `postJson` validates that a 2xx JSON body is an object; `null` and primitives now raise a named `LlmError` instead of a downstream `TypeError`
> - Explicit `timeoutMs` values below 1 second are clamped to a 1-second minimum; `undefined` still disables the client-side timeout
> - Non-retryable or already-exhausted errors retain their original error path, unaffected by the over-budget logic
> - Risk: `backoffDelayMs` now returns the full `Retry-After` value above 60s — any caller relying on the old 60s cap will see longer delays unless it handles over-budget itself
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d7bce47.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved request retry handling so server-provided retry delays are respected, with excessively long delays failing promptly.
  - Explicitly configured request timeouts now enforce a minimum of one second.
  - Improved handling of successful responses with empty or invalid JSON bodies.
  - Preserved detailed error information instead of reclassifying certain request failures as network errors.
  - Refined retry behavior for both retryable and non-retryable responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->