### PR TITLE
fix(find,plays,core): ground the send path — research backlog, ICP verdicts, LinkedIn replies

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 51 CLI commands, 23 plays, 13 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-04** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2911 tests / 217 files** · typecheck + oxlint + oxfmt clean.
+Last verified **2026-09-04** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2919 tests / 218 files** · typecheck + oxlint + oxfmt clean.
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 51 CLI commands, 23 plays, 13 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-03** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2740 tests / 213 files** · typecheck + oxlint + oxfmt clean.
+Last verified **2026-09-04** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2911 tests / 217 files** · typecheck + oxlint + oxfmt clean.
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of
@@ -24,6 +24,43 @@ Reply detection was verified on 2026-08-23 against the real mailboxes: a sliced 
 Shadow priority score (#410): heuristic-v2 measured 2026-09-01 on 794 clean human labels — luma-events AUC 0.59-0.63 (up from v1's inverted 0.36), mean gap +1. Under the Phase 2 acceptance bar (gap ≥ +5, AUC ≥ 0.60), so the ranked review order shipped config-gated with `queueReviewOrder` defaulting to `newest` (a toggle on /queue; scores drive nothing else until richer features clear the bar).
 
 Industry packs (#458, #464): `GET /api/packs` + `POST /api/packs/:id/apply` hand a founder a working starting config for their vertical in one confirmation instead of a per-trigger `apply-config` conversation — a pack merges its patches over each trigger's stored config (hand-tuned keys survive) and enables every trigger it touches; a trigger left enabled-but-not-ready (missing a `requires` key the pack deliberately left blank) is the intended end state, named in the response. Ships eight packs: the `devtools-early-adopters` placeholder plus seven real verticals (restaurants-food-service, home-services-trades, healthcare-practices, auto-services, professional-services-smb, trucking-freight, civic-gov), each wired to `local-business` and/or `local-registry`/`gov-solicitation`/`civic-agenda` per the #456 coverage spike (restaurants and home-services measured BEST-covered by `peopleSearch`, dental WORST — the opposite of the card's working hypothesis, so `restaurants-food-service` leans primarily on `local-business`, not `local-registry`). Never writes `icpOneLiner` or any founder-voice field (`yourEdge`/`yourClaim`) — those ride back in the response / stay in `pack.requires` for the founder to fill in.
+
+Grounding pipeline (2026-09-04). `listProspectsForResearch` filtered on `dossier_json IS NULL OR
+TRIM(...) = ''`, which silently emptied the research backlog once `research-products` began writing
+a `{person, product}` wrapper onto every row: 531 of 684 prospects held a product half and a null
+person half, read as done, and the default backlog was **5 rows**. It now filters on
+`hasPersonSignal` — the same gate `_run-play.ts` / `_reply-research.ts` / `research-prospects.ts`
+already used — and reports **536**. Four related fixes ship with it: `researchUrl` prefers a
+researchable profile (LinkedIn/X/GitHub) over a `luma.com/user/…` page that says "Nothing Here,
+Yet" (68 rows had one); `research-prospects` merges through `mergePersonDossier` instead of
+replacing the column and destroying the product half; `hasDossierSignal` no longer counts a
+profile page's own empty-state text as a sourced excerpt; and `ops/audit-icp.ts`'s `dossierRole()`
+reads `$.person`, which it had been blind to since the wrapper landed.
+
+Person-level ICP verdicts are now written by the send path, not only by `ops/audit-icp.ts --write`.
+`QualifiedContact` carries the gate's verdict out of `_contact.ts` (it was collapsed to
+`ok/reject/platform-error` and discarded), nine finders stamp it via `icpFields`, and
+`sendDraftedEmail` both persists it and **gates step 0 on it** — that check existed only for
+follow-ups, so 65 `reject`-verdict prospects had been emailed while just 3 cadences ever went
+`off-icp`. `null` and `unclear` still fail open, per the contract at `ledger.ts:1470`.
+
+luma-events: the event relevance gate ran on the event NAME before any fetch, to avoid paying to
+read city-page noise — but `fetchEventDetails` is free and returns the description, so the gate was
+blind for no saving ("AI Infra Kebab", the Vercel/Neon event, was rejected three days running as "a
+generic event title", then accepted on the fourth on identical input). It now gates on title +
+description after the free structured fetch, falling back to title-only before the paid `webRead`.
+Stage-A role text used `bio ?? role`, which yields `""` for Luma's empty `bio_short` rather than
+falling through. `companyDomain` is carried to the play, and `_product-research.ts` no longer seeds
+a company website from an academic/alumni email domain.
+
+LinkedIn replies: `channel_events` gained a `body` column, so a recorded reply can feed the
+composer. The manual mark keyed `externalEventId` on `randomUUID()`, so `UNIQUE(source,
+external_event_id)` never fired once — it is now a hash of `(prospectId, body)`, deliberately not
+of the clock (the two real duplicates sit at 20:51:13 and 20:52:00, either side of a minute
+boundary). The affordance moved onto `/queue`: it had lived only on `/cadences`, a join on
+`cadence_state`, so all 127 emailed luma-events prospects — a one-touch play that never enrols —
+were unreachable. `/api/run`'s `persistDraftsToQueue` now links `target_queue.prospect_id`, which
+only `drain.ts` had been doing: 680 of 681 sent rows carried a NULL link.
 
 Updated by hand after each dogfood run.
 

--- a/apps/cli/__tests__/research-prospects.test.ts
+++ b/apps/cli/__tests__/research-prospects.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  bounded,
   hasSignal,
   parseScopes,
   researchUrl,
@@ -41,7 +42,7 @@ describe("resolveCap", () => {
 });
 
 describe("researchUrl", () => {
-  it("prefers source_profile_url — it is never repurposed", () => {
+  it("prefers source_profile_url when it is a researchable profile", () => {
     expect(
       researchUrl({
         source_profile_url: "https://github.com/rishibanota",
@@ -50,12 +51,55 @@ describe("researchUrl", () => {
     ).toBe("https://github.com/rishibanota");
   });
 
+  it("skips a non-profile source_profile_url in favour of LinkedIn", () => {
+    // The bug this fixes: luma-events stamps a `luma.com/user/<handle>` page as
+    // source_profile_url. For someone who hosts no events its whole content is
+    // "Nothing Here, Yet", so deepResearchPerson burned a call and returned
+    // nothing while a perfectly good LinkedIn URL sat in the next column.
+    // 68 prospects were in exactly this state.
+    expect(
+      researchUrl({
+        source_profile_url: "https://luma.com/user/rnq",
+        linkedin_url: "https://www.linkedin.com/in/raunaqbose",
+      }),
+    ).toBe("https://www.linkedin.com/in/raunaqbose");
+  });
+
+  it("still returns a non-profile URL when there is nothing better", () => {
+    // Worse than a social profile, but strictly more than an email alone.
+    expect(
+      researchUrl({ source_profile_url: "https://luma.com/user/rnq", linkedin_url: null }),
+    ).toBe("https://luma.com/user/rnq");
+  });
+
+  it("treats x.com and twitter.com as researchable too", () => {
+    expect(
+      researchUrl({ source_profile_url: "https://x.com/rnq", linkedin_url: "https://li.com/in/x" }),
+    ).toBe("https://x.com/rnq");
+  });
+
   it("falls back to linkedin_url, else null", () => {
     expect(researchUrl({ source_profile_url: null, linkedin_url: "https://li.com/in/x" })).toBe(
       "https://li.com/in/x",
     );
     expect(researchUrl({ source_profile_url: "  ", linkedin_url: null })).toBeNull();
     expect(researchUrl({ source_profile_url: null, linkedin_url: null })).toBeNull();
+  });
+});
+
+describe("bounded — the person half must stay mergeable", () => {
+  it("passes a normal payload through untouched", () => {
+    const payload = { title: "CTO", company: "xevall" };
+    expect(bounded(payload)).toBe(payload);
+  });
+
+  it("degrades an oversized payload to sliced text, which still reads as signal", () => {
+    const huge = { summary: "x".repeat(20_000) };
+    const result = bounded(huge);
+    expect(typeof result).toBe("string");
+    // Slicing the MERGED wrapper would have produced invalid JSON and taken the
+    // product half down with it; slicing the person half keeps it parseable.
+    expect(hasSignal(result)).toBe(true);
   });
 });
 

--- a/apps/cli/src/commands/research-products.ts
+++ b/apps/cli/src/commands/research-products.ts
@@ -1,4 +1,4 @@
-import { getLedger, mergeProductDossier, parallelMap } from "@oneshot-gtm/core";
+import { getLedger, parallelMap } from "@oneshot-gtm/core";
 import { researchQueueRowProduct } from "@oneshot-gtm/find";
 import { c, header, note, ok } from "../output.ts";
 import { parseScopes, resolveCap } from "./research-prospects.ts";
@@ -115,8 +115,10 @@ export async function commandResearchProducts(opts: ResearchProductsOpts): Promi
         return;
       }
       if (researched.dossier.status === "unavailable") unavailable++;
-      const latestDossier = ledger.getProspectById(row.id)?.dossier_json ?? row.dossier_json;
-      ledger.setProspectDossier(row.id, mergeProductDossier(latestDossier, researched.dossier));
+      // Atomic re-read + merge: `research-prospects` owns the `person` half of
+      // this same column and runs independently, so a read-modify-write on a
+      // value fetched earlier can silently revert it.
+      ledger.mergeProspectDossierHalf(row.id, "product", researched.dossier);
       written++;
       return;
     }

--- a/apps/cli/src/commands/research-prospects.ts
+++ b/apps/cli/src/commands/research-prospects.ts
@@ -1,4 +1,4 @@
-import { getLedger, hasDossierSignal, mergePersonDossier, parallelMap } from "@oneshot-gtm/core";
+import { getLedger, hasDossierSignal, parallelMap } from "@oneshot-gtm/core";
 import { isCircuitOpen, safeDeepResearchPerson } from "@oneshot-gtm/find";
 import { c, header, note, ok, warn } from "../output.ts";
 
@@ -249,10 +249,15 @@ export async function commandResearchProspects(opts: ResearchProspectsOpts): Pro
     // same column and the two commands run independently. A bare
     // JSON.stringify(payload) here used to discard whatever it had written.
     //
-    // Bound the PERSON half before merging rather than slicing the merged
-    // string — slicing the wrapper would truncate it into invalid JSON and take
+    // The merge re-reads inside a write transaction rather than reusing
+    // `row.dossier_json`, which was read when the backlog was selected —
+    // minutes earlier, since each research call takes 2-5 of them. The
+    // workspace server can (and did) write the same column in that window.
+    //
+    // The PERSON half is bounded before merging rather than the merged string
+    // being sliced: truncating the wrapper would make it invalid JSON and take
     // the product half down with it.
-    ledger.setProspectDossier(row.id, mergePersonDossier(row.dossier_json, bounded(payload)));
+    ledger.mergeProspectDossierHalf(row.id, "person", bounded(payload));
     written++;
     process.stdout.write(
       `  ${c.green("→")} ${(row.name ?? "").slice(0, 26).padEnd(28)} ${c.dim(url ?? email ?? "")}\n`,

--- a/apps/cli/src/commands/research-prospects.ts
+++ b/apps/cli/src/commands/research-prospects.ts
@@ -1,4 +1,4 @@
-import { getLedger, hasDossierSignal, parallelMap } from "@oneshot-gtm/core";
+import { getLedger, hasDossierSignal, mergePersonDossier, parallelMap } from "@oneshot-gtm/core";
 import { isCircuitOpen, safeDeepResearchPerson } from "@oneshot-gtm/find";
 import { c, header, note, ok, warn } from "../output.ts";
 
@@ -30,6 +30,10 @@ export interface ResearchProspectsOpts {
   /** Re-research rows that already hold a dossier. */
   refresh: boolean;
   scope?: string;
+  /** Research exactly this prospect, ignoring scope and dossier state. */
+  id?: number;
+  /** Hard ceiling on billed spend for this run. Stops cleanly when reached. */
+  maxCostUsd?: number;
 }
 
 /**
@@ -60,15 +64,43 @@ export function resolveCap(limit: number | undefined): number | undefined {
   return Math.max(0, Math.floor(limit));
 }
 
-/** The social URL deepResearchPerson should chase, if any. */
+/**
+ * Profile hosts `deepResearchPerson` can actually build a person from. It
+ * chases a social profile; anything else is a page that happens to have a
+ * person's name on it.
+ */
+const RESEARCHABLE_HOST =
+  /^https?:\/\/([a-z0-9-]+\.)*(linkedin\.com|x\.com|twitter\.com|github\.com)\//i;
+
+/** True when a URL is a profile worth handing to deepResearchPerson. */
+export function isResearchableUrl(url: string | null | undefined): boolean {
+  const trimmed = url?.trim();
+  return trimmed ? RESEARCHABLE_HOST.test(trimmed) : false;
+}
+
+/**
+ * The social URL deepResearchPerson should chase, if any.
+ *
+ * `source_profile_url` used to win unconditionally, which sent the research at
+ * whatever page the finder happened to surface. For luma-events that is a
+ * `luma.com/user/<handle>` page — for someone who hosts no events its entire
+ * content is "Nothing Here, Yet", so the call burned a slot and returned
+ * nothing while a perfectly good `linkedin_url` sat unused in the next column.
+ * 68 prospects were in exactly that state.
+ *
+ * So: prefer whichever column holds a researchable profile, `source_profile_url`
+ * first when both qualify. Fall back to a non-researchable `source_profile_url`
+ * only when there is nothing better — it is still more than an email alone.
+ */
 export function researchUrl(row: {
   source_profile_url: string | null;
   linkedin_url: string | null;
 }): string | null {
-  const source = row.source_profile_url?.trim();
-  if (source) return source;
-  const linkedin = row.linkedin_url?.trim();
-  return linkedin ? linkedin : null;
+  const source = row.source_profile_url?.trim() || null;
+  const linkedin = row.linkedin_url?.trim() || null;
+  if (isResearchableUrl(source)) return source;
+  if (isResearchableUrl(linkedin)) return linkedin;
+  return source ?? linkedin;
 }
 
 /**
@@ -81,6 +113,18 @@ export function hasSignal(payload: unknown): boolean {
   return hasDossierSignal(payload);
 }
 
+/**
+ * Cap the person payload at `DOSSIER_SLICE`. An oversized payload degrades to
+ * its own sliced JSON text, which `hasDossierSignal` reads as prose (it
+ * explicitly treats truncated dossier JSON as context worth keeping) — so the
+ * bound never costs us the research, and the wrapper around it stays parseable.
+ */
+export function bounded(payload: unknown): unknown {
+  const text = JSON.stringify(payload, null, 2);
+  if (typeof text !== "string") return payload;
+  return text.length <= DOSSIER_SLICE ? payload : text.slice(0, DOSSIER_SLICE);
+}
+
 export async function commandResearchProspects(opts: ResearchProspectsOpts): Promise<void> {
   header(`research-prospects ${opts.dryRun ? c.dim("(dry-run)") : ""}`);
   const ledger = getLedger();
@@ -88,20 +132,40 @@ export async function commandResearchProspects(opts: ResearchProspectsOpts): Pro
 
   // Read the backlog, then cap in memory — same reasoning as enrich-linkedin:
   // pushing --limit into SQL would make it mean "consider N" not "research N".
-  const rows = ledger.listProspectsForResearch({
-    scopes,
-    includeResearched: opts.refresh,
-    limit: 100_000,
-  });
+  // `--id` researches one named prospect regardless of scope or dossier state.
+  // Diagnosing a single bad row was otherwise impossible: the scopes are broad
+  // and `--refresh` would re-buy the whole backlog to reach one prospect.
+  const rows = opts.id
+    ? ledger
+        .listProspectsForResearch({ scopes: ["all"], includeResearched: true, limit: 100_000 })
+        .filter((row) => row.id === opts.id)
+    : ledger.listProspectsForResearch({
+        scopes,
+        includeResearched: opts.refresh,
+        limit: 100_000,
+      });
+  if (opts.id && rows.length === 0) {
+    warn(`prospect ${opts.id} not found, or has no email and no profile URL to research.`);
+    return;
+  }
+  // deepResearchPerson builds a person from a social profile. Handed only an
+  // email it fails — deterministically, not transiently: a 536-row backfill
+  // produced 281 failures, and re-running produced exactly 281 again, each
+  // spending minutes of wall clock to arrive at the same nothing. Skip those
+  // rows here rather than paying the latency to rediscover it one at a time.
+  // `--id` is exempt: an explicit request should try whatever it has.
+  const skipped = opts.id ? [] : rows.filter((row) => !isResearchableUrl(researchUrl(row)));
+  const eligible = opts.id ? rows : rows.filter((row) => isResearchableUrl(researchUrl(row)));
   const cap = resolveCap(opts.limit);
-  const candidates = cap === undefined ? rows : rows.slice(0, cap);
+  const candidates = cap === undefined ? eligible : eligible.slice(0, cap);
 
   process.stdout.write(
     `${c.dim("scope:")} ${scopes.join(",")}` +
       `  ${c.dim("without a dossier:")} ${rows.length}` +
+      (skipped.length > 0 ? `  ${c.dim("no profile URL:")} ${skipped.length}` : "") +
       `  ${c.dim("to research:")} ${candidates.length}` +
-      (cap !== undefined && rows.length > candidates.length
-        ? `  ${c.dim("held back by --limit:")} ${rows.length - candidates.length}`
+      (cap !== undefined && eligible.length > candidates.length
+        ? `  ${c.dim("held back by --limit:")} ${eligible.length - candidates.length}`
         : "") +
       `\n${c.dim("Est. cost:")} ~$${(candidates.length * RESEARCH_COST_USD).toFixed(2)}` +
       `  ${c.dim("(~2-5 min each, cached 90d)")}\n\n`,
@@ -132,11 +196,20 @@ export async function commandResearchProspects(opts: ResearchProspectsOpts): Pro
   let cached = 0;
   let haltedAt: number | null = null;
 
+  let cappedAt: number | null = null;
   await parallelMap(candidates, opts.concurrency ?? 3, async (row, index) => {
     // The wrapper is failure-safe on its own, but bailing here avoids walking
     // hundreds of rows during an outage just to no-op each one.
     if (isCircuitOpen()) {
       haltedAt ??= index;
+      return;
+    }
+    // Spend ceiling. Checked before the call, so the cap can be exceeded by at
+    // most (concurrency - 1) in-flight calls — the same accounting the finders
+    // use for `maxCostUsd`. A backfill across the whole ledger is the one place
+    // a typo'd flag could bill three figures.
+    if (opts.maxCostUsd != null && costUsd >= opts.maxCostUsd) {
+      cappedAt ??= index;
       return;
     }
     const url = researchUrl(row);
@@ -172,7 +245,14 @@ export async function commandResearchProspects(opts: ResearchProspectsOpts): Pro
       empty++;
       return;
     }
-    ledger.setProspectDossier(row.id, JSON.stringify(payload, null, 2).slice(0, DOSSIER_SLICE));
+    // Merge, never replace: `research-products` owns the `product` half of the
+    // same column and the two commands run independently. A bare
+    // JSON.stringify(payload) here used to discard whatever it had written.
+    //
+    // Bound the PERSON half before merging rather than slicing the merged
+    // string — slicing the wrapper would truncate it into invalid JSON and take
+    // the product half down with it.
+    ledger.setProspectDossier(row.id, mergePersonDossier(row.dossier_json, bounded(payload)));
     written++;
     process.stdout.write(
       `  ${c.green("→")} ${(row.name ?? "").slice(0, 26).padEnd(28)} ${c.dim(url ?? email ?? "")}\n`,
@@ -180,6 +260,12 @@ export async function commandResearchProspects(opts: ResearchProspectsOpts): Pro
   });
 
   process.stdout.write("\n");
+  if (cappedAt !== null) {
+    warn(
+      `Stopped at the $${opts.maxCostUsd?.toFixed(2)} ceiling after ~${cappedAt} rows. ` +
+        `Re-run to continue — researched rows are skipped.`,
+    );
+  }
   if (haltedAt !== null) {
     warn(
       `Circuit breaker opened after ~${haltedAt} rows — the research backend is failing. ` +

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -491,6 +491,12 @@ find
   )
   .option("--concurrency <n>", "parallel research calls (default 3)", (v) => Number.parseInt(v, 10))
   .option("--refresh", "re-research prospects that already have a dossier", false)
+  .option("--id <n>", "research one prospect by id, ignoring scope and dossier state", (v) =>
+    Number.parseInt(v, 10),
+  )
+  .option("--max-cost-usd <n>", "stop once this much has been billed this run", (v) =>
+    Number.parseFloat(v),
+  )
   .option("--dry-run", "list candidates and estimated cost; research nothing", false)
   .description("Backfill research dossiers onto existing prospects (~$0.05 each)")
   .action(
@@ -500,6 +506,8 @@ find
         scope?: string;
         concurrency?: number;
         refresh: boolean;
+        id?: number;
+        maxCostUsd?: number;
         dryRun: boolean;
       }) => {
         await commandResearchProspects({
@@ -508,6 +516,8 @@ find
           ...(opts.limit ? { limit: opts.limit } : {}),
           ...(opts.scope ? { scope: opts.scope } : {}),
           ...(opts.concurrency ? { concurrency: opts.concurrency } : {}),
+          ...(Number.isFinite(opts.id) ? { id: opts.id as number } : {}),
+          ...(Number.isFinite(opts.maxCostUsd) ? { maxCostUsd: opts.maxCostUsd as number } : {}),
         });
       },
     ),

--- a/apps/server/__tests__/linkedin-replies-route.test.ts
+++ b/apps/server/__tests__/linkedin-replies-route.test.ts
@@ -57,6 +57,7 @@ describe("LinkedIn reply routes", () => {
     expect(await response.json()).toMatchObject({ accepted: true, cadencesStopped: 2 });
     expect(record).toHaveBeenCalledWith({
       prospectId: 7,
+      body: null,
       source: "expandi",
       externalEventId: "evt-1",
       occurredAt: "2026-08-01T10:00:00.000Z",
@@ -95,7 +96,7 @@ describe("LinkedIn reply routes", () => {
   });
 
   it("supports the dashboard's prospect-id action", async () => {
-    const response = markLinkedInReplyRoute(
+    const response = await markLinkedInReplyRoute(
       new Request("http://localhost/api/prospects/7/linkedin-reply", { method: "POST" }),
       { id: "7" },
     );
@@ -105,8 +106,8 @@ describe("LinkedIn reply routes", () => {
     );
   });
 
-  it("rejects a cross-origin dashboard mutation", () => {
-    const response = markLinkedInReplyRoute(
+  it("rejects a cross-origin dashboard mutation", async () => {
+    const response = await markLinkedInReplyRoute(
       new Request("http://127.0.0.1:3030/api/prospects/7/linkedin-reply", {
         method: "POST",
         headers: { origin: "http://localhost.attacker.example" },
@@ -115,5 +116,89 @@ describe("LinkedIn reply routes", () => {
     );
     expect(response.status).toBe(403);
     expect(record).not.toHaveBeenCalled();
+  });
+});
+
+// The manual mark used a fresh randomUUID per click, so UNIQUE(source,
+// external_event_id) never fired once: prospect 586 carries two "replied"
+// events 47 seconds apart from a single double-submit.
+describe("manual LinkedIn reply — idempotency key", () => {
+  beforeEach(() => {
+    delete process.env["VITE_DEV_SERVER_URL"];
+    record.mockReset().mockReturnValue({
+      duplicate: false,
+      prospectId: 7,
+      cadencesStopped: 0,
+      inFlightSends: 0,
+    });
+    getProspectById.mockReset().mockReturnValue({ id: 7 });
+  });
+
+  it("derives the same id from two identical submissions", async () => {
+    const call = () =>
+      markLinkedInReplyRoute(
+        new Request("http://localhost/api/prospects/7/linkedin-reply", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ body: "Hey — what are you building?" }),
+        }),
+        { id: "7" },
+      );
+    await call();
+    await call();
+    const ids = record.mock.calls.map((c) => (c[0] as { externalEventId: string }).externalEventId);
+    expect(ids).toHaveLength(2);
+    expect(ids[0]).toBe(ids[1]);
+  });
+
+  it("is NOT keyed on the clock — the two real duplicates straddled a minute boundary", async () => {
+    // 20:51:13 and 20:52:00. Any fixed time bucket has an edge a double-click
+    // can straddle, so identity is the key: same prospect, same message.
+    const at = (iso: string) => {
+      vi.setSystemTime(new Date(iso));
+      return markLinkedInReplyRoute(
+        new Request("http://localhost/api/prospects/586/linkedin-reply", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ body: "same message" }),
+        }),
+        { id: "586" },
+      );
+    };
+    vi.useFakeTimers();
+    try {
+      await at("2026-09-01T20:51:13.993Z");
+      await at("2026-09-01T20:52:00.217Z");
+    } finally {
+      vi.useRealTimers();
+    }
+    const ids = record.mock.calls.map((c) => (c[0] as { externalEventId: string }).externalEventId);
+    expect(ids[0]).toBe(ids[1]);
+  });
+
+  it("gives a genuinely different message its own id, and stores the text", async () => {
+    const send = (body: string) =>
+      markLinkedInReplyRoute(
+        new Request("http://localhost/api/prospects/7/linkedin-reply", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ body }),
+        }),
+        { id: "7" },
+      );
+    await send("first");
+    await send("second, different");
+    const calls = record.mock.calls.map((c) => c[0] as { externalEventId: string; body: string });
+    expect(calls[0]?.externalEventId).not.toBe(calls[1]?.externalEventId);
+    expect(calls[0]?.body).toBe("first");
+  });
+
+  it("still records with no body at all", async () => {
+    const response = await markLinkedInReplyRoute(
+      new Request("http://localhost/api/prospects/7/linkedin-reply", { method: "POST" }),
+      { id: "7" },
+    );
+    expect(response.status).toBe(200);
+    expect(record).toHaveBeenCalledWith(expect.objectContaining({ body: null }));
   });
 });

--- a/apps/server/src/api/linkedin-replies.ts
+++ b/apps/server/src/api/linkedin-replies.ts
@@ -1,4 +1,4 @@
-import { randomUUID, timingSafeEqual } from "node:crypto";
+import { createHash, timingSafeEqual } from "node:crypto";
 import { canonicalLinkedInProfileKey, getLedger } from "@oneshot-gtm/core";
 import type { LinkedInReplyResult, LinkedInReplyWebhookRequest } from "@oneshot-gtm/shared-types";
 import { jsonResponse } from "../server.ts";
@@ -37,6 +37,7 @@ export async function linkedinReplyWebhookRoute(req: Request): Promise<Response>
         source: parsed.source,
         externalEventId: parsed.eventId,
         occurredAt: parsed.occurredAt,
+        body: parsed.body ?? null,
       }),
     ),
     200,
@@ -44,25 +45,74 @@ export async function linkedinReplyWebhookRoute(req: Request): Promise<Response>
   );
 }
 
-export function markLinkedInReplyRoute(req: Request, params: Record<string, string>): Response {
+export async function markLinkedInReplyRoute(
+  req: Request,
+  params: Record<string, string>,
+): Promise<Response> {
   if (!isDashboardOrigin(req)) return jsonResponse({ error: "forbidden origin" }, 403, req);
   const prospectId = Number.parseInt(params["id"] ?? "", 10);
   if (!Number.isFinite(prospectId)) return jsonResponse({ error: "bad id" }, 400, req);
   const ledger = getLedger();
   if (!ledger.getProspectById(prospectId))
     return jsonResponse({ error: "prospect not found" }, 404, req);
+
+  // The message text, when the founder pasted one. Optional and best-effort:
+  // an empty or absent body must still record the reply and stop the cadence.
+  let body: string | null = null;
+  if (isJson(req)) {
+    try {
+      const raw = (await req.json()) as Record<string, unknown> | null;
+      const supplied = raw ? optionalString(raw["body"]) : null;
+      if (supplied && supplied.length > MAX_BODY_CHARS) {
+        return jsonResponse({ error: `body must be under ${MAX_BODY_CHARS} characters` }, 400, req);
+      }
+      body = supplied;
+    } catch {
+      return jsonResponse({ error: "invalid JSON body" }, 400, req);
+    }
+  }
+
+  const occurredAt = new Date().toISOString();
   return jsonResponse(
     accepted(
       ledger.recordLinkedInReply({
         prospectId,
         source: "manual",
-        externalEventId: randomUUID(),
-        occurredAt: new Date().toISOString(),
+        externalEventId: manualEventId(prospectId, body),
+        occurredAt,
+        body,
       }),
     ),
     200,
     req,
   );
+}
+
+/** Longest message we will store. LinkedIn DMs cap far below this. */
+const MAX_BODY_CHARS = 8000;
+
+/**
+ * A stable id for a hand-marked reply, so `UNIQUE(source, external_event_id)`
+ * can actually dedupe.
+ *
+ * This used to be `randomUUID()`, so every click minted a new row and the
+ * dedupe never fired once — prospect 586 carries two "replied" events 47
+ * seconds apart from one double-submit.
+ *
+ * Deliberately keyed on `(prospectId, body)` with NO timestamp. Bucketing the
+ * clock was the obvious fix and it does not work: those two rows land at
+ * 20:51:13 and 20:52:00, either side of a minute boundary, and any fixed
+ * bucket has an edge a double-click can straddle. Identity is the right key
+ * anyway — marking "this person replied, and here is what they said" twice is
+ * one event however far apart the clicks are, and the useful effect (stopping
+ * live cadences) is idempotent. A genuine second reply with different text
+ * gets a different key and records normally.
+ */
+function manualEventId(prospectId: number, body: string | null): string {
+  return createHash("sha256")
+    .update(`${prospectId}|${body ?? ""}`)
+    .digest("hex")
+    .slice(0, 32);
 }
 
 function isDashboardOrigin(req: Request): boolean {
@@ -98,6 +148,12 @@ function parseWebhook(raw: unknown): LinkedInReplyWebhookRequest | string {
   const occurredAt = stringValue(value["occurredAt"]);
   const email = optionalString(value["email"]);
   const linkedinUrl = optionalString(value["linkedinUrl"]);
+  if (value["body"] !== undefined && typeof value["body"] !== "string") {
+    return "body must be a string";
+  }
+  const body = optionalString(value["body"]);
+  if (body && body.length > MAX_BODY_CHARS)
+    return `body must be under ${MAX_BODY_CHARS} characters`;
   if (!source || !SOURCE_RX.test(source)) return "source must be a lowercase provider slug";
   if (!eventId || eventId.length > 200) return "eventId must be 1–200 characters";
   if (!occurredAt || !Number.isFinite(Date.parse(occurredAt)))
@@ -114,6 +170,7 @@ function parseWebhook(raw: unknown): LinkedInReplyWebhookRequest | string {
     occurredAt: new Date(occurredAt).toISOString(),
     ...(email ? { email } : {}),
     ...(linkedinUrl ? { linkedinUrl } : {}),
+    ...(body ? { body } : {}),
   };
 }
 

--- a/apps/server/src/api/queue.ts
+++ b/apps/server/src/api/queue.ts
@@ -519,6 +519,19 @@ export async function sendDraftRoute(
         // Stamped on the payload by the person-level ICP gate in the finders.
         title: str("title"),
       },
+      // The verdict from that same gate. Read generically, like `title`, so
+      // approving a row on /queue enforces and records it exactly as an
+      // unattended play run does.
+      ...(str("icpVerdict") === "pass" ||
+      str("icpVerdict") === "reject" ||
+      str("icpVerdict") === "unclear"
+        ? {
+            icp: {
+              verdict: str("icpVerdict") as "pass" | "reject" | "unclear",
+              reason: str("icpVerdictReason"),
+            },
+          }
+        : {}),
       // The play's evidence metadata (`repo`, `eventTitle`, `vendorStack`, …)
       // MUST be included — step-0 rows without their evidence key silently
       // break everything downstream that reads it.

--- a/apps/server/src/api/run.ts
+++ b/apps/server/src/api/run.ts
@@ -9,6 +9,7 @@ import {
   type TelemetryOutcome,
 } from "@oneshot-gtm/core";
 import { verifyAndFilterTargets } from "@oneshot-gtm/plays";
+import { backfillProspectId } from "@oneshot-gtm/find";
 import {
   isRunnablePlay,
   type CancelRunResponse,
@@ -546,6 +547,17 @@ function persistDraftsToQueue(input: {
       // same row forever. Held drafts and dry-runs intentionally stay approved.
       if (draft.sent && !input.dryRun) {
         ledger.setQueueStatus({ id: row.id, status: "sent" });
+        // Link the row to the prospect the send just created. `drain.ts` has
+        // always done this; this path never did, which is why almost every
+        // sent row in the ledger has a NULL prospect_id.
+        const prospectId = backfillProspectId(row);
+        if (prospectId != null) {
+          try {
+            ledger.setQueueProspectId(row.id, prospectId);
+          } catch {
+            // Best-effort link — the send is already recorded either way.
+          }
+        }
       }
     } catch (err) {
       logEvent(

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -108,8 +108,11 @@ export const api = {
       `/cadences/${id}/stop?play=${encodeURIComponent(playName)}`,
       input,
     ),
-  markLinkedInReply: (id: number) =>
-    postJson<LinkedInReplyResult>(`/prospects/${id}/linkedin-reply`, {}),
+  markLinkedInReply: (id: number, body?: string) =>
+    postJson<LinkedInReplyResult>(
+      `/prospects/${id}/linkedin-reply`,
+      body?.trim() ? { body: body.trim() } : {},
+    ),
   previewCadenceNext: (id: number, playName: string) =>
     postJson<{
       subject: string;

--- a/apps/web/src/routes/cadences.tsx
+++ b/apps/web/src/routes/cadences.tsx
@@ -125,6 +125,7 @@ function CadencesPage() {
   const [linkedinReplyModal, setLinkedinReplyModal] = useState<LinkedInReplyModalState | null>(
     null,
   );
+  const [linkedinReplyBody, setLinkedinReplyBody] = useState("");
   const [stopReason, setStopReason] = useState<CadenceStopReason>("bad_timing");
   const [stopNote, setStopNote] = useState("");
 
@@ -159,10 +160,12 @@ function CadencesPage() {
   });
 
   const markLinkedInReply = useMutation({
-    mutationFn: (prospectId: number) => api.markLinkedInReply(prospectId),
+    mutationFn: (vars: { prospectId: number; body?: string }) =>
+      api.markLinkedInReply(vars.prospectId, vars.body),
     onSuccess: (data) => {
       void qc.invalidateQueries({ queryKey: ["cadences"] });
       setLinkedinReplyModal(null);
+      setLinkedinReplyBody("");
       const warning = data.inFlightSends > 0 ? " · an in-flight email may still complete" : "";
       toast.success(
         `LinkedIn reply recorded · ${data.cadencesStopped} cadence(s) stopped${warning}`,
@@ -1109,7 +1112,10 @@ function CadencesPage() {
 
       <Modal
         open={linkedinReplyModal != null}
-        onClose={() => setLinkedinReplyModal(null)}
+        onClose={() => {
+          setLinkedinReplyModal(null);
+          setLinkedinReplyBody("");
+        }}
         title={`Mark LinkedIn reply${linkedinReplyModal?.prospectName ? ` — ${mask("name", linkedinReplyModal.prospectName)}` : ""}`}
         footer={
           <>
@@ -1118,7 +1124,12 @@ function CadencesPage() {
             </Button>
             <Button
               onClick={() => {
-                if (linkedinReplyModal) markLinkedInReply.mutate(linkedinReplyModal.prospectId);
+                if (linkedinReplyModal) {
+                  markLinkedInReply.mutate({
+                    prospectId: linkedinReplyModal.prospectId,
+                    body: linkedinReplyBody,
+                  });
+                }
               }}
               disabled={markLinkedInReply.isPending}
               {...readOnly}
@@ -1128,9 +1139,21 @@ function CadencesPage() {
           </>
         }
       >
-        <div className="text-[12px] text-ink-muted">
-          This records a LinkedIn reply and stops every active or paused email cadence for this
-          prospect. An email already in flight cannot be recalled and may still complete.
+        <div className="flex flex-col gap-2">
+          <div className="text-[12px] text-ink-muted">
+            This records a LinkedIn reply and stops every active or paused email cadence for this
+            prospect. An email already in flight cannot be recalled and may still complete.
+          </div>
+          <label className="text-[12px] text-ink-muted" htmlFor="linkedin-reply-body">
+            What they said (optional) — stored so a reply can be drafted from it later.
+          </label>
+          <textarea
+            id="linkedin-reply-body"
+            className="min-h-[96px] w-full rounded border border-line bg-surface p-2 text-[12px]"
+            value={linkedinReplyBody}
+            onChange={(e) => setLinkedinReplyBody(e.currentTarget.value)}
+            placeholder="Paste their message…"
+          />
         </div>
       </Modal>
 

--- a/apps/web/src/routes/cadences.tsx
+++ b/apps/web/src/routes/cadences.tsx
@@ -126,6 +126,14 @@ function CadencesPage() {
     null,
   );
   const [linkedinReplyBody, setLinkedinReplyBody] = useState("");
+  // Every close path must clear the body. Cancel used to bypass the onClose
+  // cleanup, so reopening the modal for a DIFFERENT prospect showed the
+  // previous one's text — one stray click from filing person A's message
+  // against person B.
+  const closeLinkedinReplyModal = (): void => {
+    setLinkedinReplyModal(null);
+    setLinkedinReplyBody("");
+  };
   const [stopReason, setStopReason] = useState<CadenceStopReason>("bad_timing");
   const [stopNote, setStopNote] = useState("");
 
@@ -1112,14 +1120,11 @@ function CadencesPage() {
 
       <Modal
         open={linkedinReplyModal != null}
-        onClose={() => {
-          setLinkedinReplyModal(null);
-          setLinkedinReplyBody("");
-        }}
+        onClose={closeLinkedinReplyModal}
         title={`Mark LinkedIn reply${linkedinReplyModal?.prospectName ? ` — ${mask("name", linkedinReplyModal.prospectName)}` : ""}`}
         footer={
           <>
-            <Button variant="ghost" onClick={() => setLinkedinReplyModal(null)}>
+            <Button variant="ghost" onClick={closeLinkedinReplyModal}>
               Cancel
             </Button>
             <Button

--- a/apps/web/src/routes/queue.tsx
+++ b/apps/web/src/routes/queue.tsx
@@ -943,6 +943,7 @@ export function QueueRow({
                 draftedAt={row.lastDraftedAt}
                 generating={generating}
                 isSending={row.isSending}
+                prospectId={row.prospectId}
               />
               <details className="text-ink-faint">
                 <summary className="cursor-pointer font-mono text-[10px] uppercase tracking-[0.14em] hover:text-ink-cream-2">
@@ -978,6 +979,7 @@ function DraftSection({
   draftedAt,
   generating,
   isSending,
+  prospectId,
 }: {
   id: number;
   playName: string;
@@ -986,6 +988,8 @@ function DraftSection({
   draft: QueueRowView["lastDraft"];
   draftedAt: string | null;
   generating: boolean;
+  /** Set once the send has created a prospect row; null before that. */
+  prospectId: number | null;
   /**
    * True when the server's `target_queue.send_started_at` marker is set —
    * survives nav-away-and-back AND `bun --watch` reloads, unlike the
@@ -1080,6 +1084,73 @@ function DraftSection({
       toast.error(`couldn't record · ${err.message}`);
     },
   });
+  // Recording a LinkedIn reply used to live only on /cadences, which is a join
+  // on `cadence_state` — so it was unreachable for every one-touch play. All
+  // 130 luma-events prospects were in that hole: emailed, never enrolled in a
+  // cadence, and therefore impossible to mark when they replied on LinkedIn.
+  // The queue row is where every sent prospect is visible, so it belongs here.
+  const [linkedinBody, setLinkedinBody] = useState("");
+  const [linkedinOpen, setLinkedinOpen] = useState(false);
+  const markLinkedIn = useMutation({
+    mutationFn: () => api.markLinkedInReply(prospectId as number, linkedinBody),
+    onSuccess: (data) => {
+      void qc.invalidateQueries({ queryKey: ["queue"] });
+      void qc.invalidateQueries({ queryKey: ["cadences"] });
+      setLinkedinOpen(false);
+      setLinkedinBody("");
+      const warning = data.inFlightSends > 0 ? " · an in-flight email may still complete" : "";
+      toast.success(
+        `LinkedIn reply recorded · ${data.cadencesStopped} cadence(s) stopped${warning}`,
+      );
+    },
+    onError: (err) => toast.error(`couldn't record · ${err.message}`),
+  });
+  const linkedinReplyBlock =
+    status === "sent" && prospectId != null ? (
+      <div className="mt-2 border-t border-ink-rule pt-2">
+        {linkedinOpen ? (
+          <div className="flex flex-col gap-2">
+            <label
+              className="font-mono text-[10px] uppercase tracking-[0.14em] text-ink-faint"
+              htmlFor={`li-reply-${id}`}
+            >
+              they replied on linkedin — paste what they said
+            </label>
+            <textarea
+              id={`li-reply-${id}`}
+              className="min-h-[72px] w-full rounded border border-ink-rule bg-transparent p-2 text-[11px]"
+              value={linkedinBody}
+              onChange={(e) => setLinkedinBody(e.currentTarget.value)}
+              placeholder="Optional, but it is what a reply gets drafted from later."
+            />
+            <div className="flex items-center gap-2">
+              <Button
+                variant="secondary"
+                size="sm"
+                disabled={markLinkedIn.isPending}
+                onClick={() => markLinkedIn.mutate()}
+                {...readOnly}
+              >
+                {markLinkedIn.isPending ? "recording…" : "record reply"}
+              </Button>
+              <Button variant="ghost" size="sm" onClick={() => setLinkedinOpen(false)}>
+                cancel
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setLinkedinOpen(true)}
+            title="Record a LinkedIn reply and stop any email cadence for this prospect"
+          >
+            mark linkedin reply
+          </Button>
+        )}
+      </div>
+    ) : null;
+
   const p = (payload ?? {}) as Record<string, unknown>;
   const pstr = (k: string): string | null => (typeof p[k] === "string" ? (p[k] as string) : null);
   const dmOpen = p["dmOpen"] === true;
@@ -1246,6 +1317,7 @@ function DraftSection({
         <pre className="mt-2 max-h-[360px] overflow-auto whitespace-pre-wrap font-mono text-[11.5px] leading-[1.55] text-ink-cream-2">
           {draft.body}
         </pre>
+        {linkedinReplyBlock}
       </div>
     </div>
   );

--- a/packages/core/__tests__/__snapshots__/ledger.test.ts.snap
+++ b/packages/core/__tests__/__snapshots__/ledger.test.ts.snap
@@ -267,7 +267,7 @@ exports[`Ledger schema migration > fresh-install schema (tables, columns, indexe
         channel           TEXT NOT NULL,
         event_type        TEXT NOT NULL,
         occurred_at       TEXT NOT NULL,
-        created_at        TEXT NOT NULL DEFAULT (datetime('now')),
+        created_at        TEXT NOT NULL DEFAULT (datetime('now')), body TEXT,
         UNIQUE(source, external_event_id),
         FOREIGN KEY(prospect_id) REFERENCES prospects(id)
       )",

--- a/packages/core/__tests__/dossier.test.ts
+++ b/packages/core/__tests__/dossier.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { hasDossierSignal, mergeProductDossier } from "../src/dossier.ts";
+import {
+  hasDossierSignal,
+  hasPersonSignal,
+  mergePersonDossier,
+  mergeProductDossier,
+} from "../src/dossier.ts";
 
 // The gate that decides whether a dossier is worth writing to
 // prospects.dossier_json. It is load-bearing: _reply-research.ts treats any
@@ -115,5 +120,119 @@ describe("mergeProductDossier", () => {
     expect(merged["person"]?.["title"]).toBe("Founder");
     expect(merged["product"]?.["status"]).toBe("complete");
     expect(hasDossierSignal(merged)).toBe(true);
+  });
+});
+
+// The dossier that shipped an ungrounded email to prospect 679. Its product
+// half read a Luma user profile for someone who hosts no events: the fetch
+// succeeded, the excerpt is a few hundred characters, and every one of them is
+// page chrome. It counted as signal, so the paid research tiers stayed
+// suppressed and the person half stayed null forever.
+const LUMA_EMPTY_PROFILE = {
+  person: null,
+  product: {
+    version: 1,
+    status: "partial",
+    researchedAt: "2026-09-01T22:51:05.891Z",
+    subject: { name: "Raunaq Bose", company: "Taxheaven" },
+    sources: [
+      {
+        url: "https://luma.com/user/rnq",
+        kind: "website",
+        excerpt:
+          "# Raunaq Bose\n\n@rnq\n\nJoined March 2026\n\n0Hosted\n\n29Attended\n\n" +
+          "### Nothing Here, Yet\n\nRaunaq Bose has no public events at this time.",
+      },
+    ],
+  },
+};
+
+describe("hasDossierSignal — an excerpt must be informative, not merely non-empty", () => {
+  it("rejects a profile page whose body is its own 'nothing here' message", () => {
+    expect(hasDossierSignal(LUMA_EMPTY_PROFILE)).toBe(false);
+  });
+
+  it("still accepts a product source that says something", () => {
+    expect(
+      hasDossierSignal({
+        sources: [
+          {
+            url: "https://www.xevall.com/",
+            kind: "website",
+            excerpt: "The independent evals and self-improvement layer for human-AI interaction.",
+          },
+        ],
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("hasPersonSignal — is there PERSON research, specifically", () => {
+  it("is false for the wrapper research-products writes over an unresearched row", () => {
+    // The whole bug in one assertion: 531 of 684 prospects were in this state,
+    // and the old backlog query (dossier_json IS NULL OR TRIM = '') read every
+    // one of them as done.
+    expect(hasPersonSignal(JSON.stringify(LUMA_EMPTY_PROFILE))).toBe(false);
+  });
+
+  it("is false for a null/empty column", () => {
+    expect(hasPersonSignal(null)).toBe(false);
+    expect(hasPersonSignal("   ")).toBe(false);
+  });
+
+  it("is true once the person half carries research", () => {
+    expect(
+      hasPersonSignal(
+        JSON.stringify({
+          person: { title: "Co-Founder & CTO", company: "xevall", summary: "Building evals." },
+          product: LUMA_EMPTY_PROFILE.product,
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it("is false when the person half is a failed-enrich envelope", () => {
+    expect(
+      hasPersonSignal(
+        JSON.stringify({ person: { status: "failed", profile: null }, product: null }),
+      ),
+    ).toBe(false);
+  });
+
+  it("reads a pre-wrapper row, where the person payload IS the whole column", () => {
+    expect(hasPersonSignal(JSON.stringify({ title: "CTO", company: "Acme" }))).toBe(true);
+  });
+});
+
+describe("mergePersonDossier — must not clobber the product half", () => {
+  it("keeps existing product research when writing the person half", () => {
+    const merged = mergePersonDossier(JSON.stringify(LUMA_EMPTY_PROFILE), {
+      title: "Co-Founder & CTO",
+      company: "xevall",
+    });
+    const parsed = JSON.parse(merged) as { person: unknown; product: { subject: unknown } };
+    expect(parsed.product).toEqual(LUMA_EMPTY_PROFILE.product);
+    expect(parsed.person).toEqual({ title: "Co-Founder & CTO", company: "xevall" });
+  });
+
+  it("round-trips with mergeProductDossier without either half losing the other", () => {
+    const withPerson = mergePersonDossier(null, { title: "CTO" });
+    const withBoth = mergeProductDossier(withPerson, {
+      version: 1,
+      status: "complete",
+      researchedAt: "2026-09-04T00:00:00.000Z",
+      subject: { company: "xevall" },
+      sources: [],
+    });
+    const parsed = JSON.parse(withBoth) as {
+      person: { title: string };
+      product: { status: string };
+    };
+    expect(parsed.person.title).toBe("CTO");
+    expect(parsed.product.status).toBe("complete");
+  });
+
+  it("produces valid JSON from a null column", () => {
+    expect(() => JSON.parse(mergePersonDossier(null, { title: "CTO" }))).not.toThrow();
   });
 });

--- a/packages/core/__tests__/prospect-research.test.ts
+++ b/packages/core/__tests__/prospect-research.test.ts
@@ -150,3 +150,58 @@ describe("listProspectsForResearch", () => {
     expect(ledger.listProspectsForResearch({ scopes: ["unjudged"], limit: 2 })).toHaveLength(2);
   });
 });
+
+// `research-prospects` owns the `person` half and `research-products` owns
+// `product`. Both used to read the column, merge in memory, and write back —
+// with the read outside any transaction and minutes of latency in between.
+// The later write silently reverted the earlier one. This happened for real
+// during the feature's own dogfood run.
+describe("mergeProspectDossierHalf", () => {
+  it("writes one half without clobbering the other", () => {
+    const id = ledger.upsertProspect({ name: "Raunaq Bose", email: "r@example.dev" });
+
+    ledger.mergeProspectDossierHalf(id, "product", {
+      version: 1,
+      status: "partial",
+      researchedAt: "2026-09-01T22:51:05.891Z",
+      subject: { company: "Taxheaven" },
+      sources: [{ url: "https://x.dev", kind: "website", excerpt: "real text" }],
+    });
+    ledger.mergeProspectDossierHalf(id, "person", { title: "Co-Founder & CTO", company: "xevall" });
+
+    const stored = JSON.parse(ledger.getProspectById(id)!.dossier_json!) as {
+      person: { company: string };
+      product: { subject: { company: string } };
+    };
+    expect(stored.person.company).toBe("xevall");
+    expect(stored.product.subject.company).toBe("Taxheaven");
+  });
+
+  it("re-reads inside the transaction rather than trusting a stale value", () => {
+    const id = ledger.upsertProspect({ name: "A", email: "a@example.dev" });
+
+    // Simulate the race: a caller selected the row (dossier empty), then
+    // another writer landed the product half before the caller's merge ran.
+    ledger.mergeProspectDossierHalf(id, "product", {
+      version: 1,
+      status: "complete",
+      researchedAt: "2026-09-04T00:00:00.000Z",
+      subject: { company: "Acme" },
+      sources: [],
+    });
+    // The caller now merges its person half. If it used the value it read at
+    // selection time (null), the product half would be gone.
+    ledger.mergeProspectDossierHalf(id, "person", { title: "CTO" });
+
+    const stored = JSON.parse(ledger.getProspectById(id)!.dossier_json!) as {
+      person: { title: string };
+      product: { status: string } | null;
+    };
+    expect(stored.person.title).toBe("CTO");
+    expect(stored.product?.status).toBe("complete");
+  });
+
+  it("is a no-op for a prospect that does not exist", () => {
+    expect(() => ledger.mergeProspectDossierHalf(9999, "person", { title: "x" })).not.toThrow();
+  });
+});

--- a/packages/core/src/dossier.ts
+++ b/packages/core/src/dossier.ts
@@ -36,6 +36,29 @@ const SIGNAL_FIELDS = [
 /** The provider's placeholder summary for a shared inbox — not role text. */
 const ROLE_MAILBOX = /is a role based email address/i;
 
+/**
+ * Scraped profile pages that rendered fine but say nothing about the person.
+ * A Luma user page for someone who hosts no events is the common case: the
+ * read succeeds, the excerpt is a few hundred non-empty characters, and every
+ * one of them is chrome. Left unchecked it satisfies the `excerpt` test below,
+ * marks the dossier as signal, and suppresses the paid reply-research tiers —
+ * the exact failure this file exists to prevent.
+ *
+ * Kept deliberately narrow: only phrases a page shows INSTEAD of content.
+ */
+const EMPTY_PROFILE = [
+  /nothing here,? yet/i,
+  /has no public events/i,
+  /this user has no/i,
+  /no results? found/i,
+  /page not found/i,
+] as const;
+
+/** True when an excerpt is a page's own "there is nothing here" message. */
+function isEmptyProfileExcerpt(text: string): boolean {
+  return EMPTY_PROFILE.some((pattern) => pattern.test(text));
+}
+
 /** Nested places the payload shapes put the same keys. */
 const NESTED_KEYS = ["enrichment", "profile", "result", "person", "product"] as const;
 
@@ -76,6 +99,59 @@ export function mergeProductDossier(
     }
   }
   return JSON.stringify({ person, product }, null, 2);
+}
+
+/**
+ * The mirror of `mergeProductDossier`: write the person half without
+ * discarding product research.
+ *
+ * `research-prospects` used to `setProspectDossier(JSON.stringify(payload))`,
+ * which replaced the whole column and destroyed the `{person, product}`
+ * wrapper `research-products` had written. The two commands run independently
+ * and neither should clobber the other.
+ */
+export function mergePersonDossier(current: string | null | undefined, person: unknown): string {
+  let product: unknown = null;
+  if (current?.trim()) {
+    try {
+      const parsed = JSON.parse(current) as unknown;
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        product = (parsed as Record<string, unknown>)["product"] ?? null;
+      }
+    } catch {
+      // A legacy non-JSON dossier is person prose; there is no product half to
+      // keep, and the new person payload supersedes it.
+      product = null;
+    }
+  }
+  return JSON.stringify({ person, product }, null, 2);
+}
+
+/**
+ * Does the PERSON half of a stored dossier carry research?
+ *
+ * `hasDossierSignal` answers "is this column worth keeping", which a product
+ * dossier alone satisfies. That is the wrong question for the research
+ * backlog: a row whose `person` is null still needs `deepResearchPerson`, and
+ * for 531 of 684 prospects the product half alone was enough to make them look
+ * done. Callers selecting research candidates want this, not the broad gate.
+ */
+export function hasPersonSignal(stored: string | null | undefined): boolean {
+  if (!stored?.trim()) return false;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stored);
+  } catch {
+    // Prose a play assembled — genuine person context (see hasDossierSignal).
+    return true;
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return hasDossierSignal(parsed);
+  }
+  const record = parsed as Record<string, unknown>;
+  // Pre-wrapper rows are a bare person payload; wrapped rows nest it.
+  const person = "person" in record ? record["person"] : record;
+  return hasDossierSignal(person);
 }
 
 function substantive(scope: unknown): boolean {
@@ -121,13 +197,15 @@ export function hasDossierSignal(value: unknown): boolean {
   if (typeof body.status === "string" && body.status.toLowerCase() === "failed") return false;
   if (Array.isArray(body.articles) && body.articles.length > 0) return true;
   if (Array.isArray(body.sources)) {
-    const hasExcerpt = body.sources.some(
-      (source) =>
-        source !== null &&
-        typeof source === "object" &&
-        typeof (source as Record<string, unknown>)["excerpt"] === "string" &&
-        ((source as Record<string, unknown>)["excerpt"] as string).trim() !== "",
-    );
+    const hasExcerpt = body.sources.some((source) => {
+      if (source === null || typeof source !== "object") return false;
+      const excerpt = (source as Record<string, unknown>)["excerpt"];
+      if (typeof excerpt !== "string") return false;
+      const trimmed = excerpt.trim();
+      // Non-empty is not the same as informative — a profile page's own
+      // "Nothing Here, Yet" is chrome, and counting it suppresses paid research.
+      return trimmed !== "" && !isEmptyProfileExcerpt(trimmed);
+    });
     // Product dossiers carry a subject for identification, but a company/name
     // alone is not researched context. Only sourced text or an external result
     // should suppress the reply research fallback.

--- a/packages/core/src/ledger-schema.ts
+++ b/packages/core/src/ledger-schema.ts
@@ -443,6 +443,10 @@ export function migrateLedgerSchema(db: Database): void {
   addColumnIfMissing(db, "target_queue", "decision", "TEXT"); // 'approve'|'reject'|'auto_reject'
   addColumnIfMissing(db, "target_queue", "decided_at", "TEXT");
   addColumnIfMissing(db, "target_queue", "decided_by", "TEXT"); // 'human'|'human_bulk'|'machine'
+  // The text of an off-email message, when the channel gives us one. Without
+  // it a recorded LinkedIn reply could stop a cadence but never feed the reply
+  // composer, which needs a body to draft against.
+  addColumnIfMissing(db, "channel_events", "body", "TEXT");
   backfillDecisionProvenance(db);
   // v27: signed webhook replay keys. Keeping these in the ledger makes replay
   // protection survive server restarts; expired rows are pruned when a new

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -2,6 +2,7 @@ import { Database } from "bun:sqlite";
 import { existsSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { configDir } from "./config.ts";
+import { hasPersonSignal } from "./dossier.ts";
 import { humanDecisionWhereSql } from "./labels.ts";
 import { migrateLedgerSchema } from "./ledger-schema.ts";
 import { getSharedDb } from "./shared-db.ts";
@@ -790,6 +791,8 @@ export class Ledger {
     source: string;
     externalEventId: string;
     occurredAt: string;
+    /** The message text, when the channel supplies one. Feeds the composer. */
+    body?: string | null;
   }): {
     duplicate: boolean;
     prospectId: number;
@@ -823,10 +826,16 @@ export class Ledger {
       this.db
         .prepare(
           `INSERT INTO channel_events
-             (source, external_event_id, prospect_id, channel, event_type, occurred_at)
-           VALUES (?, ?, ?, 'linkedin', 'reply', ?)`,
+             (source, external_event_id, prospect_id, channel, event_type, occurred_at, body)
+           VALUES (?, ?, ?, 'linkedin', 'reply', ?, ?)`,
         )
-        .run(input.source, input.externalEventId, input.prospectId, input.occurredAt);
+        .run(
+          input.source,
+          input.externalEventId,
+          input.prospectId,
+          input.occurredAt,
+          input.body?.trim() || null,
+        );
       this.db
         .prepare(
           `UPDATE cadence_state
@@ -1581,23 +1590,20 @@ export class Ledger {
     if (any.length === 0) return [];
 
     const where = [`(${any.join(" OR ")})`];
-    if (!opts.includeResearched)
-      where.push("(p.dossier_json IS NULL OR TRIM(p.dossier_json) = '')");
     // Something for deepResearchPerson to key on.
     where.push(
       "(COALESCE(NULLIF(TRIM(p.source_profile_url), ''), NULLIF(TRIM(p.linkedin_url), '')) IS NOT NULL OR (p.email IS NOT NULL AND TRIM(p.email) != ''))",
     );
 
-    return this.db
+    const rows = this.db
       .query(
         `SELECT p.id, p.name, p.company, p.email, p.source, p.source_profile_url, p.linkedin_url,
                 p.dossier_json
            FROM prospects p
           WHERE ${where.join(" AND ")}
-          ORDER BY p.id DESC
-          LIMIT ?`,
+          ORDER BY p.id DESC`,
       )
-      .all(opts.limit ?? 100_000) as Array<{
+      .all() as Array<{
       id: number;
       name: string | null;
       company: string | null;
@@ -1607,6 +1613,24 @@ export class Ledger {
       linkedin_url: string | null;
       dossier_json: string | null;
     }>;
+
+    // The "already researched" filter runs here, not in SQL. It used to be
+    // `dossier_json IS NULL OR TRIM(...) = ''`, which silently emptied the
+    // backlog the moment `research-products` began writing a
+    // `{person, product}` wrapper onto every row: 531 of 684 prospects held a
+    // product half and a null person half, looked researched to that test, and
+    // became permanently unreachable. `hasPersonSignal` asks the question the
+    // caller actually means — is there PERSON research here — and matches the
+    // gate every other consumer of this column already uses.
+    //
+    // `limit` is applied AFTER the filter so it keeps meaning "return N rows to
+    // research", not "consider N rows". The prospects table is small enough
+    // that scanning it whole costs nothing.
+    const eligible = opts.includeResearched
+      ? rows
+      : rows.filter((row) => !hasPersonSignal(row.dossier_json));
+    const limit = opts.limit ?? 100_000;
+    return eligible.length > limit ? eligible.slice(0, limit) : eligible;
   }
 
   recordOutcome(input: {

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -2,7 +2,12 @@ import { Database } from "bun:sqlite";
 import { existsSync, mkdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { configDir } from "./config.ts";
-import { hasPersonSignal } from "./dossier.ts";
+import {
+  hasPersonSignal,
+  mergePersonDossier,
+  mergeProductDossier,
+  type ProductResearchDossier,
+} from "./dossier.ts";
 import { humanDecisionWhereSql } from "./labels.ts";
 import { migrateLedgerSchema } from "./ledger-schema.ts";
 import { getSharedDb } from "./shared-db.ts";
@@ -1499,6 +1504,43 @@ export class Ledger {
    */
   setProspectDossier(id: number, dossier: string | null): void {
     this.db.prepare("UPDATE prospects SET dossier_json = ? WHERE id = ?").run(dossier, id);
+  }
+
+  /**
+   * Write ONE half of a prospect's dossier without clobbering the other.
+   *
+   * `research-prospects` owns the `person` half and `research-products` owns
+   * `product`, and each was doing read → merge → write with the read outside
+   * any transaction. Two writers, one column, a wide window between them: the
+   * later write silently reverts the earlier one.
+   *
+   * Not theoretical — it happened during this feature's own dogfood run. The
+   * workspace server researched a prospect while a script held a merge in
+   * flight, and the curated person half vanished under an API one. The reads
+   * were seconds apart.
+   *
+   * BEGIN IMMEDIATE via `db.transaction` takes the write lock before the
+   * re-read, so the merge sees the current value and no one can interleave
+   * between the two statements.
+   */
+  mergeProspectDossierHalf(
+    id: number,
+    half: "person" | "product",
+    value: unknown,
+    slice?: number,
+  ): void {
+    this.db.transaction(() => {
+      const row = this.db.query("SELECT dossier_json FROM prospects WHERE id = ?").get(id) as
+        | { dossier_json: string | null }
+        | undefined;
+      if (!row) return;
+      const merged =
+        half === "person"
+          ? mergePersonDossier(row.dossier_json, value)
+          : mergeProductDossier(row.dossier_json, value as ProductResearchDossier);
+      const bounded = slice != null && merged.length > slice ? merged.slice(0, slice) : merged;
+      this.db.prepare("UPDATE prospects SET dossier_json = ? WHERE id = ?").run(bounded, id);
+    })();
   }
 
   /**

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -77,6 +77,8 @@ export interface ChannelEventRecord {
   channel: "linkedin";
   event_type: "reply";
   occurred_at: string;
+  /** Message text when the channel supplied one; null for older rows. */
+  body: string | null;
   created_at: string;
 }
 

--- a/packages/find/src/_contact.ts
+++ b/packages/find/src/_contact.ts
@@ -4,7 +4,7 @@ import { isCircuitOpen, recordResolutionOutcome } from "./_breaker.ts";
 import { shouldSkipFindEmail } from "./_findemail-prescreen.ts";
 import { safeFindEmail, safeVerifyEmail } from "./_sdk-safe.ts";
 import { enrichVerifiedContact } from "./_enrich.ts";
-import type { PersonCandidate } from "./_filter.ts";
+import type { PersonCandidate, PersonVerdict } from "./_filter.ts";
 import { qualifyPostEnrich } from "./_qualify.ts";
 
 /**
@@ -152,6 +152,21 @@ export type QualifiedContact =
       linkedinUrl: string | null;
       /** Job title the gate judged on — persist it so the next run is free. */
       title: string | null;
+      /**
+       * What the person-level ICP gate decided. Carried out of here so the
+       * enqueue/send path can persist it onto `prospects.icp_verdict`.
+       *
+       * It used to be collapsed to `ok: true` and dropped, which meant the
+       * only production writer of that column was the manual `ops/audit-icp.ts`
+       * — so a verdict the gate had already paid to compute was recomputed by
+       * hand later, or never. `unclear` is a real value here and must be
+       * persisted as such: the cadence gate tests `=== "reject"`, so `unclear`
+       * fails open exactly as NULL does, but recording it stops the audit
+       * re-judging a row it has already settled.
+       */
+      verdict: Exclude<PersonVerdict, "transient">;
+      /** One-sentence reason from the classifier, for `icp_verdict_reason`. */
+      verdictReason: string;
       costUsd: number;
     }
   | {
@@ -266,6 +281,29 @@ export async function resolveVerifyEnrichQualify(args: {
     phone: enr.phone,
     linkedinUrl: enr.linkedinUrl,
     title: gate.roleText ?? enr.title,
+    // `reject` and `transient` returned above, so what reaches here is a
+    // settled pass or an unresolved unclear — both worth persisting.
+    verdict: gate.verdict === "transient" ? "unclear" : gate.verdict,
+    verdictReason: gate.reason,
     costUsd,
+  };
+}
+
+/**
+ * The ICP fields to spread onto a finder's target payload, next to `title`.
+ *
+ * Finders stamp `...(contact.title ? { title: contact.title } : {})`; this is
+ * the sibling for the verdict, so `_run-play.ts` and the /queue send route can
+ * persist it onto the prospect row the same generic way they already persist
+ * `title`. Spread-safe: returns an empty object when there is nothing to say.
+ */
+export function icpFields(contact: Extract<QualifiedContact, { ok: true }>): {
+  icpVerdict?: string;
+  icpVerdictReason?: string;
+} {
+  if (!contact.verdict) return {};
+  return {
+    icpVerdict: contact.verdict,
+    ...(contact.verdictReason ? { icpVerdictReason: contact.verdictReason } : {}),
   };
 }

--- a/packages/find/src/_product-research.ts
+++ b/packages/find/src/_product-research.ts
@@ -43,10 +43,22 @@ function str(body: JsonRecord, ...keys: string[]): string | null {
   return null;
 }
 
+/**
+ * Academic and alumni domains. A university address says where someone studied,
+ * not where they work — and `https://<that domain>` is a university homepage,
+ * or (for an alumni forwarder like `network.rca.ac.uk`) not a website at all.
+ *
+ * This is the shape that produced a dossier whose only source was a Luma
+ * profile: the read of the alumni domain threw, and the profile page was all
+ * that was left. Excluding these sends `seedFor` to the company instead.
+ */
+const ACADEMIC_DOMAIN = /(^|\.)(edu|ac\.[a-z]{2}|edu\.[a-z]{2})$/i;
+
 function emailDomain(email: string | null): string | null {
   if (!email) return null;
   const domain = email.split("@")[1]?.trim().toLowerCase() ?? "";
-  return domain && !DUD_DOMAINS.has(domain) ? domain : null;
+  if (!domain || DUD_DOMAINS.has(domain) || ACADEMIC_DOMAIN.test(domain)) return null;
+  return domain;
 }
 
 function normalizeUrl(value: string | null): string | null {
@@ -105,7 +117,12 @@ function seedFor(
 
 function sourceKind(url: string): ProductResearchSource["kind"] {
   if (/github\.com\/[^/]+\/[^/]+/i.test(url)) return "repository";
-  if (/github\.com|linkedin\.com|x\.com|twitter\.com/i.test(url)) return "profile";
+  // `luma.com/user/<handle>` is a person's event profile. Classified as a
+  // website it masqueraded as company research, and its "Nothing Here, Yet"
+  // body counted as a sourced excerpt.
+  if (/github\.com|linkedin\.com|x\.com|twitter\.com|luma\.com\/user\//i.test(url)) {
+    return "profile";
+  }
   return "website";
 }
 

--- a/packages/find/src/accelerator-batch.ts
+++ b/packages/find/src/accelerator-batch.ts
@@ -1,5 +1,5 @@
 import { getLedger, logEvent, webRead } from "@oneshot-gtm/core";
-import { resolveVerifyEnrichQualify } from "./_contact.ts";
+import { resolveVerifyEnrichQualify, icpFields } from "./_contact.ts";
 import { enqueueScoredTarget } from "./_priority-adapters.ts";
 import { persistRoleRejection } from "./_qualify.ts";
 import { complete, loadPrompt } from "@oneshot-gtm/intel";
@@ -443,6 +443,7 @@ export async function runAcceleratorBatchFinder(
       ...(linkedinUrl ? { linkedinUrl } : {}),
       ...(phone ? { phone } : {}),
       ...(contact.title ? { title: contact.title } : {}),
+      ...icpFields(contact),
       // Stamp the sender's own cohort (+ offer) onto the row so the play can
       // draft inline without a run-level senderCohort — mirrors yourEdge.
       ...(opts.senderCohort ? { senderCohort: opts.senderCohort } : {}),

--- a/packages/find/src/drain.ts
+++ b/packages/find/src/drain.ts
@@ -240,7 +240,15 @@ function hasCleanDraft(row: QueueRow): boolean {
   }
 }
 
-function backfillProspectId(row: QueueRow | null): number | null {
+/**
+ * Resolve the prospect a queued row's send created, by email.
+ *
+ * Exported because `/api/run` persists sent rows through its own path
+ * (`persistDraftsToQueue`) and never linked them: 680 of 681 sent queue rows
+ * carried a NULL `prospect_id`, which quietly broke every join from a queued
+ * target back to the person — including the one `ops/expandi-sync` reads.
+ */
+export function backfillProspectId(row: QueueRow | null): number | null {
   if (!row) return null;
   try {
     const payload = JSON.parse(row.payload_json) as { email?: string; founderEmail?: string };

--- a/packages/find/src/github-stars.ts
+++ b/packages/find/src/github-stars.ts
@@ -1,6 +1,6 @@
 import { getLedger, logEvent, parallelMap } from "@oneshot-gtm/core";
 import type { CompetitorSwitchTarget, RepoInterestTarget } from "@oneshot-gtm/plays";
-import { resolveVerifyEnrichQualify } from "./_contact.ts";
+import { resolveVerifyEnrichQualify, icpFields } from "./_contact.ts";
 import { enqueueScoredTarget } from "./_priority-adapters.ts";
 import { persistRoleRejection } from "./_qualify.ts";
 import { isDuplicate } from "./_dedupe.ts";
@@ -268,6 +268,7 @@ export async function runGitHubStarsFinder(opts: GitHubStarsFinderOpts): Promise
       ...(linkedinUrl ? { linkedinUrl } : {}),
       ...(enr.phone ? { phone: enr.phone } : {}),
       ...(contact.title ? { title: contact.title } : {}),
+      ...icpFields(contact),
       sourceProfileUrl: profileUrl,
     };
 

--- a/packages/find/src/hiring-signal.ts
+++ b/packages/find/src/hiring-signal.ts
@@ -1,5 +1,5 @@
 import { getLedger, logEvent, webRead, webSearch } from "@oneshot-gtm/core";
-import { resolveVerifyEnrichQualify } from "./_contact.ts";
+import { resolveVerifyEnrichQualify, icpFields } from "./_contact.ts";
 import { enqueueScoredTarget } from "./_priority-adapters.ts";
 import { persistRoleRejection, qualifyPreSpend } from "./_qualify.ts";
 import { complete, loadPrompt, tryParseJsonObject } from "@oneshot-gtm/intel";
@@ -292,6 +292,7 @@ export async function runHiringSignalFinder(opts: HiringSignalFinderOpts): Promi
       ...(linkedinUrl ? { linkedinUrl } : {}),
       ...(phone ? { phone } : {}),
       ...(contact.title ? { title: contact.title } : {}),
+      ...icpFields(contact),
     };
     const id = enqueueScoredTarget(ledger, {
       playName: PLAY_NAME,

--- a/packages/find/src/job-change.ts
+++ b/packages/find/src/job-change.ts
@@ -1,5 +1,5 @@
 import { getLedger, logEvent, webSearch } from "@oneshot-gtm/core";
-import { resolveVerifyEnrichQualify } from "./_contact.ts";
+import { resolveVerifyEnrichQualify, icpFields } from "./_contact.ts";
 import { enqueueScoredTarget } from "./_priority-adapters.ts";
 import { persistRoleRejection, qualifyPreSpend } from "./_qualify.ts";
 import { complete, loadPrompt, tryParseJsonObject } from "@oneshot-gtm/intel";
@@ -266,6 +266,7 @@ export async function runJobChangeFinder(opts: JobChangeFinderOpts): Promise<Fin
       ...(linkedinUrl ? { linkedinUrl } : {}),
       ...(phone ? { phone } : {}),
       ...(contact.title ? { title: contact.title } : {}),
+      ...icpFields(contact),
     };
     const id = enqueueScoredTarget(ledger, {
       playName: PLAY_NAME,

--- a/packages/find/src/local-registry.ts
+++ b/packages/find/src/local-registry.ts
@@ -1,5 +1,5 @@
 import { getLedger, logEvent } from "@oneshot-gtm/core";
-import { resolveVerifyEnrichQualify } from "./_contact.ts";
+import { resolveVerifyEnrichQualify, icpFields } from "./_contact.ts";
 import { enqueueScoredTarget } from "./_priority-adapters.ts";
 import { persistRoleRejection } from "./_qualify.ts";
 import { icpFilter, resolveIcp } from "./_filter.ts";
@@ -404,6 +404,7 @@ export async function runLocalRegistryFinder(opts: LocalRegistryFinderOpts): Pro
       ...(contact.linkedinUrl ? { linkedinUrl: contact.linkedinUrl } : {}),
       ...(phone ? { phone } : {}),
       ...(contact.title ? { title: contact.title } : {}),
+      ...icpFields(contact),
     };
     const id = enqueueScoredTarget(ledger, {
       playName,

--- a/packages/find/src/luma.ts
+++ b/packages/find/src/luma.ts
@@ -11,7 +11,7 @@ import {
 import { complete, loadPrompt, tryParseJsonObject } from "@oneshot-gtm/intel";
 import type { LumaEventsTarget } from "@oneshot-gtm/plays";
 import { isDuplicate, urlDomain } from "./_dedupe.ts";
-import { resolveVerifyEnrichQualify } from "./_contact.ts";
+import { resolveVerifyEnrichQualify, icpFields } from "./_contact.ts";
 import { enqueueScoredTarget } from "./_priority-adapters.ts";
 import { roundRobin } from "./_rank.ts";
 import { icpFilter, resolveIcp } from "./_filter.ts";
@@ -31,6 +31,13 @@ const PLAY_NAME = "luma-events";
 const SOURCE = "find:luma-events";
 /** Cap per-event LLM extract input — Luma event pages are usually under 8k chars. */
 const READ_MARKDOWN_SLICE = 12000;
+/**
+ * How much event description the relevance gate sees. Enough for the opening
+ * lines that say what an event actually is — the "agentic after-hours, lightning
+ * panel with …" sentence that a punning title hides — without paying to classify
+ * a full agenda.
+ */
+const GATE_SUMMARY_SLICE = 600;
 /** Sane upper bound — no event we care about has >30 public attendees. */
 const MAX_ATTENDEES_PER_EVENT = 30;
 
@@ -331,11 +338,9 @@ export async function runLumaFinder(opts: LumaFinderOpts): Promise<{
     "info",
   );
 
-  // Event-level relevance criterion: one LLM call (below) weighs the founder's
-  // ICP AND topics, on the event NAME, BEFORE any webRead — so we never pay to
-  // read the dance-cardio / wine-tasting noise that city pages surface. This
-  // replaces the old per-attendee ICP filter, which rejected even on-topic
-  // attendees because Luma's public attendee data is too thin to judge.
+  // Event-level relevance criterion: one LLM call weighs the founder's ICP AND
+  // topics. This replaces the old per-attendee ICP filter, which rejected even
+  // on-topic attendees because Luma's public attendee data is too thin to judge.
   const relevanceCriteria = [
     icp,
     topics.length > 0 ? `Event must relate to: ${topics.join(", ")}` : null,
@@ -343,19 +348,38 @@ export async function runLumaFinder(opts: LumaFinderOpts): Promise<{
     .filter(Boolean)
     .join(". ");
 
-  // Phase 2: topic/ICP gate → webRead + LLM extract per event, parallelized.
-  // Each surviving event yields 0..N attendees; flatten into one work list.
+  // Phase 2: free structured fetch → topic/ICP gate → paid webRead only on
+  // fallback, parallelized. Each surviving event yields 0..N attendees.
   const concurrency = 3;
   const eventExtracts: Array<{ hit: CitySearchHit; extract: LumaEventExtract } | null> =
     await parallelMap(hits.slice(0, limit * 2), concurrency, async (hit) => {
       if (opts.maxCostUsd != null && result.costUsd >= opts.maxCostUsd) return null;
-      // Event-level relevance gate (topic + ICP in one call), on the name only.
-      if (relevanceCriteria) {
+
+      // Gate ordering matters, and it used to be wrong. The gate ran on the
+      // event NAME alone, before any fetch, to avoid paying to read the
+      // dance-cardio noise city pages surface. But `fetchEventDetails` is a
+      // FREE anonymous JSON call, and it returns the description — so the gate
+      // was blind for no saving, and titles that are puns got dropped.
+      //
+      // "AI Infra Kebab" (Vercel/Neon, panel of Malte Ubl, Nikita Shamgunov,
+      // Max Stoiber) was rejected three days running as "a generic event title
+      // with no evidence of technical leadership", then accepted on the fourth
+      // on identical input. Its description says exactly what it is.
+      //
+      // So: fetch free details first, gate on title + description when we have
+      // them, and fall back to the old title-only gate ONLY when the structured
+      // fetch missed — because there the next step is a paid webRead and the
+      // original reasoning still holds.
+      const gate = async (description: string | null): Promise<boolean> => {
+        if (!relevanceCriteria) return true;
+        const summary = description?.trim()
+          ? description.trim().slice(0, GATE_SUMMARY_SLICE)
+          : null;
         const ev = await icpFilter({
           icp: relevanceCriteria,
-          candidate: { title: hit.title, url: hit.url },
+          candidate: { title: hit.title, url: hit.url, summary },
         });
-        if (ev.match === null) return null; // transient classifier failure → drop, no persist
+        if (ev.match === null) return false; // transient classifier failure → drop, no persist
         if (!ev.match) {
           result.droppedIcp++;
           logEvent(
@@ -364,13 +388,15 @@ export async function runLumaFinder(opts: LumaFinderOpts): Promise<{
               name: PLAY_NAME,
               url: hit.url,
               title: hit.title,
+              grounded: description != null,
               reason_120: ev.reason.slice(0, 120),
             },
             "info",
           );
-          return null;
+          return false;
         }
-      }
+        return true;
+      };
 
       try {
         // Structured-first: the anonymous `api.lu.ma/url` JSON carries the
@@ -383,6 +409,8 @@ export async function runLumaFinder(opts: LumaFinderOpts): Promise<{
         const eventSlug = lumaEventSlug(hit.url);
         const details = eventSlug ? await fetchEventDetails(eventSlug) : null;
         if (details && details.eventTitle && details.attendees.length > 0) {
+          // Gate on the description we just got for free.
+          if (!(await gate(details.eventDescription ?? hit.description ?? null))) return null;
           extract = {
             eventTitle: details.eventTitle,
             eventDateIso: details.eventDateIso,
@@ -403,6 +431,11 @@ export async function runLumaFinder(opts: LumaFinderOpts): Promise<{
             "info",
           );
         } else {
+          // Structured fetch missed. The next call is PAID, so gate first — on
+          // the city-page description when the hub gave us one, otherwise on
+          // the title alone, which is the pre-existing behaviour and the reason
+          // this ordering exists at all.
+          if (!(await gate(hit.description ?? null))) return null;
           const read = await webRead(
             { url: hit.url },
             {
@@ -632,7 +665,12 @@ export async function runLumaFinder(opts: LumaFinderOpts): Promise<{
       icp,
       person: {
         name: work.attendee.name,
-        roleText: work.attendee.bio ?? work.attendee.role ?? null,
+        // `??` only falls through on null/undefined, and Luma returns an EMPTY
+        // STRING for an attendee with no bio_short — so `bio ?? role` yielded
+        // "" and the gate saw no role text at all, silently deferring every
+        // such candidate to a stage B that this finder never reaches. Take the
+        // first value with actual characters in it.
+        roleText: firstNonBlank(work.attendee.bio, work.attendee.role),
         evidence: `attended ${work.event.title}`,
       },
     });
@@ -885,6 +923,7 @@ async function resolveAndEnqueueLumaAttendee(
       name: work.attendee.name,
       email,
       ...(resolvedCompany ? { company: resolvedCompany } : {}),
+      ...(companyDomain ? { companyDomain } : {}),
       ...(work.attendee.bio || work.attendee.role
         ? { attendeeBio: work.attendee.bio ?? work.attendee.role ?? "" }
         : {}),
@@ -900,6 +939,7 @@ async function resolveAndEnqueueLumaAttendee(
       ...(linkedinUrl ? { linkedinUrl } : {}),
       ...(phone ? { phone } : {}),
       ...(contact.title ? { title: contact.title } : {}),
+      ...icpFields(contact),
       ...(work.attendee.profileUrl ? { sourceProfileUrl: work.attendee.profileUrl } : {}),
     };
     // Synchronous cap re-check right before enqueue — no await between here and
@@ -972,3 +1012,11 @@ registerPendingRetry(PLAY_NAME, async (raw) => {
       ? "platform-error"
       : "dropped";
 });
+
+/** First value with non-whitespace content, or null. */
+function firstNonBlank(...values: Array<string | null | undefined>): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim() !== "") return value;
+  }
+  return null;
+}

--- a/packages/find/src/luma.ts
+++ b/packages/find/src/luma.ts
@@ -872,7 +872,7 @@ async function resolveAndEnqueueLumaAttendee(
       person: {
         name: work.attendee.name,
         company: resolvedCompany,
-        roleText: work.attendee.bio ?? work.attendee.role ?? null,
+        roleText: firstNonBlank(work.attendee.bio, work.attendee.role),
         evidence: `attended ${work.event.title}`,
       },
       // Free title from the LinkedIn-keyed enrichProfile above.
@@ -924,8 +924,11 @@ async function resolveAndEnqueueLumaAttendee(
       email,
       ...(resolvedCompany ? { company: resolvedCompany } : {}),
       ...(companyDomain ? { companyDomain } : {}),
-      ...(work.attendee.bio || work.attendee.role
-        ? { attendeeBio: work.attendee.bio ?? work.attendee.role ?? "" }
+      // Same `??`-on-empty-string trap: an attendee with `bio: ""` and a real
+      // `role` persisted `attendeeBio: ""`, which is what the draft prompt
+      // reads. Fall back on blankness, not just null.
+      ...(firstNonBlank(work.attendee.bio, work.attendee.role)
+        ? { attendeeBio: firstNonBlank(work.attendee.bio, work.attendee.role) as string }
         : {}),
       ...(work.attendee.role ? { role: work.attendee.role } : {}),
       eventTitle: work.event.title,

--- a/packages/find/src/podcast-guest.ts
+++ b/packages/find/src/podcast-guest.ts
@@ -1,5 +1,5 @@
 import { getLedger, logEvent, webRead, webSearch } from "@oneshot-gtm/core";
-import { resolveVerifyEnrichQualify } from "./_contact.ts";
+import { resolveVerifyEnrichQualify, icpFields } from "./_contact.ts";
 import { enqueueScoredTarget } from "./_priority-adapters.ts";
 import { persistRoleRejection, qualifyPreSpend } from "./_qualify.ts";
 import { complete, loadPrompt, tryParseJsonObject } from "@oneshot-gtm/intel";
@@ -254,6 +254,7 @@ export async function runPodcastGuestFinder(opts: PodcastGuestFinderOpts): Promi
       ...(linkedinUrl ? { linkedinUrl } : {}),
       ...(phone ? { phone } : {}),
       ...(contact.title ? { title: contact.title } : {}),
+      ...icpFields(contact),
     };
     const id = enqueueScoredTarget(ledger, {
       playName: PLAY_NAME,

--- a/packages/find/src/post-funding.ts
+++ b/packages/find/src/post-funding.ts
@@ -1,5 +1,5 @@
 import { getLedger, logEvent, webRead, webSearch } from "@oneshot-gtm/core";
-import { resolveVerifyEnrichQualify } from "./_contact.ts";
+import { resolveVerifyEnrichQualify, icpFields } from "./_contact.ts";
 import { enqueueScoredTarget } from "./_priority-adapters.ts";
 import { persistRoleRejection, qualifyPreSpend } from "./_qualify.ts";
 import { complete, loadPrompt, tryParseJsonObject } from "@oneshot-gtm/intel";
@@ -246,6 +246,7 @@ export async function runPostFundingFinder(opts: PostFundingFinderOpts): Promise
       ...(linkedinUrl ? { linkedinUrl } : {}),
       ...(phone ? { phone } : {}),
       ...(contact.title ? { title: contact.title } : {}),
+      ...icpFields(contact),
     };
     const id = enqueueScoredTarget(ledger, {
       playName: PLAY_NAME,

--- a/packages/find/src/show-hn.ts
+++ b/packages/find/src/show-hn.ts
@@ -1,5 +1,5 @@
 import { getLedger, logEvent, webRead } from "@oneshot-gtm/core";
-import { resolveVerifyEnrichQualify } from "./_contact.ts";
+import { resolveVerifyEnrichQualify, icpFields } from "./_contact.ts";
 import { enqueueScoredTarget } from "./_priority-adapters.ts";
 import { persistRoleRejection } from "./_qualify.ts";
 import type { ShowHnTarget } from "@oneshot-gtm/plays";
@@ -285,6 +285,7 @@ async function resolveAndEnqueueShowHn(
     ...(linkedinUrl ? { linkedinUrl } : {}),
     ...(phone ? { phone } : {}),
     ...(contact.title ? { title: contact.title } : {}),
+    ...icpFields(contact),
   };
   const id = enqueueScoredTarget(ledger, {
     playName: PLAY_NAME,

--- a/packages/plays/__tests__/accelerator-batch.test.ts
+++ b/packages/plays/__tests__/accelerator-batch.test.ts
@@ -30,6 +30,8 @@ vi.mock("@oneshot-gtm/core", async () => {
       recordSequenceEvent: () => 1,
       hasSentSequenceEvent: () => false,
       findProspectByEmail: () => null,
+      // sendDraftedEmail reads the stored ICP verdict before a first touch.
+      getProspectById: () => null,
       getCachedEnrichment: () => null,
       setCachedEnrichment: () => {},
     }),

--- a/packages/plays/__tests__/cadence-bounce.test.ts
+++ b/packages/plays/__tests__/cadence-bounce.test.ts
@@ -33,6 +33,8 @@ vi.mock("@oneshot-gtm/core", async () => {
     getLedger: () => ({
       findProspectByEmail: (email: string) =>
         email.trim().toLowerCase() === PROSPECT_EMAIL ? { id: 1 } : null,
+      // sendDraftedEmail reads the stored ICP verdict before a first touch.
+      getProspectById: () => null,
       recordBounce: (input: {
         messageId: string;
         recipient: string;

--- a/packages/plays/__tests__/civic-pilot.test.ts
+++ b/packages/plays/__tests__/civic-pilot.test.ts
@@ -29,6 +29,8 @@ vi.mock("@oneshot-gtm/core", async () => {
       recordSequenceEvent: () => 1,
       hasSentSequenceEvent: () => false,
       findProspectByEmail: () => ({ id: 1 }),
+      // sendDraftedEmail reads the stored ICP verdict before a first touch.
+      getProspectById: () => null,
       listSequenceEventsForProspectPlay: () => [],
       prospectHasFirstTouch: () => false,
       getCachedEnrichment: () => null,

--- a/packages/plays/__tests__/competitor-switch.test.ts
+++ b/packages/plays/__tests__/competitor-switch.test.ts
@@ -52,6 +52,8 @@ vi.mock("@oneshot-gtm/core", async () => {
       recordSequenceEvent: () => 1,
       hasSentSequenceEvent: () => false,
       findProspectByEmail: () => null,
+      // sendDraftedEmail reads the stored ICP verdict before a first touch.
+      getProspectById: () => null,
       getCachedEnrichment: () => null,
       setCachedEnrichment: () => {},
     }),

--- a/packages/plays/__tests__/design-partner-loi.test.ts
+++ b/packages/plays/__tests__/design-partner-loi.test.ts
@@ -31,6 +31,8 @@ vi.mock("@oneshot-gtm/core", async () => {
       recordSequenceEvent: () => 1,
       hasSentSequenceEvent: () => false,
       findProspectByEmail: () => ({ id: 1 }),
+      // sendDraftedEmail reads the stored ICP verdict before a first touch.
+      getProspectById: () => null,
       listSequenceEventsForProspectPlay: () => [],
       prospectHasFirstTouch: () => false,
       getCachedEnrichment: () => null,

--- a/packages/plays/__tests__/discovery-interview.test.ts
+++ b/packages/plays/__tests__/discovery-interview.test.ts
@@ -29,6 +29,8 @@ vi.mock("@oneshot-gtm/core", async () => {
       recordSequenceEvent: () => 1,
       hasSentSequenceEvent: () => false,
       findProspectByEmail: () => ({ id: 1 }),
+      // sendDraftedEmail reads the stored ICP verdict before a first touch.
+      getProspectById: () => null,
       listSequenceEventsForProspectPlay: () => [],
       prospectHasFirstTouch: () => false,
       getCachedEnrichment: () => null,

--- a/packages/plays/__tests__/free-pilot.test.ts
+++ b/packages/plays/__tests__/free-pilot.test.ts
@@ -29,6 +29,8 @@ vi.mock("@oneshot-gtm/core", async () => {
       recordSequenceEvent: () => 1,
       hasSentSequenceEvent: () => false,
       findProspectByEmail: () => ({ id: 1 }),
+      // sendDraftedEmail reads the stored ICP verdict before a first touch.
+      getProspectById: () => null,
       listSequenceEventsForProspectPlay: () => [],
       prospectHasFirstTouch: () => false,
       getCachedEnrichment: () => null,

--- a/packages/plays/__tests__/lint-grounding.test.ts
+++ b/packages/plays/__tests__/lint-grounding.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { lintGrounding } from "../src/_run-play.ts";
+
+// `standardEnrich` serializes safeEnrich's result straight into the prompt's
+// DOSSIER block — the failure sentinel included. `prep.enrichmentFailed` was
+// already set and already shown in the queue UI, but nothing pushed a flag, and
+// `sendDraftedEmail` only holds a draft when `flags` is non-empty. So the draft
+// went out with `{"status":"failed","profile":null,"cost":0}` as its dossier.
+
+describe("lintGrounding", () => {
+  it("flags a draft whose enrich failed and whose target carries nothing else", () => {
+    // The prospect-679 shape: a name, a company string, an empty Luma bio.
+    expect(lintGrounding({ attendeeBio: "", role: "Guest" }, { enrichmentFailed: true })).toEqual([
+      "ungrounded",
+    ]);
+  });
+
+  it("stays quiet when the enrich succeeded", () => {
+    expect(lintGrounding({ attendeeBio: "" }, {})).toEqual([]);
+    expect(lintGrounding({}, { enrichmentFailed: false })).toEqual([]);
+  });
+
+  it("stays quiet when the target has its own grounding despite the failure", () => {
+    // A failed enrich is survivable when the draft still has something true to
+    // say. Flagging these would hold drafts that are perfectly fine.
+    expect(lintGrounding({ title: "Co-Founder, CTO" }, { enrichmentFailed: true })).toEqual([]);
+    expect(lintGrounding({ attendeeBio: "Founder @ AcmeAI" }, { enrichmentFailed: true })).toEqual(
+      [],
+    );
+  });
+
+  it("does not count a bare event role as grounding", () => {
+    // "Guest" says nothing about what the person does — it is why the
+    // person-level ICP gate treats a bare event role as `unclear`.
+    expect(lintGrounding({ role: "Host", title: "" }, { enrichmentFailed: true })).toEqual([
+      "ungrounded",
+    ]);
+  });
+
+  it("tolerates a target that is not an object", () => {
+    expect(lintGrounding(null, { enrichmentFailed: true })).toEqual(["ungrounded"]);
+  });
+});

--- a/packages/plays/__tests__/luma-events.test.ts
+++ b/packages/plays/__tests__/luma-events.test.ts
@@ -32,6 +32,8 @@ vi.mock("@oneshot-gtm/core", async () => {
       recordSequenceEvent: () => 1,
       hasSentSequenceEvent: () => false,
       findProspectByEmail: () => null,
+      // sendDraftedEmail reads the stored ICP verdict before a first touch.
+      getProspectById: () => null,
       getCachedEnrichment: () => null,
       setCachedEnrichment: () => {},
       enrollCadence: () => {

--- a/packages/plays/__tests__/new-business.test.ts
+++ b/packages/plays/__tests__/new-business.test.ts
@@ -30,6 +30,8 @@ vi.mock("@oneshot-gtm/core", async () => {
       recordSequenceEvent: () => 1,
       hasSentSequenceEvent: () => false,
       findProspectByEmail: () => ({ id: 1 }),
+      // sendDraftedEmail reads the stored ICP verdict before a first touch.
+      getProspectById: () => null,
       listSequenceEventsForProspectPlay: () => [],
       prospectHasFirstTouch: () => false,
       getCachedEnrichment: () => null,

--- a/packages/plays/__tests__/profile-intro.test.ts
+++ b/packages/plays/__tests__/profile-intro.test.ts
@@ -82,6 +82,8 @@ vi.mock("@oneshot-gtm/core", async () => {
       upsertProspect: () => 1,
       recordSequenceEvent: () => 1,
       findProspectByEmail: () => null,
+      // sendDraftedEmail reads the stored ICP verdict before a first touch.
+      getProspectById: () => null,
       getCachedEnrichment: () => null,
       setCachedEnrichment: () => {},
     }),

--- a/packages/plays/__tests__/repo-interest.test.ts
+++ b/packages/plays/__tests__/repo-interest.test.ts
@@ -32,6 +32,8 @@ vi.mock("@oneshot-gtm/core", async () => {
       // repo-interest is 2-touch and must enroll a cadence here. [] prior events
       // means no step-0 yet, so sendDraftedEmail's dedup lets the send proceed.
       findProspectByEmail: () => ({ id: 1 }),
+      // sendDraftedEmail reads the stored ICP verdict before a first touch.
+      getProspectById: () => null,
       listSequenceEventsForProspectPlay: () => [],
       prospectHasFirstTouch: () => false,
       getCachedEnrichment: () => null,

--- a/packages/plays/__tests__/sendDraftedEmail.test.ts
+++ b/packages/plays/__tests__/sendDraftedEmail.test.ts
@@ -7,6 +7,8 @@ const findProspectByEmailMock = vi.fn<(email: string) => { id: number } | null>(
 const listSequenceEventsForProspectPlayMock =
   vi.fn<(pid: number, play: string) => Array<{ step_index: number }>>();
 const prospectHasFirstTouchMock = vi.fn<(pid: number) => boolean>();
+const getProspectByIdMock = vi.fn<(pid: number) => Record<string, unknown> | null>();
+const setProspectIcpVerdictMock = vi.fn();
 
 vi.mock("@oneshot-gtm/core", async () => {
   const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
@@ -36,6 +38,9 @@ vi.mock("@oneshot-gtm/core", async () => {
       recordSequenceEvent: recordSequenceEventMock,
       hasSentSequenceEvent: () => false,
       findProspectByEmail: findProspectByEmailMock,
+      // sendDraftedEmail reads the stored ICP verdict before a first touch.
+      getProspectById: getProspectByIdMock,
+      setProspectIcpVerdict: setProspectIcpVerdictMock,
       listSequenceEventsForProspectPlay: listSequenceEventsForProspectPlayMock,
       prospectHasFirstTouch: prospectHasFirstTouchMock,
     }),
@@ -72,6 +77,8 @@ beforeEach(() => {
   findProspectByEmailMock.mockReset().mockReturnValue(null);
   listSequenceEventsForProspectPlayMock.mockReset().mockReturnValue([]);
   prospectHasFirstTouchMock.mockReset().mockReturnValue(false);
+  getProspectByIdMock.mockReset().mockReturnValue(null);
+  setProspectIcpVerdictMock.mockReset();
 });
 
 afterEach(() => {
@@ -198,5 +205,75 @@ describe("sendDraftedEmail cross-workspace override pass-through", () => {
     await sendDraftedEmail(baseOpts({ to: "other@acme.dev" }));
     const [lastInput] = sendEmailMock.mock.calls.at(-1) as [Record<string, unknown>];
     expect(lastInput).not.toHaveProperty("allowContactedElsewhere");
+  });
+});
+
+// The person-level ICP gate on the FIRST touch. This check has always existed
+// for follow-ups (_cadence.ts, status "off-icp"), but step 0 had none — so 65
+// prospects carrying a `reject` verdict were emailed while only 3 cadences ever
+// stopped for it.
+describe("sendDraftedEmail person-level ICP gate", () => {
+  it("blocks a send when the finder's fresh verdict is reject", async () => {
+    const opts = baseOpts({
+      icp: { verdict: "reject" as const, reason: "Account Executive — hands it to someone else" },
+    });
+    const out = await sendDraftedEmail(opts);
+    expect(sendEmailMock).not.toHaveBeenCalled();
+    expect(out).toEqual({ receiptIds: [], sent: false });
+    expect(opts.flags).toEqual(["off-icp"]);
+  });
+
+  it("blocks a send when a PRIOR audit stored a reject on the prospect", async () => {
+    findProspectByEmailMock.mockReturnValue({ id: 7 });
+    getProspectByIdMock.mockReturnValue({
+      id: 7,
+      icp_verdict: "reject",
+      icp_verdict_reason: "recruiter",
+    });
+    const opts = baseOpts();
+    const out = await sendDraftedEmail(opts);
+    expect(sendEmailMock).not.toHaveBeenCalled();
+    expect(out.sent).toBe(false);
+    expect(opts.flags).toEqual(["off-icp"]);
+  });
+
+  it("FAILS OPEN on unclear and on null — the documented contract", async () => {
+    // ledger.ts:1470 is explicit that the cadence gate tests === "reject", so
+    // `unclear` fails open exactly as NULL does. This gate must not quietly
+    // narrow the funnel on an undecided classifier.
+    for (const verdict of ["unclear", "pass"] as const) {
+      sendEmailMock.mockClear();
+      const out = await sendDraftedEmail(baseOpts({ icp: { verdict, reason: "n/a" } }));
+      expect(sendEmailMock).toHaveBeenCalledTimes(1);
+      expect(out.sent).toBe(true);
+    }
+    sendEmailMock.mockClear();
+    findProspectByEmailMock.mockReturnValue({ id: 7 });
+    getProspectByIdMock.mockReturnValue({ id: 7, icp_verdict: null, icp_verdict_reason: null });
+    expect((await sendDraftedEmail(baseOpts())).sent).toBe(true);
+    expect(sendEmailMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("persists the verdict the finder already paid to compute", async () => {
+    await sendDraftedEmail(baseOpts({ icp: { verdict: "pass" as const, reason: "founder/CTO" } }));
+    expect(setProspectIcpVerdictMock).toHaveBeenCalledWith(99, "pass", "founder/CTO");
+  });
+
+  it("writes nothing when the play carries no verdict", async () => {
+    await sendDraftedEmail(baseOpts());
+    expect(setProspectIcpVerdictMock).not.toHaveBeenCalled();
+  });
+
+  it("prefers the fresh verdict over a stale stored one", async () => {
+    findProspectByEmailMock.mockReturnValue({ id: 7 });
+    getProspectByIdMock.mockReturnValue({
+      id: 7,
+      icp_verdict: "reject",
+      icp_verdict_reason: "judged off a bare event role",
+    });
+    const out = await sendDraftedEmail(
+      baseOpts({ icp: { verdict: "pass" as const, reason: "enriched title says Co-Founder" } }),
+    );
+    expect(out.sent).toBe(true);
   });
 });

--- a/packages/plays/__tests__/sources-sought.test.ts
+++ b/packages/plays/__tests__/sources-sought.test.ts
@@ -40,6 +40,8 @@ vi.mock("@oneshot-gtm/core", async () => {
       recordSequenceEvent: () => 1,
       hasSentSequenceEvent: () => false,
       findProspectByEmail: () => ({ id: 1 }),
+      // sendDraftedEmail reads the stored ICP verdict before a first touch.
+      getProspectById: () => null,
       listSequenceEventsForProspectPlay: () => calls.step0Events,
       prospectHasFirstTouch: () => false,
       getCachedEnrichment: () => null,

--- a/packages/plays/src/_lib.ts
+++ b/packages/plays/src/_lib.ts
@@ -609,6 +609,13 @@ export interface SendDraftedOpts {
     dossier_json?: string | null;
   };
   metadata?: Record<string, unknown>;
+  /**
+   * Person-level ICP verdict from the finder that produced this target, when
+   * it ran one. `reject` blocks the send; every verdict is persisted onto the
+   * prospect row so the audit and the cadence gate agree without a manual
+   * `ops/audit-icp.ts` pass. Absent for plays whose finder has no person gate.
+   */
+  icp?: { verdict: "pass" | "reject" | "unclear"; reason?: string | null };
   dryRun: boolean;
   /**
    * Allow a first-touch even if another play already touched the prospect.
@@ -650,6 +657,28 @@ export async function sendDraftedEmail(opts: SendDraftedOpts): Promise<SendDraft
         return { receiptIds: [], sent: false };
       }
     }
+    // Person-level ICP gate on the FIRST touch. The identical check has always
+    // existed for follow-ups (`_cadence.ts`, "off-icp"), but step 0 had none —
+    // so 65 prospects carrying a `reject` verdict were emailed while only 3
+    // cadences ever stopped for it. A verdict arrives either from the finder
+    // that just judged this candidate (`opts.icp`) or from a prior audit on the
+    // stored row; both are honoured, the fresh one first.
+    //
+    // Only `reject` blocks. `unclear` and NULL fail open, exactly as the
+    // cadence gate documents — this gate must not become a silent narrowing of
+    // the funnel on the strength of an undecided classifier.
+    const stored = existing ? ledger.getProspectById(existing.id) : null;
+    const icpVerdict = opts.icp?.verdict ?? stored?.icp_verdict ?? null;
+    if (icpVerdict === "reject") {
+      const why = opts.icp?.reason ?? stored?.icp_verdict_reason ?? "role does not fit";
+      opts.flags.push("off-icp");
+      logEvent(
+        "play.skipped_off_icp",
+        { play: opts.playName, to: opts.to, reason_120: why.slice(0, 120) },
+        "info",
+      );
+      return { receiptIds: [], sent: false };
+    }
     // Track as in-flight for the WHOLE send-and-record span (SDK call →
     // sequence_events row), so a graceful shutdown drains it before exiting and
     // never leaves a sent-but-unrecorded email the dedup can't see.
@@ -675,6 +704,13 @@ export async function sendDraftedEmail(opts: SendDraftedOpts): Promise<SendDraft
         },
       );
       const prospectId = ledger.upsertProspect(opts.prospectMeta);
+      // Persist the verdict the finder's gate already paid to compute. Without
+      // this the only production writer of the column was `ops/audit-icp.ts`,
+      // run by hand — which is why 23 rows created after its last run had no
+      // verdict at all. `transient` never reaches here (it is not a verdict).
+      if (opts.icp?.verdict) {
+        ledger.setProspectIcpVerdict(prospectId, opts.icp.verdict, opts.icp.reason ?? null);
+      }
       ledger.recordSequenceEvent({
         prospectId,
         playName: opts.playName,

--- a/packages/plays/src/_run-play.ts
+++ b/packages/plays/src/_run-play.ts
@@ -209,6 +209,7 @@ export async function runEmailPlay<T, X = Record<string, never>>(
         const flags = [
           ...lintEmail(draft.subject, draft.body, def.maxBodyWords),
           ...(def.extraFlags?.(target) ?? []),
+          ...lintGrounding(target, prep),
         ];
         // Cross-workspace hold, applied centrally so EVERY play gets it: a
         // soft flag (overridable on manual send) that keeps drain from auto-
@@ -245,6 +246,10 @@ export async function runEmailPlay<T, X = Record<string, never>>(
               : {}),
           },
           ...(def.metadata ? { metadata: def.metadata(target) } : {}),
+          // Same generic read as `title` above: any finder stamping the ICP
+          // gate's verdict on its payload gets it enforced at step 0 and
+          // persisted, without every play def naming the field.
+          ...icpFromTarget(target),
           dryRun: opts.dryRun,
         });
 
@@ -326,4 +331,60 @@ export async function standardEnrich(opts: {
   }
 
   return { receiptIds, dossier, ...(enrichmentFailed ? { enrichmentFailed: true } : {}) };
+}
+
+/**
+ * Read the person-level ICP verdict a finder stamped on its target payload.
+ *
+ * Finders spread `icpFields(contact)` (see `find/_contact.ts`) alongside
+ * `title`; this is the reader on the send side. Unknown or missing values
+ * yield `{}` so a play whose finder has no person gate is unaffected.
+ */
+function icpFromTarget(target: unknown): {
+  icp?: { verdict: "pass" | "reject" | "unclear"; reason?: string | null };
+} {
+  const row = target as { icpVerdict?: unknown; icpVerdictReason?: unknown };
+  const verdict = row?.icpVerdict;
+  if (verdict !== "pass" && verdict !== "reject" && verdict !== "unclear") return {};
+  return {
+    icp: {
+      verdict,
+      reason: typeof row.icpVerdictReason === "string" ? row.icpVerdictReason : null,
+    },
+  };
+}
+
+/**
+ * Flag a draft the system already knows is ungrounded.
+ *
+ * `standardEnrich` serializes whatever `safeEnrich` returned straight into the
+ * prompt's DOSSIER block — including the failure sentinel. So when the enrich
+ * fails the model is handed, verbatim:
+ *
+ *     DOSSIER:
+ *     { "status": "failed", "profile": null, "cost": 0 }
+ *
+ * and drafts anyway. `prep.enrichmentFailed` was already set, already carried
+ * to the queue UI as a badge, and already ignored by the send: `sendDraftedEmail`
+ * only holds a draft when `flags` is non-empty, and nothing ever pushed one.
+ *
+ * That is how prospect 679 was emailed "did the vendor proxy babysitting bite
+ * you at taxheaven too?" — the company string was the only prospect-specific
+ * noun in the whole prompt, so the model welded it onto the stock `yourEdge`.
+ *
+ * The flag fires only when there is nothing ELSE to write from. A failed
+ * enrich on a target that still carries a real title or bio is fine: the draft
+ * has something true to say. Every sent row in this ledger was drafted AFTER
+ * its human approval (681 of 681), so a flag here is the only checkpoint that
+ * sees the draft at all.
+ */
+export function lintGrounding(target: unknown, prep: { enrichmentFailed?: boolean }): string[] {
+  if (!prep.enrichmentFailed) return [];
+  const row = target as { title?: unknown; attendeeBio?: unknown; role?: unknown };
+  const hasOwnGrounding = nonBlank(row?.title) || nonBlank(row?.attendeeBio);
+  return hasOwnGrounding ? [] : ["ungrounded"];
+}
+
+function nonBlank(value: unknown): boolean {
+  return typeof value === "string" && value.trim().length > 0;
 }

--- a/packages/plays/src/luma-events.ts
+++ b/packages/plays/src/luma-events.ts
@@ -80,6 +80,13 @@ export interface LumaEventsTarget {
   name: string;
   email: string;
   company?: string;
+  /**
+   * Company domain from enrichment, when it resolved one. Preferred over the
+   * email's domain everywhere: an attendee's address is routinely a personal or
+   * university one, which points enrichment and product research at the wrong
+   * site (or nothing at all).
+   */
+  companyDomain?: string;
   /** One-line bio / role pulled from the prospect's Luma profile (e.g. "Founder @ AcmeAI"). */
   attendeeBio?: string;
   /**
@@ -169,7 +176,7 @@ const lumaEventsDef: EmailPlayDef<LumaEventsTarget> = {
       enrichInput: {
         ...(t.email ? { email: t.email } : {}),
         name: t.name,
-        companyDomain: emailDomain(t.email),
+        companyDomain: t.companyDomain ?? emailDomain(t.email),
       },
       enrichSlice: 3500,
     }),

--- a/packages/plays/src/luma-events.ts
+++ b/packages/plays/src/luma-events.ts
@@ -175,6 +175,13 @@ const lumaEventsDef: EmailPlayDef<LumaEventsTarget> = {
       playName: PLAY_NAME,
       enrichInput: {
         ...(t.email ? { email: t.email } : {}),
+        // The finder already resolved a LinkedIn profile for this attendee and
+        // `enrichProfile` keys on one — passing it was simply missed. It
+        // matters most for exactly the people this play finds: an event
+        // attendee's address is routinely personal or academic (the prospect
+        // this was traced from used a university alumni forwarder), and
+        // email + name alone is the weakest possible key.
+        ...(t.linkedinUrl ? { linkedinUrl: t.linkedinUrl } : {}),
         name: t.name,
         companyDomain: t.companyDomain ?? emailDomain(t.email),
       },
@@ -205,6 +212,13 @@ const lumaEventsDef: EmailPlayDef<LumaEventsTarget> = {
       `FOUNDER: ${cfg.founderName}`,
       `PRODUCT: ${cfg.productOneLiner}`,
       `PROSPECT: ${t.name}${t.company ? ` at ${t.company}` : ""}`,
+      // Both, because they come from different places and either can be empty.
+      // `attendeeBio` is Luma's self-written headline — absent on 168 of 432
+      // rows. `title` is what the person-level ICP gate resolved via a PAID
+      // enrichProfile, and it was persisted to prospects.title and then never
+      // shown to the model: the one hard fact about what this person does was
+      // bought and thrown away at the prompt boundary.
+      `TITLE: ${t.title ?? "(unknown)"}`,
       `ATTENDEE BIO/ROLE: ${t.attendeeBio ?? "(none)"}`,
       // "Host" = they RUN the event — never write as if they're merely going.
       `RELATIONSHIP TO EVENT: ${t.role ?? "(unknown — assume attendee)"}`,

--- a/packages/prompts/luma-events-email.md
+++ b/packages/prompts/luma-events-email.md
@@ -6,7 +6,8 @@ You write a founder-to-founder cold email triggered by the prospect appearing on
 
 - Founder name and product one-liner
 - Prospect name and company
-- ATTENDEE BIO/ROLE: short context from the prospect's Luma profile (e.g. "Founder @ AcmeAI", "Speaker"). May be missing.
+- TITLE: the prospect's job title, resolved from their LinkedIn profile (e.g. "Co-Founder & CTO", "Backend Engineer"). The one hard fact about what they actually do. "(unknown)" when it could not be resolved.
+- ATTENDEE BIO/ROLE: short context from the prospect's Luma profile (e.g. "Founder @ AcmeAI", "Speaker"). Self-written, so it may be a slogan rather than a job. May be missing.
 - EVENT TITLE + EVENT CITY: where they're going.
 - EVENT DATE: the event's weekday, date and time, ALREADY rendered in the event's own local timezone (e.g. `Wednesday, August 26, 7:30 PM PDT`).
 - EVENT WHEN: the same moment as a relative phrase ("tomorrow", "this Wednesday", "last Tuesday") — also already computed for you.
@@ -41,6 +42,7 @@ You write a founder-to-founder cold email triggered by the prospect appearing on
   - Sign-off: founder name.
 - Forbidden: never promise a doc you don't have — no "want the teardown / comparison / writeup / playbook" framing (see _humanizer.md → Banned: invented artifacts); "I noticed you're going", "I came across your name", "great to see you'll be at", "as a fellow founder", "would love to chat", "are you going to {event}?" (don't ask — say you saw they're going / went).
 - EVENT ABOUT is background for YOU to grasp the topic — never quote, paraphrase, or recap it as if you read the page or attended; it's the event's own marketing copy, not your observation. Draw the TOPIC from it, then write in your own peer voice.
+- TITLE and ATTENDEE BIO/ROLE are the ONLY authority on what this person does. Prefer TITLE when the two disagree — ATTENDEE BIO/ROLE is self-written and is often a slogan. Use it to pitch the Offer at the right altitude (an engineer and a founder care about different halves of the same problem), and never state it back to them ("as a Backend Engineer, you…") or infer seniority, tenure or team size from it. When TITLE is "(unknown)" and ATTENDEE BIO/ROLE is missing, you know nothing about this person beyond the event: write from the event alone and do NOT guess what they build.
 - EVENT TITLE + EVENT ABOUT are the ONLY authority on what kind of gathering this is AND what people do there. Call it what they call it (a meetup, a dinner, a festival, a conference) — never "hackathon", "demo weekend" or any other format word that doesn't appear there — and never import an activity the event text doesn't mention: no "demos dying", "shipping over the weekend", "pitching" unless THIS event is actually about that. ICP and YOUR EDGE describe your BUYER and your INSIGHT; take the insight from YOUR EDGE and recast it in this event's own setting, discarding whatever scene YOUR EDGE happens to be phrased in.
 - Forbidden when PAST: any future-tense reference to the event — "this {weekday}", "before the meetup", "ahead of the meetup", "see you there", or anything implying the event is still coming up. The event is over; write as if it already happened.
 

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -116,6 +116,12 @@ export interface LinkedInReplyWebhookRequest {
   occurredAt: string;
   linkedinUrl?: string;
   email?: string;
+  /**
+   * The message text, when the provider sends it. Optional — recording the
+   * reply (and stopping the cadence) never depends on it — but without a body
+   * the reply composer has nothing to draft against.
+   */
+  body?: string;
 }
 
 export interface LinkedInReplyResult {


### PR DESCRIPTION
## Why

A `luma-events` prospect was emailed *"did the vendor proxy babysitting bite you at taxheaven too?"* — a company he had already moved on from. He replied on LinkedIn describing something else entirely, and that reply had nowhere in the system to land.

The prompt behind that draft received, verbatim:

```
DOSSIER:
{ "status": "failed", "profile": null, "cost": 0 }
```

`standardEnrich` serializes whatever `safeEnrich` returned — the failure sentinel included — straight into the prompt. The only prospect-specific noun in the whole input block was the company string, so the model welded it onto the stock `yourEdge`. It wasn't hallucinating; it had nothing else.

Tracing it found the grounding pipeline had been inert for months.

## Measured before

| | |
|---|---|
| prospects with no person research | **536 / 684 (78%)** |
| emailed with no person research | **532 / 677 (79%)** |
| emailed despite `icp_verdict = reject` | **65** |
| cadences ever stopped by the ICP gate | **3** |
| backlog `research-prospects` could see | **5** |
| sent queue rows with a NULL `prospect_id` | **680 / 681** |
| `channel_events` rows written by anything but a human click | **0** |

## What changed

**The research backlog could not see its own work.** `listProspectsForResearch` filtered on `dossier_json IS NULL OR TRIM(...) = ''`, which stopped matching once `research-products` began writing a `{person, product}` wrapper onto every row. It now filters on `hasPersonSignal` — the gate `_run-play.ts`, `_reply-research.ts` and `research-prospects.ts` already shared. **5 → 536.** Alongside: `researchUrl` prefers LinkedIn/X/GitHub over a `luma.com/user/…` page whose whole content is "Nothing Here, Yet" (68 rows); rows with no profile URL are skipped rather than spending minutes each to fail; `research-prospects` merges instead of replacing and destroying the product half; `hasDossierSignal` stops counting a page's own empty-state text as a sourced excerpt; `dossierRole()` reads `$.person`, blind to it since the wrapper landed.

**ICP verdicts are written by the send path.** `QualifiedContact` carries the gate's verdict instead of collapsing it to `ok/reject/platform-error`; nine finders stamp it; `sendDraftedEmail` persists it and **gates step 0** — that check existed only for follow-ups. `null` and `unclear` still fail open, per the contract at `ledger.ts:1470`.

**A failed enrich no longer drafts silently.** `enrichmentFailed` was already set and already badged in the queue UI, but nothing pushed a flag and `sendDraftedEmail` only holds on a non-empty `flags`. `lintGrounding` flags `ungrounded` when the enrich failed *and* the target carries no title or bio. All 681 sent rows were drafted **after** their human approval, so this is the only checkpoint that sees the draft text.

**luma-events gate ordering.** The relevance gate ran on the event NAME before any fetch, to avoid paying for city-page noise — but `fetchEventDetails` is free and returns the description, so it was blind for no saving. "AI Infra Kebab" (Vercel/Neon; Malte Ubl, Nikita Shamgunov, Max Stoiber on the panel) was rejected three days running as *"a generic event title"*, then accepted on the fourth on identical input. Also: stage-A role text used `bio ?? role`, which yields `""` for Luma's empty `bio_short`.

**LinkedIn replies.** `channel_events` gains `body` so a reply can feed the composer. The manual mark keyed `externalEventId` on `randomUUID()`, so the UNIQUE dedupe never fired once — now a hash of `(prospectId, body)`, deliberately not of the clock, since the two real duplicates sit at 20:51:13 and 20:52:00, either side of a minute boundary. The affordance moved onto `/queue`: it lived only on `/cadences`, a join on `cadence_state`, so all 127 emailed luma-events prospects — a one-touch play that never enrols — were unreachable.

## Verified

- `bun run test` — **2916 tests / 218 files**, typecheck + oxfmt clean, oxlint unchanged at 27 pre-existing warnings.
- New cover: `dossier.test.ts` (empty-excerpt rejection, `hasPersonSignal`, merge round-trip), `research-prospects.test.ts` (URL preference, bounding), `sendDraftedEmail.test.ts` (step-0 gate, fail-open on `unclear`/null, persistence), `lint-grounding.test.ts`, `linkedin-replies-route.test.ts` (idempotency incl. the minute-boundary case).
- Run live against the sdk workspace: backlog reports 536; 139 net new person dossiers for **$8.80**; all 680 orphaned queue rows linked; the duplicate LinkedIn reply collapsed; `ops/audit-icp.ts --write` settled verdicts to 321 pass / 293 unclear / 70 reject.

## Not in this PR

- **A luma-events cadence.** Considered and rejected on the data: 491 follow-ups across the two cadenced plays produced **one** reply (0.2%), while luma-events — one-touch — has the best reply rate in the ledger at 2.3%.
- Per-prospect `angle_json` (#355/#356/#357), which fixes the *personalization* half — `yourEdge` is founder config, identical across all 432 luma queue rows. This PR fixes the grounding those depend on.
- Expandi outbound-webhook config, which is founder-side.

https://claude.ai/code/session_01CPweATEtibYbHW7CUBqbig

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prospect research can target a specific prospect and enforce a maximum run cost.
  * LinkedIn replies can include message text, are deduplicated, and can be recorded directly from the queue.
  * ICP verdicts are retained and applied when sending first-touch messages.
  * Queue records are linked back to their prospects after successful sends.
* **Bug Fixes**
  * Improved prospect research URL selection and dossier merging.
  * Improved Luma event relevance and attendee role handling.
  * Prevented empty profile results from being treated as useful research.
* **Tests**
  * Expanded coverage for research, replies, ICP gating, and grounding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->