### PR TITLE
fix(web): give /queue back to the candidates

### DIFF
--- a/apps/server/src/api/packs.ts
+++ b/apps/server/src/api/packs.ts
@@ -7,6 +7,7 @@ function toPackView(pack: (typeof PACKS)[number]): PackView {
   return {
     id: pack.id,
     label: pack.label,
+    ...(pack.summary ? { summary: pack.summary } : {}),
     buyerBrief: pack.buyerBrief,
     icpOneLiner: pack.icpOneLiner,
     triggers: Object.keys(pack.triggers),

--- a/apps/web/src/lib/queue-helpers.test.ts
+++ b/apps/web/src/lib/queue-helpers.test.ts
@@ -56,6 +56,25 @@ describe("queue selection and bulk approval", () => {
     expect(selected).toEqual(new Set([9]));
   });
 
+  it("select-all covers only the CAPPED rows, never the ones held back", () => {
+    // The page renders `rows.slice(0, ROW_CAP)` behind a "show all" disclosure,
+    // so "visible" and "fetched" diverge. Handing the full set to these two is
+    // how one click on the header checkbox silently selects rows the reader
+    // cannot see — and the bulk approve/reject bar then acts on them.
+    const fetched = Array.from({ length: 200 }, (_, i) => ({ id: i + 1 }));
+    const visible = fetched.slice(0, 50);
+
+    const picked = selectVisibleQueueRows(visible, true);
+    expect(picked.size).toBe(50);
+    expect(picked.has(50)).toBe(true);
+    expect(picked.has(51)).toBe(false);
+
+    // And the header checkbox must read "all" once every visible row is ticked,
+    // rather than sitting indeterminate against a count it never shows.
+    expect(queueSelectionState(visible, picked).allSelected).toBe(true);
+    expect(queueSelectionState(fetched, picked).allSelected).toBe(false);
+  });
+
   it("bulk-approves selected ids only, including locked or sent selections", () => {
     // Status and send-lock validation remains server-owned; preserving every
     // selected id keeps the extraction from changing the requests made today.

--- a/apps/web/src/routes/queue.tsx
+++ b/apps/web/src/routes/queue.tsx
@@ -8,7 +8,6 @@ import {
   Copy,
   ExternalLink,
   Loader2,
-  Package,
   Pencil,
   Play,
   RotateCw,
@@ -22,7 +21,6 @@ import {
   blockingFlags,
   isRunnablePlay,
   type PackApplyResult,
-  type PackView,
   type QueueRowView,
   type QueueStatusView,
   type TriggerView,
@@ -79,6 +77,13 @@ export const Route = createFileRoute("/queue")({
 
 /** Stable empty page — see `fetchedRows` below. */
 const EMPTY_ROWS: QueueRowView[] = [];
+
+/**
+ * Rows rendered before the "show all" disclosure. The API hands back up to 200
+ * (`queue-helpers.ts`), which at ~70px each is ~14,000px of uninterrupted
+ * table — and `rejected` alone holds thousands.
+ */
+const ROW_CAP = 50;
 
 const STATUSES: Array<QueueStatusView | "all"> = [
   "all",
@@ -251,6 +256,14 @@ function QueuePage() {
   // every render, which would re-fire the rowMeta effect on each one.
   const fetchedRows = queueQuery.data?.rows;
   const rows = fetchedRows ?? EMPTY_ROWS;
+  /*
+   * Rows render capped, with a "show all" row at the end. Deliberately NOT
+   * persisted: lifting the cap for one look at the 7,600 rejected rows should
+   * not follow you back here tomorrow. Reset whenever the filters change, so
+   * "show all" never silently carries across a filter switch.
+   */
+  const [showAllRows, setShowAllRows] = useState(false);
+  const visibleRows = showAllRows ? rows : rows.slice(0, ROW_CAP);
   // Whole-queue approved counts per play — NOT scoped to the current filters,
   // so the drain button works from the default `pending` view too.
   const approvedByPlay = queueQuery.data?.approvedByPlay ?? {};
@@ -324,8 +337,6 @@ function QueuePage() {
 
       <IcpBanner />
 
-      <PacksCard />
-
       <TriggersCard queueEmpty={queueQuery.isLoading ? null : rows.length === 0} />
 
       {/* Target Queue. The play filter is inline because it narrows this table only. */}
@@ -359,7 +370,10 @@ function QueuePage() {
               key={s}
               variant={statusFilter === s ? "secondary" : "ghost"}
               size="sm"
-              onClick={() => setStatusFilter(s)}
+              onClick={() => {
+                setStatusFilter(s);
+                setShowAllRows(false);
+              }}
             >
               {s}
             </Button>
@@ -418,7 +432,10 @@ function QueuePage() {
           <Button
             variant={playFilter === "all" ? "secondary" : "ghost"}
             size="sm"
-            onClick={() => setPlayFilter("all")}
+            onClick={() => {
+              setPlayFilter("all");
+              setShowAllRows(false);
+            }}
           >
             all
           </Button>
@@ -427,7 +444,10 @@ function QueuePage() {
               key={p}
               variant={playFilter === p ? "secondary" : "ghost"}
               size="sm"
-              onClick={() => setPlayFilter(p)}
+              onClick={() => {
+                setPlayFilter(p);
+                setShowAllRows(false);
+              }}
             >
               {p}
             </Button>
@@ -467,7 +487,7 @@ function QueuePage() {
               </tr>
             </thead>
             <tbody>
-              {rows.map((row, i) => (
+              {visibleRows.map((row, i) => (
                 <QueueRow
                   key={row.id}
                   row={row}
@@ -488,6 +508,25 @@ function QueuePage() {
                   busy={approve.isPending || reject.isPending}
                 />
               ))}
+              {/* The fetch returns up to 200 rows (queue-helpers.ts `limit`)
+                  and every one used to render into this tbody — ~14,000px of
+                  table. Same one-quiet-row disclosure the inactive finders use
+                  in the Triggers panel, colSpan trick included so the shared
+                  column widths hold. */}
+              {rows.length > visibleRows.length && (
+                <tr className="border-b border-ink-rule/60">
+                  <td colSpan={7} className="px-6 py-2">
+                    <button
+                      type="button"
+                      onClick={() => setShowAllRows(true)}
+                      className="flex items-center gap-1.5 font-mono text-[11px] text-ink-faint transition-colors hover:text-ink-cream-2"
+                    >
+                      <ChevronDown size={11} />
+                      {rows.length - visibleRows.length} more · show all {rows.length}
+                    </button>
+                  </td>
+                </tr>
+              )}
             </tbody>
           </table>
         )}
@@ -744,7 +783,29 @@ export function QueueRow({
           <div className="text-ink-cream">{name ? <Pii kind="name">{name}</Pii> : "(unknown)"}</div>
           <div className="font-mono text-[11px] text-ink-faint">
             {email ? <Pii kind="email">{email}</Pii> : "—"}
-            {title ? <span className="text-ink-cream-2">{` · ${title}`}</span> : null}
+            {/*
+              Clamped, because `title` is a LinkedIn headline and some are
+              paragraphs: "Crypto Visionary & AI Strategist ⚡ | Revolutionizing
+              Retail Investing with AI-Driven Insights 🚀 | Empowering Web3
+              Success 🌍 | Non-Financial Advice ⚠️" rendered three lines and
+              made one row twice the height of its neighbours.
+
+              Only the title is clamped, not the whole line. Email, company and
+              the [in] link are short and are what tell two rows apart, so they
+              have to survive; the first few words of a headline carry the job
+              and the rest is self-promotion. Same treatment the evidence line
+              below already gets.
+            */}
+            {title ? (
+              <>
+                {/* Separator outside the clamp: `inline-block` + `truncate`
+                    (overflow-hidden) swallows the span's own leading space. */}
+                {" · "}
+                <span className="inline-block max-w-[38ch] truncate align-bottom text-ink-cream-2">
+                  {title}
+                </span>
+              </>
+            ) : null}
             {company ? (
               <>
                 {" · "}
@@ -1105,49 +1166,52 @@ function DraftSection({
     },
     onError: (err) => toast.error(`couldn't record · ${err.message}`),
   });
-  const linkedinReplyBlock =
-    status === "sent" && prospectId != null ? (
-      <div className="mt-2 border-t border-ink-rule pt-2">
-        {linkedinOpen ? (
-          <div className="flex flex-col gap-2">
-            <label
-              className="font-mono text-[10px] uppercase tracking-[0.14em] text-ink-faint"
-              htmlFor={`li-reply-${id}`}
-            >
-              they replied on linkedin — paste what they said
-            </label>
-            <textarea
-              id={`li-reply-${id}`}
-              className="min-h-[72px] w-full rounded border border-ink-rule bg-transparent p-2 text-[11px]"
-              value={linkedinBody}
-              onChange={(e) => setLinkedinBody(e.currentTarget.value)}
-              placeholder="Optional, but it is what a reply gets drafted from later."
-            />
-            <div className="flex items-center gap-2">
-              <Button
-                variant="secondary"
-                size="sm"
-                disabled={markLinkedIn.isPending}
-                onClick={() => markLinkedIn.mutate()}
-                {...readOnly}
-              >
-                {markLinkedIn.isPending ? "recording…" : "record reply"}
-              </Button>
-              <Button variant="ghost" size="sm" onClick={() => setLinkedinOpen(false)}>
-                cancel
-              </Button>
-            </div>
-          </div>
-        ) : (
+  // Split in two so the trigger sits with the other row actions in the draft
+  // card's header strip — beside the receipt links, where every other
+  // row-level action already lives — while the textarea stays below the body,
+  // which is the only part that earns full width.
+  const canMarkLinkedIn = status === "sent" && prospectId != null;
+  const linkedinReplyButton =
+    canMarkLinkedIn && !linkedinOpen ? (
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => setLinkedinOpen(true)}
+        title="Record a LinkedIn reply and stop any email cadence for this prospect"
+      >
+        mark linkedin reply
+      </Button>
+    ) : null;
+  const linkedinReplyEditor =
+    canMarkLinkedIn && linkedinOpen ? (
+      <div className="mt-2 flex flex-col gap-2 border-t border-ink-rule pt-2">
+        <label
+          className="font-mono text-[10px] uppercase tracking-[0.14em] text-ink-faint"
+          htmlFor={`li-reply-${id}`}
+        >
+          they replied on linkedin — paste what they said
+        </label>
+        <textarea
+          id={`li-reply-${id}`}
+          className="min-h-[72px] w-full rounded border border-ink-rule bg-transparent p-2 text-[11px]"
+          value={linkedinBody}
+          onChange={(e) => setLinkedinBody(e.currentTarget.value)}
+          placeholder="Optional, but it is what a reply gets drafted from later."
+        />
+        <div className="flex items-center gap-2">
           <Button
-            variant="ghost"
+            variant="secondary"
             size="sm"
-            onClick={() => setLinkedinOpen(true)}
-            title="Record a LinkedIn reply and stop any email cadence for this prospect"
+            disabled={markLinkedIn.isPending}
+            onClick={() => markLinkedIn.mutate()}
+            {...readOnly}
           >
-            mark linkedin reply
+            {markLinkedIn.isPending ? "recording…" : "record reply"}
           </Button>
-        )}
+          <Button variant="ghost" size="sm" onClick={() => setLinkedinOpen(false)}>
+            cancel
+          </Button>
+        </div>
       </div>
     ) : null;
 
@@ -1245,15 +1309,22 @@ function DraftSection({
 
   if (!draft) {
     return (
-      <div className="flex items-center justify-between gap-2 rounded-[var(--radius-sm)] border border-dashed border-ink-rule bg-ink-bg-deep px-3 py-2.5">
-        <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-ink-faint">
-          no draft yet
-        </span>
-        <span className="flex items-center gap-2">
-          {manualButtons}
-          {sendButton}
-          {draftButton}
-        </span>
+      <div className="rounded-[var(--radius-sm)] border border-dashed border-ink-rule bg-ink-bg-deep px-3 py-2.5">
+        <div className="flex items-center justify-between gap-2">
+          <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-ink-faint">
+            no draft yet
+          </span>
+          <span className="flex items-center gap-2">
+            {/* A sent row whose draft was never persisted used to return here
+                before the LinkedIn control rendered — so exactly the rows most
+                likely to have been replied to by hand could not record one. */}
+            {linkedinReplyButton}
+            {manualButtons}
+            {sendButton}
+            {draftButton}
+          </span>
+        </div>
+        {linkedinReplyEditor}
       </div>
     );
   }
@@ -1307,6 +1378,7 @@ function DraftSection({
               receipt #{rid}
             </Link>
           ))}
+          {linkedinReplyButton}
           {manualButtons}
           {sendButton}
           {draftButton}
@@ -1317,7 +1389,7 @@ function DraftSection({
         <pre className="mt-2 max-h-[360px] overflow-auto whitespace-pre-wrap font-mono text-[11.5px] leading-[1.55] text-ink-cream-2">
           {draft.body}
         </pre>
-        {linkedinReplyBlock}
+        {linkedinReplyEditor}
       </div>
     </div>
   );
@@ -1371,17 +1443,27 @@ function SignalStrip({ rows, ranked = false }: { rows: QueueRowView[]; ranked?: 
 const TRIGGERS_OPEN_KEY = "oneshot-gtm:queue-triggers-open";
 
 /**
- * Industry pack cards: a working starting config for a founder's vertical,
- * applied to several triggers at once instead of one `apply-config` per
- * trigger. Sits above the Triggers panel it feeds — applying a pack is what
- * populates the trigger rows below with real config.
+ * Industry pack picker — one selector, not eight cards.
+ *
+ * A pack IS trigger config: `POST /packs/:id/apply` merges each patch over the
+ * trigger's stored config and enables it. So it belongs inside the Triggers
+ * panel, which is already collapsed by default and already auto-opens on the
+ * two occasions a pack is what you came for — nothing configured yet, or an
+ * empty queue.
+ *
+ * It used to be eight always-expanded cards sitting above the candidates on a
+ * page titled "Candidates, for review.", costing ~900px — more than a whole
+ * viewport — for a once-per-vertical action. Every founder paid that on every
+ * visit, and seven of the eight are verticals any given founder will never
+ * pick.
  */
-function PacksCard() {
+function PackPicker() {
   const qc = useQueryClient();
-  const packsQuery = useQuery({
-    queryKey: ["packs"],
-    queryFn: () => api.packs(),
-  });
+  const navigate = useNavigate();
+  const packsQuery = useQuery({ queryKey: ["packs"], queryFn: () => api.packs() });
+  const [selectedId, setSelectedId] = useState<string>("");
+  const [lastResult, setLastResult] = useState<PackApplyResult | null>(null);
+
   const applyPack = useMutation({
     mutationFn: (id: string) => api.applyPack(id),
     onSuccess: (result: PackApplyResult) => {
@@ -1401,75 +1483,74 @@ function PacksCard() {
     },
     onError: (err: Error) => toast.error(err.message),
   });
-  const [lastResult, setLastResult] = useState<PackApplyResult | null>(null);
 
   const packs = packsQuery.data?.packs ?? [];
-  if (!packsQuery.isLoading && packs.length === 0) return null;
+  if (packsQuery.isLoading || packs.length === 0) return null;
+
+  const selected = packs.find((p) => p.id === selectedId) ?? null;
+  const result = lastResult && selected && lastResult.id === selected.id ? lastResult : null;
+  const stillNeeded = result?.applied.filter((t) => !t.ready) ?? [];
 
   return (
-    <section className="border-b border-ink-rule px-6 py-5">
-      <div className="mb-3 flex items-center gap-2">
-        <Package size={12} className="text-ink-faint" />
-        <div className="ln-eyebrow">
-          Industry packs <span className="text-ink-faint">· {packs.length}</span>
-        </div>
-      </div>
-      {packsQuery.isLoading ? (
-        <SkeletonRow />
-      ) : (
-        <div className="space-y-3">
+    <div className="border-b border-ink-rule/60 px-6 py-3">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="ln-eyebrow">Start from a pack</div>
+        <select
+          value={selectedId}
+          aria-label="industry pack"
+          onChange={(e) => {
+            setSelectedId(e.currentTarget.value);
+            // The previous pack's result must not read as this one's.
+            setLastResult(null);
+          }}
+          className="h-7 rounded-[var(--radius-sm)] border border-ink-rule bg-ink-bg px-2 text-[12px] text-ink-cream"
+        >
+          <option value="">select a vertical…</option>
           {packs.map((pack) => (
-            <PackRow
-              key={pack.id}
-              pack={pack}
-              applying={applyPack.isPending && applyPack.variables === pack.id}
-              onApply={() => applyPack.mutate(pack.id)}
-              result={lastResult?.id === pack.id ? lastResult : null}
-              disabled={READ_ONLY}
-            />
+            <option key={pack.id} value={pack.id}>
+              {pack.label}
+            </option>
           ))}
+        </select>
+        {selected && (
+          <Button
+            size="sm"
+            disabled={applyPack.isPending || READ_ONLY}
+            onClick={() => applyPack.mutate(selected.id)}
+            {...readOnly}
+          >
+            {applyPack.isPending ? "Applying…" : "Apply"}
+          </Button>
+        )}
+      </div>
+
+      {selected && (
+        <div className="mt-2">
+          {/* `summary` is the founder-facing line; `buyerBrief` is the
+              provenance behind it and reads like the engineering note it is. */}
+          <div className="text-[12px] text-ink-cream-2">
+            {selected.summary ?? selected.buyerBrief}
+          </div>
+          <div className="mt-1.5 font-mono text-[11px] text-ink-faint">
+            triggers · {selected.triggers.join(", ")}
+          </div>
+          <div className="mt-1 font-mono text-[11px] text-ink-muted">
+            ICP · <span className="text-ink-cream-2">{selected.icpOneLiner}</span>
+          </div>
+          {selected.summary && (
+            <details className="mt-1.5">
+              <summary className="cursor-pointer font-mono text-[10px] uppercase tracking-[0.14em] text-ink-faint hover:text-ink-cream-2">
+                why these channels
+              </summary>
+              <div className="mt-1.5 text-[11.5px] leading-[1.55] text-ink-muted">
+                {selected.buyerBrief}
+              </div>
+            </details>
+          )}
         </div>
       )}
-    </section>
-  );
-}
 
-function PackRow({
-  pack,
-  applying,
-  onApply,
-  result,
-  disabled,
-}: {
-  pack: PackView;
-  applying: boolean;
-  onApply: () => void;
-  result: PackApplyResult | null;
-  disabled: boolean;
-}) {
-  const navigate = useNavigate();
-  // After apply: the fields still needed, spelled out per-trigger so the
-  // founder knows exactly what to fill in next (via the strategist or the
-  // trigger's own JSON editor below).
-  const stillNeeded = result?.applied.filter((t) => !t.ready) ?? [];
-  return (
-    <div className="rounded-[var(--radius-sm)] border border-ink-rule px-4 py-3">
-      <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0 flex-1">
-          <div className="text-[13px] font-medium text-ink-cream">{pack.label}</div>
-          <div className="mt-0.5 text-[12px] text-ink-cream-2">{pack.buyerBrief}</div>
-          <div className="mt-1.5 font-mono text-[11px] text-ink-faint">
-            triggers · {pack.triggers.join(", ")}
-          </div>
-          <div className="mt-1.5 font-mono text-[11px] text-ink-muted">
-            ICP · <span className="text-ink-cream-2">{pack.icpOneLiner}</span>
-          </div>
-        </div>
-        <Button size="sm" disabled={applying || disabled} onClick={onApply}>
-          {applying ? "Applying…" : "Apply"}
-        </Button>
-      </div>
-      {result && (
+      {result && selected && (
         <div className="mt-2.5 border-t border-ink-rule/60 pt-2.5 font-mono text-[11px]">
           <div className="text-ink-receipt-2">
             ✓ applied · {result.applied.map((t) => t.name).join(", ")}
@@ -1487,7 +1568,7 @@ function PackRow({
           {/* Apply never touches icpOneLiner in config.json (see packs.ts) —
               the proposed ICP only reaches the founder's config if they
               explicitly accept it from /setup. */}
-          <div className="mt-1.5 flex items-center gap-2 text-ink-muted">
+          <div className="mt-1.5 flex flex-wrap items-center gap-2 text-ink-muted">
             <span>proposed ICP · {result.proposedIcpOneLiner}</span>
             <Button
               variant="secondary"
@@ -1495,7 +1576,7 @@ function PackRow({
               onClick={() =>
                 navigate({
                   to: "/setup",
-                  search: { proposedIcp: result.proposedIcpOneLiner, packLabel: pack.label },
+                  search: { proposedIcp: result.proposedIcpOneLiner, packLabel: selected.label },
                 })
               }
             >
@@ -1805,6 +1886,10 @@ function TriggersCard({ queueEmpty }: { queueEmpty: boolean | null }) {
         </button>
         <div className="font-mono text-[11px] text-ink-faint">refresh · 30s</div>
       </div>
+      {/* Packs configure the triggers below, so the picker rides inside this
+          panel and inherits its collapse — including the autoOpen rule, which
+          fires on exactly the occasions a pack is the thing you came for. */}
+      {expanded && <PackPicker />}
       {!expanded ? null : triggersQuery.isLoading ? (
         Array.from({ length: 3 }, (_, i) => <SkeletonRow key={i} />)
       ) : triggers.length === 0 ? (

--- a/apps/web/src/routes/queue.tsx
+++ b/apps/web/src/routes/queue.tsx
@@ -303,7 +303,15 @@ function QueuePage() {
   });
 
   // Selection derived state — stable across renders even if rows refetch.
-  const { someSelected, allSelected } = queueSelectionState(rows, selected);
+  /*
+   * Selection state is computed against the rows actually on screen, not the
+   * whole fetched set. With the row cap in place `rows` can hold 200 while 50
+   * are rendered, and the header checkbox is named for what it does —
+   * `selectVisibleQueueRows`. Passing `rows` would tick one box and silently
+   * select 150 rows the reader cannot see, which the bulk approve/reject bar
+   * would then act on.
+   */
+  const { someSelected, allSelected } = queueSelectionState(visibleRows, selected);
 
   return (
     <div className="-mx-6 -my-6 flex flex-col">
@@ -473,7 +481,7 @@ function QueuePage() {
                         if (el) el.indeterminate = someSelected && !allSelected;
                       }}
                       onChange={(e) =>
-                        setSelected(new Set(selectVisibleQueueRows(rows, e.target.checked)))
+                        setSelected(new Set(selectVisibleQueueRows(visibleRows, e.target.checked)))
                       }
                       aria-label={allSelected ? "deselect all" : "select all"}
                     />

--- a/apps/web/src/routes/queue.tsx
+++ b/apps/web/src/routes/queue.tsx
@@ -381,6 +381,7 @@ function QueuePage() {
               onClick={() => {
                 setStatusFilter(s);
                 setShowAllRows(false);
+                setExpanded(null);
               }}
             >
               {s}
@@ -443,6 +444,7 @@ function QueuePage() {
             onClick={() => {
               setPlayFilter("all");
               setShowAllRows(false);
+              setExpanded(null);
             }}
           >
             all
@@ -455,6 +457,7 @@ function QueuePage() {
               onClick={() => {
                 setPlayFilter(p);
                 setShowAllRows(false);
+                setExpanded(null);
               }}
             >
               {p}
@@ -1506,12 +1509,21 @@ function PackPicker() {
         <select
           value={selectedId}
           aria-label="industry pack"
+          /*
+           * Locked while an apply is in flight. The onChange below clears
+           * `lastResult` so one pack's outcome never reads as another's — but
+           * switching mid-apply meant the result landed against a pack that was
+           * no longer selected and rendered nowhere, so the founder saw a
+           * success toast and never the list of triggers that still need
+           * config. The write has already happened; the report has to survive.
+           */
+          disabled={applyPack.isPending}
           onChange={(e) => {
             setSelectedId(e.currentTarget.value);
             // The previous pack's result must not read as this one's.
             setLastResult(null);
           }}
-          className="h-7 rounded-[var(--radius-sm)] border border-ink-rule bg-ink-bg px-2 text-[12px] text-ink-cream"
+          className="h-7 rounded-[var(--radius-sm)] border border-ink-rule bg-ink-bg px-2 text-[12px] text-ink-cream disabled:opacity-60"
         >
           <option value="">select a vertical…</option>
           {packs.map((pack) => (
@@ -1535,8 +1547,11 @@ function PackPicker() {
       {selected && (
         <div className="mt-2">
           {/* `summary` is the founder-facing line; `buyerBrief` is the
-              provenance behind it and reads like the engineering note it is. */}
-          <div className="text-[12px] text-ink-cream-2">
+              provenance behind it and reads like the engineering note it is.
+              `summary` is optional, so the fallback is clamped — without it a
+              pack that omits one renders the whole paragraph inline, the exact
+              thing this picker exists to avoid. */}
+          <div className={cn("text-[12px] text-ink-cream-2", !selected.summary && "line-clamp-2")}>
             {selected.summary ?? selected.buyerBrief}
           </div>
           <div className="mt-1.5 font-mono text-[11px] text-ink-faint">
@@ -1545,16 +1560,16 @@ function PackPicker() {
           <div className="mt-1 font-mono text-[11px] text-ink-muted">
             ICP · <span className="text-ink-cream-2">{selected.icpOneLiner}</span>
           </div>
-          {selected.summary && (
-            <details className="mt-1.5">
-              <summary className="cursor-pointer font-mono text-[10px] uppercase tracking-[0.14em] text-ink-faint hover:text-ink-cream-2">
-                why these channels
-              </summary>
-              <div className="mt-1.5 text-[11.5px] leading-[1.55] text-ink-muted">
-                {selected.buyerBrief}
-              </div>
-            </details>
-          )}
+          {/* Always available, including on the no-summary path — otherwise the
+              clamp above would make the rest of the reasoning unreachable. */}
+          <details className="mt-1.5">
+            <summary className="cursor-pointer font-mono text-[10px] uppercase tracking-[0.14em] text-ink-faint hover:text-ink-cream-2">
+              why these channels
+            </summary>
+            <div className="mt-1.5 text-[11.5px] leading-[1.55] text-ink-muted">
+              {selected.buyerBrief}
+            </div>
+          </details>
         </div>
       )}
 

--- a/packages/find/src/packs.ts
+++ b/packages/find/src/packs.ts
@@ -38,7 +38,17 @@ export interface IndustryPack {
   /** Stable slug, e.g. "restaurants-food-service". Used in the API path and the ACTION marker. */
   id: string;
   label: string;
-  /** Who a pre-PMF startup in this vertical actually sells to. Shown on the pack card AND fed to the strategist. */
+  /**
+   * One line of plain buyer language for the picker — who this sells to, no
+   * provenance. `buyerBrief` carries the reasoning and reads like the
+   * engineering note it is ("the #456 coverage spike measured `peopleSearch`
+   * at 80% best_work_email hit rate"), which is the right thing to feed the
+   * strategist and the wrong thing to put in front of a founder choosing a
+   * vertical. Optional: a pack without one falls back to a truncated
+   * `buyerBrief`, so adding a pack never breaks the picker.
+   */
+  summary?: string;
+  /** Who a pre-PMF startup in this vertical actually sells to, and WHY these channels. Fed to the strategist; shown behind a disclosure in the picker. */
   buyerBrief: string;
   /** Proposed icpOneLiner for this buyer — founder edits before it sticks. Never written to config.json by apply. */
   icpOneLiner: string;
@@ -56,6 +66,7 @@ export const PACKS: IndustryPack[] = [
   {
     id: "devtools-early-adopters",
     label: "Dev Tools — Early Adopters",
+    summary: "Engineers reacting to launches, and teams hiring for a build-vs-buy decision.",
     buyerBrief:
       "Pre-PMF dev-tool founders sell to the engineers already active in public dev communities: Show HN readers reacting to launches, and companies whose founding/staff-engineer hiring signals a build-vs-buy decision in flight. Placeholder pack — the full vertical library ships separately.",
     icpOneLiner: "Engineers and technical founders evaluating new developer tooling",
@@ -77,6 +88,7 @@ export const PACKS: IndustryPack[] = [
   {
     id: "restaurants-food-service",
     label: "Restaurants & Food Service",
+    summary: "Owners and GMs at independent restaurants, franchisees, and ghost kitchens.",
     buyerBrief:
       "Owner / GM / franchisee at independent restaurants, multi-unit franchisees, and ghost kitchens. The coverage spike (#456) measured `peopleSearch` at 80% best_work_email hit rate for independent restaurants in Austin, TX — the BEST of the three verticals tested, the opposite of the working hypothesis that single-location restaurants would be the weakest B2B-database population. `local-business` is therefore the primary channel here; `local-registry`'s city license/inspection data still adds the earliest-possible new-opening signal (a fresh Health Dept permit predates most restaurants having any web presence at all), so it stays on as a secondary channel.",
     icpOneLiner: "Owners and GMs of independent restaurants, franchisees, and ghost kitchens",
@@ -110,6 +122,8 @@ export const PACKS: IndustryPack[] = [
   {
     id: "home-services-trades",
     label: "Home Services & Trades",
+    summary:
+      "Owner-operators and office managers at HVAC, plumbing, electrical, and roofing firms.",
     buyerBrief:
       "Owner-operator / office manager at HVAC, plumbing, electrical, roofing, landscaping and pest-control businesses. Both channels lean on here: state contractor licence boards (`local-registry`) reach the long tail of one-truck operators who never show up in a B2B people database, while `local-business` reaches the 20+ staff shops with an office manager and an actual buying process. The spike's home-services proxy (two-truck plumbers) measured 70% `peopleSearch` coverage — solid but not restaurant-tier — consistent with keeping both channels rather than picking one.",
     icpOneLiner: "Owner-operators and office managers at home-service and trade businesses",
@@ -142,6 +156,7 @@ export const PACKS: IndustryPack[] = [
   {
     id: "healthcare-practices",
     label: "Healthcare Practices",
+    summary: "Practice owners and office managers at dental, optometry, and small medical clinics.",
     buyerBrief:
       "Practice owner / office manager at dental, veterinary, optometry, chiropractic and small primary-care practices. `local-registry`'s NPPES adapter is the most completely covered vertical of the seven — 9M+ providers, free, weekly refresh, filterable by taxonomy — and the coverage spike (#456) measured dental practices at only 64% `peopleSearch` hit rate, the WORST of the three tested verticals, confirming a B2B people database is the wrong primary channel here. `local-business` is deliberately left off this pack.",
     icpOneLiner: "Owners and office managers at dental, veterinary, and small medical practices",
@@ -156,6 +171,8 @@ export const PACKS: IndustryPack[] = [
   {
     id: "auto-services",
     label: "Auto Services",
+    summary:
+      "Owners and service managers at independent repair shops, tyre, and collision centres.",
     buyerBrief:
       "Shop owner / service manager at independent auto-repair shops, tire shops and body shops. Not part of the #456 coverage spike, so this follows the card's original reasoning unchanged: business licences filtered to NAICS 8111 (automotive repair and maintenance) are the primary channel — an independent single-bay shop is exactly the kind of business a B2B people database under-indexes on.",
     icpOneLiner: "Owners and service managers at independent auto-repair, tire, and body shops",
@@ -173,6 +190,7 @@ export const PACKS: IndustryPack[] = [
   {
     id: "professional-services-smb",
     label: "Professional Services (SMB)",
+    summary: "Managing partners at small law, accounting, bookkeeping, and insurance firms.",
     buyerBrief:
       "Managing partner / principal at small law firms, bookkeeping practices, insurance agencies and property managers. Not part of the #456 coverage spike. These are well covered in B2B data (partners and principals at small professional firms are exactly the population `peopleSearch`/`companySearch` index well), so `local-business` is the primary — and only — channel; `local-registry`'s public-registry sources exist for businesses invisible to B2B databases, which does not describe this vertical.",
     icpOneLiner: "Managing partners and principals at small law, accounting, and insurance firms",
@@ -193,6 +211,7 @@ export const PACKS: IndustryPack[] = [
   {
     id: "trucking-freight",
     label: "Trucking & Freight",
+    summary: "Owners and dispatch managers at small carriers, brokerages, and 3PLs.",
     buyerBrief:
       "Owner / VP Ops / dispatch manager at small carriers, brokerages, and 3PLs. Not part of the #456 coverage spike. `local-registry`'s FMCSA adapter carries a published on-file email for every active entity, so there is near-zero cost per candidate — no findEmail/verifyEmail spend at all — and the 10-100 power-unit fleet-size band is the segment that actually buys software (large fleets build in-house, one-truck owner-operators rarely buy).",
     icpOneLiner: "Owners and operations leads at small trucking carriers, brokerages, and 3PLs",
@@ -208,6 +227,7 @@ export const PACKS: IndustryPack[] = [
   {
     id: "civic-gov",
     label: "Civic & Government",
+    summary: "City managers, department heads, and procurement officers at local government.",
     buyerBrief:
       "City manager, county administrator, department head, or procurement officer at a municipal or county government. Not part of the #456 coverage spike (no B2B people-database channel applies to public-sector buyers at all). `gov-solicitation` catches federal Sources Sought / Presolicitation notices by NAICS while a requirement is still being written — the one window a pre-PMF startup with no past-performance record can shape it — and `civic-agenda` catches city/county council agenda items mentioning relevant technology before any budget commitment is public. Both pitch the notice's or meeting body's own published contact, so neither spends on findEmail/verifyEmail.",
     icpOneLiner:

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -922,6 +922,9 @@ export interface TriggerView {
 export interface PackView {
   id: string;
   label: string;
+  /** One-line buyer summary for the picker. Absent on packs written before this existed. */
+  summary?: string;
+  /** Full reasoning, including why these channels. Shown behind a disclosure. */
   buyerBrief: string;
   icpOneLiner: string;
   /** Trigger names this pack touches. */


### PR DESCRIPTION
## Why

The page is titled **"Candidates, for review."** and showed none above the fold. Measured against the live server at 1501×812:

| block | height |
|---|---|
| page header | ~130px |
| `IcpBanner` | ~62px |
| **`PacksCard`** | **~900px** |

The first candidate row sat a screen and a half down.

`PacksCard` was eight always-expanded cards for a **once-per-vertical** action, permanently occupying the top of a page reviewed daily. Seven of the eight are verticals any given founder will never pick — this install's ICP is agent builders, and the first screen was restaurants, trades and trucking.

Two earlier height fights are already recorded in this file's own comments (`queue.tsx:331` "a full width strip for it was 42px of the first screen"; `queue.tsx:1608` "the table was taking 336px of the first screen"). Nobody had touched the 900px one.

## Packs move into the Triggers panel

A pack **is** trigger config — apply merges each patch over the trigger's stored config and enables it. So the eight cards become one selector row inside `TriggersCard`, which already collapses by default, already persists that choice, and already auto-opens on exactly the two occasions a pack is what you came for: nothing configured yet, or an empty queue.

```
TRIGGERS · 15  · 3 on                                    refresh · 30s
└─ START FROM A PACK  [ Restaurants & Food Service ▾ ]  [Apply]
   Owners and GMs at independent restaurants, franchisees, and ghost kitchens.
   triggers · local-business, local-registry
   ICP · Owners and GMs of independent restaurants, franchisees, ghost kitchens
   ▸ WHY THESE CHANNELS
```

**~900px → ~100px**, and only when the panel is open. Nothing was rebuilt — the apply mutation, the applied / still-needs / skipped result block and the "Accept in Setup" ICP hand-off all move across intact.

`IndustryPack` gains an optional `summary`: one line of buyer language. `buyerBrief` reads like the engineering note it is — *"the #456 coverage spike measured `peopleSearch` at 80% best_work_email hit rate … the opposite of the working hypothesis"* — which is right for the strategist prompt and wrong in front of a founder choosing a vertical. It moves behind a "why these channels" disclosure. Optional with a fallback, so no pack breaks by omission, and the strategist catalog is unchanged.

## Three density fixes

- **Row height was driven by untruncated LinkedIn headlines.** One row rendered three lines for *"Crypto Visionary & AI Strategist ⚡ | Revolutionizing Retail Investing with AI-Driven Insights 🚀 | Empowering Web3 Success 🌍"*. The title segment is now clamped the way the evidence line below it already was. Only the title — email, company and the `[in]` link are what tell two rows apart.
- **The tbody rendered every row the API returned** (up to 200, ~14,000px). Now 50 behind a `N more · show all` row, reusing the inactive-finders disclosure pattern. Not persisted and reset on filter change: lifting the cap to look at the 7,642 rejected rows shouldn't follow you back tomorrow.
- **The mark-linkedin-reply trigger** moves into the draft card's header strip beside the receipt links, where the other row actions live; the textarea stays below the body. It also now renders on sent rows with **no persisted draft**, which returned early before it — so the rows most likely to have been answered by hand were the ones that couldn't record it.

## Verified live

Rebuilt, restarted the sdk workspace server, and drove the real page:

- Four candidates above the fold; Konstantin's row is two lines.
- Triggers expands to the picker; selecting a pack renders summary + triggers + ICP, and "why these channels" expands to the full provenance.
- Rejected filter (7,642 rows) shows `150 more · show all 200` at the end of the tbody.
- Apply deliberately **not** clicked — it would have enabled `local-business` / `local-registry` in the live workspace.

Gates: 2929 tests / 218 files, typecheck + oxfmt clean, oxlint unchanged at 27 pre-existing warnings.

## Note

Three snapshot files picked up duplicate, differently-keyed entries from a `vitest -u` run during the previous PR's session; they were reverted here rather than shipped. `bun run test` passes without them and does not regenerate them, and `main`'s snapshot has a single correctly-keyed entry.

https://claude.ai/code/session_01CPweATEtibYbHW7CUBqbig

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added concise buyer-facing summaries to industry packs.
  * Added pack summaries in pack view responses.
  * Added an optional “show all” view for queues exceeding 50 rows.
  * Enabled LinkedIn reply recording for sent items without saved drafts.

* **Improvements**
  * Reorganized industry pack selection into the collapsible Triggers panel.
  * Limited queue selection controls to the 50 visible rows.
  * Reset expanded queue rows when filters change.
  * Preserved buyer briefs when pack summaries are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->