### PR TITLE
fix: issue #96: Deferred review findings from ai/gtm/issue-90

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -9,9 +9,10 @@ type-checked in CI, and a deliberate error under `apps/web/src` fails the root s
 2026-08-29, `apps/*/__tests__` is also included, so all app test files are type-checked. Coverage
 is thin in two packages: `packages/doctor` has one test file against 799
 lines of `check.ts`, and `packages/intel`'s `retry.test.ts` covers `client.ts`'s retry surface
-(`backoffDelayMs`, `isRetryableLlmError`, `parseRetryAfter`, `complete()`'s OpenRouter paths) but
-`triage`, `synthesize`, `advise`, `weekly-review`, `complete()`'s Anthropic path, and the
-`allowTruncation` split remain untested.
+(`backoffDelayMs`, `isRetryableLlmError`, `parseRetryAfter`, `complete()`'s OpenRouter paths),
+while `reports.test.ts` covers `triageEmails`, `synthesizeInterviews`, `adviseOnce` and
+`weeklyReview`, and `truncation.test.ts` covers `complete()`'s Anthropic path and the
+`allowTruncation` split across all three providers.
 
 **Dependency pins.** The root `package.json` carries `overrides` for `seroval`, `seroval-plugins`
 (CVE-2026-59940) and `ws`. Forks inherit these.

--- a/STATUS.md
+++ b/STATUS.md
@@ -8,8 +8,10 @@ Last verified **2026-09-02** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2534 tests
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of
 2026-08-29, `apps/*/__tests__` is also included, so all app test files are type-checked. Coverage
 is thin in two packages: `packages/doctor` has one test file against 799
-lines of `check.ts`, and `packages/intel` tests cover only `_parse.ts` and `prompts.ts`, not
-`client.ts`, `triage`, `synthesize`, `advise` or `weekly-review`.
+lines of `check.ts`, and `packages/intel`'s `retry.test.ts` covers `client.ts`'s retry surface
+(`backoffDelayMs`, `isRetryableLlmError`, `parseRetryAfter`, `complete()`'s OpenRouter paths) but
+`triage`, `synthesize`, `advise`, `weekly-review`, `complete()`'s Anthropic path, and the
+`allowTruncation` split remain untested.
 
 **Dependency pins.** The root `package.json` carries `overrides` for `seroval`, `seroval-plugins`
 (CVE-2026-59940) and `ws`. Forks inherit these.


### PR DESCRIPTION
Closes #96.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 0fd396541751 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (1 errs) vs base ok (1 errs)
```

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Update `packages/intel` coverage status in `STATUS.md`
> Replaces prior "not covered" statements for client and workflow areas in [STATUS.md](https://github.com/oneshot-agent/oneshot-gtm/pull/484/files#diff-6c33a39439907887e8de50ebb50d264136cb2a7c916dc8d4c184ee24fb5cec9e). Documents three test groups: retry-focused tests for client retry surface and OpenRouter completions, report-focused tests for triage/synthesis/advice/weekly review, and truncation-focused tests for the Anthropic path and provider-specific `allowTruncation` behavior.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 15240d5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->