### PR TITLE
fix: issue #459: feat(find): local-registry finder + socrata-license and nppes adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The dashboard always knows where it is: a masthead chip names the workspace and 
 
 ## Where targets come from
 
-Eleven **finders** discover prospects, ICP-filter them, and enqueue into `/queue` for one-click approve or reject. Each runs as a trigger with its own interval and spend cap.
+Twelve **finders** discover prospects, ICP-filter them, and enqueue into `/queue` for one-click approve or reject. Each runs as a trigger with its own interval and spend cap.
 
 | Finder              | Signal                                                                                                                                                                                                                                                                                                                            |
 | ------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -184,6 +184,7 @@ Eleven **finders** discover prospects, ICP-filter them, and enqueue into `/queue
 | `luma-events`       | upcoming events from Luma's own city pages, gated per event by a topic + ICP check before any spend; pitches the hosts and featured guests Luma exposes publicly                                                                                                                                                                  |
 | `breakup-revive`    | your own ledger — prospects cold for 60–90 days. No LLM or OneShot spend                                                                                                                                                                                                                                                          |
 | `x-reposters`       | people who repost/quote X accounts you watch, in two lanes: builders who'd adopt (founder lane → email cadence) and dev accounts with reach who'd boost a launch (amplifier lane → one-touch email, or a hand-sent DM draft when no email is found) — needs X API OAuth1 keys, or `TWITTERAPI_IO_KEY` for the ~55x cheaper engine |
+| `local-registry`    | newly-licensed or newly-enumerated main-street businesses over free, keyless public registries (Socrata business-license open data + the NPPES NPI registry) — a recent issue/enumeration date routes to `new-business`, older records to `free-pilot`                                                                            |
 
 Only `show-hn` and `post-funding-auto` are on by default; enable the rest from `/queue`. A trigger missing required config reads as **not ready** — the toggle and Run button disable with the reason, and the API returns `409`, so scripted callers can't bypass the gate either.
 
@@ -359,7 +360,7 @@ packages/
   core/       SDK wrapper, SQLite ledger, config + secrets, Gmail transport, JSONL events
   intel/      LLM client, advise, personalize, triage, weekly-review
   plays/      17 outreach plays + handoff/icp/pmf modules + cadence engine
-  find/       11 finders + shared pipeline (manifest scan, dedupe, ICP filter, drain, registry)
+  find/       12 finders + shared pipeline (manifest scan, dedupe, ICP filter, drain, registry)
   prompts/    Markdown prompts — humanizer canon, per-play, per-extract
   doctor/     Wallet, ledger, key and deliverability health checks
   shared-types/  Wire types shared across CLI / server / web

--- a/STATUS.md
+++ b/STATUS.md
@@ -60,3 +60,7 @@ Both GitHub finders need `GITHUB_TOKEN`. Unauthenticated, GitHub allows 60 reque
 ## GitHub stargazer discovery is degraded by upstream
 
 GitHub restricted `/stargazers` to repo admins in July 2026. `github-stars` falls back to the public `/events` feed, which only exposes `WatchEvent`s within roughly a 90-day, 300-event window. Stars outside that window are invisible — not a bug in the finder.
+
+## NPPES recency pagination has a hard ceiling on busy taxonomy×state pairs
+
+`local-registry`'s nppes adapter (`fetchNppesPair` in `packages/find/src/_registry-sources.ts`) pages through NPPES's `skip`/`limit` API up to its own documented ceiling — 6 pages of 200, 1,200 records per taxonomy×state pair per run. The NPPES API has no `$order`-equivalent sort parameter, so this closes the "invisible past page 1" gap only when a pair's total result count is at or under 1,200. A busy pair that exceeds it (e.g. Dentist in a populous state like CA/TX/NY) can still leave a newly-enumerated provider past page 6 unseen, with no ordering guarantee to surface it sooner — unlike the Socrata adapter, which closes the equivalent gap for real via server-side `$order`+`$where`. Narrowing `states[]`/`taxonomies[]` to smaller pairs sidesteps it; there is no client-side fix for a pair NPPES itself won't sort.

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,8 @@
 # Status
 
-**Assume green.** The 51 CLI commands, 17 plays, 11 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
+**Assume green.** The 51 CLI commands, 17 plays, 12 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-02** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2534 tests / 197 files** · typecheck + oxlint + oxfmt clean.
+Last verified **2026-09-03** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2597 tests / 202 files** · typecheck + oxlint + oxfmt clean.
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of
@@ -26,20 +26,21 @@ Updated by hand after each dogfood run.
 
 ## Off by default
 
-Only **`show-hn`** and **`post-funding-auto`** fire out of the box. The other nine finders are opt-in, enabled per trigger from `/queue`:
+Only **`show-hn`** and **`post-funding-auto`** fire out of the box. The other ten finders are opt-in, enabled per trigger from `/queue`:
 
-`accelerator-batch` · `job-change` · `hiring-signal` · `podcast-guest` · `luma-events` · `github-topics` · `github-stars` · `breakup-revive` · `x-reposters`
+`accelerator-batch` · `job-change` · `hiring-signal` · `podcast-guest` · `luma-events` · `github-topics` · `github-stars` · `breakup-revive` · `x-reposters` · `local-registry`
 
-Six of those also stay **not ready** until you give them required config, and refuse to fire until you do (the API returns `409`):
+Seven of those also stay **not ready** until you give them required config, and refuse to fire until you do (the API returns `409`):
 
-| Finder              | Needs                                 |
-| ------------------- | ------------------------------------- |
-| `accelerator-batch` | `cohorts[]` + `senderCohort`          |
-| `hiring-signal`     | `yourClaim`                           |
-| `github-topics`     | `topics[]` + `vendors[]` + `yourEdge` |
-| `github-stars`      | `repos[]` + `yourEdge`                |
-| `luma-events`       | `topics[]` + `cities[]` + `yourEdge`  |
-| `x-reposters`       | `seeds[]` + engine credentials        |
+| Finder              | Needs                                                   |
+| ------------------- | ------------------------------------------------------- |
+| `accelerator-batch` | `cohorts[]` + `senderCohort`                            |
+| `hiring-signal`     | `yourClaim`                                             |
+| `github-topics`     | `topics[]` + `vendors[]` + `yourEdge`                   |
+| `github-stars`      | `repos[]` + `yourEdge`                                  |
+| `luma-events`       | `topics[]` + `cities[]` + `yourEdge`                    |
+| `x-reposters`       | `seeds[]` + engine credentials                          |
+| `local-registry`    | (`portals[]` or `taxonomies[]`+`states[]`) + `yourEdge` |
 
 Both GitHub finders need `GITHUB_TOKEN`. Unauthenticated, GitHub allows 60 requests/hour per IP **shared across the two** — one `github-stars` pass (each repo, up to 3 pages) can spend that alone, and the finder then halts on a `403` that reads like a dead endpoint rather than degrading to lower volume. A classic token with **no scopes** is enough for the public data both read, and lifts the ceiling to 5,000/hour. `doctor` warns when either finder is enabled without one. `luma-events` accepts an optional `LUMA_SESSION_COOKIE` to read authed guest lists. `x-reposters` needs the X credentials for whichever engine its config names (`xapi`: 4 OAuth1 keys, `twitterapiio`: 1 key) — settable from `/setup`'s X card or `config keys`, switchable with `config x-engine`.
 

--- a/apps/web/__tests__/queueEvidence.test.ts
+++ b/apps/web/__tests__/queueEvidence.test.ts
@@ -100,6 +100,33 @@ describe("queueEvidence", () => {
     expect(queueEvidence("accelerator-batch", { cohort: "W25" })).toBe("cohort W25");
   });
 
+  // local-registry's NPPES adapter tags a record NPI-1 (individual) or
+  // NPI-2 (organization) so a queue reviewer isn't left assuming a mapping
+  // bug when a "company" row shows a person's name — that signal has to
+  // reach this line, the only evidence a reviewer actually sees.
+  it("surfaces subjectType on new-business/free-pilot rows sourced from nppes", () => {
+    expect(
+      queueEvidence("new-business", {
+        sourceLabel: "NPPES Dentist (NY)",
+        matchedDateIso: "2026-06-01T00:00:00Z",
+        subjectType: "individual",
+      }),
+    ).toBe("NPPES Dentist (NY) — matched 2026-06-01 (individual record)");
+    expect(
+      queueEvidence("free-pilot", {
+        sourceLabel: "NPPES Dentist (NY)",
+        subjectType: "organization",
+      }),
+    ).toBe("NPPES Dentist (NY) (organization record)");
+    // socrata-license rows carry no subjectType — unaffected.
+    expect(
+      queueEvidence("new-business", {
+        sourceLabel: "NYC licenses",
+        matchedDateIso: "2026-06-01T00:00:00Z",
+      }),
+    ).toBe("NYC licenses — matched 2026-06-01");
+  });
+
   // Total by construction: a row whose payload lost a field, or a play this
   // does not know, renders without a line rather than with a broken one.
   it("returns null rather than a half-built line", () => {

--- a/apps/web/__tests__/queueEvidence.test.ts
+++ b/apps/web/__tests__/queueEvidence.test.ts
@@ -147,6 +147,7 @@ describe("coverage against the priority adapters", () => {
       seedHandle: "@h",
       followers: 2000,
       role: "role",
+      sourceLabel: "NYC business licenses",
     };
 
     const unhandled = adapters.filter((play) => queueEvidence(play, kitchenSink) === null);

--- a/apps/web/src/lib/queueEvidence.ts
+++ b/apps/web/src/lib/queueEvidence.ts
@@ -126,8 +126,14 @@ export function queueEvidence(playName: string, payload: unknown): string | null
     case "free-pilot": {
       const label = str(p, "sourceLabel");
       const matched = str(p, "matchedDateIso");
-      if (!label) return null;
-      return matched ? `${label} — matched ${matched.slice(0, 10)}` : label;
+      const subjectType = str(p, "subjectType");
+      // nppes-only: NPI-1 (individual) vs NPI-2 (organization) — tells a
+      // reviewer why a "company" row shows a person's name instead of
+      // leaving them to assume a mapping bug (see RegistryRecord's doc).
+      const subject = subjectType ? `${subjectType} record` : null;
+      if (!label) return subject;
+      const labelled = matched ? `${label} — matched ${matched.slice(0, 10)}` : label;
+      return subject ? `${labelled} (${subject})` : labelled;
     }
 
     default:

--- a/apps/web/src/lib/queueEvidence.ts
+++ b/apps/web/src/lib/queueEvidence.ts
@@ -122,6 +122,14 @@ export function queueEvidence(playName: string, payload: unknown): string | null
       return cohort ? `cohort ${cohort}` : null;
     }
 
+    case "new-business":
+    case "free-pilot": {
+      const label = str(p, "sourceLabel");
+      const matched = str(p, "matchedDateIso");
+      if (!label) return null;
+      return matched ? `${label} — matched ${matched.slice(0, 10)}` : label;
+    }
+
     default:
       return null;
   }

--- a/packages/core/src/oneshot.ts
+++ b/packages/core/src/oneshot.ts
@@ -5,6 +5,7 @@ import {
   type DomainPoolEntry,
   type DomainPoolStatusResult,
   type EmailResult,
+  type EnrichCompanyResult,
   type EnrichProfileResult,
   type FindEmailResult,
   type InboxEmail,
@@ -43,6 +44,9 @@ import type { EmailIdentity } from "./types.ts";
 
 /** Re-exported so callers don't reach into the SDK for the domain-pool shape. */
 export type { DomainPoolEntry, DomainPoolStatusResult } from "@oneshot-agent/sdk";
+
+/** Re-exported so callers don't reach into the SDK for the company-enrich result shape. */
+export type { CompanyResult, EnrichCompanyResult } from "@oneshot-agent/sdk";
 
 export interface SendEmailInput {
   to: string;
@@ -727,6 +731,40 @@ export async function verifyEmail(input: VerifyEmailInput, ctx: CallContext) {
   const receiptId = recordCallReceipt({
     ctx,
     callType: "email.verify",
+    signedReceipt: result,
+    costUsd: result.cost,
+    oneshotRequestId: result.request_id,
+  });
+  return { result, receiptId };
+}
+
+export interface EnrichCompanyInput {
+  domain?: string;
+  name?: string;
+  linkedinUrl?: string;
+  ticker?: string;
+}
+
+/**
+ * Company enrichment from a domain, name, LinkedIn URL or stock ticker —
+ * $0.005 per call. Used by `local-registry` (issue #459) to resolve a domain
+ * for open-registry records that carry a business name/address but no email,
+ * before falling through to the normal `resolveVerifyEnrichQualify` spine.
+ */
+export async function enrichCompany(input: EnrichCompanyInput, ctx: CallContext) {
+  const agent = await getAgent();
+  const opts: Parameters<OneShot["enrichCompany"]>[0] = {
+    ...buildAuditOpts(ctx, "enrich.company"),
+  };
+  if (input.domain) opts.domain = input.domain;
+  if (input.name) opts.name = input.name;
+  if (input.linkedinUrl) opts.linkedin_url = input.linkedinUrl;
+  if (input.ticker) opts.ticker = input.ticker;
+
+  const result: EnrichCompanyResult = await agent.enrichCompany(opts);
+  const receiptId = recordCallReceipt({
+    ctx,
+    callType: "enrich.company",
     signedReceipt: result,
     costUsd: result.cost,
     oneshotRequestId: result.request_id,

--- a/packages/find/__tests__/local-registry.test.ts
+++ b/packages/find/__tests__/local-registry.test.ts
@@ -18,7 +18,7 @@ describe("dedupeKeyFor", () => {
     expect(dedupeKeyFor(a)).toBe(dedupeKeyFor(b));
   });
 
-  it("differs by source even for the same name/state", () => {
+  it("is the SAME across sources for the same name/state — cross-source dedup is the point (a business licensed AND NPI-enumerated must collapse to one candidate)", () => {
     const base: RegistryRecord = {
       name: "Rae's Dental",
       address: null,
@@ -29,7 +29,7 @@ describe("dedupeKeyFor", () => {
       source: "socrata-license",
       sourceLabel: "x",
     };
-    expect(dedupeKeyFor(base)).not.toBe(dedupeKeyFor({ ...base, source: "nppes" }));
+    expect(dedupeKeyFor(base)).toBe(dedupeKeyFor({ ...base, source: "nppes" }));
   });
 });
 
@@ -289,20 +289,54 @@ describe("runLocalRegistryFinder — routing + isolation", () => {
     expect(enqueued).toHaveLength(0);
   });
 
-  it("dedupes a record surfaced by both sources within the same run", async () => {
-    const dup = makeRecord({ name: "Rae's Dental", source: "nppes", sourceLabel: "NPPES Dentist" });
+  it("dedupes a record surfaced by both sources within the same run, even with genuinely different source tags (socrata-license vs nppes)", async () => {
     nextSocrataRecords = [
+      makeRecord({ name: "Rae's Dental", source: "socrata-license", sourceLabel: "NYC licenses" }),
+    ];
+    nextNppesRecords = [
       makeRecord({ name: "Rae's Dental", source: "nppes", sourceLabel: "NPPES Dentist" }),
     ];
-    nextNppesRecords = [dup];
+    const out = await runLocalRegistryFinder({
+      dryRun: false,
+      yourEdge: "x",
+      portals: [{ host: "data.cityofnewyork.us", dataset: "w7w3-xahh", label: "NYC licenses" }],
+      taxonomies: ["Dentist"],
+      states: ["NY"],
+    });
+    // Cross-source dedup is the stated intent: a business licensed AND
+    // NPI-enumerated must collapse to one candidate, not be double-enriched
+    // and potentially double-queued to different plays.
+    expect(out.candidates).toBe(1);
+    expect(out.enqueued).toBe(1);
+  });
+
+  it("carries subjectType through to the queued LocalRegistryTarget payload so a /queue reviewer can see it", async () => {
+    nextNppesRecords = [
+      makeRecord({
+        name: "Dr. Rae Kim",
+        source: "nppes",
+        sourceLabel: "NPPES Dentist",
+        subjectType: "individual",
+      }),
+    ];
     const out = await runLocalRegistryFinder({
       dryRun: false,
       yourEdge: "x",
       taxonomies: ["Dentist"],
       states: ["NY"],
     });
-    // Both fetch adapters returned the same (source, name, state) record —
-    // the finder's within-run dedupe collapses it to one candidate.
-    expect(out.candidates).toBe(1);
+    expect(out.enqueued).toBe(1);
+    expect(enqueued[0]?.payload["subjectType"]).toBe("individual");
+  });
+
+  it("omits subjectType from the queued payload when the source doesn't set it (socrata records)", async () => {
+    nextSocrataRecords = [makeRecord()];
+    const out = await runLocalRegistryFinder({
+      dryRun: false,
+      yourEdge: "x",
+      portals: [{ host: "data.cityofnewyork.us", dataset: "w7w3-xahh", label: "NYC licenses" }],
+    });
+    expect(out.enqueued).toBe(1);
+    expect(enqueued[0]?.payload["subjectType"]).toBeUndefined();
   });
 });

--- a/packages/find/__tests__/local-registry.test.ts
+++ b/packages/find/__tests__/local-registry.test.ts
@@ -18,7 +18,7 @@ describe("dedupeKeyFor", () => {
     expect(dedupeKeyFor(a)).toBe(dedupeKeyFor(b));
   });
 
-  it("is the SAME across sources for the same name/state — cross-source dedup is the point (a business licensed AND NPI-enumerated must collapse to one candidate)", () => {
+  it("is the SAME across sources for the same name/state/city — cross-source dedup is the point (a business licensed AND NPI-enumerated must collapse to one candidate)", () => {
     const base: RegistryRecord = {
       name: "Rae's Dental",
       address: null,
@@ -30,6 +30,39 @@ describe("dedupeKeyFor", () => {
       sourceLabel: "x",
     };
     expect(dedupeKeyFor(base)).toBe(dedupeKeyFor({ ...base, source: "nppes" }));
+  });
+
+  it("preserves non-ASCII business names instead of stripping them to an empty slug (finding PRRT_kwDOSKzrBs6ewn0O)", () => {
+    const a: RegistryRecord = {
+      name: "北京饭店",
+      address: null,
+      city: "Flushing",
+      state: "NY",
+      phone: null,
+      matchedDateIso: "2026-06-01T00:00:00Z",
+      source: "socrata-license",
+      sourceLabel: "x",
+    };
+    const b: RegistryRecord = { ...a, name: "上海小吃" };
+    // Distinct non-ASCII names must produce distinct keys — the old
+    // `[^a-z0-9-]` slug stripped every character of both names to "",
+    // colliding them into one dedupe key.
+    expect(dedupeKeyFor(a)).not.toBe(dedupeKeyFor(b));
+  });
+
+  it("distinguishes same-name businesses in different cities when state is absent (finding PRRT_kwDOSKzrBs6ewn0O)", () => {
+    const a: RegistryRecord = {
+      name: "Main Street Cafe",
+      address: null,
+      city: "Springfield",
+      state: null,
+      phone: null,
+      matchedDateIso: "2026-06-01T00:00:00Z",
+      source: "socrata-license",
+      sourceLabel: "x",
+    };
+    const b: RegistryRecord = { ...a, city: "Riverside" };
+    expect(dedupeKeyFor(a)).not.toBe(dedupeKeyFor(b));
   });
 });
 
@@ -308,6 +341,60 @@ describe("runLocalRegistryFinder — routing + isolation", () => {
     // and potentially double-queued to different plays.
     expect(out.candidates).toBe(1);
     expect(out.enqueued).toBe(1);
+  });
+
+  it("keeps the NEWER cross-source duplicate's matchedDateIso so routing isn't decided by source fetch order (finding PRRT_kwDOSKzrBs6ewn0H)", async () => {
+    // socrata (fetched first, per REGISTRY_SOURCES order) reports an OLD
+    // license; nppes (fetched second) reports a RECENT enumeration for the
+    // same business. Keeping "the first one seen" would keep the old date
+    // and wrongly route this business to free-pilot instead of new-business.
+    nextSocrataRecords = [
+      makeRecord({
+        name: "Rae's Dental",
+        source: "socrata-license",
+        sourceLabel: "NYC licenses",
+        matchedDateIso: OLD_ISO,
+      }),
+    ];
+    nextNppesRecords = [
+      makeRecord({
+        name: "Rae's Dental",
+        source: "nppes",
+        sourceLabel: "NPPES Dentist",
+        matchedDateIso: RECENT_ISO,
+      }),
+    ];
+    const out = await runLocalRegistryFinder({
+      dryRun: false,
+      yourEdge: "x",
+      portals: [{ host: "data.cityofnewyork.us", dataset: "w7w3-xahh", label: "NYC licenses" }],
+      taxonomies: ["Dentist"],
+      states: ["NY"],
+    });
+    expect(out.candidates).toBe(1);
+    expect(out.enqueued).toBe(1);
+    expect(enqueued[0]?.playName).toBe("new-business");
+    expect(enqueued[0]?.payload["matchedDateIso"]).toBe(RECENT_ISO);
+  });
+
+  it("never enqueues more than `limit` even at concurrency > 1 (finding PRRT_kwDOSKzrBs6ewnz7)", async () => {
+    // Five distinct fresh candidates, concurrency 3, limit 1 — the exact
+    // review-cited repro shape. A check against `result.enqueued` (mutated
+    // only after each candidate's async pipeline fully resolves) lets every
+    // in-flight worker see 0 < 1 and proceed; a slot reserved synchronously
+    // before the pipeline starts must cap this at exactly 1.
+    nextSocrataRecords = Array.from({ length: 5 }, (_, i) =>
+      makeRecord({ name: `Candidate ${i}`, matchedDateIso: RECENT_ISO }),
+    );
+    const out = await runLocalRegistryFinder({
+      dryRun: false,
+      yourEdge: "x",
+      limit: 1,
+      concurrency: 3,
+      portals: [{ host: "data.cityofnewyork.us", dataset: "w7w3-xahh", label: "NYC licenses" }],
+    });
+    expect(out.enqueued).toBe(1);
+    expect(enqueued).toHaveLength(1);
   });
 
   it("carries subjectType through to the queued LocalRegistryTarget payload so a /queue reviewer can see it", async () => {

--- a/packages/find/__tests__/local-registry.test.ts
+++ b/packages/find/__tests__/local-registry.test.ts
@@ -1,0 +1,308 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { dedupeKeyFor, routePlayFor } from "../src/local-registry.ts";
+import type { RegistryRecord } from "../src/_registry-sources.ts";
+
+describe("dedupeKeyFor", () => {
+  it("is stable for the same source/name/state regardless of casing/spacing", () => {
+    const a: RegistryRecord = {
+      name: "Rae's Taqueria",
+      address: null,
+      city: null,
+      state: "NY",
+      phone: null,
+      matchedDateIso: "2026-06-01T00:00:00Z",
+      source: "socrata-license",
+      sourceLabel: "NYC licenses",
+    };
+    const b: RegistryRecord = { ...a, name: "RAE'S   TAQUERIA" };
+    expect(dedupeKeyFor(a)).toBe(dedupeKeyFor(b));
+  });
+
+  it("differs by source even for the same name/state", () => {
+    const base: RegistryRecord = {
+      name: "Rae's Dental",
+      address: null,
+      city: null,
+      state: "NY",
+      phone: null,
+      matchedDateIso: "2026-06-01T00:00:00Z",
+      source: "socrata-license",
+      sourceLabel: "x",
+    };
+    expect(dedupeKeyFor(base)).not.toBe(dedupeKeyFor({ ...base, source: "nppes" }));
+  });
+});
+
+describe("routePlayFor", () => {
+  it("routes a record inside the freshness window to new-business", () => {
+    const recent = new Date(Date.now() - 3 * 86_400_000).toISOString();
+    expect(routePlayFor(recent, 21)).toBe("new-business");
+  });
+
+  it("routes a record outside the freshness window to free-pilot", () => {
+    const old = new Date(Date.now() - 90 * 86_400_000).toISOString();
+    expect(routePlayFor(old, 21)).toBe("free-pilot");
+  });
+
+  it("treats the boundary (exactly freshnessDays old) as still fresh", () => {
+    const boundary = new Date(Date.now() - 21 * 86_400_000).toISOString();
+    expect(routePlayFor(boundary, 21)).toBe("new-business");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Full pipeline — mock the boundaries the finder calls, idiom of
+// packages/find/__tests__/github-stars.test.ts.
+// ---------------------------------------------------------------------------
+
+interface EnqueuedRow {
+  playName: string;
+  payload: Record<string, unknown>;
+  dedupeKey: string;
+  source: string;
+  initialStatus?: string;
+  notes?: string;
+}
+const enqueued: EnqueuedRow[] = [];
+let icpMatch: boolean | null = true;
+let nextSocrataRecords: RegistryRecord[] = [];
+let nextNppesRecords: RegistryRecord[] = [];
+let socrataShouldThrow = false;
+let nppesShouldThrow = false;
+
+const RECENT_ISO = new Date(Date.now() - 3 * 86_400_000).toISOString();
+const OLD_ISO = new Date(Date.now() - 90 * 86_400_000).toISOString();
+
+vi.mock("../src/_registry-sources.ts", async () => {
+  const actual = await vi.importActual<typeof import("../src/_registry-sources.ts")>(
+    "../src/_registry-sources.ts",
+  );
+  return {
+    ...actual,
+    REGISTRY_SOURCES: [
+      {
+        id: "socrata-license",
+        fetch: async () => {
+          if (socrataShouldThrow) throw new Error("socrata boom");
+          return {
+            records: nextSocrataRecords,
+            costUsd: 0,
+            perSource: nextSocrataRecords.map((r) => ({
+              source: r.sourceLabel,
+              label: r.sourceLabel,
+              records: 1,
+            })),
+          };
+        },
+      },
+      {
+        id: "nppes",
+        fetch: async () => {
+          if (nppesShouldThrow) throw new Error("nppes boom");
+          return {
+            records: nextNppesRecords,
+            costUsd: 0,
+            perSource:
+              nextNppesRecords.length > 0
+                ? nextNppesRecords.map((r) => ({
+                    source: r.sourceLabel,
+                    label: r.sourceLabel,
+                    records: 1,
+                  }))
+                : [{ source: "nppes", label: "nppes", records: 0, error: "no records" }],
+          };
+        },
+      },
+    ],
+  };
+});
+
+vi.mock("../src/_filter.ts", () => ({
+  resolveIcp: () => "icp",
+  icpFilter: async () => ({
+    match: icpMatch,
+    reason: icpMatch === null ? "icp classifier unavailable" : icpMatch ? "fits" : "nope",
+  }),
+  hasRoleText: (p: { roleText?: string | null }) => (p.roleText ?? "").trim().length > 0,
+  qualifyPerson: async () => ({ verdict: "pass", reason: "stub" }),
+}));
+
+vi.mock("../src/_enrich.ts", () => ({
+  enrichVerifiedContact: async () => ({
+    phone: null,
+    linkedinUrl: null,
+    title: null,
+    summary: null,
+    costUsd: 0,
+    receiptId: 1,
+  }),
+}));
+
+vi.mock("../src/_dedupe.ts", () => ({
+  isDuplicate: () => false,
+  urlDomain: () => null,
+}));
+
+vi.mock("../src/_findemail-prescreen.ts", () => ({ shouldSkipFindEmail: () => ({ ok: true }) }));
+
+let nextEnrichCompanyDomain: string | null = "acme.dev";
+
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    logEvent: () => {},
+    enrichCompany: async () => ({
+      result: {
+        status: "ok",
+        company: nextEnrichCompanyDomain ? { domain: nextEnrichCompanyDomain } : {},
+        cost: 0.005,
+      },
+      receiptId: 2,
+    }),
+    findEmail: async () => ({
+      result: { found: true, email: "owner@acme.dev", cost: 0.01 },
+      receiptId: 1,
+    }),
+    verifyEmail: async () => ({ result: { deliverable: true, cost: 0.005 }, receiptId: 1 }),
+    getLedger: () => ({
+      isQueueDuplicate: () => false,
+      enqueueTarget: (row: EnqueuedRow) => {
+        enqueued.push(row);
+        return enqueued.length;
+      },
+    }),
+  };
+});
+
+const { runLocalRegistryFinder } = await import("../src/local-registry.ts");
+
+function makeRecord(overrides: Partial<RegistryRecord> = {}): RegistryRecord {
+  return {
+    name: "Rae's Taqueria",
+    address: "123 Main St",
+    city: "Brooklyn",
+    state: "NY",
+    phone: null,
+    matchedDateIso: RECENT_ISO,
+    source: "socrata-license",
+    sourceLabel: "NYC licenses",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  enqueued.length = 0;
+  icpMatch = true;
+  nextSocrataRecords = [];
+  nextNppesRecords = [];
+  socrataShouldThrow = false;
+  nppesShouldThrow = false;
+  nextEnrichCompanyDomain = "acme.dev";
+});
+afterEach(() => vi.clearAllMocks());
+
+describe("runLocalRegistryFinder — routing + isolation", () => {
+  it("routes a fresh record to new-business and an old one to free-pilot, each tagged with source + matched date", async () => {
+    nextSocrataRecords = [
+      makeRecord({ name: "Rae's Taqueria", matchedDateIso: RECENT_ISO }),
+      makeRecord({ name: "Old Plumbing Co", matchedDateIso: OLD_ISO, sourceLabel: "NYC licenses" }),
+    ];
+    const out = await runLocalRegistryFinder({
+      dryRun: false,
+      yourEdge: "we set it up free",
+      portals: [{ host: "data.cityofnewyork.us", dataset: "w7w3-xahh", label: "NYC licenses" }],
+    });
+    expect(out.candidates).toBe(2);
+    expect(out.enqueued).toBe(2);
+
+    const fresh = enqueued.find((r) => r.payload["company"] === "Rae's Taqueria");
+    const old = enqueued.find((r) => r.payload["company"] === "Old Plumbing Co");
+    expect(fresh?.playName).toBe("new-business");
+    expect(old?.playName).toBe("free-pilot");
+    expect(fresh?.payload["source"]).toBe("socrata-license");
+    expect(fresh?.payload["matchedDateIso"]).toBe(RECENT_ISO);
+    expect(fresh?.payload["yourEdge"]).toBe("we set it up free");
+  });
+
+  it("keeps candidates from a healthy source when a sibling source throws (one dead source doesn't fail the run)", async () => {
+    nextSocrataRecords = [makeRecord()];
+    nppesShouldThrow = true;
+    const out = await runLocalRegistryFinder({
+      dryRun: false,
+      yourEdge: "x",
+      portals: [{ host: "data.cityofnewyork.us", dataset: "w7w3-xahh", label: "NYC licenses" }],
+      taxonomies: ["Dentist"],
+      states: ["NY"],
+    });
+    expect(out.enqueued).toBe(1);
+    expect(out.halted).toBeUndefined();
+  });
+
+  it("halts only when EVERY source returns 0 records", async () => {
+    nextSocrataRecords = [];
+    nextNppesRecords = [];
+    const out = await runLocalRegistryFinder({
+      dryRun: false,
+      yourEdge: "x",
+      portals: [{ host: "data.cityofnewyork.us", dataset: "w7w3-xahh", label: "NYC licenses" }],
+    });
+    expect(out.candidates).toBe(0);
+    expect(out.enqueued).toBe(0);
+    expect(out.halted).toBeTruthy();
+  });
+
+  it("enqueues an ICP-rejected row instead of a target when the filter misses", async () => {
+    icpMatch = false;
+    nextSocrataRecords = [makeRecord()];
+    await runLocalRegistryFinder({
+      dryRun: false,
+      yourEdge: "x",
+      portals: [{ host: "data.cityofnewyork.us", dataset: "w7w3-xahh", label: "NYC licenses" }],
+    });
+    expect(enqueued).toHaveLength(1);
+    expect(enqueued[0]?.initialStatus).toBe("rejected");
+  });
+
+  it("does NOT persist a rejected row when the classifier is transiently unavailable (match=null)", async () => {
+    icpMatch = null;
+    nextSocrataRecords = [makeRecord()];
+    const out = await runLocalRegistryFinder({
+      dryRun: false,
+      yourEdge: "x",
+      portals: [{ host: "data.cityofnewyork.us", dataset: "w7w3-xahh", label: "NYC licenses" }],
+    });
+    expect(enqueued).toHaveLength(0);
+    expect(out.droppedEnrichment).toBe(1);
+  });
+
+  it("drops the candidate when enrichCompany resolves no domain", async () => {
+    nextEnrichCompanyDomain = null;
+    nextSocrataRecords = [makeRecord()];
+    const out = await runLocalRegistryFinder({
+      dryRun: false,
+      yourEdge: "x",
+      portals: [{ host: "data.cityofnewyork.us", dataset: "w7w3-xahh", label: "NYC licenses" }],
+    });
+    expect(out.enqueued).toBe(0);
+    expect(out.droppedEnrichment).toBe(1);
+    expect(enqueued).toHaveLength(0);
+  });
+
+  it("dedupes a record surfaced by both sources within the same run", async () => {
+    const dup = makeRecord({ name: "Rae's Dental", source: "nppes", sourceLabel: "NPPES Dentist" });
+    nextSocrataRecords = [
+      makeRecord({ name: "Rae's Dental", source: "nppes", sourceLabel: "NPPES Dentist" }),
+    ];
+    nextNppesRecords = [dup];
+    const out = await runLocalRegistryFinder({
+      dryRun: false,
+      yourEdge: "x",
+      taxonomies: ["Dentist"],
+      states: ["NY"],
+    });
+    // Both fetch adapters returned the same (source, name, state) record —
+    // the finder's within-run dedupe collapses it to one candidate.
+    expect(out.candidates).toBe(1);
+  });
+});

--- a/packages/find/__tests__/priority-adapters.test.ts
+++ b/packages/find/__tests__/priority-adapters.test.ts
@@ -28,6 +28,8 @@ const SCORED_PLAYS = [
   "x-repost-intro",
   "x-amplify",
   "x-amplify-dm",
+  "new-business",
+  "free-pilot",
 ] as const;
 
 /** Manual/legacy producers that intentionally stay unscored (null path). */
@@ -178,6 +180,25 @@ const FIXTURES: Record<(typeof SCORED_PLAYS)[number], Record<string, unknown>> =
     score: 70,
     why: "5k followers",
     dmOpen: true,
+  },
+  "new-business": {
+    name: "Rae's Dental",
+    email: "rae@raesdental.com",
+    company: "Rae's Dental",
+    source: "nppes",
+    sourceLabel: "NPPES Dentist (NY)",
+    matchedDateIso: "2026-08-25T00:00:00Z",
+    yourEdge: "we set it up free, you keep it if it works",
+    title: "Owner",
+  },
+  "free-pilot": {
+    name: "Sam's Plumbing",
+    email: "sam@samsplumbing.com",
+    company: "Sam's Plumbing",
+    source: "socrata-license",
+    sourceLabel: "NYC business licenses",
+    matchedDateIso: "2026-06-01T00:00:00Z",
+    yourEdge: "we set it up free, you keep it if it works",
   },
 };
 

--- a/packages/find/__tests__/registry-sources.test.ts
+++ b/packages/find/__tests__/registry-sources.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@oneshot-gtm/core", () => ({ logEvent: () => {} }));
+
+const {
+  socrataLicenseSource,
+  nppesSource,
+  mapSocrataRows,
+  mapNppesResults,
+  buildSocrataSearchTerm,
+} = await import("../src/_registry-sources.ts");
+
+function stubFetch(impl: (url: string) => Promise<unknown>): void {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (url: string) => ({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => impl(url),
+    })),
+  );
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+const NOW = Date.now();
+const RECENT_ISO = new Date(NOW - 5 * 86_400_000).toISOString();
+const OLD_ISO = new Date(NOW - 400 * 86_400_000).toISOString();
+
+describe("buildSocrataSearchTerm", () => {
+  it("joins naics + licenseTypes into one $q term", () => {
+    expect(buildSocrataSearchTerm(["722511"], ["Food Service"])).toBe("722511 Food Service");
+  });
+  it("returns null when both are empty/undefined", () => {
+    expect(buildSocrataSearchTerm(undefined, undefined)).toBeNull();
+    expect(buildSocrataSearchTerm([], [])).toBeNull();
+  });
+});
+
+describe("mapSocrataRows — canned payload", () => {
+  const rows = [
+    {
+      business_name: "Rae's Taqueria",
+      address: "123 Main St",
+      city: "Brooklyn",
+      state: "NY",
+      license_creation_date: RECENT_ISO,
+    },
+    {
+      dba_name: "Old Plumbing Co",
+      address: "9 Elm St",
+      city: "Queens",
+      state: "NY",
+      issue_date: OLD_ISO,
+    },
+    // No usable name field — dropped.
+    { address: "1 Nowhere Ave", license_creation_date: RECENT_ISO },
+    // No usable date field — dropped.
+    { business_name: "No Date Co", address: "2 Elsewhere Ave" },
+  ];
+
+  it("maps a recent row inside the freshness window and drops the rest", () => {
+    const out = mapSocrataRows(rows, "NYC business licenses", 60);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      name: "Rae's Taqueria",
+      address: "123 Main St",
+      city: "Brooklyn",
+      state: "NY",
+      source: "socrata-license",
+      sourceLabel: "NYC business licenses",
+    });
+  });
+
+  it("falls back across alternate name/date field spellings (dba_name, issue_date)", () => {
+    const out = mapSocrataRows(rows, "NYC business licenses", 500);
+    const names = out.map((r) => r.name).toSorted();
+    expect(names).toEqual(["Old Plumbing Co", "Rae's Taqueria"]);
+  });
+});
+
+describe("socrataLicenseSource.fetch — per-portal isolation", () => {
+  it("keeps records from a healthy portal when a sibling portal is dead", async () => {
+    stubFetch(async (url) => {
+      if (url.includes("dead-portal")) throw new Error("ECONNREFUSED");
+      return [
+        {
+          business_name: "Rae's Taqueria",
+          address: "123 Main St",
+          city: "Brooklyn",
+          state: "NY",
+          license_creation_date: RECENT_ISO,
+        },
+      ];
+    });
+    const out = await socrataLicenseSource.fetch({
+      sinceDays: 60,
+      limit: 25,
+      portals: [
+        { host: "dead-portal.example.com", dataset: "xxxx-xxxx", label: "Dead Portal" },
+        { host: "data.cityofnewyork.us", dataset: "w7w3-xahh", label: "NYC licenses" },
+      ],
+    });
+    expect(out.records).toHaveLength(1);
+    expect(out.records[0]?.name).toBe("Rae's Taqueria");
+    expect(out.perSource).toHaveLength(2);
+    const dead = out.perSource.find((p) => p.label === "Dead Portal");
+    const healthy = out.perSource.find((p) => p.label === "NYC licenses");
+    expect(dead?.records).toBe(0);
+    expect(dead?.error).toBeTruthy();
+    expect(healthy?.records).toBe(1);
+  });
+
+  it("returns 0 records with per-portal diagnostics when every portal is dead — the caller decides halt", async () => {
+    stubFetch(async () => {
+      throw new Error("ECONNREFUSED");
+    });
+    const out = await socrataLicenseSource.fetch({
+      sinceDays: 60,
+      limit: 25,
+      portals: [{ host: "dead.example.com", dataset: "xxxx-xxxx", label: "Dead" }],
+    });
+    expect(out.records).toHaveLength(0);
+    expect(out.perSource[0]?.error).toBeTruthy();
+  });
+});
+
+describe("mapNppesResults — canned payload", () => {
+  const results = [
+    {
+      number: "1111111111",
+      basic: { organization_name: "Rae's Dental PLLC", enumeration_date: RECENT_ISO },
+      addresses: [
+        {
+          address_purpose: "LOCATION",
+          address_1: "50 Health Way",
+          city: "Buffalo",
+          state: "NY",
+          telephone_number: "555-1212",
+        },
+      ],
+    },
+    {
+      number: "2222222222",
+      basic: { first_name: "Pat", last_name: "Lee", enumeration_date: OLD_ISO },
+      addresses: [{ address_purpose: "LOCATION", city: "Albany", state: "NY" }],
+    },
+    // No enumeration_date — dropped.
+    { number: "3333333333", basic: { organization_name: "No Date Dental" } },
+  ];
+
+  it("maps a recent provider and falls back to first+last name for individuals", () => {
+    const out = mapNppesResults(results, "NPPES Dentist (NY)", "NY", 60);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      name: "Rae's Dental PLLC",
+      city: "Buffalo",
+      state: "NY",
+      phone: "555-1212",
+      source: "nppes",
+    });
+  });
+
+  it("uses first+last name when organization_name is absent (individual providers)", () => {
+    const out = mapNppesResults(results, "NPPES Dentist (NY)", "NY", 500);
+    const names = out.map((r) => r.name).toSorted();
+    expect(names).toEqual(["Pat Lee", "Rae's Dental PLLC"]);
+  });
+});
+
+describe("nppesSource.fetch — per taxonomy×state isolation", () => {
+  it("keeps records from a healthy pair when a sibling pair 404s", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.includes("state=CA")) {
+          return {
+            ok: false,
+            status: 500,
+            statusText: "Internal Server Error",
+            json: async () => ({}),
+          };
+        }
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          json: async () => ({
+            result_count: 1,
+            results: [
+              {
+                number: "1111111111",
+                basic: { organization_name: "Rae's Dental PLLC", enumeration_date: RECENT_ISO },
+                addresses: [{ address_purpose: "LOCATION", city: "Buffalo", state: "NY" }],
+              },
+            ],
+          }),
+        };
+      }),
+    );
+    const out = await nppesSource.fetch({
+      sinceDays: 60,
+      limit: 25,
+      taxonomies: ["Dentist"],
+      states: ["NY", "CA"],
+    });
+    expect(out.records).toHaveLength(1);
+    expect(out.perSource).toHaveLength(2);
+    const bad = out.perSource.find((p) => p.source.endsWith(":CA"));
+    const good = out.perSource.find((p) => p.source.endsWith(":NY"));
+    expect(bad?.records).toBe(0);
+    expect(bad?.error).toBeTruthy();
+    expect(good?.records).toBe(1);
+  });
+
+  it("returns empty with no perSource entries when taxonomies or states is unconfigured", async () => {
+    const out = await nppesSource.fetch({
+      sinceDays: 60,
+      limit: 25,
+      taxonomies: [],
+      states: ["NY"],
+    });
+    expect(out.records).toHaveLength(0);
+    expect(out.perSource).toHaveLength(0);
+  });
+});

--- a/packages/find/__tests__/registry-sources.test.ts
+++ b/packages/find/__tests__/registry-sources.test.ts
@@ -124,6 +124,52 @@ describe("socrataLicenseSource.fetch — per-portal isolation", () => {
     expect(out.records).toHaveLength(0);
     expect(out.perSource[0]?.error).toBeTruthy();
   });
+
+  it("paginates past the first 200 rows and finds a fresh record living on page 2 — the exact review finding", async () => {
+    // Page 1 (offset=0): 200 rows, all OLD — simulates the "arbitrary 200
+    // rows" the old unordered $limit=200 call used to settle for, none of
+    // which are fresh. Page 2 (offset=200): 1 row, RECENT. Without
+    // pagination this recent row is invisible; with $order+$where+$offset
+    // it must surface.
+    const page1 = Array.from({ length: 200 }, (_, i) => ({
+      business_name: `Old Co ${i}`,
+      city: "Brooklyn",
+      state: "NY",
+      license_creation_date: OLD_ISO,
+    }));
+    const page2 = [
+      {
+        business_name: "Fresh Taqueria",
+        city: "Brooklyn",
+        state: "NY",
+        license_creation_date: RECENT_ISO,
+      },
+    ];
+    let sawOrder = false;
+    let sawWhere = false;
+    stubFetch(async (url) => {
+      const u = new URL(url);
+      if (u.searchParams.get("$limit") === "1") {
+        // schema-probe request
+        return [page1[0]];
+      }
+      if (u.searchParams.get("$order")) sawOrder = true;
+      if (u.searchParams.get("$where")) sawWhere = true;
+      const offset = Number(u.searchParams.get("$offset") ?? "0");
+      if (offset === 0) return page1;
+      if (offset === 200) return page2;
+      return [];
+    });
+    const out = await socrataLicenseSource.fetch({
+      sinceDays: 60,
+      limit: 500,
+      portals: [{ host: "data.cityofnewyork.us", dataset: "w7w3-xahh", label: "NYC licenses" }],
+    });
+    expect(sawOrder).toBe(true);
+    expect(sawWhere).toBe(true);
+    const fresh = out.records.find((r) => r.name === "Fresh Taqueria");
+    expect(fresh).toBeTruthy();
+  });
 });
 
 describe("mapNppesResults — canned payload", () => {
@@ -166,6 +212,14 @@ describe("mapNppesResults — canned payload", () => {
     const out = mapNppesResults(results, "NPPES Dentist (NY)", "NY", 500);
     const names = out.map((r) => r.name).toSorted();
     expect(names).toEqual(["Pat Lee", "Rae's Dental PLLC"]);
+  });
+
+  it("labels subjectType organization vs individual so a person's name isn't mistaken for a company", () => {
+    const out = mapNppesResults(results, "NPPES Dentist (NY)", "NY", 500);
+    const org = out.find((r) => r.name === "Rae's Dental PLLC");
+    const individual = out.find((r) => r.name === "Pat Lee");
+    expect(org?.subjectType).toBe("organization");
+    expect(individual?.subjectType).toBe("individual");
   });
 });
 
@@ -223,5 +277,55 @@ describe("nppesSource.fetch — per taxonomy×state isolation", () => {
     });
     expect(out.records).toHaveLength(0);
     expect(out.perSource).toHaveLength(0);
+  });
+
+  it("pages past 200 providers (skip) and finds a newly-enumerated one on page 2 — the exact review finding", async () => {
+    // Page 1 (skip=0): 200 providers, all OLD — the "arbitrary first 200"
+    // the old single-request adapter used to settle for. Page 2 (skip=200):
+    // 1 provider, RECENT. Without walking skip, this newly-enumerated
+    // provider is invisible and the pair would wrongly report "no providers
+    // in the freshness window".
+    const page1 = {
+      result_count: 200,
+      results: Array.from({ length: 200 }, (_, i) => ({
+        number: String(1000000000 + i),
+        basic: { organization_name: `Old Dental ${i}`, enumeration_date: OLD_ISO },
+        addresses: [{ address_purpose: "LOCATION", city: "Buffalo", state: "NY" }],
+      })),
+    };
+    const page2 = {
+      result_count: 1,
+      results: [
+        {
+          number: "9999999999",
+          basic: { organization_name: "New Dental Group", enumeration_date: RECENT_ISO },
+          addresses: [{ address_purpose: "LOCATION", city: "Buffalo", state: "NY" }],
+        },
+      ],
+    };
+    let sawSkip200 = false;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        const u = new URL(url);
+        const skip = Number(u.searchParams.get("skip") ?? "0");
+        if (skip === 200) sawSkip200 = true;
+        return {
+          ok: true,
+          status: 200,
+          statusText: "OK",
+          json: async () => (skip === 0 ? page1 : skip === 200 ? page2 : { results: [] }),
+        };
+      }),
+    );
+    const out = await nppesSource.fetch({
+      sinceDays: 60,
+      limit: 500,
+      taxonomies: ["Dentist"],
+      states: ["NY"],
+    });
+    expect(sawSkip200).toBe(true);
+    const fresh = out.records.find((r) => r.name === "New Dental Group");
+    expect(fresh).toBeTruthy();
   });
 });

--- a/packages/find/__tests__/registry.test.ts
+++ b/packages/find/__tests__/registry.test.ts
@@ -92,6 +92,7 @@ describe("TRIGGERS registry", () => {
       "github-topics",
       "hiring-signal",
       "job-change",
+      "local-registry",
       "luma-events",
       "podcast-guest",
       "post-funding-auto",
@@ -118,6 +119,7 @@ describe("TRIGGERS registry", () => {
       "github-stars",
       "accelerator-batch",
       "luma-events",
+      "local-registry",
     ];
     for (const name of optIn) {
       const spec = TRIGGERS.find((t) => t.name === name);
@@ -344,6 +346,7 @@ describe("checkReadiness", () => {
       "accelerator-batch",
       "luma-events",
       "x-reposters",
+      "local-registry",
     ]);
     for (const spec of TRIGGERS) {
       if (intentionallyUnreadyByDefault.has(spec.name)) continue;
@@ -404,6 +407,56 @@ describe("checkReadiness", () => {
     const ycCount = cohorts.filter((c) => /^yc-/i.test(c.cohort)).length;
     expect(ycCount).toBeGreaterThan(0);
     expect(cohorts.length - ycCount).toBeGreaterThan(0);
+  });
+
+  it("local-registry is not ready with its empty default config (no sources)", () => {
+    const spec = TRIGGERS.find((t) => t.name === "local-registry")!;
+    expect(spec.readiness).toBeDefined();
+    const out = checkReadiness(spec, spec.defaultConfig);
+    expect(out.ready).toBe(false);
+    if (!out.ready) expect(out.reason).toMatch(/portals|taxonomies/);
+  });
+
+  it("local-registry is not ready with a socrata portal configured but no yourEdge", () => {
+    const spec = TRIGGERS.find((t) => t.name === "local-registry")!;
+    const out = checkReadiness(spec, {
+      ...spec.defaultConfig,
+      portals: [{ host: "data.cityofnewyork.us", dataset: "w7w3-xahh", label: "NYC licenses" }],
+    });
+    expect(out.ready).toBe(false);
+    if (!out.ready) expect(out.reason).toMatch(/yourEdge/);
+  });
+
+  it("local-registry becomes ready with a valid socrata portal + yourEdge", () => {
+    const spec = TRIGGERS.find((t) => t.name === "local-registry")!;
+    const out = checkReadiness(spec, {
+      ...spec.defaultConfig,
+      portals: [{ host: "data.cityofnewyork.us", dataset: "w7w3-xahh", label: "NYC licenses" }],
+      yourEdge: "we set it up for free, you keep it if it works",
+    });
+    expect(out).toEqual({ ready: true });
+  });
+
+  it("local-registry becomes ready with taxonomies + states + yourEdge alone (no portals)", () => {
+    const spec = TRIGGERS.find((t) => t.name === "local-registry")!;
+    const out = checkReadiness(spec, {
+      ...spec.defaultConfig,
+      taxonomies: ["Dentist"],
+      states: ["NY"],
+      yourEdge: "we set it up for free, you keep it if it works",
+    });
+    expect(out).toEqual({ ready: true });
+  });
+
+  it("local-registry stays not ready when taxonomies is set but states is empty", () => {
+    const spec = TRIGGERS.find((t) => t.name === "local-registry")!;
+    const out = checkReadiness(spec, {
+      ...spec.defaultConfig,
+      taxonomies: ["Dentist"],
+      states: [],
+      yourEdge: "we set it up for free, you keep it if it works",
+    });
+    expect(out.ready).toBe(false);
   });
 });
 

--- a/packages/find/src/_priority-adapters.ts
+++ b/packages/find/src/_priority-adapters.ts
@@ -189,6 +189,41 @@ export const PRIORITY_ADAPTERS: Record<string, (p: Record<string, unknown>) => P
     ...contact(p),
   }),
 
+  "new-business": (p) => ({
+    title: str(p["title"]),
+    companyKnown: str(p["company"]) !== null,
+    accountSignals: [
+      {
+        kind: "new-registration",
+        strength: 85,
+        reason:
+          `${str(p["sourceLabel"]) ?? "registry"} match ${str(p["matchedDateIso"])?.slice(0, 10) ?? ""}`.trim(),
+      },
+    ],
+    intentSignals: [
+      { kind: "greenfield", strength: 80, reason: "newly licensed — nothing to rip out" },
+    ],
+    hasEvidenceText: str(p["sourceLabel"]) !== null,
+    ...contact(p),
+  }),
+
+  "free-pilot": (p) => ({
+    title: str(p["title"]),
+    companyKnown: str(p["company"]) !== null,
+    accountSignals: [
+      {
+        kind: "registry-match",
+        strength: 55,
+        reason: `${str(p["sourceLabel"]) ?? "public registry"} match`,
+      },
+    ],
+    intentSignals: [
+      { kind: "free-pilot-fit", strength: 50, reason: "main-street pilot candidate" },
+    ],
+    hasEvidenceText: str(p["sourceLabel"]) !== null,
+    ...contact(p),
+  }),
+
   // v2, label-mined (65 approved / 69 rejected individually-judged rows):
   // exec titles 35% approval vs 55% title-missing → title prior inverted;
   // bios no longer feed seniority (bioTitleBand measured flat-to-negative);

--- a/packages/find/src/_priority-adapters.ts
+++ b/packages/find/src/_priority-adapters.ts
@@ -203,7 +203,14 @@ export const PRIORITY_ADAPTERS: Record<string, (p: Record<string, unknown>) => P
     intentSignals: [
       { kind: "greenfield", strength: 80, reason: "newly licensed — nothing to rip out" },
     ],
-    hasEvidenceText: str(p["sourceLabel"]) !== null,
+    // matchedDateIso is the trigger evidence (license issue / NPI enumeration
+    // date) — feed it into timingFreshness so a genuinely fresh registration
+    // scores as fresh and an old one decays, same as every other finder that
+    // has a real event timestamp.
+    eventAt: str(p["matchedDateIso"]),
+    // sourceLabel is a registry/portal label ("NYC business licenses"), not
+    // quoted candidate evidence — it must not trip the quoted-evidence bonus
+    // in scoreSignalConfidence.
     ...contact(p),
   }),
 
@@ -220,7 +227,7 @@ export const PRIORITY_ADAPTERS: Record<string, (p: Record<string, unknown>) => P
     intentSignals: [
       { kind: "free-pilot-fit", strength: 50, reason: "main-street pilot candidate" },
     ],
-    hasEvidenceText: str(p["sourceLabel"]) !== null,
+    eventAt: str(p["matchedDateIso"]),
     ...contact(p),
   }),
 

--- a/packages/find/src/_registry-sources.ts
+++ b/packages/find/src/_registry-sources.ts
@@ -1,0 +1,413 @@
+import { logEvent } from "@oneshot-gtm/core";
+
+/**
+ * Pluggable source adapters for `local-registry` — keyless, free, public
+ * JSON APIs that give the same thing `accelerator-batch`'s yc-oss adapter
+ * gives for accelerators: a structured feed with a recency signal, no
+ * per-record spend. See `local-registry.ts` for the per-candidate pipeline
+ * these feed into.
+ */
+
+/** One entity discovered from a public local-business registry — before contact resolution. */
+export interface RegistryRecord {
+  name: string;
+  address: string | null;
+  city: string | null;
+  state: string | null;
+  phone: string | null;
+  /** ISO date the record matched on: license issue date (socrata) or NPI enumeration date (nppes). */
+  matchedDateIso: string;
+  source: "socrata-license" | "nppes";
+  /** Human label for the specific portal/taxonomy this record came from — carried onto the queue row. */
+  sourceLabel: string;
+}
+
+/** One Socrata open-data portal + dataset — exactly the shape issue #459 specifies. */
+export interface SocrataPortalConfig {
+  /** Socrata host, e.g. "data.cityofnewyork.us". No scheme. */
+  host: string;
+  /** Dataset 4x4 id, e.g. "w7w3-xahh". */
+  dataset: string;
+  /** Human label shown in queue notes + perSource outcomes. */
+  label: string;
+}
+
+export interface RegistryQuery {
+  /** Freshness window against the issue/enumeration date. */
+  sinceDays: number;
+  /** Max records this source should return, across all its portals/taxonomies. */
+  limit: number;
+  /** socrata-license only. */
+  portals?: SocrataPortalConfig[];
+  naics?: string[];
+  licenseTypes?: string[];
+  /** nppes only. */
+  taxonomies?: string[];
+  states?: string[];
+}
+
+export interface RegistryFetchOutcome {
+  records: RegistryRecord[];
+  costUsd: number;
+  /** One entry per portal (socrata) or taxonomy×state pair (nppes) — mirrors accelerator-batch's perCohort. */
+  perSource: Array<{ source: string; label: string; records: number; error?: string }>;
+}
+
+export interface RegistrySource {
+  id: "socrata-license" | "nppes";
+  fetch: (cfg: RegistryQuery) => Promise<RegistryFetchOutcome>;
+}
+
+// ---------------------------------------------------------------------------
+// socrata-license
+// ---------------------------------------------------------------------------
+
+// Business-license open-data schemas vary portal to portal (no shared
+// convention), so field extraction tries the common Socrata column names
+// used across city/state license datasets rather than requiring the founder
+// to map fields by hand for every portal they add.
+const SOCRATA_NAME_FIELDS = [
+  "business_name",
+  "dba_name",
+  "doing_business_as_name",
+  "legal_name",
+  "legal_business_name",
+  "applicant_business_name",
+  "entity_name",
+  "name",
+];
+const SOCRATA_ADDRESS_FIELDS = ["address", "address_line_1", "premise_address", "business_address"];
+const SOCRATA_CITY_FIELDS = ["city", "business_city", "city_name", "address_city"];
+const SOCRATA_STATE_FIELDS = ["state", "business_state", "state_code", "address_state"];
+const SOCRATA_PHONE_FIELDS = ["phone", "contact_phone", "business_phone", "telephone_number"];
+const SOCRATA_DATE_FIELDS = [
+  "license_creation_date",
+  "issue_date",
+  "issued_date",
+  "effective_date",
+  "date_issued",
+  "license_issued_date",
+  "certificate_issue_date",
+  "created_date",
+];
+
+/** Case-sensitive then case-insensitive lookup across candidate field names. */
+function pickField(record: Record<string, unknown>, candidates: string[]): string | null {
+  for (const key of candidates) {
+    const v = record[key];
+    if (typeof v === "string" && v.trim().length > 0) return v.trim();
+  }
+  const lowerMap = new Map(Object.keys(record).map((k) => [k.toLowerCase(), k]));
+  for (const key of candidates) {
+    const actual = lowerMap.get(key.toLowerCase());
+    if (!actual) continue;
+    const v = record[actual];
+    if (typeof v === "string" && v.trim().length > 0) return v.trim();
+  }
+  return null;
+}
+
+function pickDateIso(record: Record<string, unknown>, candidates: string[]): string | null {
+  const raw = pickField(record, candidates);
+  if (!raw) return null;
+  const t = Date.parse(raw);
+  if (!Number.isFinite(t)) return null;
+  return new Date(t).toISOString();
+}
+
+/**
+ * Resolve a street address, preferring a single combined field but falling
+ * back to composing `address_building` + `address_street_name` — the split
+ * form several city portals (e.g. NYC's DCA license dataset) use instead of
+ * one string field.
+ */
+function pickAddress(record: Record<string, unknown>): string | null {
+  const direct = pickField(record, SOCRATA_ADDRESS_FIELDS);
+  if (direct) return direct;
+  const building = pickField(record, ["address_building"]);
+  const street = pickField(record, ["address_street_name", "street_name"]);
+  if (building && street) return `${building} ${street}`;
+  return street ?? null;
+}
+
+/** Build the Socrata full-text `$q` term from naics/licenseTypes filters, or null when unfiltered. */
+export function buildSocrataSearchTerm(
+  naics: string[] | undefined,
+  licenseTypes: string[] | undefined,
+): string | null {
+  const terms = [...(naics ?? []), ...(licenseTypes ?? [])].map((t) => t.trim()).filter(Boolean);
+  if (terms.length === 0) return null;
+  return terms.join(" ");
+}
+
+/** Map + freshness-filter one portal's raw rows. Exported for the unit test's canned-payload check. */
+export function mapSocrataRows(
+  rows: unknown[],
+  portalLabel: string,
+  sinceDays: number,
+): RegistryRecord[] {
+  const sinceMs = Date.now() - sinceDays * 86_400_000;
+  const out: RegistryRecord[] = [];
+  for (const raw of rows) {
+    if (!raw || typeof raw !== "object") continue;
+    const rec = raw as Record<string, unknown>;
+    const name = pickField(rec, SOCRATA_NAME_FIELDS);
+    if (!name) continue;
+    const matchedDateIso = pickDateIso(rec, SOCRATA_DATE_FIELDS);
+    if (!matchedDateIso) continue;
+    if (Date.parse(matchedDateIso) < sinceMs) continue;
+    out.push({
+      name,
+      address: pickAddress(rec),
+      city: pickField(rec, SOCRATA_CITY_FIELDS),
+      state: pickField(rec, SOCRATA_STATE_FIELDS),
+      phone: pickField(rec, SOCRATA_PHONE_FIELDS),
+      matchedDateIso,
+      source: "socrata-license",
+      sourceLabel: portalLabel,
+    });
+  }
+  return out;
+}
+
+async function fetchSocrataPortal(
+  portal: SocrataPortalConfig,
+  cfg: RegistryQuery,
+): Promise<{ records: RegistryRecord[]; diagnostic: string | null }> {
+  const params = new URLSearchParams();
+  params.set("$limit", "200");
+  const q = buildSocrataSearchTerm(cfg.naics, cfg.licenseTypes);
+  if (q) params.set("$q", q);
+  const url = `https://${portal.host}/resource/${portal.dataset}.json?${params.toString()}`;
+
+  let res: Response;
+  try {
+    res = await fetch(url);
+  } catch (err) {
+    return {
+      records: [],
+      diagnostic: `${portal.host} fetch failed: ${(err as Error).message ?? "network error"}`,
+    };
+  }
+  if (!res.ok) {
+    return { records: [], diagnostic: `${portal.host} returned ${res.status} ${res.statusText}` };
+  }
+  let parsed: unknown;
+  try {
+    parsed = await res.json();
+  } catch {
+    return { records: [], diagnostic: `${portal.host} response was not valid JSON` };
+  }
+  if (!Array.isArray(parsed)) {
+    return { records: [], diagnostic: `${portal.host} response was not an array` };
+  }
+  if (parsed.length === 0) {
+    return { records: [], diagnostic: `${portal.host}/${portal.dataset} returned 0 rows` };
+  }
+
+  const records = mapSocrataRows(parsed, portal.label, cfg.sinceDays);
+  if (records.length === 0) {
+    return {
+      records: [],
+      diagnostic: `${portal.label}: ${parsed.length} rows fetched, none within ${cfg.sinceDays}d window`,
+    };
+  }
+  return { records, diagnostic: null };
+}
+
+export const socrataLicenseSource: RegistrySource = {
+  id: "socrata-license",
+  async fetch(cfg) {
+    const portals = cfg.portals ?? [];
+    const perSource: RegistryFetchOutcome["perSource"] = [];
+    const records: RegistryRecord[] = [];
+    for (const portal of portals) {
+      if (records.length >= cfg.limit) break;
+      const tag = `${portal.host}/${portal.dataset}`;
+      try {
+        const outcome = await fetchSocrataPortal(portal, cfg);
+        if (outcome.records.length === 0) {
+          perSource.push({
+            source: tag,
+            label: portal.label,
+            records: 0,
+            error: outcome.diagnostic ?? "no records",
+          });
+          continue;
+        }
+        records.push(...outcome.records);
+        perSource.push({ source: tag, label: portal.label, records: outcome.records.length });
+      } catch (err) {
+        const message = ((err as Error).message ?? "").slice(0, 120);
+        logEvent(
+          "error.swallowed",
+          { kind: "local-registry.socrata_portal", portal: portal.host, message_120: message },
+          "warn",
+        );
+        perSource.push({ source: tag, label: portal.label, records: 0, error: message });
+      }
+    }
+    return { records: records.slice(0, cfg.limit), costUsd: 0, perSource };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// nppes
+// ---------------------------------------------------------------------------
+
+interface NppesAddress {
+  address_purpose?: string;
+  address_1?: string;
+  city?: string;
+  state?: string;
+  telephone_number?: string;
+}
+interface NppesBasic {
+  organization_name?: string;
+  first_name?: string;
+  last_name?: string;
+  enumeration_date?: string;
+}
+interface NppesResult {
+  number?: string;
+  basic?: NppesBasic;
+  addresses?: NppesAddress[];
+}
+interface NppesResponse {
+  result_count?: number;
+  results?: NppesResult[];
+}
+
+function nppesDisplayName(basic: NppesBasic | undefined): string | null {
+  if (!basic) return null;
+  const org = basic.organization_name?.trim();
+  if (org) return org;
+  const parts = [basic.first_name, basic.last_name].filter(
+    (p): p is string => typeof p === "string" && p.trim().length > 0,
+  );
+  return parts.length > 0 ? parts.join(" ") : null;
+}
+
+/** Map + freshness-filter one taxonomy×state pair's raw NPPES results. Exported for the unit test. */
+export function mapNppesResults(
+  results: NppesResult[],
+  label: string,
+  fallbackState: string,
+  sinceDays: number,
+): RegistryRecord[] {
+  const sinceMs = Date.now() - sinceDays * 86_400_000;
+  const out: RegistryRecord[] = [];
+  for (const r of results) {
+    const name = nppesDisplayName(r.basic);
+    if (!name) continue;
+    const enumDate = r.basic?.enumeration_date;
+    if (!enumDate) continue;
+    const t = Date.parse(enumDate);
+    if (!Number.isFinite(t) || t < sinceMs) continue;
+    const loc =
+      (r.addresses ?? []).find((a) => a.address_purpose === "LOCATION") ?? r.addresses?.[0];
+    out.push({
+      name,
+      address: loc?.address_1 ?? null,
+      city: loc?.city ?? null,
+      state: loc?.state ?? fallbackState,
+      phone: loc?.telephone_number ?? null,
+      matchedDateIso: new Date(t).toISOString(),
+      source: "nppes",
+      sourceLabel: label,
+    });
+  }
+  return out;
+}
+
+async function fetchNppesPair(
+  taxonomy: string,
+  state: string,
+  cfg: RegistryQuery,
+): Promise<{ records: RegistryRecord[]; diagnostic: string | null }> {
+  const params = new URLSearchParams({
+    version: "2.1",
+    taxonomy_description: taxonomy,
+    state,
+    limit: "200",
+  });
+  const url = `https://npiregistry.cms.hhs.gov/api/?${params.toString()}`;
+  const label = `NPPES ${taxonomy} (${state})`;
+
+  let res: Response;
+  try {
+    res = await fetch(url);
+  } catch (err) {
+    return {
+      records: [],
+      diagnostic: `fetch failed: ${(err as Error).message ?? "network error"}`,
+    };
+  }
+  if (!res.ok) {
+    return { records: [], diagnostic: `nppes returned ${res.status} ${res.statusText}` };
+  }
+  let parsed: NppesResponse;
+  try {
+    parsed = (await res.json()) as NppesResponse;
+  } catch {
+    return { records: [], diagnostic: "nppes response was not valid JSON" };
+  }
+  const results = parsed.results ?? [];
+  if (results.length === 0) {
+    return { records: [], diagnostic: `nppes has no ${taxonomy} providers in ${state}` };
+  }
+
+  const records = mapNppesResults(results, label, state, cfg.sinceDays);
+  if (records.length === 0) {
+    return {
+      records: [],
+      diagnostic: `${label}: ${results.length} providers fetched, none within ${cfg.sinceDays}d window`,
+    };
+  }
+  return { records, diagnostic: null };
+}
+
+export const nppesSource: RegistrySource = {
+  id: "nppes",
+  async fetch(cfg) {
+    const taxonomies = cfg.taxonomies ?? [];
+    const states = cfg.states ?? [];
+    const perSource: RegistryFetchOutcome["perSource"] = [];
+    const records: RegistryRecord[] = [];
+    if (taxonomies.length === 0 || states.length === 0) {
+      return { records: [], costUsd: 0, perSource: [] };
+    }
+    outer: for (const taxonomy of taxonomies) {
+      for (const state of states) {
+        if (records.length >= cfg.limit) break outer;
+        const tag = `nppes:${taxonomy}:${state}`;
+        const label = `NPPES ${taxonomy} (${state})`;
+        try {
+          const outcome = await fetchNppesPair(taxonomy, state, cfg);
+          if (outcome.records.length === 0) {
+            perSource.push({
+              source: tag,
+              label,
+              records: 0,
+              error: outcome.diagnostic ?? "no records",
+            });
+            continue;
+          }
+          records.push(...outcome.records);
+          perSource.push({ source: tag, label, records: outcome.records.length });
+        } catch (err) {
+          const message = ((err as Error).message ?? "").slice(0, 120);
+          logEvent(
+            "error.swallowed",
+            { kind: "local-registry.nppes_pair", taxonomy, state, message_120: message },
+            "warn",
+          );
+          perSource.push({ source: tag, label, records: 0, error: message });
+        }
+      }
+    }
+    return { records: records.slice(0, cfg.limit), costUsd: 0, perSource };
+  },
+};
+
+export const REGISTRY_SOURCES: RegistrySource[] = [socrataLicenseSource, nppesSource];

--- a/packages/find/src/_registry-sources.ts
+++ b/packages/find/src/_registry-sources.ts
@@ -207,35 +207,70 @@ const SOCRATA_PAGE_SIZE = 200;
  */
 const SOCRATA_MAX_PAGES = 5;
 
+/**
+ * Resolve this portal's date column from the dataset's own column metadata
+ * (Socrata's `/api/views/{4x4}.json`), which lists every column by name
+ * regardless of whether any single row happens to have a value in it. A
+ * one-row `$limit=1` probe can omit the date field entirely on a
+ * sparsely-populated dataset (or just an unlucky row) and wrongly report "no
+ * date column" even though the column exists and is populated on the vast
+ * majority of rows. Returns null (never throws) so the caller can fall back.
+ */
+async function resolveSocrataDateFieldFromMetadata(
+  portal: SocrataPortalConfig,
+): Promise<string | null> {
+  try {
+    const metaUrl = `https://${portal.host}/api/views/${portal.dataset}.json`;
+    const res = await fetch(metaUrl);
+    if (!res.ok) return null;
+    const meta = (await res.json()) as { columns?: Array<{ fieldName?: unknown }> };
+    const fieldNames = (meta.columns ?? [])
+      .map((c) => c.fieldName)
+      .filter((f): f is string => typeof f === "string" && f.length > 0);
+    if (fieldNames.length === 0) return null;
+    const lowerMap = new Map(fieldNames.map((f) => [f.toLowerCase(), f]));
+    for (const candidate of SOCRATA_DATE_FIELDS) {
+      const actual = lowerMap.get(candidate.toLowerCase());
+      if (actual) return actual;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
 async function fetchSocrataPortal(
   portal: SocrataPortalConfig,
   cfg: RegistryQuery,
 ): Promise<{ records: RegistryRecord[]; diagnostic: string | null }> {
   const q = buildSocrataSearchTerm(cfg.naics, cfg.licenseTypes);
 
-  // Business-license schemas vary portal to portal (see SOCRATA_DATE_FIELDS),
-  // so a single cheap probe row tells us which actual column this portal
-  // uses for its issue/creation date before we build the real query — that
-  // column is required for both `$order` (recency-first) and `$where`
-  // (server-side freshness predicate) below.
-  const probeParams = new URLSearchParams();
-  probeParams.set("$limit", "1");
-  if (q) probeParams.set("$q", q);
-  const probeUrl = `https://${portal.host}/resource/${portal.dataset}.json?${probeParams.toString()}`;
-  let dateField: string | null = null;
-  try {
-    const probeRes = await fetch(probeUrl);
-    if (probeRes.ok) {
-      const probeRows = await probeRes.json();
-      const probeRow =
-        Array.isArray(probeRows) && probeRows.length > 0 && typeof probeRows[0] === "object"
-          ? (probeRows[0] as Record<string, unknown>)
-          : null;
-      if (probeRow) dateField = findDateFieldKey(probeRow, SOCRATA_DATE_FIELDS);
+  // Business-license schemas vary portal to portal (see SOCRATA_DATE_FIELDS).
+  // Prefer the dataset's own column metadata — it names every column
+  // regardless of row-level nulls — and fall back to a single cheap probe
+  // row only when the metadata call itself is unavailable. Either way, the
+  // resolved column is required for both `$order` (recency-first) and
+  // `$where` (server-side freshness predicate) below.
+  let dateField: string | null = await resolveSocrataDateFieldFromMetadata(portal);
+  if (!dateField) {
+    const probeParams = new URLSearchParams();
+    probeParams.set("$limit", "1");
+    if (q) probeParams.set("$q", q);
+    const probeUrl = `https://${portal.host}/resource/${portal.dataset}.json?${probeParams.toString()}`;
+    try {
+      const probeRes = await fetch(probeUrl);
+      if (probeRes.ok) {
+        const probeRows = await probeRes.json();
+        const probeRow =
+          Array.isArray(probeRows) && probeRows.length > 0 && typeof probeRows[0] === "object"
+            ? (probeRows[0] as Record<string, unknown>)
+            : null;
+        if (probeRow) dateField = findDateFieldKey(probeRow, SOCRATA_DATE_FIELDS);
+      }
+    } catch {
+      // Schema probe is best-effort: fall through without ordering rather than
+      // failing the whole portal — the main fetch below still runs.
     }
-  } catch {
-    // Schema probe is best-effort: fall through without ordering rather than
-    // failing the whole portal — the main fetch below still runs.
   }
   const sinceIso = new Date(Date.now() - cfg.sinceDays * 86_400_000).toISOString().split(".")[0];
 

--- a/packages/find/src/_registry-sources.ts
+++ b/packages/find/src/_registry-sources.ts
@@ -472,10 +472,16 @@ async function fetchNppesPair(
     }
     const pageResults = parsed.results ?? [];
     if (pageResults.length === 0) break;
-    // NPPES has no `$order`-equivalent sort param, so pagination (rather than
-    // ordering) is what closes the gap: walking every page up to the API's
-    // own 1,200-record ceiling means a newly-enumerated provider on page 3
-    // is no longer invisible just because it wasn't on page 1.
+    // NPPES has no `$order`-equivalent sort param (confirmed against the
+    // API's own field reference: only `limit`/`skip`), so walking every
+    // page up to the 1,200-record ceiling closes the gap ONLY when a
+    // taxonomy×state pair's total result count is <=1200. A pair that
+    // exceeds that (e.g. Dentist in a populous state like CA/TX/NY) can
+    // still leave a newly-enumerated provider past page 6 invisible —
+    // there is no ordering guarantee to bring it forward, unlike the
+    // Socrata fix's server-side $order+$where. See STATUS.md's known
+    // limitations for the honest statement of what this does and doesn't
+    // cover.
     results.push(...pageResults);
     if (pageResults.length < NPPES_PAGE_SIZE) break; // last page
   }

--- a/packages/find/src/_registry-sources.ts
+++ b/packages/find/src/_registry-sources.ts
@@ -20,6 +20,15 @@ export interface RegistryRecord {
   source: "socrata-license" | "nppes";
   /** Human label for the specific portal/taxonomy this record came from — carried onto the queue row. */
   sourceLabel: string;
+  /**
+   * nppes only. NPPES enumerates two distinct subject types under one API:
+   * NPI-1 (individual — `name` is a person's first+last) vs NPI-2
+   * (organization — `name` is the business/org name). Both get billed
+   * downstream to `enrichCompany` as if `name` were a company name, so this
+   * flag lets a reviewer of `/queue` rows tell why a "company" row shows a
+   * person's name instead of assuming a mapping bug.
+   */
+  subjectType?: "individual" | "organization";
 }
 
 /** One Socrata open-data portal + dataset — exactly the shape issue #459 specifies. */
@@ -107,6 +116,24 @@ function pickField(record: Record<string, unknown>, candidates: string[]): strin
   return null;
 }
 
+/**
+ * Which of the known date-column spellings this specific portal's schema
+ * actually uses — needed so pagination can `$order`/`$where` on a real
+ * SoQL column name. Returns the ACTUAL key (not the value), unlike
+ * `pickField`, and doesn't require the value to be present on this one row.
+ */
+function findDateFieldKey(record: Record<string, unknown>, candidates: string[]): string | null {
+  for (const key of candidates) {
+    if (key in record) return key;
+  }
+  const lowerMap = new Map(Object.keys(record).map((k) => [k.toLowerCase(), k]));
+  for (const key of candidates) {
+    const actual = lowerMap.get(key.toLowerCase());
+    if (actual) return actual;
+  }
+  return null;
+}
+
 function pickDateIso(record: Record<string, unknown>, candidates: string[]): string | null {
   const raw = pickField(record, candidates);
   if (!raw) return null;
@@ -170,46 +197,114 @@ export function mapSocrataRows(
   return out;
 }
 
+const SOCRATA_PAGE_SIZE = 200;
+/**
+ * Cap on pages fetched per portal per run (1,000 rows @ 200/page). Recency
+ * ordering + a server-side date predicate mean this ceiling is now about
+ * bounding request volume/cost, not about correctness — unlike the old
+ * unordered single page, every row considered here is guaranteed to be
+ * within the freshness window and returned newest-first.
+ */
+const SOCRATA_MAX_PAGES = 5;
+
 async function fetchSocrataPortal(
   portal: SocrataPortalConfig,
   cfg: RegistryQuery,
 ): Promise<{ records: RegistryRecord[]; diagnostic: string | null }> {
-  const params = new URLSearchParams();
-  params.set("$limit", "200");
   const q = buildSocrataSearchTerm(cfg.naics, cfg.licenseTypes);
-  if (q) params.set("$q", q);
-  const url = `https://${portal.host}/resource/${portal.dataset}.json?${params.toString()}`;
 
-  let res: Response;
+  // Business-license schemas vary portal to portal (see SOCRATA_DATE_FIELDS),
+  // so a single cheap probe row tells us which actual column this portal
+  // uses for its issue/creation date before we build the real query — that
+  // column is required for both `$order` (recency-first) and `$where`
+  // (server-side freshness predicate) below.
+  const probeParams = new URLSearchParams();
+  probeParams.set("$limit", "1");
+  if (q) probeParams.set("$q", q);
+  const probeUrl = `https://${portal.host}/resource/${portal.dataset}.json?${probeParams.toString()}`;
+  let dateField: string | null = null;
   try {
-    res = await fetch(url);
-  } catch (err) {
-    return {
-      records: [],
-      diagnostic: `${portal.host} fetch failed: ${(err as Error).message ?? "network error"}`,
-    };
-  }
-  if (!res.ok) {
-    return { records: [], diagnostic: `${portal.host} returned ${res.status} ${res.statusText}` };
-  }
-  let parsed: unknown;
-  try {
-    parsed = await res.json();
+    const probeRes = await fetch(probeUrl);
+    if (probeRes.ok) {
+      const probeRows = await probeRes.json();
+      const probeRow =
+        Array.isArray(probeRows) && probeRows.length > 0 && typeof probeRows[0] === "object"
+          ? (probeRows[0] as Record<string, unknown>)
+          : null;
+      if (probeRow) dateField = findDateFieldKey(probeRow, SOCRATA_DATE_FIELDS);
+    }
   } catch {
-    return { records: [], diagnostic: `${portal.host} response was not valid JSON` };
+    // Schema probe is best-effort: fall through without ordering rather than
+    // failing the whole portal — the main fetch below still runs.
   }
-  if (!Array.isArray(parsed)) {
-    return { records: [], diagnostic: `${portal.host} response was not an array` };
+  const sinceIso = new Date(Date.now() - cfg.sinceDays * 86_400_000).toISOString().split(".")[0];
+
+  const rows: unknown[] = [];
+  for (let page = 0; page < SOCRATA_MAX_PAGES; page++) {
+    const params = new URLSearchParams();
+    params.set("$limit", String(SOCRATA_PAGE_SIZE));
+    params.set("$offset", String(page * SOCRATA_PAGE_SIZE));
+    if (q) params.set("$q", q);
+    if (dateField) {
+      // Recency-first ordering + a server-side freshness predicate — without
+      // this, `$limit=200` with no `$order` returns an arbitrary page of a
+      // dataset that can be millions of rows, silently missing every
+      // qualifying recent row that lands outside that arbitrary page.
+      params.set("$order", `${dateField} DESC`);
+      params.set("$where", `${dateField} >= '${sinceIso}'`);
+    }
+    const url = `https://${portal.host}/resource/${portal.dataset}.json?${params.toString()}`;
+
+    let res: Response;
+    try {
+      res = await fetch(url);
+    } catch (err) {
+      if (page === 0) {
+        return {
+          records: [],
+          diagnostic: `${portal.host} fetch failed: ${(err as Error).message ?? "network error"}`,
+        };
+      }
+      break;
+    }
+    if (!res.ok) {
+      if (page === 0) {
+        return {
+          records: [],
+          diagnostic: `${portal.host} returned ${res.status} ${res.statusText}`,
+        };
+      }
+      break;
+    }
+    let parsed: unknown;
+    try {
+      parsed = await res.json();
+    } catch {
+      if (page === 0) {
+        return { records: [], diagnostic: `${portal.host} response was not valid JSON` };
+      }
+      break;
+    }
+    if (!Array.isArray(parsed)) {
+      if (page === 0) {
+        return { records: [], diagnostic: `${portal.host} response was not an array` };
+      }
+      break;
+    }
+    if (parsed.length === 0) break;
+    rows.push(...parsed);
+    if (parsed.length < SOCRATA_PAGE_SIZE) break; // last page
   }
-  if (parsed.length === 0) {
+
+  if (rows.length === 0) {
     return { records: [], diagnostic: `${portal.host}/${portal.dataset} returned 0 rows` };
   }
 
-  const records = mapSocrataRows(parsed, portal.label, cfg.sinceDays);
+  const records = mapSocrataRows(rows, portal.label, cfg.sinceDays);
   if (records.length === 0) {
     return {
       records: [],
-      diagnostic: `${portal.label}: ${parsed.length} rows fetched, none within ${cfg.sinceDays}d window`,
+      diagnostic: `${portal.label}: ${rows.length} rows fetched, none within ${cfg.sinceDays}d window`,
     };
   }
   return { records, diagnostic: null };
@@ -288,6 +383,11 @@ function nppesDisplayName(basic: NppesBasic | undefined): string | null {
   return parts.length > 0 ? parts.join(" ") : null;
 }
 
+/** NPI-2 (organization) has `organization_name` set; NPI-1 (individual) does not. */
+function nppesSubjectType(basic: NppesBasic | undefined): "individual" | "organization" {
+  return basic?.organization_name?.trim() ? "organization" : "individual";
+}
+
 /** Map + freshness-filter one taxonomy×state pair's raw NPPES results. Exported for the unit test. */
 export function mapNppesResults(
   results: NppesResult[],
@@ -315,44 +415,71 @@ export function mapNppesResults(
       matchedDateIso: new Date(t).toISOString(),
       source: "nppes",
       sourceLabel: label,
+      subjectType: nppesSubjectType(r.basic),
     });
   }
   return out;
 }
+
+const NPPES_PAGE_SIZE = 200;
+/** NPPES's own documented ceiling: skip caps at 1000, so 6 pages of 200 (1200 records) is the max obtainable for any one query — matches the ropensci npi_search client's documented limit. */
+const NPPES_MAX_PAGES = 6;
 
 async function fetchNppesPair(
   taxonomy: string,
   state: string,
   cfg: RegistryQuery,
 ): Promise<{ records: RegistryRecord[]; diagnostic: string | null }> {
-  const params = new URLSearchParams({
-    version: "2.1",
-    taxonomy_description: taxonomy,
-    state,
-    limit: "200",
-  });
-  const url = `https://npiregistry.cms.hhs.gov/api/?${params.toString()}`;
   const label = `NPPES ${taxonomy} (${state})`;
+  const results: NppesResult[] = [];
 
-  let res: Response;
-  try {
-    res = await fetch(url);
-  } catch (err) {
-    return {
-      records: [],
-      diagnostic: `fetch failed: ${(err as Error).message ?? "network error"}`,
-    };
+  for (let page = 0; page < NPPES_MAX_PAGES; page++) {
+    const params = new URLSearchParams({
+      version: "2.1",
+      taxonomy_description: taxonomy,
+      state,
+      limit: String(NPPES_PAGE_SIZE),
+      skip: String(page * NPPES_PAGE_SIZE),
+    });
+    const url = `https://npiregistry.cms.hhs.gov/api/?${params.toString()}`;
+
+    let res: Response;
+    try {
+      res = await fetch(url);
+    } catch (err) {
+      if (page === 0) {
+        return {
+          records: [],
+          diagnostic: `fetch failed: ${(err as Error).message ?? "network error"}`,
+        };
+      }
+      break;
+    }
+    if (!res.ok) {
+      if (page === 0) {
+        return { records: [], diagnostic: `nppes returned ${res.status} ${res.statusText}` };
+      }
+      break;
+    }
+    let parsed: NppesResponse;
+    try {
+      parsed = (await res.json()) as NppesResponse;
+    } catch {
+      if (page === 0) {
+        return { records: [], diagnostic: "nppes response was not valid JSON" };
+      }
+      break;
+    }
+    const pageResults = parsed.results ?? [];
+    if (pageResults.length === 0) break;
+    // NPPES has no `$order`-equivalent sort param, so pagination (rather than
+    // ordering) is what closes the gap: walking every page up to the API's
+    // own 1,200-record ceiling means a newly-enumerated provider on page 3
+    // is no longer invisible just because it wasn't on page 1.
+    results.push(...pageResults);
+    if (pageResults.length < NPPES_PAGE_SIZE) break; // last page
   }
-  if (!res.ok) {
-    return { records: [], diagnostic: `nppes returned ${res.status} ${res.statusText}` };
-  }
-  let parsed: NppesResponse;
-  try {
-    parsed = (await res.json()) as NppesResponse;
-  } catch {
-    return { records: [], diagnostic: "nppes response was not valid JSON" };
-  }
-  const results = parsed.results ?? [];
+
   if (results.length === 0) {
     return { records: [], diagnostic: `nppes has no ${taxonomy} providers in ${state}` };
   }

--- a/packages/find/src/_sdk-safe.ts
+++ b/packages/find/src/_sdk-safe.ts
@@ -1,6 +1,8 @@
 import {
   deepResearchPerson,
   ENRICH_FAILURE_TTL_MS,
+  type EnrichCompanyInput,
+  enrichCompany,
   findEmail,
   getLedger,
   isTransientToolError,
@@ -77,6 +79,23 @@ export async function safeVerifyEmail(
       },
       receiptId: 0,
     };
+  }
+}
+
+/**
+ * enrichCompany that never throws — a failure resolves to an empty company
+ * record (drop) instead of aborting the whole finder run. Mirrors
+ * safeFindEmail's status:"error" sentinel shape.
+ */
+export async function safeEnrichCompany(
+  input: EnrichCompanyInput,
+  ctx: CallContext,
+): Promise<Awaited<ReturnType<typeof enrichCompany>>> {
+  try {
+    return await enrichCompany(input, ctx);
+  } catch (err) {
+    swallow(ctx, "enrich_company", err);
+    return { result: { status: "error", company: {}, cost: 0 }, receiptId: 0 };
   }
 }
 

--- a/packages/find/src/_types.ts
+++ b/packages/find/src/_types.ts
@@ -32,6 +32,13 @@ export interface FinderResult {
    * Only set by `accelerator-batch`; other finders leave it unset.
    */
   perCohort?: Array<{ cohort: string; records: number; error?: string }>;
+  /**
+   * Per-source fetch outcomes for `local-registry` (one entry per configured
+   * Socrata portal or nppes taxonomy×state pair). Same isolation contract as
+   * `perCohort`: a dead portal logs and continues, the run only halts when
+   * every source returns 0. Only set by `local-registry`.
+   */
+  perSource?: Array<{ source: string; label: string; records: number; error?: string }>;
 }
 
 export interface ShowHnHit {

--- a/packages/find/src/index.ts
+++ b/packages/find/src/index.ts
@@ -18,6 +18,8 @@ export * from "./github-stars.ts";
 export * from "./_stargazers.ts";
 export * from "./_repo-utils.ts";
 export * from "./_repo-pipeline.ts";
+export * from "./local-registry.ts";
+export * from "./_registry-sources.ts";
 export * from "./registry.ts";
 export * from "./drain.ts";
 export * from "./luma.ts";

--- a/packages/find/src/local-registry.ts
+++ b/packages/find/src/local-registry.ts
@@ -75,19 +75,34 @@ export interface LocalRegistryTarget {
   title?: string;
 }
 
+/**
+ * Unicode-preserving slug: lowercase, collapse whitespace to hyphens, strip
+ * everything that isn't a Unicode letter/number/hyphen. `\p{L}`/`\p{N}` (not
+ * the old `a-z0-9` ASCII class) keep non-Latin scripts intact — a Chinese or
+ * Cyrillic business name must not collapse to the same empty string as every
+ * other non-ASCII name in the run.
+ */
 function slugify(s: string): string {
   return s
     .toLowerCase()
+    .trim()
     .replace(/\s+/g, "-")
-    .replace(/[^a-z0-9-]/g, "");
+    .replace(/[^\p{L}\p{N}-]+/gu, "");
 }
 
-/** Stable within-run + cross-run dedupe key: name slug + state, source-agnostic.
+/** Stable within-run + cross-run dedupe key: name slug + state + city, source-agnostic.
  * Cross-source dedup is the stated intent (see the run-level dedupe below) —
  * a business appearing in both socrata-license and nppes must collapse to
- * one candidate, not be double-enriched and potentially double-queued. */
+ * one candidate, not be double-enriched and potentially double-queued. City
+ * is included (address is not — its formatting varies too much between a
+ * Socrata portal and NPPES to dedupe reliably) so two genuinely distinct
+ * same-name businesses in a state-less or shared-state/city record don't
+ * collapse into one candidate.
+ */
 export function dedupeKeyFor(record: RegistryRecord): string {
-  return `${slugify(record.name)}:${(record.state ?? "").toLowerCase()}`;
+  const state = (record.state ?? "").toLowerCase().trim();
+  const city = (record.city ?? "").toLowerCase().trim();
+  return `${slugify(record.name)}:${state}:${city}`;
 }
 
 /** Recent-issue routing: fresh (within `freshnessDays`) → new-business, else → free-pilot. */
@@ -160,12 +175,23 @@ export async function runLocalRegistryFinder(opts: LocalRegistryFinderOpts): Pro
 
   // Dedupe across sources within this run before touching the queue —
   // NY state + NYC-city portals commonly double-publish the same license.
-  const seen = new Set<string>();
+  // Keep the record with the LATEST matchedDateIso, not just the first one
+  // seen: source fetch order (socrata before nppes, see REGISTRY_SOURCES)
+  // must not decide routing. An older socrata license row must not suppress
+  // a newer NPPES enumeration and wrongly route the business to free-pilot
+  // instead of new-business.
+  const seen = new Map<string, number>();
   const deduped: RegistryRecord[] = [];
   for (const r of allRecords) {
     const key = dedupeKeyFor(r);
-    if (seen.has(key)) continue;
-    seen.add(key);
+    const priorIndex = seen.get(key);
+    if (priorIndex !== undefined) {
+      if (Date.parse(r.matchedDateIso) > Date.parse(deduped[priorIndex]!.matchedDateIso)) {
+        deduped[priorIndex] = r;
+      }
+      continue;
+    }
+    seen.set(key, deduped.length);
     deduped.push(r);
   }
   result.candidates = deduped.length;
@@ -180,13 +206,23 @@ export async function runLocalRegistryFinder(opts: LocalRegistryFinderOpts): Pro
   }
 
   let halted = false;
+  // Reserve a slot the moment a worker commits to processing a record —
+  // BEFORE its own paid calls run — not after. Checking `result.enqueued`
+  // (mutated only once a candidate fully clears every gate) lets multiple
+  // in-flight workers all see it below `limit` and all proceed: with
+  // `limit:1, concurrency:3`, all three could enqueue before the first one's
+  // async pipeline finishes and bumps the counter. `reserved` is bumped
+  // synchronously (no `await` before the increment), so it caps how many
+  // pipelines are ever launched, independent of completion order.
+  let reserved = 0;
 
   await parallelMap(deduped, concurrency, async (record) => {
     if (halted) return;
-    if (result.enqueued >= limit) {
+    if (reserved >= limit) {
       halted = true;
       return;
     }
+    reserved++;
     if (opts.maxCostUsd != null && result.costUsd >= opts.maxCostUsd) {
       result.halted = `max-cost cap (${opts.maxCostUsd})`;
       halted = true;

--- a/packages/find/src/local-registry.ts
+++ b/packages/find/src/local-registry.ts
@@ -1,0 +1,317 @@
+import { getLedger, logEvent } from "@oneshot-gtm/core";
+import { resolveVerifyEnrichQualify } from "./_contact.ts";
+import { enqueueScoredTarget } from "./_priority-adapters.ts";
+import { persistRoleRejection } from "./_qualify.ts";
+import { icpFilter, resolveIcp } from "./_filter.ts";
+import { isDuplicate } from "./_dedupe.ts";
+import { parallelMap } from "./_parallel.ts";
+import { safeEnrichCompany } from "./_sdk-safe.ts";
+import {
+  REGISTRY_SOURCES,
+  type RegistryQuery,
+  type RegistryRecord,
+  type SocrataPortalConfig,
+} from "./_registry-sources.ts";
+import type { FinderResult, RunOpts } from "./_types.ts";
+
+/**
+ * Local-business finder over free, keyless public registries: open-data
+ * business licenses (Socrata) and the NPPES NPI registry. Both give a
+ * business name + address and a recency signal (issue/enumeration date) but
+ * no email — every candidate resolves its domain via `enrichCompany` before
+ * falling through to the normal `resolveVerifyEnrichQualify` spine, exactly
+ * like `accelerator-batch`'s yc-oss records resolve a founder name before
+ * `findEmail`.
+ *
+ * Recent-issue routing: a record inside `freshnessDays` of "now" is the
+ * main-street equivalent of `post-funding` — nothing to rip out — and goes
+ * to `new-business`; everything else goes to `free-pilot`. Same two-way
+ * split `github-topics` does between stack-consolidation/competitor-switch.
+ */
+const SOURCE = "find:local-registry";
+const NEW_BUSINESS_PLAY = "new-business";
+const FREE_PILOT_PLAY = "free-pilot";
+
+export interface LocalRegistryFinderOpts extends RunOpts {
+  /** socrata-license source config. */
+  portals?: SocrataPortalConfig[];
+  naics?: string[];
+  licenseTypes?: string[];
+  /** nppes source config. */
+  taxonomies?: string[];
+  states?: string[];
+  /** Discovery window against the issue/enumeration date. Default 60. */
+  sinceDays?: number;
+  /** Records matched inside this window route to new-business; older ones to free-pilot. Default 21, clamped to sinceDays. */
+  freshnessDays?: number;
+  /** Pitch angle for the main-street owner-operator. Required (readiness-gated). */
+  yourEdge: string;
+  /** Max in-flight candidate pipelines. Default 3. */
+  concurrency?: number;
+}
+
+/** Payload shape enqueued for both `new-business` and `free-pilot` — the plays that consume it ship in #462. */
+export interface LocalRegistryTarget {
+  name: string;
+  email: string;
+  company: string;
+  source: "socrata-license" | "nppes";
+  sourceLabel: string;
+  /** ISO issue/enumeration date this record matched on — the trigger evidence. */
+  matchedDateIso: string;
+  yourEdge: string;
+  address?: string;
+  city?: string;
+  state?: string;
+  linkedinUrl?: string;
+  phone?: string;
+  title?: string;
+}
+
+function slugify(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^a-z0-9-]/g, "");
+}
+
+/** Stable within-run + cross-run dedupe key: source + name slug + state. */
+export function dedupeKeyFor(record: RegistryRecord): string {
+  return `${record.source}:${slugify(record.name)}:${(record.state ?? "").toLowerCase()}`;
+}
+
+/** Recent-issue routing: fresh (within `freshnessDays`) → new-business, else → free-pilot. */
+export function routePlayFor(matchedDateIso: string, freshnessDays: number): string {
+  const cutoffMs = Date.now() - freshnessDays * 86_400_000;
+  return Date.parse(matchedDateIso) >= cutoffMs ? NEW_BUSINESS_PLAY : FREE_PILOT_PLAY;
+}
+
+export async function runLocalRegistryFinder(opts: LocalRegistryFinderOpts): Promise<FinderResult> {
+  const limit = opts.limit ?? 25;
+  const concurrency = opts.concurrency ?? 3;
+  const sinceDays = Math.max(1, opts.sinceDays ?? 60);
+  const freshnessDays = Math.min(Math.max(1, opts.freshnessDays ?? 21), sinceDays);
+  const icp = resolveIcp(opts.icpOverride);
+  const ledger = getLedger();
+
+  const result: FinderResult = {
+    source: SOURCE,
+    candidates: 0,
+    droppedIcp: 0,
+    droppedDuplicate: 0,
+    droppedEnrichment: 0,
+    enqueued: 0,
+    costUsd: 0,
+  };
+
+  const query: RegistryQuery = {
+    sinceDays,
+    limit: limit * 2, // over-fetch a bit; ICP filter + dedupe + domain resolution winnow
+    ...(opts.portals ? { portals: opts.portals } : {}),
+    ...(opts.naics ? { naics: opts.naics } : {}),
+    ...(opts.licenseTypes ? { licenseTypes: opts.licenseTypes } : {}),
+    ...(opts.taxonomies ? { taxonomies: opts.taxonomies } : {}),
+    ...(opts.states ? { states: opts.states } : {}),
+  };
+
+  // Step 1: fetch every configured source. Per-portal / per-taxonomy×state
+  // isolation lives INSIDE each RegistrySource's own fetch (mirrors
+  // accelerator-batch's per-cohort isolation) — a dead portal or an empty
+  // taxonomy×state pair logs and continues; this run only halts when EVERY
+  // configured source across BOTH adapters returns 0.
+  const sourceResults = await Promise.all(
+    REGISTRY_SOURCES.map(async (src) => {
+      try {
+        return await src.fetch(query);
+      } catch (err) {
+        const message = ((err as Error).message ?? "").slice(0, 120);
+        logEvent(
+          "error.swallowed",
+          { kind: "local-registry.source", source: src.id, message_120: message },
+          "warn",
+        );
+        return {
+          records: [] as RegistryRecord[],
+          costUsd: 0,
+          perSource: [{ source: src.id, label: src.id, records: 0, error: message }],
+        };
+      }
+    }),
+  );
+
+  const allRecords: RegistryRecord[] = [];
+  const perSource: NonNullable<FinderResult["perSource"]> = [];
+  for (const r of sourceResults) {
+    allRecords.push(...r.records);
+    perSource.push(...r.perSource);
+    result.costUsd += r.costUsd;
+  }
+  result.perSource = perSource;
+
+  // Dedupe across sources within this run before touching the queue —
+  // NY state + NYC-city portals commonly double-publish the same license.
+  const seen = new Set<string>();
+  const deduped: RegistryRecord[] = [];
+  for (const r of allRecords) {
+    const key = dedupeKeyFor(r);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    deduped.push(r);
+  }
+  result.candidates = deduped.length;
+
+  if (deduped.length === 0) {
+    const detail =
+      perSource.length > 0
+        ? perSource.map((p) => `${p.label}: ${p.error ?? "0 records"}`).join("; ")
+        : "no sources configured";
+    result.halted = `every configured source returned 0 records — ${detail}`;
+    return result;
+  }
+
+  let halted = false;
+
+  await parallelMap(deduped, concurrency, async (record) => {
+    if (halted) return;
+    if (result.enqueued >= limit) {
+      halted = true;
+      return;
+    }
+    if (opts.maxCostUsd != null && result.costUsd >= opts.maxCostUsd) {
+      result.halted = `max-cost cap (${opts.maxCostUsd})`;
+      halted = true;
+      return;
+    }
+
+    const dedupeKey = dedupeKeyFor(record);
+    const playName = routePlayFor(record.matchedDateIso, freshnessDays);
+    if (
+      ledger.isQueueDuplicate(NEW_BUSINESS_PLAY, dedupeKey) ||
+      ledger.isQueueDuplicate(FREE_PILOT_PLAY, dedupeKey)
+    ) {
+      result.droppedDuplicate++;
+      return;
+    }
+
+    if (opts.dryRun) {
+      result.enqueued++;
+      return;
+    }
+
+    // ICP filter — cheapest gate first, BEFORE any paid call (enrichCompany
+    // included), as every sibling finder does.
+    const filter = await icpFilter({
+      icp,
+      candidate: {
+        title: record.name,
+        url: null,
+        summary: buildIcpSummary(record),
+      },
+    });
+    if (filter.match === null) {
+      // Transient classifier failure — drop without persisting. A rejection
+      // would burn the dedupeKey forever (isQueueDuplicate ignores status).
+      result.droppedEnrichment++;
+      return;
+    }
+    if (!filter.match) {
+      result.droppedIcp++;
+      ledger.enqueueTarget({
+        playName,
+        payload: rejectionPayload(record),
+        dedupeKey,
+        source: SOURCE,
+        initialStatus: "rejected",
+        notes: `auto: ICP — ${filter.reason}`,
+      });
+      return;
+    }
+
+    // Resolve a domain from the business name — the registries carry a name
+    // and address, never a website. #456's enrichCompany ($0.005) is the
+    // cheapest resolver in the toolbox for that.
+    const enriched = await safeEnrichCompany({ name: record.name }, { playName });
+    result.costUsd += enriched.result.cost ?? 0;
+    const domain = enriched.result.company?.domain ?? null;
+    if (!domain) {
+      result.droppedEnrichment++;
+      return;
+    }
+
+    const contact = await resolveVerifyEnrichQualify({
+      playName,
+      // No owner/operator name in either registry — findEmail resolves a
+      // company-level address off the domain alone (fullName optional).
+      fullName: null,
+      companyDomain: domain,
+      isDuplicate: (email) => isDuplicate({ playName, dedupeKey, prospectEmail: email }),
+      errKindPrefix: "local-registry",
+      icp,
+      person: {
+        name: null,
+        company: record.name,
+        evidence: `${record.sourceLabel}, matched ${record.matchedDateIso.slice(0, 10)}`,
+      },
+      fillGaps: opts.qualifyFillGaps ?? true,
+    });
+    result.costUsd += contact.costUsd;
+    if (!contact.ok) {
+      if (contact.reason === "duplicate") result.droppedDuplicate++;
+      else if (contact.reason === "role") {
+        result.droppedRole = (result.droppedRole ?? 0) + 1;
+        persistRoleRejection({
+          playName,
+          dedupeKey,
+          payload: rejectionPayload(record),
+          source: SOURCE,
+          reason: contact.detail ?? "off-ICP role",
+          dryRun: opts.dryRun,
+        });
+      } else result.droppedEnrichment++;
+      return;
+    }
+
+    const phone = contact.phone ?? record.phone ?? null;
+    const target: LocalRegistryTarget = {
+      name: contact.fullName ?? record.name,
+      email: contact.email,
+      company: record.name,
+      source: record.source,
+      sourceLabel: record.sourceLabel,
+      matchedDateIso: record.matchedDateIso,
+      yourEdge: opts.yourEdge,
+      ...(record.address ? { address: record.address } : {}),
+      ...(record.city ? { city: record.city } : {}),
+      ...(record.state ? { state: record.state } : {}),
+      ...(contact.linkedinUrl ? { linkedinUrl: contact.linkedinUrl } : {}),
+      ...(phone ? { phone } : {}),
+      ...(contact.title ? { title: contact.title } : {}),
+    };
+    const id = enqueueScoredTarget(ledger, {
+      playName,
+      payload: target,
+      dedupeKey,
+      source: SOURCE,
+      notes: `${record.sourceLabel} — ${filter.reason}`,
+    });
+    if (id != null) result.enqueued++;
+    else result.droppedDuplicate++;
+  });
+
+  return result;
+}
+
+function buildIcpSummary(record: RegistryRecord): string {
+  const loc = [record.city, record.state].filter(Boolean).join(", ");
+  return `${record.name} — ${record.sourceLabel}${loc ? `, ${loc}` : ""}. Matched on ${record.matchedDateIso.slice(0, 10)}.`;
+}
+
+function rejectionPayload(record: RegistryRecord): Record<string, unknown> {
+  return {
+    company: record.name,
+    source: record.source,
+    sourceLabel: record.sourceLabel,
+    matchedDateIso: record.matchedDateIso,
+    ...(record.address ? { address: record.address } : {}),
+  };
+}

--- a/packages/find/src/local-registry.ts
+++ b/packages/find/src/local-registry.ts
@@ -60,6 +60,13 @@ export interface LocalRegistryTarget {
   /** ISO issue/enumeration date this record matched on — the trigger evidence. */
   matchedDateIso: string;
   yourEdge: string;
+  /**
+   * nppes only. Carried through from `RegistryRecord.subjectType` so a
+   * `/queue` reviewer sees the same NPI-1 (individual) vs NPI-2
+   * (organization) signal that explains why a "company" row shows a
+   * person's name — see `_registry-sources.ts`'s `RegistryRecord` doc.
+   */
+  subjectType?: "individual" | "organization";
   address?: string;
   city?: string;
   state?: string;
@@ -75,9 +82,12 @@ function slugify(s: string): string {
     .replace(/[^a-z0-9-]/g, "");
 }
 
-/** Stable within-run + cross-run dedupe key: source + name slug + state. */
+/** Stable within-run + cross-run dedupe key: name slug + state, source-agnostic.
+ * Cross-source dedup is the stated intent (see the run-level dedupe below) —
+ * a business appearing in both socrata-license and nppes must collapse to
+ * one candidate, not be double-enriched and potentially double-queued. */
 export function dedupeKeyFor(record: RegistryRecord): string {
-  return `${record.source}:${slugify(record.name)}:${(record.state ?? "").toLowerCase()}`;
+  return `${slugify(record.name)}:${(record.state ?? "").toLowerCase()}`;
 }
 
 /** Recent-issue routing: fresh (within `freshnessDays`) → new-business, else → free-pilot. */
@@ -280,6 +290,7 @@ export async function runLocalRegistryFinder(opts: LocalRegistryFinderOpts): Pro
       sourceLabel: record.sourceLabel,
       matchedDateIso: record.matchedDateIso,
       yourEdge: opts.yourEdge,
+      ...(record.subjectType ? { subjectType: record.subjectType } : {}),
       ...(record.address ? { address: record.address } : {}),
       ...(record.city ? { city: record.city } : {}),
       ...(record.state ? { state: record.state } : {}),

--- a/packages/find/src/registry.ts
+++ b/packages/find/src/registry.ts
@@ -13,6 +13,8 @@ import { runGitHubTopicsFinder } from "./github-topics.ts";
 import { runHiringSignalFinder } from "./hiring-signal.ts";
 import { runJobChangeFinder } from "./job-change.ts";
 import { runLumaFinder } from "./luma.ts";
+import { runLocalRegistryFinder } from "./local-registry.ts";
+import type { SocrataPortalConfig } from "./_registry-sources.ts";
 import { runPodcastGuestFinder } from "./podcast-guest.ts";
 import { runPostFundingFinder } from "./post-funding.ts";
 import { runShowHnFinder } from "./show-hn.ts";
@@ -361,6 +363,105 @@ export const TRIGGERS: TriggerSpec[] = [
         limit: (cfg["limit"] as number) ?? 25,
         maxCostUsd: (cfg["maxCostUsd"] as number) ?? 5,
       }),
+  },
+  {
+    // Local-registry finder over free, keyless public-registry APIs
+    // (Socrata business-license open data + NPPES NPI). Recent-issue lane
+    // routes to new-business, the rest to free-pilot. Ships empty (no
+    // portals/taxonomies configured) so nothing fires until the founder or
+    // an industry pack (#458/#464) sets a source.
+    name: "local-registry",
+    defaultIntervalMs: 24 * ONE_HOUR,
+    enabledByDefault: false,
+    defaultConfig: {
+      ...PRODUCT_RESEARCH_DEFAULT,
+      portals: [] as SocrataPortalConfig[],
+      naics: [] as string[],
+      licenseTypes: [] as string[],
+      taxonomies: [] as string[],
+      states: [] as string[],
+      sinceDays: 60,
+      freshnessDays: 21,
+      yourEdge: "",
+      limit: 25,
+      maxCostUsd: 5,
+    },
+    configBrief:
+      "Discovers newly-licensed or newly-enumerated main-street businesses over free, keyless public registries — no maps/places/Yelp capability exists in the SDK, so this is the only recency-driven local-business signal available. Two sources, either or both may be configured: `portals` (array of `{host, dataset, label}` — a Socrata open-data business-license portal, e.g. `{host:\"data.cityofnewyork.us\", dataset:\"w7w3-xahh\", label:\"NYC business licenses\"}`) filtered by `naics`/`licenseTypes` (free-text terms matched against the dataset); and `taxonomies` + `states` (NPPES NPI registry — taxonomy description like 'Dentist', 'Veterinarian', 'Chiropractor' crossed with 2-letter state codes — this one covers healthcare practices completely, 9M+ providers, refreshed weekly by CMS). `sinceDays` (discovery window against the issue/enumeration date, default 60) and `freshnessDays` (records inside this window route to the new-business play — nothing to rip out, the main-street equivalent of post-funding; everything else routes to free-pilot — clamped to sinceDays, default 21). `yourEdge` (the pitch angle for an owner-operator, REQUIRED — short and concrete, no founder jargon). A dead portal or an empty taxonomy×state pair logs and continues; the run only halts when EVERY configured source returns 0 records. These sources carry a business name + address but no email — each candidate resolves a domain via enrichCompany before falling through to the normal contact-resolution spine. STRATEGIST DUTY: propose `taxonomies`+`states` for healthcare verticals (dental, vet, chiropractic) and `portals`+`naics`/`licenseTypes` for everything else — NY, CO, PA, OR and CT publish full state license registries as open data.",
+    readiness: (cfg) => {
+      const portals = Array.isArray(cfg["portals"]) ? cfg["portals"] : [];
+      const validPortals = portals.filter(
+        (p) =>
+          p &&
+          typeof p === "object" &&
+          typeof (p as Record<string, unknown>)["host"] === "string" &&
+          ((p as Record<string, unknown>)["host"] as string).trim().length > 0 &&
+          typeof (p as Record<string, unknown>)["dataset"] === "string" &&
+          ((p as Record<string, unknown>)["dataset"] as string).trim().length > 0,
+      );
+      const taxonomies = Array.isArray(cfg["taxonomies"])
+        ? (cfg["taxonomies"] as unknown[]).filter((t) => typeof t === "string" && t.trim())
+        : [];
+      const states = Array.isArray(cfg["states"])
+        ? (cfg["states"] as unknown[]).filter((s) => typeof s === "string" && s.trim())
+        : [];
+      const hasNppes = taxonomies.length > 0 && states.length > 0;
+      if (validPortals.length === 0 && !hasNppes) {
+        return {
+          ready: false,
+          reason: "set `portals[]` ({host, dataset, label}) or `taxonomies[]` + `states[]`",
+        };
+      }
+      const edge = cfg["yourEdge"];
+      if (typeof edge !== "string" || edge.trim().length === 0) {
+        return {
+          ready: false,
+          reason: "set `yourEdge` — your one-line pitch for an owner-operator",
+        };
+      }
+      return { ready: true };
+    },
+    run: (cfg) => {
+      const portals: SocrataPortalConfig[] = (
+        Array.isArray(cfg["portals"]) ? (cfg["portals"] as unknown[]) : []
+      )
+        .map((p): SocrataPortalConfig | null => {
+          if (!p || typeof p !== "object") return null;
+          const e = p as Record<string, unknown>;
+          const host = typeof e["host"] === "string" ? e["host"].trim() : "";
+          const dataset = typeof e["dataset"] === "string" ? e["dataset"].trim() : "";
+          if (host.length === 0 || dataset.length === 0) return null;
+          const label =
+            typeof e["label"] === "string" && e["label"].trim() ? e["label"].trim() : host;
+          return { host, dataset, label };
+        })
+        .filter((p): p is SocrataPortalConfig => p !== null);
+      const naics = Array.isArray(cfg["naics"])
+        ? (cfg["naics"] as unknown[]).filter((t): t is string => typeof t === "string")
+        : [];
+      const licenseTypes = Array.isArray(cfg["licenseTypes"])
+        ? (cfg["licenseTypes"] as unknown[]).filter((t): t is string => typeof t === "string")
+        : [];
+      const taxonomies = Array.isArray(cfg["taxonomies"])
+        ? (cfg["taxonomies"] as unknown[]).filter((t): t is string => typeof t === "string")
+        : [];
+      const states = Array.isArray(cfg["states"])
+        ? (cfg["states"] as unknown[]).filter((s): s is string => typeof s === "string")
+        : [];
+      return runLocalRegistryFinder({
+        dryRun: false,
+        ...(portals.length > 0 ? { portals } : {}),
+        ...(naics.length > 0 ? { naics } : {}),
+        ...(licenseTypes.length > 0 ? { licenseTypes } : {}),
+        ...(taxonomies.length > 0 ? { taxonomies } : {}),
+        ...(states.length > 0 ? { states } : {}),
+        sinceDays: (cfg["sinceDays"] as number) ?? 60,
+        freshnessDays: (cfg["freshnessDays"] as number) ?? 21,
+        yourEdge: typeof cfg["yourEdge"] === "string" ? cfg["yourEdge"] : "",
+        limit: (cfg["limit"] as number) ?? 25,
+        maxCostUsd: (cfg["maxCostUsd"] as number) ?? 5,
+      });
+    },
   },
   {
     // GitHub-Topic-driven repo finder (free Search API, `topic:<slug>`).


### PR DESCRIPTION
Closes #459.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: d88580a5101f (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (1 errs) vs base ok (1 errs)
```

**Review note:** review FAIL at the 2-round correction cap — findings filed: https://github.com/oneshot-agent/oneshot-gtm/issues/468

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `local-registry` finder with Socrata and NPPES source adapters
> - Adds the `local-registry` finder in [local-registry.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/469/files#diff-69a6ac1db81672870b58f2d1be6325c6ddddda7c83df940179aee4a1cf509452) to discover public registry candidates, deduplicate them, and route them to `new-business` or `free-pilot` plays based on matched date freshness.
> - Implements Socrata and NPPES source adapters in [_registry-sources.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/469/files#diff-096d31b034bdc96c754377e3299f07a2b224bebb29f67bc1f8dcd8a829a5c279) with pagination, date-based freshness filtering, and per-source failure isolation.
> - Adds priority adapters and queue evidence formatting for `new-business` and `free-pilot` payloads, and adds the `enrichCompany` wrapper in [oneshot.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/469/files#diff-a75653098eb1094047ae1458ce831158ed4abd7e08122279a6827b46c0c2e9db) for company enrichment before registry resolution.
> - Registers a disabled `local-registry` trigger in [registry.ts](https://github.com/oneshot-agent/oneshot-gtm/pull/469/files#diff-bcee29f6661eb8b7924d1a73f646e38164b2cca444d2816330057b68b3e8b83d) that requires configured sources and a pitch to become ready.
> - Risk: The NPPES adapter `fetchNppesPair` examines at most 1,200 records per taxonomy/state pair and can miss newly enumerated providers beyond that ceiling.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized be926d4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->