### PR TITLE
fix: issue #491: Fix 1 shipped review finding(s) from merged PR #470

### DIFF
--- a/packages/find/src/local-business.ts
+++ b/packages/find/src/local-business.ts
@@ -200,8 +200,8 @@ export async function runLocalBusinessFinder(opts: LocalBusinessFinderOpts): Pro
 
   const fallbackBusinessType = industries.length > 0 ? industries.join(" / ") : "local business";
 
-  for (const person of candidates) {
-    if (result.enqueued >= limit) break;
+  for (const [index, person] of candidates.entries()) {
+    if (index >= limit) break;
     if (opts.maxCostUsd != null && result.costUsd >= opts.maxCostUsd) {
       result.halted = `max-cost cap (${opts.maxCostUsd})`;
       break;


### PR DESCRIPTION
Closes #491.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 5f3ac5ad03fa (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (1 errs) vs base ok (1 errs)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Local business searches now stop clearly when the company or people search service reports an error, rather than treating the failure as an empty result.
  * Candidate processing now examines only the first configured number of search results, including results that are filtered out or cannot be enqueued.
  * Existing filtering, enrichment, deduplication, and enqueue behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->