### PR TITLE
fix: issue #364: Deferred review findings from ai/gtm/issue-342

### DIFF
--- a/apps/server/__tests__/scheduler.test.ts
+++ b/apps/server/__tests__/scheduler.test.ts
@@ -4,11 +4,17 @@ import type { TriggerRunOutcome } from "@oneshot-gtm/find";
 let nextOutcomes: TriggerRunOutcome[] = [];
 let nextSleepValue = 60_000;
 let throwOnNextRun: Error | null = null;
+// When set, runDueTriggers awaits this before resolving/throwing, so a test
+// can suspend a tick mid-flight and control exactly when it resumes.
+let runDueTriggersGate: Promise<void> | null = null;
 const calls = { runDueTriggers: 0, nextSleepMs: 0, eventKinds: [] as string[] };
 
 vi.mock("@oneshot-gtm/find", () => ({
   runDueTriggers: async () => {
     calls.runDueTriggers++;
+    if (runDueTriggersGate) {
+      await runDueTriggersGate;
+    }
     if (throwOnNextRun) {
       const err = throwOnNextRun;
       throwOnNextRun = null;
@@ -44,6 +50,7 @@ beforeEach(() => {
   nextOutcomes = [];
   nextSleepValue = 60_000;
   throwOnNextRun = null;
+  runDueTriggersGate = null;
   demoModeValue = false;
 });
 
@@ -125,42 +132,32 @@ describe("startScheduler", () => {
   });
 
   it("stop() called while runDueTriggers is in flight does NOT reschedule", async () => {
-    // Simulate a slow finder by returning a promise that resolves after a
-    // controlled delay. The scheduler awaits it; we stop() during the await.
-    let resolveSlow: (() => void) | null = null;
-    const slowPromise = new Promise<void>((res) => {
-      resolveSlow = res;
+    // Suspend runDueTriggers on a controllable gate so the tick genuinely
+    // stays in flight (awaiting a real, unresolved promise) while we call
+    // stop() — this is what "in flight" has to mean for the test to prove
+    // anything about in-flight cancellation.
+    let resolveGate: (() => void) | null = null;
+    runDueTriggersGate = new Promise<void>((res) => {
+      resolveGate = res;
     });
     nextOutcomes = [];
     nextSleepValue = 1_000;
 
-    // Hijack the mock for one tick to insert the slow promise.
-    let inFlight = false;
-    const original = (await import("@oneshot-gtm/find")).runDueTriggers;
-    void original; // not used; we already mocked it
-
-    // The simplest trick: make our existing mock await a controllable promise.
-    // We do this by piggy-backing on `throwOnNextRun` mechanics — instead,
-    // wrap the mock's body to wait on slowPromise the first time it's called.
     const handle = startScheduler();
-    // Replace the mock's behavior on the fly is brittle, so simulate by:
-    // 1) advance to first tick start
-    // 2) before it completes, advance time to "schedule the await suspend"
-    // The vi.useFakeTimers makes Promise.resolve still microtask, so the
-    // simplest approach: have the tick await a real (non-faked) microtask.
-    void inFlight;
-    void slowPromise;
-    void resolveSlow;
-
-    // Direct test: stop AFTER a tick completes but BEFORE the next setTimeout
-    // fires. The cancelled check at the top of tick (the `if (cancelled) return`
-    // before runDueTriggers) handles the "fires anyway" case.
-    await vi.advanceTimersByTimeAsync(5_000); // tick 1 done
-    expect(calls.runDueTriggers).toBe(1);
-    handle.stop();
-    // Even if the timer was already scheduled by tick 1's success path,
-    // the next tick's first line `if (cancelled) return` aborts it.
+    // Fire the first tick; runDueTriggers is called and suspends on the gate.
     await vi.advanceTimersByTimeAsync(5_000);
+    expect(calls.runDueTriggers).toBe(1);
+
+    // Stop while runDueTriggers has genuinely not resolved yet.
+    handle.stop();
+    // Let the in-flight tick resume and run to completion (post-processing,
+    // then the `if (cancelled) return` guard before scheduling the next tick).
+    resolveGate!();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // The tick must not have rescheduled itself: advancing well past
+    // nextSleepValue produces no further calls.
+    await vi.advanceTimersByTimeAsync(60_000);
     expect(calls.runDueTriggers).toBe(1);
   });
 


### PR DESCRIPTION
Closes #364.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 0fd396541751 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (1 errs) vs base ok (1 errs)
```

**External surfaces this change makes stale** (follow-up issue filed):
- no affected external or internal surfaces — no README/docs/CLI help text describes this test's internals, and I did not touch ROADMAP.md's "Approved, not yet started" section (line 83, issue #364) per the card's explicit instruction that section is dev-runner-maintained and must not be hand-edited.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix scheduler stop-in-flight test to use controllable promise gate for `runDueTriggers`
> - Adds a controllable promise gate to the scheduler test fixtures so the mocked `find.runDueTriggers` can stay unresolved until the test releases it.
> - Rewrites the `startScheduler` stop-in-flight test to start the scheduler, confirm `runDueTriggers` is suspended, call `stop` mid-flight, then release the gate and verify no further tick is scheduled.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f362210.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved scheduler coverage for stopping while a trigger run is in progress.
  * Added reliable control over suspended trigger execution and verified that stopping prevents subsequent scheduled ticks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->