### PR TITLE
fix: issue #481: feat(find): enforce an install-wide daily USD spend ceiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,12 @@ bun run cli -- find drain podcast-guest --dry-run  # preview approved /queue row
 bun run cli -- cadence advance                     # daily tick: poll inbox, fire follow-ups
 ```
 
-55 commands — fourteen groups, plus `init`, `doctor` and `ui` at the top level. `bun run cli -- --help` (or `oneshot-gtm --help` once linked) is the reference:
+56 commands — fourteen groups, plus `init`, `doctor` and `ui` at the top level. `bun run cli -- --help` (or `oneshot-gtm --help` once linked) is the reference:
 
 | Group                    | Commands                                                                                                                                                                                                                                                                                            |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `init` · `doctor` · `ui` | setup wizard · health check · open the dashboard                                                                                                                                                                                                                                                    |
-| `config`                 | `llm` · `founder` · `keys` · `telemetry on\|off` · `x-engine [engine]`                                                                                                                                                                                                                              |
+| `config`                 | `llm` · `founder` · `keys` · `telemetry on\|off` · `x-engine [engine]` · `spend-ceiling [amount\|off]`                                                                                                                                                                                              |
 | `gmail`                  | `auth` (OAuth a sending account) · `placement` (inbox-placement canary)                                                                                                                                                                                                                             |
 | `identities`             | `list` · `add` · `remove <id>` — the sender pool                                                                                                                                                                                                                                                    |
 | `smartlead`              | `connect` — API key + pick Smartlead mailboxes into the pool (send-only)                                                                                                                                                                                                                            |
@@ -187,6 +187,8 @@ Twelve **finders** discover prospects, ICP-filter them, and enqueue into `/queue
 | `local-business`    | main-street businesses via `peopleSearch`/`companySearch` (job title × industry × location × company size) — routed to the `free-pilot` play; a candidate carrying `best_work_email` skips `findEmail`/`verifyEmail` entirely, but `qualifyPostEnrich` may still perform paid `enrichProfile` lookups when `fillGaps` is enabled  |
 
 Only `show-hn` and `post-funding-auto` are on by default; enable the rest from `/queue`. A trigger missing required config reads as **not ready** — the toggle and Run button disable with the reason, and the API returns `409`, so scripted callers can't bypass the gate either.
+
+Per-run caps (`maxCostUsd` on a finder, `maxSpendPerRun` on x-reposters) bound one call; they don't stop eleven independently-scheduled finders and automatic drains from collectively overspending across a day. `config spend-ceiling <amount>` (or the Wallet card on `/setup`) sets an install-wide daily USD ceiling, checked before every automated finder run and drain — a reservation held for the call's duration closes the race between two concurrent automated paths, so they can't both slip under the ceiling before either one's spend has posted. Once reached, scheduled/run-now finders and drains halt with a named reason (`daily spend ceiling reached ($X.XX/$Y.YY spent today)`) visible on the trigger cards and in `doctor`; manual `/queue` sends (approve, reject, mark-sent, send-draft) are never gated by it — a founder reviewing and sending one email by hand is a deliberate decision the ceiling should never block. The counter resets at local midnight, same boundary the per-identity send caps use. Unset (the default) is unlimited, matching the historical behavior.
 
 Qualified first-touch rows receive a product dossier before the trigger completes: up to two known first-party pages plus quick external research covering the product, ecosystem, architecture, and business model. Set `productResearch: false` on a trigger to disable it. Research counts toward that trigger's `maxCostUsd`; a failure or exhausted cap leaves the row reviewable with an explicit warning. `find research-products` backfills the same context onto active/replied prospects and pending queue rows (`--dry-run`, `--limit`, and `--refresh` are supported). Use `--first-party-only` for a resilient bulk backfill when the external research provider is unavailable.
 
@@ -353,7 +355,7 @@ Successful responses include `duplicate`, `prospectId`, `cadencesStopped`, and `
 
 ```
 apps/
-  cli/        55-command CLI (commander); src/demo/ seeds the demo install, src/main.ts picks the workspace
+  cli/        56-command CLI (commander); src/demo/ seeds the demo install, src/main.ts picks the workspace
   server/     Bun.serve + SSE; tsdown bundle published as `oneshot-gtm-server`
   web/        Vite + React 19 + TanStack + Base UI — 9 pages, run form, strategist dock, privacy mode
 packages/

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -38,7 +38,7 @@ The verify gate has holes an agent can close without touching product behaviour.
 
 ## Reliability
 
-- [ ] **Install-wide daily spend ceiling** · M — spend caps are per trigger run (`maxCostUsd`, `maxSpendPerRun` in `packages/find/src/registry.ts`). Eleven finders on their own intervals, plus drains and cadence steps, have no shared daily bound and no kill switch.
+- [x] **Install-wide daily spend ceiling** · M — spend caps are per trigger run (`maxCostUsd`, `maxSpendPerRun` in `packages/find/src/registry.ts`). Eleven finders on their own intervals, plus drains and cadence steps, have no shared daily bound and no kill switch.
       _Done when:_ a configurable daily USD ceiling is checked before any paid call; crossing it halts finders and auto-drains with a named reason surfaced on the trigger cards and in `doctor`; manual sends from `/queue` still go through; the counter resets at local midnight and is covered by tests around the boundary.
       _Done when:_ `--once` exits 1 if any due trigger errored, 0 otherwise; the daemon loop keeps its current behaviour; both covered.
 

--- a/apps/cli/__tests__/init-config.test.ts
+++ b/apps/cli/__tests__/init-config.test.ts
@@ -25,6 +25,7 @@ const current = {
   mobileSignature: true,
   timezone: "Europe/Vienna",
   clientId: "client-1",
+  dailySpendCeilingUsd: null,
 } satisfies OneShotConfig;
 
 describe("init config writer", () => {

--- a/apps/cli/src/commands/config.ts
+++ b/apps/cli/src/commands/config.ts
@@ -1,4 +1,11 @@
-import { getLedger, loadConfig, saveConfig, saveSecrets, secretsPath } from "@oneshot-gtm/core";
+import {
+  getLedger,
+  dailySpendStatus,
+  loadConfig,
+  saveConfig,
+  saveSecrets,
+  secretsPath,
+} from "@oneshot-gtm/core";
 import { TRIGGERS, checkReadiness } from "@oneshot-gtm/find";
 import { withXEngine, type XEngine } from "@oneshot-gtm/shared-types";
 import prompts from "prompts";
@@ -124,6 +131,43 @@ export async function configTelemetry(state: "on" | "off"): Promise<void> {
   const cfg = loadConfig();
   saveConfig({ ...cfg, telemetryEnabled: state === "on" });
   ok(`telemetry ${state === "on" ? c.green("enabled") : c.dim("disabled")}`);
+}
+
+/**
+ * Show or set the install-wide daily USD spend ceiling (issue #481). No
+ * argument prints the current ceiling + today's spend; `off` clears it back
+ * to unlimited (the historical default); any other value must parse as a
+ * positive number.
+ */
+export async function configSpendCeiling(amountArg?: string): Promise<void> {
+  header("Daily spend ceiling");
+  const cfg = loadConfig();
+
+  if (amountArg === undefined) {
+    const status = dailySpendStatus();
+    if (cfg.dailySpendCeilingUsd == null) {
+      note("unlimited (no ceiling set)");
+    } else {
+      note(
+        `$${status.effectiveUsd.toFixed(2)} / $${cfg.dailySpendCeilingUsd.toFixed(2)} spent today${status.ceilingReached ? c.dim(" — ceiling reached, automated paths halted") : ""}`,
+      );
+    }
+    note(c.dim(`set with: oneshot-gtm config spend-ceiling <amount|off>`));
+    return;
+  }
+
+  if (amountArg === "off") {
+    saveConfig({ ...cfg, dailySpendCeilingUsd: null });
+    ok("daily spend ceiling cleared — unlimited");
+    return;
+  }
+
+  const amount = Number.parseFloat(amountArg);
+  if (!Number.isFinite(amount) || amount <= 0) {
+    throw new Error(`invalid amount '${amountArg}' — pass a positive number of USD, or 'off'`);
+  }
+  saveConfig({ ...cfg, dailySpendCeilingUsd: amount });
+  ok(`daily spend ceiling set to $${amount.toFixed(2)}`);
 }
 
 const X_TRIGGER = "x-reposters";

--- a/apps/cli/src/commands/config.ts
+++ b/apps/cli/src/commands/config.ts
@@ -162,7 +162,11 @@ export async function configSpendCeiling(amountArg?: string): Promise<void> {
     return;
   }
 
-  const amount = Number.parseFloat(amountArg);
+  // Number(), not Number.parseFloat(): parseFloat parses a numeric PREFIX
+  // and ignores trailing garbage (e.g. "2usd" -> 2), silently persisting a
+  // ceiling the user didn't type. Number() requires the whole string to be
+  // numeric, so "2usd" -> NaN and falls into the rejection below.
+  const amount = Number(amountArg);
   if (!Number.isFinite(amount) || amount <= 0) {
     throw new Error(`invalid amount '${amountArg}' — pass a positive number of USD, or 'off'`);
   }

--- a/apps/cli/src/commands/find.ts
+++ b/apps/cli/src/commands/find.ts
@@ -96,7 +96,18 @@ export async function commandFindDrain(opts: {
       sent: result.sent,
       deferred: result.deferred,
       errors: result.errors.map((e) => ({ id: e.id, message: e.message })),
+      ...(result.haltedReason ? { haltedReason: result.haltedReason } : {}),
     });
+  }
+
+  // Daily spend ceiling (issue #481): distinct from "nothing to drain" — rows
+  // ARE approved and waiting, the automated path is just blocked until the
+  // ceiling resets at local midnight or the founder raises it. Manual sends
+  // from /queue still work; only this batch path is gated.
+  if (result.haltedReason) {
+    warn(`find drain ${opts.play}: ${result.haltedReason}`);
+    if (opts.failOnEmpty) bail(`find drain ${opts.play}: ${result.haltedReason}`);
+    return;
   }
 
   // Errors beat emptiness: a drain with row errors (or an invalid play) exits 1,

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -14,6 +14,7 @@ import {
   configFounder,
   configKeys,
   configLlm,
+  configSpendCeiling,
   configTelemetry,
   configXEngine,
 } from "./commands/config.ts";
@@ -234,6 +235,12 @@ config
     "Show or switch the x-reposters data provider (xapi = first-party X API, twitterapiio = ~55x cheaper third-party)",
   )
   .action(runOrFail((engine?: string) => configXEngine(engine)));
+config
+  .command("spend-ceiling [amount]")
+  .description(
+    "Show or set the install-wide daily USD spend ceiling (halts automated finder/drain runs once reached; 'off' clears it)",
+  )
+  .action(runOrFail((amount?: string) => configSpendCeiling(amount)));
 
 // Gmail send path: OAuth consent flow for the alternate (non-OneShot) provider.
 const gmail = program

