### PR TITLE
chore(coderabbit): add repo config so auto-review covers non-default bases

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,38 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+#
+# Without this file CodeRabbit runs on UI defaults, and the default auto-review
+# covers ONLY the default branch. Every PR in the tormine/oneshot stack targets
+# `staging` or another `feat/*` branch, so CodeRabbit skipped all four with
+# "Auto reviews are disabled on base/target branches other than the default
+# branch" — the stack had no CodeRabbit coverage at all.
+reviews:
+  profile: chill
+
+  # Do NOT turn this off. CodeRabbit posts no check-run of its own (measured on
+  # gtm#453 and gtm#477, whose only checks are CodeQL, Macroscope and Actions),
+  # so this status comment is the single signal that a CLEAN review happened —
+  # a pass with no findings leaves no review threads either. dev-runner reads
+  # the comment to answer "has any reviewer run?"; with it off, every clean PR
+  # would be flagged NO INDEPENDENT REVIEW in the review queue.
+  # See codeRabbitReviewRan() in packs/dev-runner/findings.ts (second-brain-pack).
+  review_status: true
+
+  auto_review:
+    enabled: true
+    drafts: false
+    # The default branch is always reviewed; these are the EXTRA bases. `feat/.*`
+    # is a regex, not a glob — the schema takes regex here.
+    base_branches:
+      - staging
+      - "feat/.*"
+
+  # Generated and vendored files carry no review signal and cost real money.
+  # This is not theoretical: Macroscope refused gtm#477 outright at an estimated
+  # $10.77 against a $10.00 per-review cap, and nto-optimizer#120 is 234 files.
+  path_filters:
+    - "!**/*.lock"
+    - "!**/*.lockb"
+    - "!**/package-lock.json"
+    - "!**/dist/**"
+    - "!**/build/**"
+    - "!**/*.snap"


### PR DESCRIPTION
Adds a repo-level CodeRabbit config. Without one, CodeRabbit runs on UI defaults and auto-review covers **only the default branch**.

That is not theoretical: every PR in the `tormine/oneshot` stack targets `staging` or another `feat/*` branch, and CodeRabbit skipped all four with _"Auto reviews are disabled on base/target branches other than the default branch"_ — the stack had no CodeRabbit coverage at all.

**What it sets**

- `auto_review.base_branches: [staging, feat/.*]` — the extra bases. The default branch is always reviewed, so this only adds to it.
- `review_status: true` — pinned deliberately. CodeRabbit posts no check-run of its own, so its status comment is the only signal that a *clean* review happened (a pass with no findings leaves no review threads either). dev-runner reads that comment to answer "has any reviewer run?"; turning it off would flag every clean PR as NO INDEPENDENT REVIEW.
- `path_filters` — excludes lockfiles, `dist/`, `build/` and snapshots. Macroscope refused oneshot-gtm#477 outright at an estimated $10.77 against a $10.00 per-review cap, and nto-optimizer#120 is 234 files.
- `profile: chill` — the current default, pinned so it stops depending on UI state.

Validated against `https://coderabbit.ai/integrations/schema.v2.json`.

https://claude.ai/code/session_011UAwMEsTQJF1bQCfG3iFtP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code review configuration for selected branches.
  * Excluded draft changes, lockfiles, generated build outputs, and snapshots from automated reviews.
  * Enabled review-status signaling and a less intensive review profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->