### PR TITLE
fix: issue #493: feat(find): local-registry finder + socrata-license and nppes adapters (rebuild on main)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,8 @@
 # Status
 
-**Assume green.** The 51 CLI commands, 23 plays, 12 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
+**Assume green.** The 51 CLI commands, 23 plays, 13 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-03** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2586 tests / 202 files** · typecheck + oxlint + oxfmt clean.
+Last verified **2026-09-03** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2740 tests / 213 files** · typecheck + oxlint + oxfmt clean.
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of
@@ -29,21 +29,22 @@ Updated by hand after each dogfood run.
 
 ## Off by default
 
-Only **`show-hn`** and **`post-funding-auto`** fire out of the box. The other ten finders are opt-in, enabled per trigger from `/queue`:
+Only **`show-hn`** and **`post-funding-auto`** fire out of the box. The other eleven finders are opt-in, enabled per trigger from `/queue`:
 
-`accelerator-batch` · `job-change` · `hiring-signal` · `podcast-guest` · `luma-events` · `github-topics` · `github-stars` · `breakup-revive` · `x-reposters` · `local-business`
+`accelerator-batch` · `job-change` · `hiring-signal` · `podcast-guest` · `luma-events` · `github-topics` · `github-stars` · `breakup-revive` · `x-reposters` · `local-business` · `local-registry`
 
-Seven of those also stay **not ready** until you give them required config, and refuse to fire until you do (the API returns `409`):
+Eight of those also stay **not ready** until you give them required config, and refuse to fire until you do (the API returns `409`):
 
-| Finder              | Needs                                        |
-| ------------------- | -------------------------------------------- |
-| `accelerator-batch` | `cohorts[]` + `senderCohort`                 |
-| `hiring-signal`     | `yourClaim`                                  |
-| `github-topics`     | `topics[]` + `vendors[]` + `yourEdge`        |
-| `github-stars`      | `repos[]` + `yourEdge`                       |
-| `luma-events`       | `topics[]` + `cities[]` + `yourEdge`         |
-| `x-reposters`       | `seeds[]` + engine credentials               |
-| `local-business`    | `jobTitles[]` or `industries[]` + `yourEdge` |
+| Finder              | Needs                                                                                                                      |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `accelerator-batch` | `cohorts[]` + `senderCohort`                                                                                               |
+| `hiring-signal`     | `yourClaim`                                                                                                                |
+| `github-topics`     | `topics[]` + `vendors[]` + `yourEdge`                                                                                      |
+| `github-stars`      | `repos[]` + `yourEdge`                                                                                                     |
+| `luma-events`       | `topics[]` + `cities[]` + `yourEdge`                                                                                       |
+| `x-reposters`       | `seeds[]` + engine credentials                                                                                             |
+| `local-business`    | `jobTitles[]` or `industries[]` + `yourEdge`                                                                               |
+| `local-registry`    | at least one of `portals[]` / `taxonomies[]`+`states[]` / `entityTypes[]`+`states[]` / `inspectionPortals[]`, + `yourEdge` |
 
 Both GitHub finders need `GITHUB_TOKEN`. Unauthenticated, GitHub allows 60 requests/hour per IP **shared across the two** — one `github-stars` pass (each repo, up to 3 pages) can spend that alone, and the finder then halts on a `403` that reads like a dead endpoint rather than degrading to lower volume. A classic token with **no scopes** is enough for the public data both read, and lifts the ceiling to 5,000/hour. `doctor` warns when either finder is enabled without one. `luma-events` accepts an optional `LUMA_SESSION_COOKIE` to read authed guest lists. `x-reposters` needs the X credentials for whichever engine its config names (`xapi`: 4 OAuth1 keys, `twitterapiio`: 1 key) — settable from `/setup`'s X card or `config keys`, switchable with `config x-engine`.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -35,16 +35,16 @@ Only **`show-hn`** and **`post-funding-auto`** fire out of the box. The other el
 
 Eight of those also stay **not ready** until you give them required config, and refuse to fire until you do (the API returns `409`):
 
-| Finder              | Needs                                                                                                                      |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------- |
-| `accelerator-batch` | `cohorts[]` + `senderCohort`                                                                                               |
-| `hiring-signal`     | `yourClaim`                                                                                                                |
-| `github-topics`     | `topics[]` + `vendors[]` + `yourEdge`                                                                                      |
-| `github-stars`      | `repos[]` + `yourEdge`                                                                                                     |
-| `luma-events`       | `topics[]` + `cities[]` + `yourEdge`                                                                                       |
-| `x-reposters`       | `seeds[]` + engine credentials                                                                                             |
-| `local-business`    | `jobTitles[]` or `industries[]` + `yourEdge`                                                                               |
-| `local-registry`    | at least one of `portals[]` / `taxonomies[]`+`states[]` / `entityTypes[]`+`states[]` / `inspectionPortals[]`, + `yourEdge` |
+| Finder              | Needs                                                                                                                                                                            |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `accelerator-batch` | `cohorts[]` + `senderCohort`                                                                                                                                                     |
+| `hiring-signal`     | `yourClaim`                                                                                                                                                                      |
+| `github-topics`     | `topics[]` + `vendors[]` + `yourEdge`                                                                                                                                            |
+| `github-stars`      | `repos[]` + `yourEdge`                                                                                                                                                           |
+| `luma-events`       | `topics[]` + `cities[]` + `yourEdge`                                                                                                                                             |
+| `x-reposters`       | `seeds[]` + engine credentials                                                                                                                                                   |
+| `local-business`    | `jobTitles[]` or `industries[]` + `yourEdge`                                                                                                                                     |
+| `local-registry`    | at least one of `portals[]` / `taxonomies[]`+`states[]` / `entityTypes[]` or `minPowerUnits`/`maxPowerUnits` (fmcsa, no `states[]` needed) / `inspectionPortals[]`, + `yourEdge` |
 
 Both GitHub finders need `GITHUB_TOKEN`. Unauthenticated, GitHub allows 60 requests/hour per IP **shared across the two** — one `github-stars` pass (each repo, up to 3 pages) can spend that alone, and the finder then halts on a `403` that reads like a dead endpoint rather than degrading to lower volume. A classic token with **no scopes** is enough for the public data both read, and lifts the ceiling to 5,000/hour. `doctor` warns when either finder is enabled without one. `luma-events` accepts an optional `LUMA_SESSION_COOKIE` to read authed guest lists. `x-reposters` needs the X credentials for whichever engine its config names (`xapi`: 4 OAuth1 keys, `twitterapiio`: 1 key) — settable from `/setup`'s X card or `config keys`, switchable with `config x-engine`.
 


### PR DESCRIPTION
Closes #493.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 340156217371 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (1 errs) vs base ok (1 errs)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an opt-in local registry finder with required configuration.

* **Documentation**
  * Updated project status metrics to reflect 13 finders, 2,740 tests across 213 files, and eight ready finders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->