--- a/apps/server/__tests__/setup-public-cfg.test.ts
+++ b/apps/server/__tests__/setup-public-cfg.test.ts
@@ -34,6 +34,7 @@ const FULL_CFG: OneShotConfig = {
   mobileSignature: false,
   timezone: "Europe/Vienna",
   clientId: "11111111-2222-3333-4444-555555555555",
+  dailySpendCeilingUsd: null,
 };
 
 describe("publicCfg — privacy boundary", () => {

--- a/apps/server/__tests__/setup-public-cfg.test.ts
+++ b/apps/server/__tests__/setup-public-cfg.test.ts
@@ -80,4 +80,63 @@ describe("setup config writer", () => {
     expect(next.timezone).toBe("Europe/Vienna");
     expect(next.cadenceOverrides).toEqual({ "show-hn": [2, 5] });
   });
+
+  // Round-1 review finding: the CLI path (configSpendCeiling) validates the
+  // ceiling must be a finite positive number, but this API path accepted
+  // body.dailySpendCeilingUsd verbatim. A ceiling of 0 makes
+  // effectiveUsd (0) >= ceilingUsd (0) true immediately, silently halting
+  // every automated finder/drain install-wide.
+  describe("dailySpendCeilingUsd validation", () => {
+    it("undefined leaves the existing ceiling untouched", () => {
+      const next = mergeSetupConfig(
+        { ...FULL_CFG, dailySpendCeilingUsd: 25 },
+        {},
+        FULL_CFG.emailIdentities,
+      );
+      expect(next.dailySpendCeilingUsd).toBe(25);
+    });
+
+    it("null clears the ceiling back to unlimited", () => {
+      const next = mergeSetupConfig(
+        { ...FULL_CFG, dailySpendCeilingUsd: 25 },
+        { dailySpendCeilingUsd: null },
+        FULL_CFG.emailIdentities,
+      );
+      expect(next.dailySpendCeilingUsd).toBeNull();
+    });
+
+    it("accepts a positive finite number", () => {
+      const next = mergeSetupConfig(
+        FULL_CFG,
+        { dailySpendCeilingUsd: 12.5 },
+        FULL_CFG.emailIdentities,
+      );
+      expect(next.dailySpendCeilingUsd).toBe(12.5);
+    });
+
+    it("rejects 0 — would halt every automated path immediately", () => {
+      expect(() =>
+        mergeSetupConfig(FULL_CFG, { dailySpendCeilingUsd: 0 }, FULL_CFG.emailIdentities),
+      ).toThrow(/invalid dailySpendCeilingUsd/);
+    });
+
+    it("rejects a negative number", () => {
+      expect(() =>
+        mergeSetupConfig(FULL_CFG, { dailySpendCeilingUsd: -5 }, FULL_CFG.emailIdentities),
+      ).toThrow(/invalid dailySpendCeilingUsd/);
+    });
+
+    it("rejects NaN and Infinity (a raw JSON body can smuggle these via JSON.parse edge cases)", () => {
+      expect(() =>
+        mergeSetupConfig(FULL_CFG, { dailySpendCeilingUsd: Number.NaN }, FULL_CFG.emailIdentities),
+      ).toThrow(/invalid dailySpendCeilingUsd/);
+      expect(() =>
+        mergeSetupConfig(
+          FULL_CFG,
+          { dailySpendCeilingUsd: Number.POSITIVE_INFINITY },
+          FULL_CFG.emailIdentities,
+        ),
+      ).toThrow(/invalid dailySpendCeilingUsd/);
+    });
+  });
 });

--- a/apps/server/src/api/queue.ts
+++ b/apps/server/src/api/queue.ts
@@ -214,6 +214,7 @@ export async function drainQueueRoute(req: Request): Promise<Response> {
       drained: result.drained,
       sent: result.sent,
       errors: result.errors,
+      ...(result.haltedReason ? { haltedReason: result.haltedReason } : {}),
     };
     return jsonResponse(view, 200, req);
   } catch (err) {

--- a/apps/server/src/api/setup.ts
+++ b/apps/server/src/api/setup.ts
@@ -235,7 +235,7 @@ export function mergeSetupConfig(
     dailySpendCeilingUsd:
       body.dailySpendCeilingUsd === undefined
         ? current.dailySpendCeilingUsd
-        : body.dailySpendCeilingUsd,
+        : validateSpendCeiling(body.dailySpendCeilingUsd),
   };
 }
 
@@ -249,4 +249,25 @@ function mergeString(incoming: string | undefined, current: string | null): stri
   if (incoming === undefined) return current;
   const trimmed = incoming.trim();
   return trimmed.length === 0 ? null : trimmed;
+}
+
+/**
+ * Same validation the CLI path (`configSpendCeiling`) already enforces
+ * before persisting the daily USD spend ceiling — `null` clears it back to
+ * unlimited, anything else must be a positive finite number. Without this,
+ * a direct API client (or a founder typing/submitting 0 in the /setup form,
+ * whose `<Input type="number" min="0">` doesn't stop 0) could persist a
+ * ceiling of 0, negative, or NaN. A ceiling of 0 makes
+ * `effectiveUsd (0) >= ceilingUsd (0)` true immediately with zero spend —
+ * silently halting every scheduled finder, run-now, and automatic drain
+ * install-wide, the opposite of the unlimited default this feature ships.
+ */
+function validateSpendCeiling(value: number | null): number | null {
+  if (value === null) return null;
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(
+      `invalid dailySpendCeilingUsd '${value}' — must be a positive number of USD, or null to clear`,
+    );
+  }
+  return value;
 }

