### PR TITLE
fix: issue #503: Fix 1 shipped review finding(s) from merged PR #477

### DIFF
--- a/packages/find/__tests__/civic-agenda.test.ts
+++ b/packages/find/__tests__/civic-agenda.test.ts
@@ -271,6 +271,32 @@ describe("runCivicAgendaFinder — happy path", () => {
     expect(enqueued).toHaveLength(1);
     expect(enqueued[0]!.payload["email"]).toBe("alex.chen+nyc-10@council.nyc.gov");
   });
+
+  it("accounts for icpFilter spend in result.costUsd so maxCostUsd can halt the run", async () => {
+    // Regression for #503: icpFilter is the ONLY paid call this finder makes
+    // (fetchBodyContact is a free, keyless Legistar lookup) — before the fix,
+    // result.costUsd never left 0, so maxCostUsd could never trip regardless
+    // of classifier spend.
+    itemsByEventId = {
+      1: [
+        { eventItemId: 100, title: "Resolution on AI use in permitting", matterFile: "R-1" },
+        { eventItemId: 102, title: "AI automation budget amendment", matterFile: null },
+      ],
+    };
+    const unlimited = await runCivicAgendaFinder(baseConfig);
+    expect(icpCalls).toBe(2);
+    expect(unlimited.costUsd).toBeGreaterThan(0);
+    expect(unlimited.costUsd).toBeCloseTo(0.002, 5);
+
+    icpCalls = 0;
+    enqueued.length = 0;
+    const capped = await runCivicAgendaFinder({ ...baseConfig, maxCostUsd: 0.001 });
+    // The cap is checked before each icpFilter call: one call is allowed
+    // through (costUsd 0 < 0.001), which pushes costUsd to 0.001 and halts
+    // the loop before the second candidate's classifier call.
+    expect(icpCalls).toBe(1);
+    expect(capped.halted).toMatch(/max-cost cap/);
+  });
 });
 
 describe("runCivicAgendaFinder — readiness / halts", () => {

--- a/packages/find/src/civic-agenda.ts
+++ b/packages/find/src/civic-agenda.ts
@@ -16,6 +16,18 @@ import type { FinderResult, RunOpts } from "./_types.ts";
 
 const PLAY_NAME = "civic-agenda";
 const SOURCE = "find:civic-agenda";
+/**
+ * Rough per-call LLM cost for the `icpFilter` classifier — same estimate
+ * documented (but never applied) at job-change.ts's and show-hn.ts's call
+ * sites. Those finders have a real downstream paid call to fall back on, but
+ * this finder's only network call after icpFilter is the free, keyless
+ * Legistar `OfficeRecords` contact lookup (see resolveAndEnqueueAgendaItem's
+ * docstring) — icpFilter is the ONLY spend source here. Leaving it out of
+ * `result.costUsd` left `opts.maxCostUsd` fully inert: costUsd never left 0,
+ * so a configured cap could never halt a run regardless of how many paid
+ * classifier calls it made.
+ */
+const ICP_FILTER_COST_ESTIMATE_USD = 0.001;
 
 export interface CivicAgendaFinderOpts extends RunOpts {
   /** City names mapped to Legistar clients (see `_civic-legistar.ts`). REQUIRED via readiness gate. */
@@ -223,6 +235,10 @@ export async function runCivicAgendaFinder(opts: CivicAgendaFinderOpts): Promise
         summary: `${candidate.event.eventBodyName ?? "a city body"} in ${candidate.city}`,
       },
     });
+    // icpFilter is a pass-through with no LLM call when no ICP is configured
+    // (see _filter.ts) — only count spend once an ICP is actually set, or a
+    // no-ICP dry sweep would falsely trip maxCostUsd.
+    if (icp) result.costUsd += ICP_FILTER_COST_ESTIMATE_USD;
     if (filter.match === null) {
       // Transient classifier failure — drop without persisting (same
       // reasoning as every other finder's icpFilter call site).


### PR DESCRIPTION
Closes #503.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: ba92297de34c (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (1 errs) vs base ok (1 errs)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - ICP classifier costs are now included in Civic Agenda Finder results.
  - Cost limits now stop processing before additional paid classifier calls when the configured maximum is reached.
  - Cost tracking correctly applies only when ICP filtering is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->