### PR TITLE
fix: issue #504: Fix 1 shipped review finding(s) from merged PR #477

### DIFF
--- a/packages/find/__tests__/civic-agenda.test.ts
+++ b/packages/find/__tests__/civic-agenda.test.ts
@@ -271,6 +271,22 @@ describe("runCivicAgendaFinder — happy path", () => {
     expect(enqueued).toHaveLength(1);
     expect(enqueued[0]!.payload["email"]).toBe("alex.chen+nyc-10@council.nyc.gov");
   });
+
+  it("accounts icpFilter spend in costUsd so maxCostUsd can halt the run", async () => {
+    // Two distinct agenda items both survive the free keyword gate, so two
+    // paid icpFilter calls are possible — but a cap sized for exactly one
+    // call's approximate cost must stop the loop after the first.
+    itemsByEventId = {
+      1: [
+        { eventItemId: 100, title: "Resolution on AI use in permitting", matterFile: "R-1" },
+        { eventItemId: 102, title: "AI automation budget amendment", matterFile: null },
+      ],
+    };
+    const out = await runCivicAgendaFinder({ ...baseConfig, maxCostUsd: 0.001 });
+    expect(icpCalls).toBe(1);
+    expect(out.costUsd).toBeGreaterThanOrEqual(0.001);
+    expect(out.halted).toMatch(/max-cost cap/);
+  });
 });
 
 describe("runCivicAgendaFinder — readiness / halts", () => {

--- a/packages/find/__tests__/civic-agenda.test.ts
+++ b/packages/find/__tests__/civic-agenda.test.ts
@@ -299,6 +299,26 @@ describe("runCivicAgendaFinder — happy path", () => {
     expect(icpCalls).toBe(1);
     expect(capped.halted).toMatch(/max-cost cap/);
   });
+
+  it("does not charge icpFilter spend when no ICP is configured (pass-through)", async () => {
+    // resolveIcp() returning null is a normal, documented state (see
+    // _filter.ts's tri-state contract) — icpFilter() is then a free
+    // pass-through with zero LLM calls, so result.costUsd must stay at 0
+    // no matter how many keyword-surviving candidates it classifies.
+    // Without the `if (icp)` gate this would falsely accrue spend and could
+    // trip maxCostUsd on cost that was never incurred.
+    icpResolved = null;
+    itemsByEventId = {
+      1: [
+        { eventItemId: 100, title: "Resolution on AI use in permitting", matterFile: "R-1" },
+        { eventItemId: 102, title: "AI automation budget amendment", matterFile: null },
+      ],
+    };
+    const out = await runCivicAgendaFinder(baseConfig);
+    expect(icpCalls).toBe(2);
+    expect(out.costUsd).toBe(0);
+    expect(out.halted).toBeUndefined();
+  });
 });
 
 describe("runCivicAgendaFinder — readiness / halts", () => {

--- a/packages/find/__tests__/civic-agenda.test.ts
+++ b/packages/find/__tests__/civic-agenda.test.ts
@@ -34,6 +34,7 @@ const pendingPersisted: Array<{
 }> = [];
 let icpMatch: boolean | null = true;
 let icpCalls = 0;
+let icpResolved: string | null = "icp";
 let eventsBySlug: Record<string, Array<Record<string, unknown>>> = {};
 let itemsByEventId: Record<number, Array<Record<string, unknown>>> = {};
 
@@ -54,7 +55,7 @@ vi.mock("../src/_pending.ts", () => ({
 }));
 
 vi.mock("../src/_filter.ts", () => ({
-  resolveIcp: () => "icp",
+  resolveIcp: () => icpResolved,
   icpFilter: async (input: { candidate: { title: string } }) => {
     icpCalls++;
     return { match: icpMatch, reason: icpMatch ? `fits: ${input.candidate.title}` : "nope" };
@@ -102,6 +103,7 @@ beforeEach(() => {
   pendingPersisted.length = 0;
   icpMatch = true;
   icpCalls = 0;
+  icpResolved = "icp";
   officeRecordsBehavior = "contact";
   eventsBySlug = {
     nyc: [
@@ -286,6 +288,26 @@ describe("runCivicAgendaFinder — happy path", () => {
     expect(icpCalls).toBe(1);
     expect(out.costUsd).toBeGreaterThanOrEqual(0.001);
     expect(out.halted).toMatch(/max-cost cap/);
+  });
+
+  it("does not charge icpFilter spend when no ICP is configured (pass-through)", async () => {
+    // resolveIcp() returning null is a normal, documented state (see
+    // _filter.ts's tri-state contract) — icpFilter() is then a free
+    // pass-through with zero LLM calls, so result.costUsd must stay at 0
+    // no matter how many keyword-surviving candidates it classifies.
+    // Without the `if (icp)` gate this would falsely accrue spend and could
+    // trip maxCostUsd on cost that was never incurred.
+    icpResolved = null;
+    itemsByEventId = {
+      1: [
+        { eventItemId: 100, title: "Resolution on AI use in permitting", matterFile: "R-1" },
+        { eventItemId: 102, title: "AI automation budget amendment", matterFile: null },
+      ],
+    };
+    const out = await runCivicAgendaFinder(baseConfig);
+    expect(icpCalls).toBe(2);
+    expect(out.costUsd).toBe(0);
+    expect(out.halted).toBeUndefined();
   });
 });
 

--- a/packages/find/src/civic-agenda.ts
+++ b/packages/find/src/civic-agenda.ts
@@ -16,6 +16,17 @@ import type { FinderResult, RunOpts } from "./_types.ts";
 
 const PLAY_NAME = "civic-agenda";
 const SOURCE = "find:civic-agenda";
+/**
+ * Rough per-call cost of the paid `icpFilter` classifier (LLM tokens, not
+ * OneShot SDK spend) — same approximation every sibling finder's `icpFilter`
+ * call site comments (job-change.ts, accelerator-batch.ts, show-hn.ts). This
+ * finder has NO other paid call in its loop (the Legistar contact lookup is
+ * free), so unlike those siblings — where a later resolveVerifyEnrichQualify
+ * or webRead call still contributes real spend to `result.costUsd` — leaving
+ * this uncounted makes `maxCostUsd` a complete no-op here: the cap could
+ * never trip no matter how many keyword-surviving candidates it classifies.
+ */
+const ICP_FILTER_APPROX_COST_USD = 0.001;
 
 export interface CivicAgendaFinderOpts extends RunOpts {
   /** City names mapped to Legistar clients (see `_civic-legistar.ts`). REQUIRED via readiness gate. */
@@ -223,6 +234,7 @@ export async function runCivicAgendaFinder(opts: CivicAgendaFinderOpts): Promise
         summary: `${candidate.event.eventBodyName ?? "a city body"} in ${candidate.city}`,
       },
     });
+    result.costUsd += ICP_FILTER_APPROX_COST_USD;
     if (filter.match === null) {
       // Transient classifier failure — drop without persisting (same
       // reasoning as every other finder's icpFilter call site).

--- a/packages/find/src/civic-agenda.ts
+++ b/packages/find/src/civic-agenda.ts
@@ -234,7 +234,10 @@ export async function runCivicAgendaFinder(opts: CivicAgendaFinderOpts): Promise
         summary: `${candidate.event.eventBodyName ?? "a city body"} in ${candidate.city}`,
       },
     });
-    result.costUsd += ICP_FILTER_APPROX_COST_USD;
+    // icpFilter is a free pass-through when no ICP is configured (icp ===
+    // null): zero LLM calls, so nothing to charge — only count the estimate
+    // when a real classifier call was made.
+    if (icp) result.costUsd += ICP_FILTER_APPROX_COST_USD;
     if (filter.match === null) {
       // Transient classifier failure — drop without persisting (same
       // reasoning as every other finder's icpFilter call site).


### PR DESCRIPTION
Closes #504.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: ba92297de34c (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (1 errs) vs base ok (1 errs)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cost tracking for ICP spend, including accurate `costUsd` calculations and enforcement of `maxCostUsd`.
  * Preserved pass-through behavior when no ICP configuration is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->