### PR TITLE
fix: issue #522: Fix 2 shipped review finding(s) from merged PR #515

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # Status
 
-**Assume green.** The 51 CLI commands, 23 plays, 13 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
+**Assume green.** The 51 CLI commands, 23 plays, 15 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
 Last verified **2026-09-04** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2919 tests / 218 files** · typecheck + oxlint + oxfmt clean.
 

--- a/packages/find/__tests__/gov-solicitation.test.ts
+++ b/packages/find/__tests__/gov-solicitation.test.ts
@@ -187,6 +187,24 @@ describe("runGovSolicitationFinder — happy path", () => {
     expect(out.droppedEnrichment).toBe(1);
   });
 
+  it("drops a notice with a malformed (non-array) pointOfContact instead of throwing", async () => {
+    // SAM.gov's per-element shape isn't contractually guaranteed — a single
+    // object (or any other non-array value) in place of the expected list
+    // must not crash the `for...of` in pickPoc and abort the whole batch.
+    searchResponses["541511"] = [
+      samOpportunity({
+        noticeId: "bad-poc",
+        pointOfContact: { email: "solo@gsa.gov", fullName: "Solo Object" } as unknown as unknown[],
+      }),
+      samOpportunity({ noticeId: "good-poc" }),
+    ];
+    const out = await runGovSolicitationFinder(baseConfig);
+    expect(out.enqueued).toBe(1);
+    expect(out.droppedEnrichment).toBe(1);
+    expect(enqueued).toHaveLength(1);
+    expect(enqueued[0]!.dedupeKey).toBe("good-poc");
+  });
+
   it("filters by agencies (case-insensitive substring) before any fetch", async () => {
     const out = await runGovSolicitationFinder({
       ...baseConfig,

--- a/packages/find/__tests__/gov-solicitation.test.ts
+++ b/packages/find/__tests__/gov-solicitation.test.ts
@@ -205,6 +205,26 @@ describe("runGovSolicitationFinder — happy path", () => {
     expect(enqueued[0]!.dedupeKey).toBe("good-poc");
   });
 
+  it("drops a notice with non-string email/fullName in an otherwise valid POC entry instead of throwing", async () => {
+    // The declared `SamPointOfContact` field types aren't contractually
+    // guaranteed at runtime — a single POC object can carry a non-string
+    // `email` or `fullName` (e.g. a number). `.trim()` on a non-string
+    // throws a TypeError outside any try/catch here, which would abort the
+    // whole enqueue loop and drop every later opportunity in the batch.
+    searchResponses["541511"] = [
+      samOpportunity({
+        noticeId: "bad-poc-types",
+        pointOfContact: [{ email: 12345, fullName: "Numeric Email" }] as unknown as unknown[],
+      }),
+      samOpportunity({ noticeId: "good-poc-2" }),
+    ];
+    const out = await runGovSolicitationFinder(baseConfig);
+    expect(out.enqueued).toBe(1);
+    expect(out.droppedEnrichment).toBe(1);
+    expect(enqueued).toHaveLength(1);
+    expect(enqueued[0]!.dedupeKey).toBe("good-poc-2");
+  });
+
   it("filters by agencies (case-insensitive substring) before any fetch", async () => {
     const out = await runGovSolicitationFinder({
       ...baseConfig,

--- a/packages/find/src/gov-solicitation.ts
+++ b/packages/find/src/gov-solicitation.ts
@@ -223,7 +223,15 @@ interface GovSolicitationCandidate {
 
 /** First POC entry carrying BOTH a name and an email — the only usable kind. */
 function pickPoc(pocs: SamPointOfContact[] | null | undefined): SamPointOfContact | null {
-  for (const p of pocs ?? []) {
+  // SAM.gov's response shape isn't contractually guaranteed per-element: a
+  // malformed opportunity can carry a non-array `pointOfContact` (e.g. a
+  // single object instead of a list). `for...of` on a non-iterable throws a
+  // TypeError outside any try/catch here, which aborts the whole enqueue
+  // loop in runGovSolicitationFinder and drops every later opportunity in
+  // the batch — treat anything that isn't an array as "no usable POC".
+  if (!Array.isArray(pocs)) return null;
+  for (const p of pocs) {
+    if (!p || typeof p !== "object") continue;
     if (p.email && p.email.trim().length > 0 && p.fullName && p.fullName.trim().length > 0) {
       return p;
     }

--- a/packages/find/src/gov-solicitation.ts
+++ b/packages/find/src/gov-solicitation.ts
@@ -232,7 +232,18 @@ function pickPoc(pocs: SamPointOfContact[] | null | undefined): SamPointOfContac
   if (!Array.isArray(pocs)) return null;
   for (const p of pocs) {
     if (!p || typeof p !== "object") continue;
-    if (p.email && p.email.trim().length > 0 && p.fullName && p.fullName.trim().length > 0) {
+    // The declared `string | null` type isn't contractually guaranteed at
+    // runtime — SAM.gov can hand back a non-string email/fullName (e.g. a
+    // number). `.trim()` on a non-string throws a TypeError outside any
+    // try/catch here, which aborts the whole enqueue loop in
+    // runGovSolicitationFinder and drops every later opportunity in the
+    // batch, so require both fields to actually be strings before trimming.
+    if (
+      typeof p.email === "string" &&
+      p.email.trim().length > 0 &&
+      typeof p.fullName === "string" &&
+      p.fullName.trim().length > 0
+    ) {
       return p;
     }
   }


### PR DESCRIPTION
Closes #522.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 93f3db515500 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (1 errs) vs base ok (1 errs)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved SAM.gov solicitation processing so malformed notices and contact information are skipped without interrupting subsequent results.
  - Invalid opportunities with missing or blank identifiers are now safely ignored.
  - Description links outside the approved SAM.gov API host are no longer requested.
  - Description requests no longer follow redirects, helping prevent unintended external requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->