### PR TITLE
fix: issue #513: Fix 1 shipped review finding(s) from merged PR #509

### DIFF
--- a/packages/find/__tests__/civic-agenda.test.ts
+++ b/packages/find/__tests__/civic-agenda.test.ts
@@ -297,6 +297,21 @@ describe("runCivicAgendaFinder — happy path", () => {
     expect(icpCalls).toBe(1);
     expect(capped.halted).toMatch(/max-cost cap/);
   });
+
+  it("halts BEFORE any classifier call when maxCostUsd is below one estimate (#513)", async () => {
+    // Regression for #513: the guard used to check only cost already spent
+    // (0 < 0.0005), letting one over-budget icpFilter call through and only
+    // recording the breach a full iteration late. The guard must check the
+    // PROJECTED cost (already spent + this call's estimate) instead.
+    itemsByEventId = {
+      1: [{ eventItemId: 100, title: "Resolution on AI use in permitting", matterFile: "R-1" }],
+    };
+    const capped = await runCivicAgendaFinder({ ...baseConfig, maxCostUsd: 0.0005 });
+    expect(icpCalls).toBe(0);
+    expect(capped.enqueued).toBe(0);
+    expect(capped.costUsd).toBe(0);
+    expect(capped.halted).toMatch(/max-cost cap/);
+  });
 });
 
 describe("runCivicAgendaFinder — readiness / halts", () => {

--- a/packages/find/src/civic-agenda.ts
+++ b/packages/find/src/civic-agenda.ts
@@ -214,10 +214,6 @@ export async function runCivicAgendaFinder(opts: CivicAgendaFinderOpts): Promise
   // how small `limit` is.
   for (const candidate of gated.slice(0, Math.max(0, limit))) {
     if (result.enqueued >= limit) break;
-    if (opts.maxCostUsd != null && result.costUsd >= opts.maxCostUsd) {
-      result.halted = `max-cost cap (${opts.maxCostUsd})`;
-      break;
-    }
 
     const dedupeKey = dedupeKeyFor(candidate);
     if (
@@ -228,6 +224,20 @@ export async function runCivicAgendaFinder(opts: CivicAgendaFinderOpts): Promise
       continue;
     }
 
+    // icpFilter is a pass-through with no LLM call when no ICP is configured
+    // (see _filter.ts) — only count/guard spend once an ICP is actually set,
+    // or a no-ICP dry sweep would falsely trip maxCostUsd. Check the
+    // PROJECTED cost (already spent + this call's estimate) BEFORE calling,
+    // not just cost already spent — otherwise a cap below one classifier
+    // estimate (e.g. maxCostUsd 0.0005 with a 0.001 estimate) let one
+    // over-budget call through, since 0 < 0.0005 passed the old pre-call
+    // check and the breach was only caught a full iteration late (#513).
+    const projectedCostUsd = result.costUsd + (icp ? ICP_FILTER_COST_ESTIMATE_USD : 0);
+    if (opts.maxCostUsd != null && projectedCostUsd > opts.maxCostUsd) {
+      result.halted = `max-cost cap (${opts.maxCostUsd})`;
+      break;
+    }
+
     const filter = await icpFilter({
       icp,
       candidate: {
@@ -235,10 +245,7 @@ export async function runCivicAgendaFinder(opts: CivicAgendaFinderOpts): Promise
         summary: `${candidate.event.eventBodyName ?? "a city body"} in ${candidate.city}`,
       },
     });
-    // icpFilter is a pass-through with no LLM call when no ICP is configured
-    // (see _filter.ts) — only count spend once an ICP is actually set, or a
-    // no-ICP dry sweep would falsely trip maxCostUsd.
-    if (icp) result.costUsd += ICP_FILTER_COST_ESTIMATE_USD;
+    result.costUsd = projectedCostUsd;
     if (filter.match === null) {
       // Transient classifier failure — drop without persisting (same
       // reasoning as every other finder's icpFilter call site).


### PR DESCRIPTION
Closes #513.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: be83f6ee7ff5 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (1 errs) vs base fail (4 errs)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Civic agenda processing now stops before making a classifier call when the configured maximum cost would be exceeded.
  - Cost tracking is updated immediately after classifier processing, improving enforcement of spending limits.
- **Tests**
  - Added regression coverage confirming that no classifier calls or follow-up processing occur when the cost limit is too low.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->