--- a/apps/server/src/api/setup.ts
+++ b/apps/server/src/api/setup.ts
@@ -232,6 +232,10 @@ export function mergeSetupConfig(
     founderAdmission: mergeString(body.founderAdmission, current.founderAdmission),
     productBrief: mergeString(body.productBrief, current.productBrief),
     mobileSignature: body.mobileSignature ?? current.mobileSignature,
+    dailySpendCeilingUsd:
+      body.dailySpendCeilingUsd === undefined
+        ? current.dailySpendCeilingUsd
+        : body.dailySpendCeilingUsd,
   };
 }
 

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -199,6 +199,7 @@ export const api = {
         founderAdmission: string | null;
         productBrief: string | null;
         mobileSignature: boolean;
+        dailySpendCeilingUsd: number | null;
         llmProvider: "openrouter" | "openai" | "anthropic";
         llmModel: string;
         telemetryEnabled: boolean;

--- a/apps/web/src/routes/setup.tsx
+++ b/apps/web/src/routes/setup.tsx
@@ -122,7 +122,12 @@ function SetupPage() {
   const [mobileSignature, setMobileSignature] = useState(false);
   // "" = unlimited (no ceiling). A positive-number string is the ceiling in
   // USD; kept as a string so the field can be temporarily empty while typing.
+  // Same dirty-flag pattern as briefDirty: a pause/resume action invalidates
+  // ["setup"] mid-edit, and without this the hydrate effect below would
+  // silently overwrite whatever the founder just typed with the persisted
+  // value.
   const [dailySpendCeiling, setDailySpendCeiling] = useState("");
+  const spendCeilingDirty = useRef(false);
   const [secrets, setSecrets] = useState<Record<string, string>>({});
   const [savedAt, setSavedAt] = useState<number | null>(null);
 
@@ -158,7 +163,13 @@ function SetupPage() {
     if (!briefDirty.current) setProductBrief(c.productBrief ?? "");
     setBriefSources((prev) => prev || (c.productDomain ? `https://${c.productDomain}` : ""));
     setMobileSignature(c.mobileSignature ?? false);
-    setDailySpendCeiling(c.dailySpendCeilingUsd != null ? String(c.dailySpendCeilingUsd) : "");
+    setDailySpendCeiling((prev) =>
+      spendCeilingDirty.current
+        ? prev
+        : c.dailySpendCeilingUsd != null
+          ? String(c.dailySpendCeilingUsd)
+          : "",
+    );
     setLlmProvider(c.llmProvider);
     setLlmModel(c.llmModel || LLM_DEFAULTS[c.llmProvider] || "");
     setTelemetryEnabled(c.telemetryEnabled);
@@ -309,6 +320,7 @@ function SetupPage() {
       setAddMailbox("");
       setAddCap("");
       briefDirty.current = false;
+      spendCeilingDirty.current = false;
       setSavedAt(Date.now());
       // Re-seed the engine select from the refetched trigger row.
       xEngineSeeded.current = false;
@@ -781,7 +793,10 @@ function SetupPage() {
                 step="0.01"
                 placeholder="unlimited"
                 value={dailySpendCeiling}
-                onChange={(e) => setDailySpendCeiling(e.target.value)}
+                onChange={(e) => {
+                  setDailySpendCeiling(e.target.value);
+                  spendCeilingDirty.current = true;
+                }}
               />
             </Field>
           </div>

--- a/apps/web/src/routes/setup.tsx
+++ b/apps/web/src/routes/setup.tsx
@@ -101,6 +101,9 @@ function SetupPage() {
   const [briefSources, setBriefSources] = useState("");
   const [briefDeriveInfo, setBriefDeriveInfo] = useState<string | null>(null);
   const [mobileSignature, setMobileSignature] = useState(false);
+  // "" = unlimited (no ceiling). A positive-number string is the ceiling in
+  // USD; kept as a string so the field can be temporarily empty while typing.
+  const [dailySpendCeiling, setDailySpendCeiling] = useState("");
   const [secrets, setSecrets] = useState<Record<string, string>>({});
   const [savedAt, setSavedAt] = useState<number | null>(null);
 
@@ -136,6 +139,7 @@ function SetupPage() {
     if (!briefDirty.current) setProductBrief(c.productBrief ?? "");
     setBriefSources((prev) => prev || (c.productDomain ? `https://${c.productDomain}` : ""));
     setMobileSignature(c.mobileSignature ?? false);
+    setDailySpendCeiling(c.dailySpendCeilingUsd != null ? String(c.dailySpendCeilingUsd) : "");
     setLlmProvider(c.llmProvider);
     setLlmModel(c.llmModel || LLM_DEFAULTS[c.llmProvider] || "");
     setTelemetryEnabled(c.telemetryEnabled);
@@ -258,6 +262,8 @@ function SetupPage() {
         founderAdmission,
         productBrief,
         mobileSignature,
+        dailySpendCeilingUsd:
+          dailySpendCeiling.trim() === "" ? null : Number.parseFloat(dailySpendCeiling),
         llmProvider,
         llmModel,
         telemetryEnabled,
@@ -746,6 +752,20 @@ function SetupPage() {
                 />
               </Field>
             )}
+            <Field
+              label="Daily spend ceiling (USD)"
+              className="md:col-span-2"
+              hint="Install-wide cap across every automated finder run and drain — blank = unlimited. Once reached, scheduled/run-now finders and drains halt with a named reason (visible here and in doctor) until local midnight; manual /queue sends are never blocked."
+            >
+              <Input
+                type="number"
+                min="0"
+                step="0.01"
+                placeholder="unlimited"
+                value={dailySpendCeiling}
+                onChange={(e) => setDailySpendCeiling(e.target.value)}
+              />
+            </Field>
           </div>
         </LedgerSection>
 

--- a/apps/web/src/routes/setup.tsx
+++ b/apps/web/src/routes/setup.tsx
@@ -48,6 +48,25 @@ const SECRET_LABELS: Record<string, string> = {
 
 const X_OAUTH_KEYS = ["X_API_KEY", "X_API_SECRET", "X_ACCESS_TOKEN", "X_ACCESS_SECRET"] as const;
 
+/**
+ * Blank = unlimited (null). Otherwise must parse to a positive finite
+ * number — matches the CLI path's validation (`configSpendCeiling`) and
+ * the server's own re-check (`mergeSetupConfig` → `validateSpendCeiling`).
+ * A submitted 0/negative/NaN throws here instead of silently reaching the
+ * API, where a ceiling of 0 would halt every automated finder and drain
+ * install-wide immediately.
+ */
+function parseDailySpendCeiling(raw: string): number | null {
+  if (raw.trim() === "") return null;
+  const n = Number.parseFloat(raw);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new Error(
+      `invalid daily spend ceiling '${raw}' — enter a positive number of USD, or leave blank`,
+    );
+  }
+  return n;
+}
+
 function SetupPage() {
   const qc = useQueryClient();
   const status = useQuery({ queryKey: ["setup"], queryFn: api.setupStatus });
@@ -262,8 +281,7 @@ function SetupPage() {
         founderAdmission,
         productBrief,
         mobileSignature,
-        dailySpendCeilingUsd:
-          dailySpendCeiling.trim() === "" ? null : Number.parseFloat(dailySpendCeiling),
+        dailySpendCeilingUsd: parseDailySpendCeiling(dailySpendCeiling),
         llmProvider,
         llmModel,
         telemetryEnabled,
@@ -759,7 +777,7 @@ function SetupPage() {
             >
               <Input
                 type="number"
-                min="0"
+                min="0.01"
                 step="0.01"
                 placeholder="unlimited"
                 value={dailySpendCeiling}

--- a/packages/core/__tests__/__snapshots__/ledger.test.ts.snap
+++ b/packages/core/__tests__/__snapshots__/ledger.test.ts.snap
@@ -193,6 +193,12 @@ exports[`Ledger schema migration > fresh-install schema (tables, columns, indexe
       "type": "index",
     },
     {
+      "name": "idx_spend_reservations_created",
+      "sql": "CREATE INDEX idx_spend_reservations_created ON spend_reservations(created_at)",
+      "tbl_name": "spend_reservations",
+      "type": "index",
+    },
+    {
       "name": "idx_webhook_replays_expiry",
       "sql": "CREATE INDEX idx_webhook_replays_expiry
         ON webhook_replays(expires_at)",
@@ -483,6 +489,16 @@ exports[`Ledger schema migration > fresh-install schema (tables, columns, indexe
         FOREIGN KEY(prospect_id) REFERENCES prospects(id)
       )",
       "tbl_name": "sequence_events",
+      "type": "table",
+    },
+    {
+      "name": "spend_reservations",
+      "sql": "CREATE TABLE spend_reservations (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        amount_usd REAL NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      )",
+      "tbl_name": "spend_reservations",
       "type": "table",
     },
     {

--- a/packages/core/__tests__/config.test.ts
+++ b/packages/core/__tests__/config.test.ts
@@ -96,6 +96,7 @@ describe("bootstrapClientId", () => {
     mobileSignature: false,
     timezone: null,
     clientId: null,
+    dailySpendCeilingUsd: null,
   };
 
   it("mints a UUID-shaped clientId when none is stored", () => {

--- a/packages/core/__tests__/daily-spend.test.ts
+++ b/packages/core/__tests__/daily-spend.test.ts
@@ -239,3 +239,62 @@ describe("estimation defaults", () => {
     expect(DEFAULT_DRAIN_ROW_RESERVATION_USD).toBeGreaterThan(0);
   });
 });
+
+describe("Ledger.reserveSpendIfUnderCeiling — cross-connection atomicity", () => {
+  // Round-1 review finding: tryReserveDailySpend's check-then-reserve used to
+  // be a plain SELECT (dailySpendStatus) followed by a separate INSERT
+  // (ledger.reserveSpend) — two round-trips. That's serialized for free
+  // within one Bun process (same event loop, same Ledger instance, as every
+  // other test in this file exercises), but the issue's own scope is eleven
+  // independently-scheduled finders, and this repo runs `find watch --once`
+  // as a SEPARATE OS process from the server's in-process scheduler. Two
+  // separate SQLite connections in WAL mode can each pass a plain SELECT
+  // before either INSERTs. This test opens a SECOND real connection to the
+  // SAME on-disk database — not just a second call on the same Ledger
+  // instance — to prove the check-then-reserve is atomic across connections,
+  // the way Ledger.dequeueApproved's own BEGIN IMMEDIATE closes the same
+  // TOCTOU class for concurrent drains.
+  it("two separate connections racing the same budget: only one is granted", () => {
+    const secondConnection = new Ledger(dbPath);
+    try {
+      const sinceIso = "1970-01-01 00:00:00";
+      const ceilingUsd = 6;
+      // Both "processes" read the SAME pre-reservation state (nothing spent
+      // yet) before either reserves — simulating two finders firing on the
+      // same tick from different OS processes.
+      const first = ledger.reserveSpendIfUnderCeiling({ sinceIso, ceilingUsd, amountUsd: 4 });
+      const second = secondConnection.reserveSpendIfUnderCeiling({
+        sinceIso,
+        ceilingUsd,
+        amountUsd: 4,
+      });
+      expect(first).not.toBeNull();
+      // Without cross-connection atomicity, `second` would also read "0
+      // reserved" and be granted too — 4+4=8 blowing past the 6 ceiling
+      // before either reservation's estimate was accounted for.
+      expect(second).toBeNull();
+      expect(ledger.reservedSpendUsd(sinceIso)).toBe(4);
+    } finally {
+      secondConnection.close();
+    }
+  });
+
+  it("a released reservation on one connection frees room seen by another connection", () => {
+    const secondConnection = new Ledger(dbPath);
+    try {
+      const sinceIso = "1970-01-01 00:00:00";
+      const ceilingUsd = 6;
+      const first = ledger.reserveSpendIfUnderCeiling({ sinceIso, ceilingUsd, amountUsd: 4 });
+      expect(first).not.toBeNull();
+      ledger.releaseSpendReservation(first as number);
+      const second = secondConnection.reserveSpendIfUnderCeiling({
+        sinceIso,
+        ceilingUsd,
+        amountUsd: 4,
+      });
+      expect(second).not.toBeNull();
+    } finally {
+      secondConnection.close();
+    }
+  });
+});

--- a/packages/core/__tests__/daily-spend.test.ts
+++ b/packages/core/__tests__/daily-spend.test.ts
@@ -1,0 +1,241 @@
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Ledger } from "../src/ledger.ts";
+import type { OneShotConfig } from "../src/types.ts";
+
+/**
+ * Install-wide daily USD spend ceiling (issue #481). Covers:
+ *  - aggregation (posted receipts + held reservations = "effective" spend)
+ *  - concurrent reservations (two callers racing the same tick both get
+ *    counted before either one's spend posts to `receipts`)
+ *  - blocked-path reporting (the named reason string, refused-not-reserved)
+ *  - manual-send behavior (nothing here ever calls tryReserveDailySpend —
+ *    that's the acceptance criterion: manual /queue actions never consult
+ *    the ceiling. Asserted by omission: manual routes only ever call
+ *    ledger.setQueueStatus/setQueueDraft directly, never daily-spend.ts)
+ *  - midnight-boundary behavior (yesterday's spend/reservations don't count
+ *    against today; the ceiling resets)
+ */
+
+let dbPath: string;
+let ledger: Ledger;
+let mockCfg: Partial<OneShotConfig>;
+
+vi.mock("../src/config.ts", async () => {
+  const actual = await vi.importActual<typeof import("../src/config.ts")>("../src/config.ts");
+  return {
+    ...actual,
+    loadConfig: () => ({ ...actual.loadConfig(), ...mockCfg }),
+  };
+});
+
+vi.mock("../src/ledger.ts", async () => {
+  const actual = await vi.importActual<typeof import("../src/ledger.ts")>("../src/ledger.ts");
+  return {
+    ...actual,
+    getLedger: () => ledger,
+  };
+});
+
+const {
+  dailySpendStatus,
+  spendCeilingReason,
+  tryReserveDailySpend,
+  DEFAULT_SPEND_RESERVATION_USD,
+  DEFAULT_DRAIN_ROW_RESERVATION_USD,
+} = await import("../src/daily-spend.ts");
+
+/** Reach the private `db` handle for backdating created_at (same pattern send-routing.test.ts uses). */
+function rawDb(): { prepare(s: string): { run(...a: unknown[]): unknown } } {
+  return (ledger as unknown as { db: { prepare(s: string): { run(...a: unknown[]): unknown } } })
+    .db;
+}
+
+function recordSpend(amountUsd: number, whenIso?: string): void {
+  const id = ledger.recordReceipt({
+    playName: "test-play",
+    callType: "email.find",
+    costUsd: amountUsd,
+  });
+  if (whenIso) {
+    // Backdate the receipt directly — recordReceipt always stamps "now".
+    rawDb().prepare(`UPDATE receipts SET created_at = ? WHERE id = ?`).run(whenIso, id);
+  }
+}
+
+/** SQLite UTC timestamp for `hoursAgo` hours before now, in receipts.created_at's format. */
+function hoursAgoSqlite(hoursAgo: number): string {
+  return new Date(Date.now() - hoursAgo * 3600 * 1000).toISOString().slice(0, 19).replace("T", " ");
+}
+
+beforeEach(() => {
+  dbPath = join(
+    tmpdir(),
+    `oneshot-gtm-daily-spend-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`,
+  );
+  ledger = new Ledger(dbPath);
+  mockCfg = { dailySpendCeilingUsd: null };
+});
+
+afterEach(() => {
+  ledger.close();
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      rmSync(`${dbPath}${suffix}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+describe("dailySpendStatus — aggregation", () => {
+  it("unlimited (ceilingUsd null) when no ceiling is configured", () => {
+    const status = dailySpendStatus();
+    expect(status.ceilingUsd).toBeNull();
+    expect(status.remainingUsd).toBeNull();
+    expect(status.ceilingReached).toBe(false);
+  });
+
+  it("effectiveUsd sums posted spend AND held reservations", () => {
+    mockCfg = { dailySpendCeilingUsd: 10 };
+    recordSpend(3);
+    const held = tryReserveDailySpend(2);
+    expect(held.granted).toBe(true);
+
+    const status = dailySpendStatus();
+    expect(status.spentUsd).toBe(3);
+    expect(status.reservedUsd).toBe(2);
+    expect(status.effectiveUsd).toBe(5);
+    expect(status.remainingUsd).toBe(5);
+    expect(status.ceilingReached).toBe(false);
+  });
+
+  it("ceilingReached flips true once effective spend meets (>=) the ceiling", () => {
+    mockCfg = { dailySpendCeilingUsd: 5 };
+    recordSpend(5);
+    const status = dailySpendStatus();
+    expect(status.ceilingReached).toBe(true);
+    expect(status.remainingUsd).toBe(0); // floored at 0, never negative
+  });
+
+  it("remainingUsd never goes negative when spend overshoots the ceiling", () => {
+    mockCfg = { dailySpendCeilingUsd: 5 };
+    recordSpend(8);
+    expect(dailySpendStatus().remainingUsd).toBe(0);
+  });
+});
+
+describe("tryReserveDailySpend — blocked-path reporting", () => {
+  it("grants a reservation and releases cleanly under the ceiling", () => {
+    mockCfg = { dailySpendCeilingUsd: 10 };
+    const outcome = tryReserveDailySpend(4);
+    expect(outcome.granted).toBe(true);
+    if (!outcome.granted) throw new Error("expected granted");
+    expect(dailySpendStatus().reservedUsd).toBe(4);
+    outcome.release();
+    expect(dailySpendStatus().reservedUsd).toBe(0);
+  });
+
+  it("refuses outright — never reserves-then-over — once at/over the ceiling", () => {
+    mockCfg = { dailySpendCeilingUsd: 5 };
+    recordSpend(5);
+    const outcome = tryReserveDailySpend(1);
+    expect(outcome.granted).toBe(false);
+    if (outcome.granted) throw new Error("expected refused");
+    // The named reason surfaced on trigger cards / doctor / drain output.
+    expect(outcome.reason).toBe(spendCeilingReason(outcome.status));
+    expect(outcome.reason).toContain("daily spend ceiling reached");
+    expect(outcome.reason).toContain("$5.00");
+    // Refusing must not have reserved anything against the day.
+    expect(dailySpendStatus().reservedUsd).toBe(0);
+  });
+
+  it("release() is idempotent — a finally + an explicit release must not double-delete", () => {
+    mockCfg = { dailySpendCeilingUsd: 10 };
+    const outcome = tryReserveDailySpend(3);
+    if (!outcome.granted) throw new Error("expected granted");
+    outcome.release();
+    outcome.release(); // second call must be a no-op, not throw or double-decrement
+    expect(dailySpendStatus().reservedUsd).toBe(0);
+  });
+});
+
+describe("tryReserveDailySpend — concurrent reservations", () => {
+  it("two racing automated calls both count before either one's spend posts", () => {
+    // The whole point of reservations: without them, two calls reading
+    // "today's spend = $0" at the same tick could both start and together
+    // blow past the ceiling before either one's receipt lands.
+    mockCfg = { dailySpendCeilingUsd: 6 };
+    const first = tryReserveDailySpend(4);
+    const second = tryReserveDailySpend(4);
+    expect(first.granted).toBe(true);
+    // Second call sees the first's reservation already counted (4+4=8 > 6),
+    // so it must be refused even though NO actual spend has posted to
+    // `receipts` yet.
+    expect(second.granted).toBe(false);
+    if (second.granted) throw new Error("expected refused");
+    expect(second.reason).toContain("daily spend ceiling reached");
+  });
+
+  it("a released reservation frees room for the next caller in the same tick", () => {
+    mockCfg = { dailySpendCeilingUsd: 6 };
+    const first = tryReserveDailySpend(4);
+    if (!first.granted) throw new Error("expected granted");
+    first.release(); // simulates the first call finishing (success or failure)
+    const second = tryReserveDailySpend(4);
+    expect(second.granted).toBe(true);
+  });
+
+  it("sweeps a stale (crashed-process) reservation before checking the ceiling", () => {
+    mockCfg = { dailySpendCeilingUsd: 6 };
+    // Simulate an orphaned reservation from a killed process: reserve, never release.
+    const orphan = tryReserveDailySpend(5);
+    expect(orphan.granted).toBe(true);
+    // A fresh caller shortly after would normally be refused (5 held + a new
+    // 5 estimate tips over 6), but tryReserveDailySpend sweeps anything past
+    // its stale window first — simulate that by aging the row past it.
+    rawDb().prepare(`UPDATE spend_reservations SET created_at = datetime('now', '-3 hours')`).run();
+    const later = tryReserveDailySpend(5);
+    expect(later.granted).toBe(true); // the orphan was swept, so full room is available
+  });
+});
+
+describe("dailySpendStatus / tryReserveDailySpend — midnight-boundary behavior", () => {
+  it("yesterday's posted spend does not count against today", () => {
+    mockCfg = { dailySpendCeilingUsd: 5 };
+    recordSpend(5, hoursAgoSqlite(25)); // well before local midnight
+    const status = dailySpendStatus();
+    expect(status.spentUsd).toBe(0);
+    expect(status.ceilingReached).toBe(false);
+  });
+
+  it("yesterday's stale reservation is excluded from today's reservedUsd window", () => {
+    mockCfg = { dailySpendCeilingUsd: 5 };
+    const outcome = tryReserveDailySpend(4);
+    if (!outcome.granted) throw new Error("expected granted");
+    // Backdate the reservation itself to yesterday (crashed before release,
+    // AND happens to straddle the day boundary).
+    rawDb().prepare(`UPDATE spend_reservations SET created_at = ?`).run(hoursAgoSqlite(25));
+    expect(dailySpendStatus().reservedUsd).toBe(0);
+  });
+
+  it("a trigger that halted yesterday at the ceiling is not halted today (reset)", () => {
+    mockCfg = { dailySpendCeilingUsd: 5 };
+    recordSpend(5, hoursAgoSqlite(25)); // yesterday's spend reached the ceiling
+    const outcome = tryReserveDailySpend(1); // today's first automated call
+    expect(outcome.granted).toBe(true); // fresh day, fresh budget
+  });
+});
+
+describe("estimation defaults", () => {
+  it("DEFAULT_SPEND_RESERVATION_USD and DEFAULT_DRAIN_ROW_RESERVATION_USD are positive", () => {
+    // Sanity check on the constants estimatedTriggerSpendUsd / drainQueue
+    // fall back to for a finder/drain with no explicit spend cap — a zero or
+    // negative default would let a "free" caller starve nothing (harmless)
+    // or reserve nothing (defeats the whole point of reserving).
+    expect(DEFAULT_SPEND_RESERVATION_USD).toBeGreaterThan(0);
+    expect(DEFAULT_DRAIN_ROW_RESERVATION_USD).toBeGreaterThan(0);
+  });
+});

--- a/packages/core/__tests__/daily-spend.test.ts
+++ b/packages/core/__tests__/daily-spend.test.ts
@@ -196,7 +196,7 @@ describe("tryReserveDailySpend — concurrent reservations", () => {
     // A fresh caller shortly after would normally be refused (5 held + a new
     // 5 estimate tips over 6), but tryReserveDailySpend sweeps anything past
     // its stale window first — simulate that by aging the row past it.
-    rawDb().prepare(`UPDATE spend_reservations SET created_at = datetime('now', '-3 hours')`).run();
+    rawDb().prepare(`UPDATE spend_reservations SET created_at = datetime('now', '-6 hours')`).run();
     const later = tryReserveDailySpend(5);
     expect(later.granted).toBe(true); // the orphan was swept, so full room is available
   });

--- a/packages/core/__tests__/identities-oneshot.test.ts
+++ b/packages/core/__tests__/identities-oneshot.test.ts
@@ -46,6 +46,7 @@ const BASE: OneShotConfig = {
   mobileSignature: false,
   timezone: null,
   clientId: null,
+  dailySpendCeilingUsd: null,
 };
 
 beforeEach(() => {

--- a/packages/core/__tests__/identities-smartlead.test.ts
+++ b/packages/core/__tests__/identities-smartlead.test.ts
@@ -42,6 +42,7 @@ const BASE: OneShotConfig = {
   mobileSignature: false,
   timezone: null,
   clientId: null,
+  dailySpendCeilingUsd: null,
 };
 
 beforeEach(() => {

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -52,6 +52,7 @@ const DEFAULTS: OneShotConfig = {
   mobileSignature: false,
   timezone: null,
   clientId: null,
+  dailySpendCeilingUsd: null,
 };
 
 export function configDir(): string {

--- a/packages/core/src/daily-spend.ts
+++ b/packages/core/src/daily-spend.ts
@@ -98,9 +98,23 @@ export type SpendReservationOutcome =
  * Gate + reserve in one call: the shared entry point for every automated
  * paid path (finder trigger runs, automatic drains). Sweeps orphaned
  * reservations first so a crashed process can't hold spend hostage for the
- * rest of the day, then checks the ceiling BEFORE reserving — a call that
- * would push effective spend at/over the ceiling is refused outright rather
- * than reserved-then-immediately-over.
+ * rest of the day, then checks the ceiling and reserves atomically — a call
+ * that would push effective spend at/over the ceiling is refused outright
+ * rather than reserved-then-immediately-over.
+ *
+ * The check-then-reserve itself happens in ONE SQLite transaction on the
+ * ledger connection (`Ledger.reserveSpendIfUnderCeiling`, `BEGIN IMMEDIATE`
+ * — the same pattern `Ledger.dequeueApproved`/`claimMarker` use to close
+ * their own cross-process claim races). That matters beyond this one Bun
+ * process: the issue's own scope is eleven independently-scheduled finders,
+ * and this repo runs `find watch --once` as a separate cron/launchd process
+ * from the server's in-process scheduler (apps/cli/src/commands/install-service.ts,
+ * apps/server/src/scheduler.ts) — two OS processes hitting the same SQLite
+ * file in WAL mode. A plain SELECT-then-INSERT across two connections can
+ * let both pass the SELECT before either INSERTs; wrapping both steps in one
+ * IMMEDIATE transaction on the ledger's own connection serializes them, so
+ * the second caller's read only happens after the first caller's write has
+ * committed (or vice versa).
  *
  * `estimateUsd` should be the caller's own worst-case bound for this one
  * call (a finder's `maxCostUsd`, a drain's conservative per-batch estimate)
@@ -114,21 +128,24 @@ export function tryReserveDailySpend(
 ): SpendReservationOutcome {
   const ledger = getLedger();
   ledger.sweepStaleSpendReservations(SPEND_RESERVATION_STALE_MS, now);
+  const amountUsd = Math.max(0, estimateUsd);
+  const ceilingUsd = loadConfig().dailySpendCeilingUsd;
+
+  // Unlimited (no ceiling configured): nothing to race against — reserve
+  // directly so `reservedUsd` still reports accurately, same as before.
+  const id =
+    ceilingUsd == null
+      ? ledger.reserveSpend(amountUsd)
+      : ledger.reserveSpendIfUnderCeiling({
+          sinceIso: todayStartSqliteUtc(now),
+          ceilingUsd,
+          amountUsd,
+        });
+
   const status = dailySpendStatus(now);
-  // Refuse when EITHER the ceiling is already reached OR this call's own
-  // worst-case estimate would push effective spend at/over it. Checking
-  // `status.ceilingReached` alone (the current effective spend) is not
-  // enough: two concurrent calls can each pass that check against the SAME
-  // pre-reservation total and both reserve, together blowing past the
-  // ceiling before either one's estimate is accounted for. Folding the
-  // incoming estimate into the comparison is what actually closes the race.
-  const wouldExceed =
-    status.ceilingUsd != null &&
-    status.effectiveUsd + Math.max(0, estimateUsd) >= status.ceilingUsd;
-  if (status.ceilingReached || wouldExceed) {
+  if (id == null) {
     return { granted: false, reason: spendCeilingReason(status), status };
   }
-  const id = ledger.reserveSpend(Math.max(0, estimateUsd));
   let released = false;
   return {
     granted: true,

--- a/packages/core/src/daily-spend.ts
+++ b/packages/core/src/daily-spend.ts
@@ -31,8 +31,21 @@ import { todayStartSqliteUtc } from "./send-routing.ts";
  * starts and reset together.
  */
 
-/** A held-open reservation older than this is presumed orphaned by a crashed process and swept. */
-const SPEND_RESERVATION_STALE_MS = 2 * 3600 * 1000;
+/**
+ * A held-open reservation older than this is presumed orphaned by a crashed
+ * process and swept. Must stay ABOVE `find/src/registry.ts`'s
+ * `MAX_RUN_AGE_MS` (4h) — that's the threshold governing how long a
+ * trigger's own claim (`running_started_at`) is still treated as a
+ * legitimately-running, non-crashed process. `core` can't import that
+ * constant directly (`find` depends on `core`, not the reverse), so this is
+ * a deliberately-generous fixed value instead of a shared import; if
+ * `MAX_RUN_AGE_MS` ever changes, this needs a matching bump. A shorter
+ * staleness window here than the claim's own would let any concurrent
+ * `tryReserveDailySpend` caller sweep — and re-grant to someone else — the
+ * reservation of a run that's still legitimately in flight and whose real
+ * spend hasn't posted to `receipts` yet.
+ */
+const SPEND_RESERVATION_STALE_MS = 5 * 3600 * 1000;
 
 /**
  * Reservation estimate for an automated call whose own config doesn't state
@@ -45,11 +58,16 @@ export const DEFAULT_SPEND_RESERVATION_USD = 1;
 /**
  * Worst-case per-row reservation for an automatic drain call. Drain rows are
  * already enriched (email found + verified) at enqueue time, so a drain's
- * per-row cost is just drafting (LLM) + send — the low end of the "$0.05-$2
- * per outbound touch" range this repo's own launch copy quotes — not a fresh
- * finder's per-candidate discovery + enrichment cost.
+ * per-row cost is just drafting (LLM) + send — but `tryReserveDailySpend`'s
+ * own contract requires callers pass their worst-case bound, not a typical
+ * or low-end estimate. This repo's own launch copy quotes "$0.05-$2 per
+ * outbound touch" depending on what enrichment/research is stacked on, so
+ * the worst case for a drafting+send touch is the top of that range, not
+ * the bottom — reserving the low end would let a batch of real per-touch
+ * cost above $0.05 blow through the install-wide ceiling substantially
+ * before the release-on-completion true-up ever catches it.
  */
-export const DEFAULT_DRAIN_ROW_RESERVATION_USD = 0.05;
+export const DEFAULT_DRAIN_ROW_RESERVATION_USD = 2;
 
 export interface DailySpendStatus {
   /** The configured ceiling, or null when unlimited (default). */

--- a/packages/core/src/daily-spend.ts
+++ b/packages/core/src/daily-spend.ts
@@ -1,0 +1,142 @@
+import { loadConfig } from "./config.ts";
+import { getLedger } from "./ledger.ts";
+import { todayStartSqliteUtc } from "./send-routing.ts";
+
+/**
+ * Install-wide daily USD spend ceiling (issue #481). Per-run caps
+ * (`maxCostUsd` on a finder, `maxSpendPerRun` on x-reposters) bound one
+ * automated call; this bounds the SUM of every automated paid call —
+ * finder trigger runs (scheduled AND ad-hoc "run now") plus automatic
+ * drains — over the local calendar day. Manual `/queue` row actions
+ * (approve, reject, mark-sent, send-draft) never consult this: a founder
+ * reviewing and sending ONE email by hand is a deliberate decision the
+ * ceiling should never block.
+ *
+ * Two numbers make up "effective" spend for the day:
+ *  - `spentUsd`   — already-posted receipts (`receipts.cost_usd`, the same
+ *                   column every other spend rollup in this codebase reads).
+ *  - `reservedUsd` — amounts held by calls CURRENTLY in flight, via
+ *                    `reserveSpend`/`releaseSpendReservation`. Without this,
+ *                    two automated calls racing the same tick could both
+ *                    read "today's spend" as $0 and both start, together
+ *                    blowing past the ceiling before either one's receipts
+ *                    post. The reservation is released the instant the call
+ *                    ends (success, failure, or halt) — actual spend is
+ *                    already reflected in `receipts` by then, so releasing
+ *                    promptly never double-counts.
+ *
+ * Both figures are windowed from local midnight (`todayStartSqliteUtc`,
+ * the same boundary `send-routing.ts` uses for per-identity daily caps), so
+ * this guardrail and the per-identity send caps agree about when a new day
+ * starts and reset together.
+ */
+
+/** A held-open reservation older than this is presumed orphaned by a crashed process and swept. */
+const SPEND_RESERVATION_STALE_MS = 2 * 3600 * 1000;
+
+/**
+ * Reservation estimate for an automated call whose own config doesn't state
+ * a spend cap (e.g. `breakup-revive`, which is ledger-only and spends
+ * nothing) — small on purpose so a truly free finder can't starve the day's
+ * budget for other finders on the tiny chance it collides with a paid one.
+ */
+export const DEFAULT_SPEND_RESERVATION_USD = 1;
+
+/**
+ * Worst-case per-row reservation for an automatic drain call. Drain rows are
+ * already enriched (email found + verified) at enqueue time, so a drain's
+ * per-row cost is just drafting (LLM) + send — the low end of the "$0.05-$2
+ * per outbound touch" range this repo's own launch copy quotes — not a fresh
+ * finder's per-candidate discovery + enrichment cost.
+ */
+export const DEFAULT_DRAIN_ROW_RESERVATION_USD = 0.05;
+
+export interface DailySpendStatus {
+  /** The configured ceiling, or null when unlimited (default). */
+  ceilingUsd: number | null;
+  /** Sum of posted receipts since local midnight. */
+  spentUsd: number;
+  /** Sum of currently-held reservations since local midnight. */
+  reservedUsd: number;
+  /** spentUsd + reservedUsd — what the ceiling is actually compared against. */
+  effectiveUsd: number;
+  /** ceilingUsd - effectiveUsd, floored at 0; null when unlimited. */
+  remainingUsd: number | null;
+  /** True when effectiveUsd has reached (>=) the ceiling. Always false when unlimited. */
+  ceilingReached: boolean;
+}
+
+/** Current daily spend status. Pure read — never mutates reservations. */
+export function dailySpendStatus(now = new Date()): DailySpendStatus {
+  const ceilingUsd = loadConfig().dailySpendCeilingUsd;
+  const sinceIso = todayStartSqliteUtc(now);
+  const ledger = getLedger();
+  const spentUsd = ledger.totalSpendUsd({ sinceIso });
+  const reservedUsd = ledger.reservedSpendUsd(sinceIso);
+  const effectiveUsd = spentUsd + reservedUsd;
+  const remainingUsd = ceilingUsd == null ? null : Math.max(0, ceilingUsd - effectiveUsd);
+  return {
+    ceilingUsd,
+    spentUsd,
+    reservedUsd,
+    effectiveUsd,
+    remainingUsd,
+    ceilingReached: ceilingUsd != null && effectiveUsd >= ceilingUsd,
+  };
+}
+
+/** The named reason string surfaced on trigger cards, in `doctor`, and in drain output. */
+export function spendCeilingReason(status: DailySpendStatus): string {
+  return `daily spend ceiling reached ($${status.spentUsd.toFixed(2)}/$${(status.ceilingUsd ?? 0).toFixed(2)} spent today)`;
+}
+
+export type SpendReservationOutcome =
+  | { granted: true; release: () => void; status: DailySpendStatus }
+  | { granted: false; reason: string; status: DailySpendStatus };
+
+/**
+ * Gate + reserve in one call: the shared entry point for every automated
+ * paid path (finder trigger runs, automatic drains). Sweeps orphaned
+ * reservations first so a crashed process can't hold spend hostage for the
+ * rest of the day, then checks the ceiling BEFORE reserving — a call that
+ * would push effective spend at/over the ceiling is refused outright rather
+ * than reserved-then-immediately-over.
+ *
+ * `estimateUsd` should be the caller's own worst-case bound for this one
+ * call (a finder's `maxCostUsd`, a drain's conservative per-batch estimate)
+ * — it only needs to be good enough to close the race between two
+ * concurrently-starting automated calls; actual spend is what ultimately
+ * lands in `receipts` regardless of the estimate.
+ */
+export function tryReserveDailySpend(
+  estimateUsd: number,
+  now = new Date(),
+): SpendReservationOutcome {
+  const ledger = getLedger();
+  ledger.sweepStaleSpendReservations(SPEND_RESERVATION_STALE_MS, now);
+  const status = dailySpendStatus(now);
+  // Refuse when EITHER the ceiling is already reached OR this call's own
+  // worst-case estimate would push effective spend at/over it. Checking
+  // `status.ceilingReached` alone (the current effective spend) is not
+  // enough: two concurrent calls can each pass that check against the SAME
+  // pre-reservation total and both reserve, together blowing past the
+  // ceiling before either one's estimate is accounted for. Folding the
+  // incoming estimate into the comparison is what actually closes the race.
+  const wouldExceed =
+    status.ceilingUsd != null &&
+    status.effectiveUsd + Math.max(0, estimateUsd) >= status.ceilingUsd;
+  if (status.ceilingReached || wouldExceed) {
+    return { granted: false, reason: spendCeilingReason(status), status };
+  }
+  const id = ledger.reserveSpend(Math.max(0, estimateUsd));
+  let released = false;
+  return {
+    granted: true,
+    status,
+    release: () => {
+      if (released) return; // idempotent — a finally + an explicit release must not double-delete
+      released = true;
+      ledger.releaseSpendReservation(id);
+    },
+  };
+}

--- a/packages/core/src/daily-spend.ts
+++ b/packages/core/src/daily-spend.ts
@@ -105,7 +105,14 @@ export function dailySpendStatus(now = new Date()): DailySpendStatus {
 
 /** The named reason string surfaced on trigger cards, in `doctor`, and in drain output. */
 export function spendCeilingReason(status: DailySpendStatus): string {
-  return `daily spend ceiling reached ($${status.spentUsd.toFixed(2)}/$${(status.ceilingUsd ?? 0).toFixed(2)} spent today)`;
+  // effectiveUsd (posted + reserved) is what ceilingReached and the
+  // reservation refusal actually compare against the ceiling — quoting
+  // spentUsd here would understate the number that triggered the halt
+  // whenever another in-flight call is holding a reservation (e.g. ceiling
+  // $10, posted $1, a concurrent run holding a $9.50 reservation: refusing
+  // at effectiveUsd=$10.50 while reporting "$1.00/$10.00 spent" reads as
+  // the ceiling being reached with $9 of headroom still open).
+  return `daily spend ceiling reached ($${status.effectiveUsd.toFixed(2)}/$${(status.ceilingUsd ?? 0).toFixed(2)} spent or reserved today)`;
 }
 
 export type SpendReservationOutcome =

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,3 +25,4 @@ export * from "./types.ts";
 export { activeSendCount } from "./inflight.ts";
 export * from "./reply-classify.ts";
 export * from "./timezone.ts";
+export * from "./daily-spend.ts";

--- a/packages/core/src/ledger-schema.ts
+++ b/packages/core/src/ledger-schema.ts
@@ -455,6 +455,25 @@ export function migrateLedgerSchema(db: Database): void {
       CREATE INDEX IF NOT EXISTS idx_webhook_replays_expiry
         ON webhook_replays(expires_at);
     `);
+  // v28 (issue #481): install-wide daily USD spend ceiling — reservations
+  // held for the duration of an automated call (finder trigger run,
+  // automatic drain) so two concurrent automated paths across processes
+  // can't both slip under the ceiling before either one's spend has
+  // posted to `receipts`. `created_at` uses the same SQLite UTC format
+  // (and the same local-midnight boundary, via `todayStartSqliteUtc`) as
+  // `receipts.created_at`, so the spend ceiling and the per-identity send
+  // caps agree about when a new day starts. A row is deleted (not
+  // soft-released) once the caller finishes; a crashed process's orphaned
+  // reservation is swept by age (`SPEND_RESERVATION_STALE_MS`) so it can't
+  // haunt the rest of the day.
+  db.exec(`
+      CREATE TABLE IF NOT EXISTS spend_reservations (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        amount_usd REAL NOT NULL,
+        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+      CREATE INDEX IF NOT EXISTS idx_spend_reservations_created ON spend_reservations(created_at);
+    `);
 }
 
 /**

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -3146,6 +3146,26 @@ export class Ledger {
   }
 
   /**
+   * Release a trigger's in-flight claim WITHOUT stamping `last_polled_at`
+   * (issue #481 review finding). Used only when the finder never actually
+   * ran — currently the daily spend ceiling refusal branches in
+   * `registry.ts`. `updateTriggerLastPoll` would treat the refusal as a
+   * completed poll and push `dueAt` a full interval into the future, so a
+   * trigger blocked by the ceiling would sit unpolled long after headroom
+   * (or a new day) opens back up. `last_run_summary` still records the
+   * refusal reason so the dashboard/doctor surface it, same as before.
+   */
+  clearTriggerClaim(input: { name: string; summary: unknown }): void {
+    this.db
+      .prepare(
+        `UPDATE triggers
+         SET last_run_summary = ?, running_started_at = NULL
+         WHERE name = ?`,
+      )
+      .run(JSON.stringify(input.summary), input.name);
+  }
+
+  /**
    * Atomic claim: marks a trigger in-flight only if not already running — the
    * conditional UPDATE closes the TOCTOU race where two fireTriggerNow calls
    * both fire and double-spend. `staleCutoffIso` also lets the claim succeed

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -2149,6 +2149,52 @@ export class Ledger {
     return (this.db.query(sql).get(...(args as never[])) as { total: number } | null)?.total ?? 0;
   }
 
+  // ── spend_reservations (issue #481: install-wide daily USD spend ceiling) ──
+
+  /**
+   * Hold `amountUsd` against the daily ceiling for the duration of an
+   * automated call. Returns the reservation id — callers MUST release it
+   * (on success or failure) via `releaseSpendReservation`, else it counts
+   * against the ceiling until `sweepStaleSpendReservations` reclaims it.
+   */
+  reserveSpend(amountUsd: number): number {
+    const result = this.db
+      .prepare(`INSERT INTO spend_reservations(amount_usd) VALUES(?)`)
+      .run(amountUsd);
+    return Number(result.lastInsertRowid);
+  }
+
+  /** Release a reservation once the caller's actual spend has posted (or the call was skipped/failed). */
+  releaseSpendReservation(id: number): void {
+    this.db.prepare(`DELETE FROM spend_reservations WHERE id = ?`).run(id);
+  }
+
+  /** Sum of currently-held reservations since `sinceIso` (the local-midnight boundary). */
+  reservedSpendUsd(sinceIso: string): number {
+    const row = this.db
+      .query(
+        `SELECT COALESCE(SUM(amount_usd), 0) AS total FROM spend_reservations WHERE created_at >= ?`,
+      )
+      .get(sinceIso) as { total: number } | null;
+    return row?.total ?? 0;
+  }
+
+  /**
+   * Sweep reservations older than `maxAgeMs` — a crashed process (kill -9
+   * between reserve and release) must not hold spend against the ceiling for
+   * the rest of the day. Returns the number of rows swept.
+   */
+  sweepStaleSpendReservations(maxAgeMs: number, now = new Date()): number {
+    const cutoffIso = new Date(now.getTime() - maxAgeMs)
+      .toISOString()
+      .slice(0, 19)
+      .replace("T", " ");
+    const result = this.db
+      .prepare(`DELETE FROM spend_reservations WHERE created_at < ?`)
+      .run(cutoffIso);
+    return Number(result.changes);
+  }
+
   // ── target_queue ────────────────────────────────────────────────────────────
 
   /** Recent reviewed rows for few-shot ICP classification. */

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -2180,6 +2180,37 @@ export class Ledger {
   }
 
   /**
+   * Atomic check-then-reserve against the daily ceiling (issue #481
+   * round-1 review finding). The read (posted spend + held reservations
+   * since `sinceIso`) and the write (INSERT into `spend_reservations`)
+   * happen inside ONE transaction on this connection — the same
+   * `BEGIN IMMEDIATE` pattern `dequeueApproved` uses to close its own
+   * cross-process claim race. IMMEDIATE takes SQLite's RESERVED write lock
+   * at the START of the transaction (not the default DEFERRED, which only
+   * locks on the first write), so in WAL mode two separate OS processes —
+   * e.g. a `find watch --once` cron run and the server's in-process
+   * scheduler firing the same tick — cannot both read the pre-reservation
+   * total and both pass the check before either commits: the second
+   * caller's transaction blocks until the first one's reservation is
+   * already reflected in the sum it reads. Returns the new reservation id
+   * when granted, or null when posted+reserved+`amountUsd` would meet or
+   * exceed `ceilingUsd`.
+   */
+  reserveSpendIfUnderCeiling(opts: {
+    sinceIso: string;
+    ceilingUsd: number;
+    amountUsd: number;
+  }): number | null {
+    const txn = this.db.transaction((): number | null => {
+      const effectiveUsd =
+        this.totalSpendUsd({ sinceIso: opts.sinceIso }) + this.reservedSpendUsd(opts.sinceIso);
+      if (effectiveUsd + opts.amountUsd >= opts.ceilingUsd) return null;
+      return this.reserveSpend(opts.amountUsd);
+    });
+    return txn.immediate();
+  }
+
+  /**
    * Sweep reservations older than `maxAgeMs` — a crashed process (kill -9
    * between reserve and release) must not hold spend against the ceiling for
    * the rest of the day. Returns the number of rows swept.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -303,6 +303,17 @@ export interface OneShotConfig {
    * pre-launch installs aren't attribution-orphaned later.
    */
   clientId: string | null;
+  /**
+   * Install-wide daily USD spend ceiling (issue #481). Per-run caps
+   * (`maxCostUsd`/`maxSpendPerRun`) bound one finder or drain call; this
+   * bounds the SUM across every automated paid call — every finder trigger
+   * plus every automatic drain — over the local calendar day. Null =
+   * unlimited (the historical behavior). Checked before each automated call
+   * via a reservation against `receipts.cost_usd` summed since local
+   * midnight; manual `/queue` sends (approve/reject/mark-sent/send-draft)
+   * never consult it. Set from `config spend-ceiling <amount>` or `/setup`.
+   */
+  dailySpendCeilingUsd: number | null;
 }
 
 export type QueueStatus = "pending" | "approved" | "rejected" | "sent" | "expired";

--- a/packages/doctor/src/check.ts
+++ b/packages/doctor/src/check.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import {
   capGroupKey,
   configDir,
+  dailySpendStatus,
   daysAgoSqliteUtc,
   getBalance,
   getGmailProfile,
@@ -24,6 +25,7 @@ import {
   currentWorkspaceName,
   listWorkspaces,
   loadGmailTokens,
+  spendCeilingReason,
 } from "@oneshot-gtm/core";
 import { finderApprovalHealth, storedTriggerConfig, TRIGGERS } from "@oneshot-gtm/find";
 
@@ -531,6 +533,40 @@ function readJson<T>(path: string): T | null {
   }
 }
 
+/**
+ * Install-wide daily USD spend ceiling (issue #481). Read-only: never
+ * reserves or mutates anything, just reports today's spend against the
+ * configured ceiling so a founder sees the same number that gates automated
+ * finder/drain runs. Absent a configured ceiling, this is silent — the
+ * historical behavior — so an install that never opted in doesn't get a
+ * confusing "unlimited" line cluttering the panel.
+ */
+function dailySpendCeilingCheck(): CheckResult | null {
+  let status: ReturnType<typeof dailySpendStatus>;
+  try {
+    status = dailySpendStatus();
+  } catch (err) {
+    return {
+      name: "daily spend ceiling",
+      group: "spend",
+      severity: "warn",
+      message: `could not evaluate: ${(err as Error).message}`,
+    };
+  }
+  if (status.ceilingUsd == null) return null;
+  return {
+    name: "daily spend ceiling",
+    group: "spend",
+    severity: status.ceilingReached ? "warn" : "ok",
+    message: status.ceilingReached
+      ? spendCeilingReason(status)
+      : `$${status.effectiveUsd.toFixed(2)}/$${status.ceilingUsd.toFixed(2)} spent today (resets at local midnight)`,
+    ...(status.ceilingReached
+      ? { hint: "automated finder runs + drains are halted; manual /queue sends still work" }
+      : {}),
+  };
+}
+
 export async function runDoctor(): Promise<CheckResult[]> {
   const cfg = loadConfig();
   const results: CheckResult[] = [];
@@ -845,6 +881,9 @@ export async function runDoctor(): Promise<CheckResult[]> {
       });
     }
   }
+
+  const spendCeiling = dailySpendCeilingCheck();
+  if (spendCeiling) results.push(spendCeiling);
 
   return results;
 }

--- a/packages/doctor/src/check.ts
+++ b/packages/doctor/src/check.ts
@@ -560,7 +560,11 @@ function dailySpendCeilingCheck(): CheckResult | null {
     severity: status.ceilingReached ? "warn" : "ok",
     message: status.ceilingReached
       ? spendCeilingReason(status)
-      : `$${status.effectiveUsd.toFixed(2)}/$${status.ceilingUsd.toFixed(2)} spent today (resets at local midnight)`,
+      : // effectiveUsd = spentUsd (posted receipts) + reservedUsd (calls
+        // currently in flight) — the same total the ceiling is compared
+        // against. Labeling it "spent" alone would understate it whenever a
+        // concurrent automated call is holding a reservation.
+        `$${status.effectiveUsd.toFixed(2)}/$${status.ceilingUsd.toFixed(2)} spent or reserved today (resets at local midnight)`,
     ...(status.ceilingReached
       ? { hint: "automated finder runs + drains are halted; manual /queue sends still work" }
       : {}),

--- a/packages/find/__tests__/drain.test.ts
+++ b/packages/find/__tests__/drain.test.ts
@@ -49,8 +49,10 @@ vi.mock("@oneshot-gtm/core", () => ({
   // Daily spend ceiling (issue #481): the drain test suite exercises drain
   // dispatch/persistence behavior, not the ceiling gate itself (that's
   // covered in daily-spend.test.ts and registry-claim.test.ts), so every
-  // reservation here is granted with a no-op release.
-  tryReserveDailySpend: () => ({ granted: true, status: {}, release: () => {} }),
+  // reservation here is granted with a no-op release by default. The
+  // "downsizes the batch to headroom" test below overrides this per-call to
+  // exercise the refusal + retry path.
+  tryReserveDailySpend: vi.fn(() => ({ granted: true, status: {}, release: () => {} })),
 }));
 
 vi.mock("@oneshot-gtm/plays", () => {
@@ -74,6 +76,7 @@ vi.mock("@oneshot-gtm/plays", () => {
 });
 
 const { drainQueue, idsForSentDrafts } = await import("../src/drain.ts");
+const { tryReserveDailySpend: tryReserveDailySpendMock } = await import("@oneshot-gtm/core");
 
 beforeEach(() => {
   ledgerStub.dequeueApproved.mockReset();
@@ -83,6 +86,12 @@ beforeEach(() => {
   ledgerStub.findProspectByEmail.mockReset().mockReturnValue(null);
   runStackConsolidationMock.mockReset();
   runXAmplifyDmMock.mockReset();
+  vi.mocked(tryReserveDailySpendMock).mockReset();
+  vi.mocked(tryReserveDailySpendMock).mockReturnValue({
+    granted: true,
+    status: {} as never,
+    release: () => {},
+  });
 });
 
 afterEach(() => {
@@ -251,6 +260,52 @@ describe("drainQueue per-target dispatch + persistence", () => {
     expect(out.errors[0]?.id).toBe(-1);
     expect(out.errors[0]?.message).toMatch(/unsupported/);
     expect(ledgerStub.setQueueDraft).not.toHaveBeenCalled();
+  });
+
+  it("downsizes the batch to headroom instead of refusing outright (issue #481 finding)", async () => {
+    // $10 ceiling, $0 spent, 10 rows at $2/row = a $20 ask that the ceiling
+    // refuses outright. remainingUsd=10 means 4 rows ($8) fit under the
+    // strict `<` reservation check (5 rows = $10 would land AT the ceiling).
+    const rows = Array.from({ length: 10 }, (_, i) => row((i + 1) * 10));
+    ledgerStub.dequeueApproved.mockReturnValue(rows);
+    vi.mocked(tryReserveDailySpendMock)
+      .mockReturnValueOnce({
+        granted: false,
+        reason: "daily spend ceiling reached ($0.00/$10.00 spent or reserved today)",
+        status: { remainingUsd: 10 } as never,
+      })
+      .mockReturnValueOnce({ granted: true, status: {} as never, release: () => {} });
+    runStackConsolidationMock.mockResolvedValue({
+      drafted: [{ subject: "ok", body: "b", flags: [], sent: true, receiptIds: [1] }],
+    });
+
+    const out = await drainQueue({ playName: "stack-consolidation", dryRun: false });
+
+    // Only the affordable 4 rows were dispatched, not zero.
+    expect(out.drained).toBe(4);
+    expect(runStackConsolidationMock).toHaveBeenCalledTimes(4);
+    expect(out.haltedReason).toBeUndefined();
+    // Second reservation call asked for the downsized batch's cost (4 * $2 = $8).
+    expect(tryReserveDailySpendMock).toHaveBeenCalledTimes(2);
+    expect(tryReserveDailySpendMock).toHaveBeenNthCalledWith(1, 10 * 2);
+    expect(tryReserveDailySpendMock).toHaveBeenNthCalledWith(2, 4 * 2);
+  });
+
+  it("still refuses outright when even the downsized batch doesn't fit (no headroom)", async () => {
+    ledgerStub.dequeueApproved.mockReturnValue([row(10), row(20)]);
+    vi.mocked(tryReserveDailySpendMock).mockReturnValue({
+      granted: false,
+      reason: "daily spend ceiling reached ($10.00/$10.00 spent or reserved today)",
+      status: { remainingUsd: 0 } as never,
+    });
+
+    const out = await drainQueue({ playName: "stack-consolidation", dryRun: false });
+
+    expect(out.drained).toBe(0);
+    expect(out.haltedReason).toContain("daily spend ceiling reached");
+    expect(runStackConsolidationMock).not.toHaveBeenCalled();
+    // No retry attempted — affordableRows was 0.
+    expect(tryReserveDailySpendMock).toHaveBeenCalledTimes(1);
   });
 
   it("manual-play rows with a clean draft are left alone — no re-draft, no stomp", async () => {

--- a/packages/find/__tests__/drain.test.ts
+++ b/packages/find/__tests__/drain.test.ts
@@ -45,7 +45,7 @@ const runXAmplifyDmMock = vi.fn();
 vi.mock("@oneshot-gtm/core", () => ({
   getLedger: () => ledgerStub,
   isSendDeferred: (err: unknown) => err instanceof Error && err.name === "SendDeferredError",
-  DEFAULT_DRAIN_ROW_RESERVATION_USD: 0.05,
+  DEFAULT_DRAIN_ROW_RESERVATION_USD: 2,
   // Daily spend ceiling (issue #481): the drain test suite exercises drain
   // dispatch/persistence behavior, not the ceiling gate itself (that's
   // covered in daily-spend.test.ts and registry-claim.test.ts), so every

--- a/packages/find/__tests__/drain.test.ts
+++ b/packages/find/__tests__/drain.test.ts
@@ -45,6 +45,12 @@ const runXAmplifyDmMock = vi.fn();
 vi.mock("@oneshot-gtm/core", () => ({
   getLedger: () => ledgerStub,
   isSendDeferred: (err: unknown) => err instanceof Error && err.name === "SendDeferredError",
+  DEFAULT_DRAIN_ROW_RESERVATION_USD: 0.05,
+  // Daily spend ceiling (issue #481): the drain test suite exercises drain
+  // dispatch/persistence behavior, not the ceiling gate itself (that's
+  // covered in daily-spend.test.ts and registry-claim.test.ts), so every
+  // reservation here is granted with a no-op release.
+  tryReserveDailySpend: () => ({ granted: true, status: {}, release: () => {} }),
 }));
 
 vi.mock("@oneshot-gtm/plays", () => {

--- a/packages/find/__tests__/queue.test.ts
+++ b/packages/find/__tests__/queue.test.ts
@@ -268,6 +268,29 @@ describe("trigger registry state", () => {
     expect(JSON.parse(t!.last_run_summary ?? "{}")).toEqual({ found: 5, kept: 2 });
   });
 
+  it("clearTriggerClaim clears running_started_at + records summary WITHOUT touching last_polled_at (issue #481 review finding)", () => {
+    const iso = "2026-04-24T18:23:54.607Z";
+    ledger.upsertTrigger({ name: "show-hn", configJson: "{}" });
+    ledger.markTriggerRunning("show-hn", iso);
+    expect(ledger.getTrigger("show-hn")?.running_started_at).toBe(iso);
+    // last_polled_at starts null (never successfully polled) — a ceiling
+    // refusal must leave it null so the trigger is still "due" the instant
+    // headroom opens, not stuck for a full interval as if it had run.
+    expect(ledger.getTrigger("show-hn")?.last_polled_at).toBeNull();
+
+    ledger.clearTriggerClaim({
+      name: "show-hn",
+      summary: { error: "daily spend ceiling reached ($10.00/$10.00 spent or reserved today)" },
+    });
+
+    const t = ledger.getTrigger("show-hn");
+    expect(t?.running_started_at).toBeNull(); // claim released
+    expect(t?.last_polled_at).toBeNull(); // NOT stamped — the key behavior
+    expect(JSON.parse(t!.last_run_summary ?? "{}")).toMatchObject({
+      error: expect.stringContaining("ceiling reached"),
+    });
+  });
+
   it("setTriggerEnabled flips the flag", () => {
     ledger.upsertTrigger({ name: "show-hn", configJson: "{}" });
     ledger.setTriggerEnabled("show-hn", false);

--- a/packages/find/__tests__/registry-claim.test.ts
+++ b/packages/find/__tests__/registry-claim.test.ts
@@ -12,6 +12,7 @@ const fakeStore: Record<string, FakeRow> = {};
 const calls = {
   markTriggerRunning: [] as Array<{ name: string; nowIso: string; staleCutoffIso?: string }>,
   updateTriggerLastPoll: [] as string[],
+  clearTriggerClaim: [] as string[],
   events: [] as Array<{ kind: string; ctx: Record<string, unknown> }>,
 };
 let markReturnsTrue = false;
@@ -44,6 +45,9 @@ vi.mock("@oneshot-gtm/core", async () => {
       updateTriggerLastPoll: (input: { name: string }) => {
         calls.updateTriggerLastPoll.push(input.name);
       },
+      clearTriggerClaim: (input: { name: string }) => {
+        calls.clearTriggerClaim.push(input.name);
+      },
       finderApprovalStats: () => ({ approved: 0, reviewed: 0, rate: null }),
       latestQueueId: () => 0,
       listPendingQueueAfterId: () => [],
@@ -63,6 +67,7 @@ beforeEach(() => {
   for (const k of Object.keys(fakeStore)) delete fakeStore[k];
   calls.markTriggerRunning = [];
   calls.updateTriggerLastPoll = [];
+  calls.clearTriggerClaim = [];
   calls.events = [];
   markReturnsTrue = false;
 

--- a/packages/find/src/drain.ts
+++ b/packages/find/src/drain.ts
@@ -87,9 +87,33 @@ export async function drainQueue(opts: DrainOpts): Promise<DrainOutcome> {
   // posted to `receipts`. When refused, the claimed rows are left approved
   // untouched (dequeueApproved's lease self-expires) so the next drain
   // (today with headroom, or tomorrow after the reset) picks them up.
-  const reservation = tryReserveDailySpend(rows.length * DEFAULT_DRAIN_ROW_RESERVATION_USD);
+  //
+  // A refusal at the FULL batch size doesn't mean zero headroom, though —
+  // it only means the whole batch's worst-case cost doesn't fit. Size the
+  // batch down to what remainingUsd actually allows and retry once before
+  // giving up outright, so e.g. a $10 ceiling with $0 spent and 10 rows at
+  // $2/row (a $20 ask) still dispatches the four rows that fit under the
+  // ceiling instead of none. The retry is still one atomic
+  // reserveSpendIfUnderCeiling call — this only changes how large a batch
+  // we ask it to reserve, never how the reservation itself is checked.
+  let reservation = tryReserveDailySpend(rows.length * DEFAULT_DRAIN_ROW_RESERVATION_USD);
   if (!reservation.granted) {
-    return { drained: 0, sent: 0, deferred: 0, errors: [], haltedReason: reservation.reason };
+    const rowCost = DEFAULT_DRAIN_ROW_RESERVATION_USD;
+    const remainingUsd = reservation.status.remainingUsd ?? 0;
+    // Subtract a tiny epsilon before flooring so a remainingUsd that's an
+    // exact multiple of rowCost doesn't round up into a batch cost that
+    // would land AT the ceiling — reserveSpendIfUnderCeiling's own check is
+    // strict (`>=` refuses), so the affordable batch must cost strictly
+    // less than remainingUsd, not merely no more than it.
+    const affordableRows = Math.max(0, Math.floor((remainingUsd - 1e-9) / rowCost));
+    if (affordableRows > 0 && affordableRows < rows.length) {
+      rows.length = affordableRows;
+      outcome.drained = rows.length;
+      reservation = tryReserveDailySpend(rows.length * rowCost);
+    }
+    if (!reservation.granted) {
+      return { drained: 0, sent: 0, deferred: 0, errors: [], haltedReason: reservation.reason };
+    }
   }
 
   try {

--- a/packages/find/src/drain.ts
+++ b/packages/find/src/drain.ts
@@ -1,4 +1,11 @@
-import { getLedger, isSendDeferred, type ProspectRecord, type QueueRow } from "@oneshot-gtm/core";
+import {
+  DEFAULT_DRAIN_ROW_RESERVATION_USD,
+  getLedger,
+  isSendDeferred,
+  tryReserveDailySpend,
+  type ProspectRecord,
+  type QueueRow,
+} from "@oneshot-gtm/core";
 import { type DraftedRow, isSupportedPlay, MANUAL_PLAYS, PLAYS } from "@oneshot-gtm/plays";
 
 export interface DrainOpts {
@@ -16,6 +23,14 @@ export interface DrainOutcome {
   /** Rows left approved because every sender identity hit its daily cap. */
   deferred: number;
   errors: Array<{ id: number; message: string }>;
+  /**
+   * Set when the install-wide daily spend ceiling (issue #481) was already
+   * reached before this drain could claim any rows — the named reason
+   * surfaced on trigger cards / in `doctor`. Rows stay approved untouched;
+   * a manual `/queue` send-draft or mark-sent for an individual row still
+   * works, only this BATCH drain path is bound by the ceiling.
+   */
+  haltedReason?: string;
 }
 
 /**
@@ -64,62 +79,79 @@ export async function drainQueue(opts: DrainOpts): Promise<DrainOutcome> {
 
   if (rows.length === 0) return outcome;
 
-  for (let r = 0; r < rows.length; r++) {
-    const row = rows[r]!;
-    let draft: DraftedRow;
-    try {
-      draft = await dispatchOneTarget(opts, row);
-    } catch (err) {
-      // Daily caps exhausted: leave this row (and the rest of the batch)
-      // approved with their reviewed drafts intact — the 15-min drain lease
-      // expires and tomorrow's drain picks them up with fresh capacity.
-      // Writing the "(error)" stub here would stomp a founder-reviewed draft.
-      if (isSendDeferred(err)) {
-        outcome.deferred += rows.length - r;
-        break;
-      }
-      const msg = ((err as Error).message ?? "play failed").slice(0, 200);
-      draft = {
-        subject: "(error)",
-        body: "",
-        flags: [`error: ${msg}`],
-        sent: false,
-        receiptIds: [],
-      };
-      outcome.errors.push({ id: row.id, message: msg });
-    }
+  // Install-wide daily spend ceiling (issue #481): a drain is an AUTOMATED
+  // paid path (whether fired by the button, `find drain`, or a cron-driven
+  // `--once`), so it's bound by the same ceiling as finder trigger runs.
+  // Reserved for the whole claimed batch up front — a conservative
+  // worst-case per row — and released once every row's actual spend has
+  // posted to `receipts`. When refused, the claimed rows are left approved
+  // untouched (dequeueApproved's lease self-expires) so the next drain
+  // (today with headroom, or tomorrow after the reset) picks them up.
+  const reservation = tryReserveDailySpend(rows.length * DEFAULT_DRAIN_ROW_RESERVATION_USD);
+  if (!reservation.granted) {
+    return { drained: 0, sent: 0, deferred: 0, errors: [], haltedReason: reservation.reason };
+  }
 
-    try {
-      ledger.setQueueDraft({
-        id: row.id,
-        draft: {
-          subject: draft.subject,
-          body: draft.body,
-          flags: draft.flags,
-          sent: draft.sent,
-          receiptIds: draft.receiptIds,
-          dryRun: opts.dryRun,
-          ...(draft.enrichmentFailed ? { enrichmentFailed: true } : {}),
-        },
-      });
-      if (draft.sent && !opts.dryRun) {
-        ledger.setQueueStatus({ id: row.id, status: "sent" });
-        const prospectId = backfillProspectId(row);
-        if (prospectId != null) {
-          try {
-            ledger.setQueueProspectId(row.id, prospectId);
-          } catch {
-            // best-effort backfill — a schema mismatch shouldn't break the drain
-          }
+  try {
+    for (let r = 0; r < rows.length; r++) {
+      const row = rows[r]!;
+      let draft: DraftedRow;
+      try {
+        draft = await dispatchOneTarget(opts, row);
+      } catch (err) {
+        // Daily caps exhausted: leave this row (and the rest of the batch)
+        // approved with their reviewed drafts intact — the 15-min drain lease
+        // expires and tomorrow's drain picks them up with fresh capacity.
+        // Writing the "(error)" stub here would stomp a founder-reviewed draft.
+        if (isSendDeferred(err)) {
+          outcome.deferred += rows.length - r;
+          break;
         }
-        outcome.sent++;
+        const msg = ((err as Error).message ?? "play failed").slice(0, 200);
+        draft = {
+          subject: "(error)",
+          body: "",
+          flags: [`error: ${msg}`],
+          sent: false,
+          receiptIds: [],
+        };
+        outcome.errors.push({ id: row.id, message: msg });
       }
-    } catch (err) {
-      outcome.errors.push({
-        id: row.id,
-        message: ((err as Error).message ?? "persist failed").slice(0, 200),
-      });
+
+      try {
+        ledger.setQueueDraft({
+          id: row.id,
+          draft: {
+            subject: draft.subject,
+            body: draft.body,
+            flags: draft.flags,
+            sent: draft.sent,
+            receiptIds: draft.receiptIds,
+            dryRun: opts.dryRun,
+            ...(draft.enrichmentFailed ? { enrichmentFailed: true } : {}),
+          },
+        });
+        if (draft.sent && !opts.dryRun) {
+          ledger.setQueueStatus({ id: row.id, status: "sent" });
+          const prospectId = backfillProspectId(row);
+          if (prospectId != null) {
+            try {
+              ledger.setQueueProspectId(row.id, prospectId);
+            } catch {
+              // best-effort backfill — a schema mismatch shouldn't break the drain
+            }
+          }
+          outcome.sent++;
+        }
+      } catch (err) {
+        outcome.errors.push({
+          id: row.id,
+          message: ((err as Error).message ?? "persist failed").slice(0, 200),
+        });
+      }
     }
+  } finally {
+    reservation.release();
   }
 
   if (opts.dryRun) outcome.sent = rows.length; // would-be-sent (no actual send in dryRun)

--- a/packages/find/src/registry.ts
+++ b/packages/find/src/registry.ts
@@ -947,7 +947,13 @@ export async function runTriggerNow(
   // a phantom in-flight marker.
   const reservation = tryReserveDailySpend(estimatedTriggerSpendUsd(config));
   if (!reservation.granted) {
-    ledger.updateTriggerLastPoll({
+    // clearTriggerClaim, not updateTriggerLastPoll: the finder never ran, so
+    // stamping last_polled_at would push this trigger's next-due a full
+    // interval out even though it was refused with $0 spent — the ceiling
+    // resetting (or headroom opening from a released reservation) wouldn't
+    // un-stick it until the next scheduled poll, which could be hours away
+    // (issue #481 review finding).
+    ledger.clearTriggerClaim({
       name,
       summary: { error: reservation.reason, at: new Date().toISOString() },
     });
@@ -1092,7 +1098,11 @@ export async function runDueTriggers(
     // "running" for the rest of the day.
     const reservation = tryReserveDailySpend(estimatedTriggerSpendUsd(config));
     if (!reservation.granted) {
-      ledger.updateTriggerLastPoll({
+      // clearTriggerClaim, not updateTriggerLastPoll (issue #481 review
+      // finding) — see fireTriggerNow's matching comment: stamping
+      // last_polled_at on a refusal would delay the NEXT scheduled attempt
+      // by a full interval even though this one never actually ran.
+      ledger.clearTriggerClaim({
         name: spec.name,
         summary: { error: reservation.reason, at: new Date().toISOString() },
       });

--- a/packages/find/src/registry.ts
+++ b/packages/find/src/registry.ts
@@ -1,8 +1,12 @@
 import {
+  DEFAULT_SPEND_RESERVATION_USD,
+  dailySpendStatus,
   getLedger,
   logEvent,
   safeParseJsonRecord,
+  spendCeilingReason,
   startRun,
+  tryReserveDailySpend,
   type TriggerRow,
 } from "@oneshot-gtm/core";
 import { type CohortEntry, runAcceleratorBatchFinder } from "./accelerator-batch.ts";
@@ -68,6 +72,23 @@ export async function runFinderWithProductResearch(
 }
 
 export type Readiness = { ready: true } | { ready: false; reason: string };
+
+/**
+ * Worst-case spend estimate for reserving against the daily ceiling before a
+ * trigger fires. Reads `maxCostUsd` (every finder's SDK/LLM cap) plus, for
+ * x-reposters, `maxSpendPerRun` (its separate X-read meter) — the two are
+ * independent budgets on that one finder, so both must be held. Falls back
+ * to `DEFAULT_SPEND_RESERVATION_USD` for a finder with neither configured
+ * (e.g. `breakup-revive`, which is ledger-only and spends nothing) so a
+ * free finder can't starve the day's reservation slot for a paid one.
+ */
+export function estimatedTriggerSpendUsd(config: Record<string, unknown>): number {
+  const maxCostUsd = typeof config["maxCostUsd"] === "number" ? config["maxCostUsd"] : 0;
+  const maxSpendPerRun =
+    typeof config["maxSpendPerRun"] === "number" ? config["maxSpendPerRun"] : 0;
+  const total = maxCostUsd + maxSpendPerRun;
+  return total > 0 ? total : DEFAULT_SPEND_RESERVATION_USD;
+}
 
 /** Evaluate a spec's readiness fn (defaulting to ready when absent). */
 export function checkReadiness(spec: TriggerSpec, config: Record<string, unknown>): Readiness {
@@ -830,6 +851,16 @@ export function fireTriggerNow(name: string): void {
   if (!readiness.ready) {
     throw new Error(`not ready: ${readiness.reason}`);
   }
+  // Daily spend ceiling gate (issue #481): a manual "run now" click is still
+  // an AUTOMATED paid call (as opposed to a human-reviewed /queue send), so it
+  // is bound by the same install-wide ceiling as scheduled runs. This is an
+  // early read-only check for a fast 409 — runTriggerNow re-checks
+  // atomically via tryReserveDailySpend right before firing, which is what
+  // actually closes the race between two concurrent automated calls.
+  const status = dailySpendStatus();
+  if (status.ceilingReached) {
+    throw new Error(`not ready: ${spendCeilingReason(status)}`);
+  }
   // Bootstrap the row if it doesn't exist yet — markTriggerRunning is an
   // UPDATE that no-ops on a missing row, so we'd silently lose state.
   if (!stored) {
@@ -909,6 +940,20 @@ export async function runTriggerNow(
       return { name, fired: false, error: message, nextDueInMs: intervalMs };
     }
   }
+  // Install-wide daily spend ceiling (issue #481): reserve this run's
+  // worst-case cost against the day's budget BEFORE firing the finder. A
+  // refusal here still clears the claim taken above (updateTriggerLastPoll
+  // resets running_started_at), so a later run-now click isn't stuck behind
+  // a phantom in-flight marker.
+  const reservation = tryReserveDailySpend(estimatedTriggerSpendUsd(config));
+  if (!reservation.granted) {
+    ledger.updateTriggerLastPoll({
+      name,
+      summary: { error: reservation.reason, at: new Date().toISOString() },
+    });
+    logEvent("trigger.run.skipped", { name, source: "ad_hoc", reason: reservation.reason });
+    return { name, fired: false, error: reservation.reason, nextDueInMs: intervalMs };
+  }
   const startedAt = Date.now();
   logEvent("trigger.run.start", { name, source: "ad_hoc" });
   try {
@@ -943,6 +988,8 @@ export async function runTriggerNow(
       "error",
     );
     return { name, fired: true, error: message, nextDueInMs: intervalMs };
+  } finally {
+    reservation.release();
   }
 }
 
@@ -1039,6 +1086,30 @@ export async function runDueTriggers(
       continue;
     }
 
+    // Install-wide daily spend ceiling (issue #481): reserve this run's
+    // worst-case cost before firing. Refused calls clear the claim taken
+    // above (via updateTriggerLastPoll) so the trigger isn't stuck
+    // "running" for the rest of the day.
+    const reservation = tryReserveDailySpend(estimatedTriggerSpendUsd(config));
+    if (!reservation.granted) {
+      ledger.updateTriggerLastPoll({
+        name: spec.name,
+        summary: { error: reservation.reason, at: new Date().toISOString() },
+      });
+      outcomes.push({
+        name: spec.name,
+        fired: false,
+        nextDueInMs: intervalMs,
+        skippedReason: reservation.reason,
+      });
+      logEvent("trigger.run.skipped", {
+        name: spec.name,
+        source: "watch",
+        reason: reservation.reason,
+      });
+      continue;
+    }
+
     const startedAt = Date.now();
     logEvent("trigger.run.start", { name: spec.name, source: "watch" });
     try {
@@ -1087,6 +1158,8 @@ export async function runDueTriggers(
         duration_ms: durationMs,
         nextDueInMs: intervalMs,
       });
+    } finally {
+      reservation.release();
     }
   }
   logEvent("watch.tick.done", { fired: outcomes.filter((o) => o.fired).length });

--- a/packages/plays/__tests__/cadence-prior-emails.test.ts
+++ b/packages/plays/__tests__/cadence-prior-emails.test.ts
@@ -29,6 +29,7 @@ vi.mock("@oneshot-gtm/core", async () => {
       mobileSignature: false,
       timezone: null,
       clientId: null,
+      dailySpendCeilingUsd: null,
     }),
     getLedger: () => ({
       // Opener-frequency cap: no send history in these fakes, so nothing is worn out.
@@ -106,6 +107,7 @@ function ctx(prospectId = 42) {
       mobileSignature: false,
       timezone: null,
       clientId: null,
+      dailySpendCeilingUsd: null,
     },
     metadata: {},
   };

--- a/packages/plays/__tests__/cadence.test.ts
+++ b/packages/plays/__tests__/cadence.test.ts
@@ -55,6 +55,7 @@ function makeCtx(overrides: Partial<ProspectRecord> = {}): CadenceContext {
       mobileSignature: false,
       timezone: null,
       clientId: null,
+      dailySpendCeilingUsd: null,
     },
     metadata: {},
   };

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -325,6 +325,11 @@ export interface SetupRequest {
   productBrief?: string;
   /** When true, signature appends a literal "Sent from my iPhone" line. */
   mobileSignature?: boolean;
+  /**
+   * Install-wide daily USD spend ceiling (issue #481). `undefined` = leave
+   * unchanged; `null` = clear it (unlimited); a positive number = set it.
+   */
+  dailySpendCeilingUsd?: number | null;
   llmProvider?: LlmProvider;
   llmModel?: string;
   telemetryEnabled?: boolean;
@@ -866,6 +871,8 @@ export interface DrainResult {
   drained: number;
   sent: number;
   errors: Array<{ id: number; message: string }>;
+  /** Named reason the daily spend ceiling (issue #481) blocked this drain, if it did. */
+  haltedReason?: string;
 }
 
 export interface TriggerView {


### PR DESCRIPTION
Closes #481.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 0fd396541751 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (1 errs) vs base ok (1 errs)
```

**Review note:** review FAIL at the 2-round correction cap — findings filed: https://github.com/oneshot-agent/oneshot-gtm/issues/488

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an install-wide daily USD spending ceiling for automated runs, with setup-page controls and the `config spend-ceiling` CLI command.
  - Added spend status reporting, reservation handling, and daily reset behavior; manual queue sends remain unaffected.
  - Added the `local-business` finder and three plays: `sources-sought`, `civic-pilot`, and `design-partner-loi`.
  - Added pack browsing and application, including proposed ICP details during setup.

- **Bug Fixes**
  - Halted drains now report clear reasons in CLI and API responses.

- **Documentation**
  - Updated command counts, architecture documentation, and roadmap status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->