### PR TITLE
fix: issue #516: Fix 1 shipped review finding(s) from merged PR #510

### DIFF
--- a/packages/find/__tests__/civic-agenda.test.ts
+++ b/packages/find/__tests__/civic-agenda.test.ts
@@ -37,6 +37,8 @@ let icpCalls = 0;
 let icpResolved: string | null = "icp";
 let eventsBySlug: Record<string, Array<Record<string, unknown>>> = {};
 let itemsByEventId: Record<number, Array<Record<string, unknown>>> = {};
+/** dedupeKeys (`${slug}:${eventId}:${eventItemId}`) that isQueueDuplicate should report as duplicates. */
+let queueDuplicateKeys: Set<string> = new Set();
 
 /** Controls what the stubbed global `fetch` returns for the OfficeRecords call. */
 type OfficeRecordsBehavior = "contact" | "no-email" | "throw" | "5xx";
@@ -83,7 +85,7 @@ vi.mock("@oneshot-gtm/core", async () => {
     ...actual,
     logEvent: () => {},
     getLedger: () => ({
-      isQueueDuplicate: () => false,
+      isQueueDuplicate: (_playName: string, dedupeKey: string) => queueDuplicateKeys.has(dedupeKey),
       isPendingResolution: () => false,
       findProspectByEmail: () => null,
       isEmailPendingInQueue: (email: string) =>
@@ -105,6 +107,7 @@ beforeEach(() => {
   icpCalls = 0;
   icpResolved = "icp";
   officeRecordsBehavior = "contact";
+  queueDuplicateKeys = new Set();
   eventsBySlug = {
     nyc: [
       {
@@ -337,6 +340,36 @@ describe("runCivicAgendaFinder — max-cost cap", () => {
     expect(icpCalls).toBe(1);
     expect(out.enqueued).toBe(1);
     expect(out.halted).toBeUndefined();
+  });
+
+  it("does not let a duplicate's zero prospective cost halt the run before a later non-duplicate candidate", async () => {
+    // Regression for finding PRRT_kwDOSKzrBs6fG5vp: the cost guard used to
+    // run BEFORE the duplicate check. A duplicate never reaches icpFilter,
+    // so its prospective cost is always 0 — with 0 < maxCostUsd <
+    // ICP_FILTER_COST_ESTIMATE_USD, that 0 cost passed the guard and then
+    // the duplicate `continue` skipped straight past the halt, but a later
+    // NON-duplicate candidate would then find `result.halted` never got
+    // set even though its own prospective cost exceeds the cap — worse,
+    // in the actual bug the duplicate's continue meant the halt check was
+    // simply skipped for it, silently letting the loop under-halt. Moving
+    // the duplicate check first ensures duplicates are dropped as
+    // duplicates (not misreported as cost halts) and the very next
+    // non-duplicate candidate is what the cap is evaluated against.
+    itemsByEventId = {
+      1: [
+        { eventItemId: 100, title: "Resolution on AI use in permitting", matterFile: "R-1" },
+        { eventItemId: 102, title: "AI automation budget amendment", matterFile: null },
+      ],
+    };
+    queueDuplicateKeys = new Set(["nyc:1:100"]);
+    const out = await runCivicAgendaFinder({ ...baseConfig, maxCostUsd: 0.0001 });
+    expect(out.droppedDuplicate).toBe(1);
+    // The first candidate is dropped as a duplicate without ever reaching
+    // the cost guard. The second (non-duplicate) candidate's prospective
+    // cost then exceeds the cap and halts the run before its icpFilter call.
+    expect(icpCalls).toBe(0);
+    expect(out.enqueued).toBe(0);
+    expect(out.halted).toMatch(/max-cost cap/);
   });
 });
 

--- a/packages/find/src/civic-agenda.ts
+++ b/packages/find/src/civic-agenda.ts
@@ -214,20 +214,6 @@ export async function runCivicAgendaFinder(opts: CivicAgendaFinderOpts): Promise
   // how small `limit` is.
   for (const candidate of gated.slice(0, Math.max(0, limit))) {
     if (result.enqueued >= limit) break;
-    // Compare the PROSPECTIVE cost (current spend + this candidate's paid
-    // icpFilter call, if one will actually happen) against the cap — not
-    // just the spend accrued so far. icpFilter is the only cost source in
-    // this finder, and it's free (no LLM call) when `icp` is null, so the
-    // estimate is 0 in that case. Checking post-hoc spend alone would let a
-    // single call through whenever `0 < maxCostUsd < ICP_FILTER_COST_ESTIMATE_USD`,
-    // since costUsd is still 0 right up until this call runs.
-    if (
-      opts.maxCostUsd != null &&
-      result.costUsd + (icp ? ICP_FILTER_COST_ESTIMATE_USD : 0) > opts.maxCostUsd
-    ) {
-      result.halted = `max-cost cap (${opts.maxCostUsd})`;
-      break;
-    }
 
     const dedupeKey = dedupeKeyFor(candidate);
     if (
@@ -236,6 +222,25 @@ export async function runCivicAgendaFinder(opts: CivicAgendaFinderOpts): Promise
     ) {
       result.droppedDuplicate++;
       continue;
+    }
+
+    // Compare the PROSPECTIVE cost (current spend + this candidate's paid
+    // icpFilter call, if one will actually happen) against the cap — not
+    // just the spend accrued so far. icpFilter is the only cost source in
+    // this finder, and it's free (no LLM call) when `icp` is null, so the
+    // estimate is 0 in that case. Checking post-hoc spend alone would let a
+    // single call through whenever `0 < maxCostUsd < ICP_FILTER_COST_ESTIMATE_USD`,
+    // since costUsd is still 0 right up until this call runs. This check
+    // runs AFTER the duplicate check above: a duplicate never reaches
+    // icpFilter, so its prospective cost is always 0 and it must not be
+    // able to trip the cap and halt the run before later, non-duplicate
+    // candidates get a chance.
+    if (
+      opts.maxCostUsd != null &&
+      result.costUsd + (icp ? ICP_FILTER_COST_ESTIMATE_USD : 0) > opts.maxCostUsd
+    ) {
+      result.halted = `max-cost cap (${opts.maxCostUsd})`;
+      break;
     }
 
     const filter = await icpFilter({


### PR DESCRIPTION
Closes #516.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: a12280f887ee (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (1 errs) vs base ok (1 errs)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded civic agenda coverage for duplicate-item handling.
  * Added scenarios verifying duplicate items bypass cost and paid-content filters.
  * Added regression coverage confirming processing halts when a later non-duplicate exceeds the maximum cost.
  * Improved test isolation by resetting duplicate state between tests.
  * Added coverage for behavior when no ICP is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->