### PR TITLE
fix: issue #501: Fix 19 shipped review finding(s) from merged PR #475

### DIFF
--- a/packages/find/src/_civic-legistar.ts
+++ b/packages/find/src/_civic-legistar.ts
@@ -320,6 +320,15 @@ export function pickOfficeContact(records: LegistarContact[]): LegistarContact |
 }
 
 function parseOfficeRecord(raw: RawOfficeRecord): LegistarContact | null {
+  // An `OfficeRecords` response can contain a null/malformed element
+  // alongside good ones, same as `Events`/`EventItems` above. Without this
+  // guard, reading `.OfficeRecordFullName` off a null `raw` throws inside
+  // fetchBodyContact's `.map`, the outer catch turns that into a full
+  // `{ ok: false, transient: true }` failure, and EVERY valid contact in the
+  // same response is discarded — plus civic-agenda.ts maps `platform-error`
+  // to `persistPending`, so the item is retried forever on a payload that
+  // will never change.
+  if (!raw || typeof raw !== "object") return null;
   const fullName =
     typeof raw.OfficeRecordFullName === "string" ? raw.OfficeRecordFullName.trim() : "";
   const email = typeof raw.OfficeRecordEmail === "string" ? raw.OfficeRecordEmail.trim() : "";

--- a/packages/find/src/gov-solicitation.ts
+++ b/packages/find/src/gov-solicitation.ts
@@ -130,8 +130,24 @@ type DescriptionOutcome = { ok: true; text: string | null } | { ok: false; trans
  * 404 (deleted notice, or "Description Not Found") is a real negative, so the
  * candidate still enqueues with an empty description rather than looping
  * forever on a link that will never resolve.
+ *
+ * `url` comes from the upstream `description` field on an untrusted SAM.gov
+ * response, not a value this code constructs — before attaching the API key,
+ * it must be an `https://api.sam.gov/...` URL, or a compromised/incorrect
+ * upstream response could exfiltrate `SAM_GOV_API_KEY` to an arbitrary host.
+ * `redirect: "manual"` on the credentialed request closes the same hole via
+ * a same-origin 3xx that redirects off api.sam.gov after the key is attached.
  */
 async function fetchDescription(url: string, apiKey: string): Promise<DescriptionOutcome> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { ok: true, text: null };
+  }
+  if (parsed.protocol !== "https:" || parsed.hostname !== "api.sam.gov") {
+    return { ok: true, text: null };
+  }
   const withKey = url.includes("?")
     ? `${url}&api_key=${encodeURIComponent(apiKey)}`
     : `${url}?api_key=${encodeURIComponent(apiKey)}`;
@@ -139,6 +155,7 @@ async function fetchDescription(url: string, apiKey: string): Promise<Descriptio
     const res = await fetch(withKey, {
       method: "GET",
       headers: { Accept: "application/json" },
+      redirect: "manual",
       signal: AbortSignal.timeout(DESCRIPTION_TIMEOUT_MS),
     });
     if (res.status === 404) return { ok: true, text: null };
@@ -398,6 +415,21 @@ export async function runGovSolicitationFinder(
     if (opportunities == null) continue;
     anyFetchSucceeded = true;
     for (const o of opportunities) {
+      // `data.opportunitiesData` is only cast `as SamSearchResponse`, never
+      // validated element-by-element — a null/non-object entry, or one
+      // missing a real `noticeId`, would otherwise throw reading `o.noticeId`
+      // below (outside any try/catch, failing the WHOLE run and losing every
+      // already-fetched notice) or silently produce an `undefined` dedupe key
+      // / a `https://sam.gov/opp/undefined/view` notice URL. Same defensive
+      // posture as `_civic-legistar.ts`'s `parseEvent`/`parseEventItem`.
+      if (
+        !o ||
+        typeof o !== "object" ||
+        typeof o.noticeId !== "string" ||
+        o.noticeId.trim().length === 0
+      ) {
+        continue;
+      }
       if (seenNoticeIds.has(o.noticeId)) continue;
       seenNoticeIds.add(o.noticeId);
       rawOpportunities.push(o);

--- a/packages/find/src/registry.ts
+++ b/packages/find/src/registry.ts
@@ -885,7 +885,9 @@ export const TRIGGERS: TriggerSpec[] = [
         ...(Array.isArray(cfg["naics"])
           ? { naics: (cfg["naics"] as unknown[]).filter((n): n is string => typeof n === "string") }
           : {}),
-        ...(Array.isArray(cfg["noticeTypes"])
+        ...(Array.isArray(cfg["noticeTypes"]) &&
+        (cfg["noticeTypes"] as unknown[]).filter((t): t is string => typeof t === "string").length >
+          0
           ? {
               noticeTypes: (cfg["noticeTypes"] as unknown[]).filter(
                 (t): t is string => typeof t === "string",


### PR DESCRIPTION
Closes #501.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: ba92297de34c (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (1 errs) vs base ok (1 errs)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Contact lookups now continue when individual office records are malformed, rather than failing the entire lookup.
  - Government solicitation searches now skip invalid opportunity entries instead of processing incomplete data.
  - Solicitation descriptions are fetched only from secure, approved SAM.gov API URLs, with redirects disabled.
  - Empty or invalid solicitation type filters are no longer sent when starting a search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->