### PR TITLE
fix: issue #433: Deferred review findings from ai/gtm/issue-430

### DIFF
--- a/apps/server/__tests__/webhook-triggers-route.test.ts
+++ b/apps/server/__tests__/webhook-triggers-route.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const enqueued: Array<Record<string, unknown>> = [];
 let icpMatch: boolean | null = true;
+let icpFilterImpl: (() => Promise<{ match: boolean | null; reason: string }>) | null = null;
 const webhookReplays = new Map<string, number>();
 
 vi.mock("@oneshot-gtm/core", () => ({
@@ -22,6 +23,9 @@ vi.mock("@oneshot-gtm/core", () => ({
       return true;
     },
     clearWebhookReplays: () => webhookReplays.clear(),
+    releaseWebhookReplay: (key: string) => {
+      webhookReplays.delete(key);
+    },
     enqueueTarget: (row: Record<string, unknown>) => {
       enqueued.push(row);
       return 42;
@@ -31,7 +35,8 @@ vi.mock("@oneshot-gtm/core", () => ({
 
 vi.mock("@oneshot-gtm/find", () => ({
   resolveIcp: () => "technical SaaS founders",
-  icpFilter: async () => ({ match: icpMatch, reason: icpMatch ? "fits" : "not a fit" }),
+  icpFilter: async () =>
+    icpFilterImpl ? icpFilterImpl() : { match: icpMatch, reason: icpMatch ? "fits" : "not a fit" },
 }));
 
 const { calNoShowWebhookRoute, signupWebhookRoute } =
@@ -61,6 +66,7 @@ function request(
 beforeEach(() => {
   enqueued.length = 0;
   icpMatch = true;
+  icpFilterImpl = null;
   delete process.env["WEBHOOK_SECRET"];
   resetWebhookReplayCache();
 });
@@ -169,8 +175,33 @@ describe("webhook trigger intake", () => {
 
   it("keeps unsigned local intake enabled when no secret is configured", async () => {
     const response = await signupWebhookRoute(
-      request("signup", { name: "Pat", email: "pat@example.com", phone: "+15555550102" }),
+      request("signup", { name: "Pat", email: "pat@example.com", phone: "+155****0102" }),
     );
     expect(response.status).toBe(202);
+  });
+
+  it("releases the replay key on a downstream ICP-filter failure so a retry is not rejected as replayed", async () => {
+    const secret = "whsec-test";
+    process.env["WEBHOOK_SECRET"] = secret;
+    const signup = { name: "Grace", email: "grace@example.com", phone: "+155****0101" };
+    const signed = request("signup", signup, secret);
+
+    // First attempt: icpFilter throws (transient LLM error). intakeWebhook
+    // re-throws after releasing the replay key (buildFetchHandler in
+    // server.ts turns this into a 500 in production); calling the route
+    // directly here bypasses that wrapper, so assert the throw itself.
+    icpFilterImpl = async () => {
+      throw new Error("transient LLM error");
+    };
+    await expect(signupWebhookRoute(signed.clone())).rejects.toThrow("transient LLM error");
+    expect(enqueued).toHaveLength(0);
+
+    // Retry with the identical signed payload (same timestamp + signature):
+    // must succeed now that the transient failure is over, proving the
+    // replay key was released rather than burned by the failed attempt.
+    icpFilterImpl = async () => ({ match: true, reason: "fits" });
+    const retry = await signupWebhookRoute(signed.clone());
+    expect(retry.status).toBe(202);
+    expect(enqueued).toHaveLength(1);
   });
 });

--- a/apps/server/__tests__/webhook-triggers-route.test.ts
+++ b/apps/server/__tests__/webhook-triggers-route.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const enqueued: Array<Record<string, unknown>> = [];
 let icpMatch: boolean | null = true;
 let icpFilterImpl: (() => Promise<{ match: boolean | null; reason: string }>) | null = null;
+let enqueueTargetImpl: ((row: Record<string, unknown>) => number | null) | null = null;
 const webhookReplays = new Map<string, number>();
 
 vi.mock("@oneshot-gtm/core", () => ({
@@ -27,6 +28,7 @@ vi.mock("@oneshot-gtm/core", () => ({
       webhookReplays.delete(key);
     },
     enqueueTarget: (row: Record<string, unknown>) => {
+      if (enqueueTargetImpl) return enqueueTargetImpl(row);
       enqueued.push(row);
       return 42;
     },
@@ -67,6 +69,7 @@ beforeEach(() => {
   enqueued.length = 0;
   icpMatch = true;
   icpFilterImpl = null;
+  enqueueTargetImpl = null;
   delete process.env["WEBHOOK_SECRET"];
   resetWebhookReplayCache();
 });
@@ -200,6 +203,30 @@ describe("webhook trigger intake", () => {
     // must succeed now that the transient failure is over, proving the
     // replay key was released rather than burned by the failed attempt.
     icpFilterImpl = async () => ({ match: true, reason: "fits" });
+    const retry = await signupWebhookRoute(signed.clone());
+    expect(retry.status).toBe(202);
+    expect(enqueued).toHaveLength(1);
+  });
+
+  it("releases the replay key on a downstream enqueueTarget failure so a retry is not rejected as replayed", async () => {
+    const secret = "whsec-test";
+    process.env["WEBHOOK_SECRET"] = secret;
+    const signup = { name: "Grace", email: "grace@example.com", phone: "+155****0101" };
+    const signed = request("signup", signup, secret);
+
+    // First attempt: icpFilter passes but enqueueTarget throws (simulated
+    // DB enqueue failure — the exact "database enqueue failure" scenario
+    // named by issue #433).
+    enqueueTargetImpl = () => {
+      throw new Error("database enqueue failure");
+    };
+    await expect(signupWebhookRoute(signed.clone())).rejects.toThrow("database enqueue failure");
+    expect(enqueued).toHaveLength(0);
+
+    // Retry with the identical signed payload: must succeed now that the
+    // transient failure is over, proving the replay key was released
+    // rather than burned by the failed enqueueTarget attempt.
+    enqueueTargetImpl = null;
     const retry = await signupWebhookRoute(signed.clone());
     expect(retry.status).toBe(202);
     expect(enqueued).toHaveLength(1);

--- a/apps/server/src/api/webhook-triggers.ts
+++ b/apps/server/src/api/webhook-triggers.ts
@@ -14,6 +14,23 @@ export async function signupWebhookRoute(req: Request): Promise<Response> {
   return intakeWebhook(req, "signup");
 }
 
+/**
+ * Best-effort replay-key release: this performs its own ledger write, which
+ * can itself throw under the same failure condition (DB unavailable) that
+ * triggered the cleanup in the first place. Never let that mask the
+ * original error that's about to be re-thrown by the caller.
+ */
+function releaseReplayBestEffort(replayKey: string | null): void {
+  try {
+    releaseWebhookReplay(replayKey);
+  } catch {
+    // Swallow: the original error takes priority and is re-thrown by the
+    // caller. Worst case here is the replay key stays consumed until it
+    // expires, which is safe (just delays a retry) — unlike masking the
+    // original error, which is not.
+  }
+}
+
 async function intakeWebhook(req: Request, kind: WebhookKind): Promise<Response> {
   if (!isJsonRequest(req)) {
     return jsonResponse({ error: "content-type must be application/json" }, 400, req);
@@ -77,7 +94,7 @@ async function intakeWebhook(req: Request, kind: WebhookKind): Promise<Response>
     // replay key so the provider's retry of this same signed payload isn't
     // rejected as replayed. Only a successful 2xx response should
     // permanently consume the key.
-    releaseWebhookReplay(replayKey);
+    releaseReplayBestEffort(replayKey);
     throw err;
   }
 
@@ -95,7 +112,7 @@ async function intakeWebhook(req: Request, kind: WebhookKind): Promise<Response>
       source: `webhook:${kind}`,
     });
   } catch (err) {
-    releaseWebhookReplay(replayKey);
+    releaseReplayBestEffort(replayKey);
     throw err;
   }
   return jsonResponse({ accepted: true, queued: id !== null, id }, 202, req);

--- a/apps/server/src/api/webhook-triggers.ts
+++ b/apps/server/src/api/webhook-triggers.ts
@@ -2,7 +2,7 @@ import { getLedger } from "@oneshot-gtm/core";
 import { icpFilter, resolveIcp } from "@oneshot-gtm/find";
 import type { ConciergeTarget, DemoNoShowTarget } from "@oneshot-gtm/plays";
 import { jsonResponse } from "../server.ts";
-import { verifyWebhook } from "./webhook-verifier.ts";
+import { releaseWebhookReplay, verifyWebhook } from "./webhook-verifier.ts";
 
 type WebhookKind = "cal-no-show" | "signup";
 
@@ -39,6 +39,7 @@ async function intakeWebhook(req: Request, kind: WebhookKind): Promise<Response>
     process.env["WEBHOOK_SECRET"],
   );
   if (!verification.ok) return jsonResponse({ error: verification.error }, 401, req);
+  const { replayKey } = verification;
 
   let payload: ConciergeTarget | DemoNoShowTarget;
   let company: string | null;
@@ -59,27 +60,44 @@ async function intakeWebhook(req: Request, kind: WebhookKind): Promise<Response>
     context = payload.whatTheyWanted ?? `missed demo at ${payload.missedAt}`;
     eventIdentity = `${payload.email}:${payload.missedAt}`;
   }
-  const filter = await icpFilter({
-    icp: await resolveIcp(),
-    candidate: {
-      title: company ? `${payload.name} at ${company}` : payload.name,
-      summary: context,
-      author: payload.name,
-      url: payload.linkedinUrl ?? null,
-    },
-  });
+
+  let filter: Awaited<ReturnType<typeof icpFilter>>;
+  try {
+    filter = await icpFilter({
+      icp: await resolveIcp(),
+      candidate: {
+        title: company ? `${payload.name} at ${company}` : payload.name,
+        summary: context,
+        author: payload.name,
+        url: payload.linkedinUrl ?? null,
+      },
+    });
+  } catch (err) {
+    // Downstream failure after a successful verification: release the
+    // replay key so the provider's retry of this same signed payload isn't
+    // rejected as replayed. Only a successful 2xx response should
+    // permanently consume the key.
+    releaseWebhookReplay(replayKey);
+    throw err;
+  }
 
   if (filter.match !== true) {
     return jsonResponse({ accepted: false, reason: filter.reason }, 200, req);
   }
 
   const playName = kind === "signup" ? "concierge" : "demo-no-show";
-  const id = getLedger().enqueueTarget({
-    playName,
-    payload,
-    dedupeKey: `webhook:${kind}:${eventIdentity.toLowerCase()}`,
-    source: `webhook:${kind}`,
-  });
+  let id: number | null;
+  try {
+    id = getLedger().enqueueTarget({
+      playName,
+      payload,
+      dedupeKey: `webhook:${kind}:${eventIdentity.toLowerCase()}`,
+      source: `webhook:${kind}`,
+    });
+  } catch (err) {
+    releaseWebhookReplay(replayKey);
+    throw err;
+  }
   return jsonResponse({ accepted: true, queued: id !== null, id }, 202, req);
 }
 

--- a/apps/server/src/api/webhook-verifier.ts
+++ b/apps/server/src/api/webhook-verifier.ts
@@ -4,7 +4,7 @@ import { getLedger } from "@oneshot-gtm/core";
 export const WEBHOOK_REPLAY_WINDOW_SECONDS = 5 * 60;
 
 export type WebhookVerification =
-  | { ok: true }
+  | { ok: true; replayKey: string | null }
   | { ok: false; error: "invalid webhook signature" | "stale webhook" | "replayed webhook" };
 
 /**
@@ -19,7 +19,7 @@ export function verifyWebhook(
   now = Date.now(),
 ): WebhookVerification {
   const secret = configuredSecret?.trim() ?? "";
-  if (!secret) return { ok: true };
+  if (!secret) return { ok: true, replayKey: null };
 
   const parsed = parseSignature(signature);
   if (!parsed) return { ok: false, error: "invalid webhook signature" };
@@ -40,7 +40,20 @@ export function verifyWebhook(
     now,
   );
   if (!consumed) return { ok: false, error: "replayed webhook" };
-  return { ok: true };
+  return { ok: true, replayKey };
+}
+
+/**
+ * Release a replay key that `verifyWebhook` consumed, so a provider retry of
+ * the same signed payload isn't rejected as replayed. Callers must invoke
+ * this when downstream processing fails after successful verification but
+ * before the webhook is durably queued, so a genuine retry after a
+ * transient failure (e.g. LLM API error, DB enqueue failure) isn't
+ * permanently dropped.
+ */
+export function releaseWebhookReplay(replayKey: string | null): void {
+  if (replayKey === null) return;
+  getLedger().releaseWebhookReplay(replayKey);
 }
 
 function parseSignature(value: string | null): { timestamp: number; signatures: Buffer[] } | null {

--- a/packages/core/__tests__/ledger.test.ts
+++ b/packages/core/__tests__/ledger.test.ts
@@ -53,6 +53,17 @@ describe("Ledger schema migration", () => {
     expect(ledger.consumeWebhookReplay("signed-event", 3_000, 2_001)).toBe(true);
   });
 
+  it("releases a consumed webhook replay key so it can be consumed again", () => {
+    expect(ledger.consumeWebhookReplay("signed-event", 2_000, 1_000)).toBe(true);
+    expect(ledger.consumeWebhookReplay("signed-event", 2_000, 1_100)).toBe(false);
+    ledger.releaseWebhookReplay("signed-event");
+    expect(ledger.consumeWebhookReplay("signed-event", 2_000, 1_200)).toBe(true);
+  });
+
+  it("releasing an unknown webhook replay key is a no-op", () => {
+    expect(() => ledger.releaseWebhookReplay("never-consumed")).not.toThrow();
+  });
+
   it("lists only new pending queue rows after a queue watermark", () => {
     const before = ledger.latestQueueId();
     ledger.enqueueTarget({

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -3919,6 +3919,16 @@ export class Ledger {
   clearWebhookReplays(): void {
     this.db.exec("DELETE FROM webhook_replays");
   }
+
+  /**
+   * Release a previously-consumed replay key. Used when a webhook was
+   * verified but downstream processing (ICP filtering, enqueueing) failed
+   * before a success response was sent, so the provider's retry of the same
+   * signed payload isn't rejected as a replay.
+   */
+  releaseWebhookReplay(replayKey: string): void {
+    this.db.prepare("DELETE FROM webhook_replays WHERE replay_key = ?").run(replayKey);
+  }
 }
 
 let singleton: Ledger | null = null;


### PR DESCRIPTION
Closes #433.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: d88580a5101f (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (1 errs) vs base ok (1 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Release webhook replay key on ICP-filter or enqueue exceptions in `intakeWebhook`
> - When a signed webhook passes verification, `intakeWebhook` now wraps ICP resolution/filtering and target enqueueing in separate exception handlers that best-effort release the consumed replay key via `releaseReplayBestEffort` before rethrowing the original exception
> - `verifyWebhook` returns the consumed replay key with successful signed verification (null for unsigned); new `releaseWebhookReplay` utility and `Ledger.releaseWebhookReplay` method delete the replay record so the same signed request can be consumed again
> - Tests cover both ICP-filter and enqueue failure replay scenarios, asserting the exception propagates without permanently consuming the replay key and the identical request succeeds on retry
> - Risk: `releaseWebhookReplay` silently no-ops on unknown keys; if best-effort release fails, the replay key remains consumed and the downstream exception is still propagated — the request cannot be retried until the replay window expires
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized af61224. 3 files reviewed, 1 issue evaluated, 0 issues filtered, 1 comment posted</summary>
>
> ### 🗂️ Filtered Issues
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->