### PR TITLE
fix: issue #514: Fix 1 shipped review finding(s) from merged PR #509

### DIFF
--- a/packages/find/__tests__/civic-agenda.test.ts
+++ b/packages/find/__tests__/civic-agenda.test.ts
@@ -297,6 +297,22 @@ describe("runCivicAgendaFinder — happy path", () => {
     expect(icpCalls).toBe(1);
     expect(capped.halted).toMatch(/max-cost cap/);
   });
+
+  it("halts before any icpFilter call when maxCostUsd is below one classifier estimate (#514)", async () => {
+    // Regression for #514: the cap must be compared against the PROJECTED
+    // cost of the upcoming call, not the cost already spent. With
+    // maxCostUsd 0.0005 and a 0.001 per-call estimate, the old
+    // `result.costUsd >= opts.maxCostUsd` guard saw 0 < 0.0005, let one paid
+    // classifier call through, and only then recorded 0.001 — exceeding the
+    // configured cap by 2x before ever halting.
+    itemsByEventId = {
+      1: [{ eventItemId: 100, title: "Resolution on AI use in permitting", matterFile: "R-1" }],
+    };
+    const capped = await runCivicAgendaFinder({ ...baseConfig, maxCostUsd: 0.0005 });
+    expect(icpCalls).toBe(0);
+    expect(capped.costUsd).toBe(0);
+    expect(capped.halted).toMatch(/max-cost cap/);
+  });
 });
 
 describe("runCivicAgendaFinder — readiness / halts", () => {

--- a/packages/find/src/civic-agenda.ts
+++ b/packages/find/src/civic-agenda.ts
@@ -214,7 +214,12 @@ export async function runCivicAgendaFinder(opts: CivicAgendaFinderOpts): Promise
   // how small `limit` is.
   for (const candidate of gated.slice(0, Math.max(0, limit))) {
     if (result.enqueued >= limit) break;
-    if (opts.maxCostUsd != null && result.costUsd >= opts.maxCostUsd) {
+    // Compare the CAP against the cost this call would leave behind, not the
+    // cost already spent — checking result.costUsd alone let a cap smaller
+    // than one classifier estimate (e.g. 0.0005 against a 0.001 estimate)
+    // slip a paid icpFilter call through before ever tripping (issue #514).
+    const projectedCostUsd = result.costUsd + (icp ? ICP_FILTER_COST_ESTIMATE_USD : 0);
+    if (opts.maxCostUsd != null && projectedCostUsd > opts.maxCostUsd) {
       result.halted = `max-cost cap (${opts.maxCostUsd})`;
       break;
     }
@@ -238,7 +243,7 @@ export async function runCivicAgendaFinder(opts: CivicAgendaFinderOpts): Promise
     // icpFilter is a pass-through with no LLM call when no ICP is configured
     // (see _filter.ts) — only count spend once an ICP is actually set, or a
     // no-ICP dry sweep would falsely trip maxCostUsd.
-    if (icp) result.costUsd += ICP_FILTER_COST_ESTIMATE_USD;
+    result.costUsd = projectedCostUsd;
     if (filter.match === null) {
       // Transient classifier failure — drop without persisting (same
       // reasoning as every other finder's icpFilter call site).


### PR DESCRIPTION
Closes #514.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: be83f6ee7ff5 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (1 errs) vs base fail (4 errs)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Civic agenda searches now stop before making a classifier request when the configured maximum cost would be exceeded.
  * Results accurately report zero classifier usage when processing halts before the request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->