### PR TITLE
fix: issue #506: Fix 1 shipped review finding(s) from merged PR #477

### DIFF
--- a/packages/find/__tests__/civic-agenda.test.ts
+++ b/packages/find/__tests__/civic-agenda.test.ts
@@ -273,6 +273,25 @@ describe("runCivicAgendaFinder — happy path", () => {
   });
 });
 
+describe("runCivicAgendaFinder — max-cost cap", () => {
+  it("halts BEFORE the paid icpFilter call when maxCostUsd is positive but below one call's cost", async () => {
+    // Regression for finding PRRT_kwDOSKzrBs6fGix5: the guard used to check
+    // costUsd (still 0 at this point) instead of the PROSPECTIVE cost, so
+    // 0 < maxCostUsd < ICP_FILTER_COST_USD let the call through anyway.
+    const out = await runCivicAgendaFinder({ ...baseConfig, maxCostUsd: 0.0001 });
+    expect(icpCalls).toBe(0);
+    expect(out.enqueued).toBe(0);
+    expect(out.halted).toMatch(/max-cost cap/);
+  });
+
+  it("still allows the call when maxCostUsd comfortably covers one icpFilter call", async () => {
+    const out = await runCivicAgendaFinder({ ...baseConfig, maxCostUsd: 1 });
+    expect(icpCalls).toBe(1);
+    expect(out.enqueued).toBe(1);
+    expect(out.halted).toBeUndefined();
+  });
+});
+
 describe("runCivicAgendaFinder — readiness / halts", () => {
   it("halts when cities is empty", async () => {
     const out = await runCivicAgendaFinder({ ...baseConfig, cities: [] });

--- a/packages/find/src/civic-agenda.ts
+++ b/packages/find/src/civic-agenda.ts
@@ -204,7 +204,17 @@ export async function runCivicAgendaFinder(opts: CivicAgendaFinderOpts): Promise
   // how small `limit` is.
   for (const candidate of gated.slice(0, Math.max(0, limit))) {
     if (result.enqueued >= limit) break;
-    if (opts.maxCostUsd != null && result.costUsd >= opts.maxCostUsd) {
+    // Compare the PROSPECTIVE cost (current spend + this candidate's paid
+    // icpFilter call, if one will actually happen) against the cap — not
+    // just the spend accrued so far. icpFilter is the only cost source in
+    // this finder, and it's free (no LLM call) when `icp` is null, so the
+    // estimate is 0 in that case. Checking post-hoc spend alone would let a
+    // single call through whenever `0 < maxCostUsd < ICP_FILTER_COST_USD`,
+    // since costUsd is still 0 right up until this call runs.
+    if (
+      opts.maxCostUsd != null &&
+      result.costUsd + (icp ? ICP_FILTER_COST_USD : 0) > opts.maxCostUsd
+    ) {
       result.halted = `max-cost cap (${opts.maxCostUsd})`;
       break;
     }

--- a/packages/find/src/civic-agenda.ts
+++ b/packages/find/src/civic-agenda.ts
@@ -225,7 +225,10 @@ export async function runCivicAgendaFinder(opts: CivicAgendaFinderOpts): Promise
         summary: `${candidate.event.eventBodyName ?? "a city body"} in ${candidate.city}`,
       },
     });
-    result.costUsd += ICP_FILTER_COST_USD;
+    // icpFilter is a free pass-through when no ICP is configured (icp ===
+    // null): zero LLM calls, so nothing to charge — only count the estimate
+    // when a real classifier call was made.
+    if (icp) result.costUsd += ICP_FILTER_COST_USD;
     if (filter.match === null) {
       // Transient classifier failure — drop without persisting (same
       // reasoning as every other finder's icpFilter call site).

--- a/packages/find/src/civic-agenda.ts
+++ b/packages/find/src/civic-agenda.ts
@@ -219,11 +219,11 @@ export async function runCivicAgendaFinder(opts: CivicAgendaFinderOpts): Promise
     // just the spend accrued so far. icpFilter is the only cost source in
     // this finder, and it's free (no LLM call) when `icp` is null, so the
     // estimate is 0 in that case. Checking post-hoc spend alone would let a
-    // single call through whenever `0 < maxCostUsd < ICP_FILTER_COST_USD`,
+    // single call through whenever `0 < maxCostUsd < ICP_FILTER_COST_ESTIMATE_USD`,
     // since costUsd is still 0 right up until this call runs.
     if (
       opts.maxCostUsd != null &&
-      result.costUsd + (icp ? ICP_FILTER_COST_USD : 0) > opts.maxCostUsd
+      result.costUsd + (icp ? ICP_FILTER_COST_ESTIMATE_USD : 0) > opts.maxCostUsd
     ) {
       result.halted = `max-cost cap (${opts.maxCostUsd})`;
       break;

--- a/packages/find/src/civic-agenda.ts
+++ b/packages/find/src/civic-agenda.ts
@@ -16,6 +16,8 @@ import type { FinderResult, RunOpts } from "./_types.ts";
 
 const PLAY_NAME = "civic-agenda";
 const SOURCE = "find:civic-agenda";
+/** Rough LLM cost per icpFilter call, same estimate used by show-hn.ts / accelerator-batch.ts. */
+const ICP_FILTER_COST_USD = 0.001;
 
 export interface CivicAgendaFinderOpts extends RunOpts {
   /** City names mapped to Legistar clients (see `_civic-legistar.ts`). REQUIRED via readiness gate. */
@@ -223,6 +225,7 @@ export async function runCivicAgendaFinder(opts: CivicAgendaFinderOpts): Promise
         summary: `${candidate.event.eventBodyName ?? "a city body"} in ${candidate.city}`,
       },
     });
+    result.costUsd += ICP_FILTER_COST_USD;
     if (filter.match === null) {
       // Transient classifier failure — drop without persisting (same
       // reasoning as every other finder's icpFilter call site).


### PR DESCRIPTION
Closes #506.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: ba92297de34c (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (1 errs) vs base ok (1 errs)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Usage Updates**
  * Civic agenda runs now account for the estimated cost of each ICP filtering call when enforcing the maximum-cost limit.
  * Runs stop before invoking ICP filtering when the remaining budget is insufficient.
  * Runs with sufficient budget continue to filter and enqueue prospects.
  * Civic agenda runs without an ICP classifier remain free of additional filtering charges.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->