### PR TITLE
fix(find): four shipped review findings — #516, #517, #522, #524

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,6 +1,6 @@
 # Status
 
-**Assume green.** The 51 CLI commands, 23 plays, 13 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
+**Assume green.** The 51 CLI commands, 23 plays, 15 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
 Last verified **2026-09-04** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2919 tests / 218 files** · typecheck + oxlint + oxfmt clean.
 

--- a/packages/find/__tests__/civic-agenda.test.ts
+++ b/packages/find/__tests__/civic-agenda.test.ts
@@ -35,6 +35,7 @@ const pendingPersisted: Array<{
 let icpMatch: boolean | null = true;
 let icpCalls = 0;
 let icpResolved: string | null = "icp";
+let queueDuplicate = false;
 let eventsBySlug: Record<string, Array<Record<string, unknown>>> = {};
 let itemsByEventId: Record<number, Array<Record<string, unknown>>> = {};
 
@@ -83,7 +84,7 @@ vi.mock("@oneshot-gtm/core", async () => {
     ...actual,
     logEvent: () => {},
     getLedger: () => ({
-      isQueueDuplicate: () => false,
+      isQueueDuplicate: () => queueDuplicate,
       isPendingResolution: () => false,
       findProspectByEmail: () => null,
       isEmailPendingInQueue: (email: string) =>
@@ -104,6 +105,7 @@ beforeEach(() => {
   icpMatch = true;
   icpCalls = 0;
   icpResolved = "icp";
+  queueDuplicate = false;
   officeRecordsBehavior = "contact";
   eventsBySlug = {
     nyc: [
@@ -300,6 +302,26 @@ describe("runCivicAgendaFinder — happy path", () => {
     expect(capped.halted).toMatch(/max-cost cap/);
   });
 
+  it("a duplicate does not trip maxCostUsd — it never reaches the paid call", async () => {
+    // The cost guard sits BELOW the duplicate check. A duplicate returns before
+    // icpFilter, so its prospective cost is zero and a cap must not halt on it.
+    // With the guard above the duplicate check, a cap under one classifier
+    // estimate (0.0005 < 0.001) halted the whole run on the first candidate —
+    // one that was never going to spend anything.
+    queueDuplicate = true;
+    itemsByEventId = {
+      1: [
+        { eventItemId: 100, title: "Resolution on AI use in permitting", matterFile: "R-1" },
+        { eventItemId: 102, title: "AI automation budget amendment", matterFile: null },
+      ],
+    };
+    const out = await runCivicAgendaFinder({ ...baseConfig, maxCostUsd: 0.0005 });
+    expect(out.halted).toBeUndefined();
+    expect(icpCalls).toBe(0);
+    expect(out.costUsd).toBe(0);
+    expect(out.droppedDuplicate).toBe(2);
+  });
+
   it("does not charge icpFilter spend when no ICP is configured (pass-through)", async () => {
     // resolveIcp() returning null is a normal, documented state (see
     // _filter.ts's tri-state contract) — icpFilter() is then a free
@@ -314,7 +336,11 @@ describe("runCivicAgendaFinder — happy path", () => {
         { eventItemId: 102, title: "AI automation budget amendment", matterFile: null },
       ],
     };
-    const out = await runCivicAgendaFinder(baseConfig);
+    // maxCostUsd is set DELIBERATELY, and low enough that a single wrongly
+    // charged call would breach it. Without a cap configured,
+    // is undefined no matter what costUsd does, and the assertion below
+    // proves nothing about pass-through charging.
+    const out = await runCivicAgendaFinder({ ...baseConfig, maxCostUsd: 0.001 });
     expect(icpCalls).toBe(2);
     expect(out.costUsd).toBe(0);
     expect(out.halted).toBeUndefined();

--- a/packages/find/src/civic-agenda.ts
+++ b/packages/find/src/civic-agenda.ts
@@ -214,21 +214,6 @@ export async function runCivicAgendaFinder(opts: CivicAgendaFinderOpts): Promise
   // how small `limit` is.
   for (const candidate of gated.slice(0, Math.max(0, limit))) {
     if (result.enqueued >= limit) break;
-    // Compare the PROSPECTIVE cost (current spend + this candidate's paid
-    // icpFilter call, if one will actually happen) against the cap — not
-    // just the spend accrued so far. icpFilter is the only cost source in
-    // this finder, and it's free (no LLM call) when `icp` is null, so the
-    // estimate is 0 in that case. Checking post-hoc spend alone would let a
-    // single call through whenever `0 < maxCostUsd < ICP_FILTER_COST_ESTIMATE_USD`,
-    // since costUsd is still 0 right up until this call runs.
-    if (
-      opts.maxCostUsd != null &&
-      result.costUsd + (icp ? ICP_FILTER_COST_ESTIMATE_USD : 0) > opts.maxCostUsd
-    ) {
-      result.halted = `max-cost cap (${opts.maxCostUsd})`;
-      break;
-    }
-
     const dedupeKey = dedupeKeyFor(candidate);
     if (
       ledger.isQueueDuplicate("civic-pilot", dedupeKey) ||
@@ -236,6 +221,25 @@ export async function runCivicAgendaFinder(opts: CivicAgendaFinderOpts): Promise
     ) {
       result.droppedDuplicate++;
       continue;
+    }
+
+    // Compare the PROSPECTIVE cost (current spend + this candidate's paid
+    // icpFilter call, if one will actually happen) against the cap — not
+    // just the spend accrued so far. icpFilter is the only cost source in
+    // this finder, and it's free (no LLM call) when `icp` is null, so the
+    // estimate is 0 in that case. Checking post-hoc spend alone would let a
+    // single call through whenever `0 < maxCostUsd < ICP_FILTER_COST_ESTIMATE_USD`,
+    // since costUsd is still 0 right up until this call runs.
+    //
+    // BELOW the duplicate check on purpose: a duplicate never reaches
+    // icpFilter, so its prospective cost is zero. Guarding above it halted
+    // the whole run on a candidate that would not have spent anything.
+    if (
+      opts.maxCostUsd != null &&
+      result.costUsd + (icp ? ICP_FILTER_COST_ESTIMATE_USD : 0) > opts.maxCostUsd
+    ) {
+      result.halted = `max-cost cap (${opts.maxCostUsd})`;
+      break;
     }
 
     const filter = await icpFilter({

--- a/packages/find/src/gov-solicitation.ts
+++ b/packages/find/src/gov-solicitation.ts
@@ -223,7 +223,11 @@ interface GovSolicitationCandidate {
 
 /** First POC entry carrying BOTH a name and an email — the only usable kind. */
 function pickPoc(pocs: SamPointOfContact[] | null | undefined): SamPointOfContact | null {
-  for (const p of pocs ?? []) {
+  // Array.isArray, not `?? []`: SAM.gov is an external feed, and a
+  // non-iterable pointOfContact (object, string) survives the nullish
+  // coalesce and makes for...of throw, aborting the finder before it
+  // reaches any later opportunity.
+  for (const p of Array.isArray(pocs) ? pocs : []) {
     if (p.email && p.email.trim().length > 0 && p.fullName && p.fullName.trim().length > 0) {
       return p;
     }

--- a/packages/find/src/registry.ts
+++ b/packages/find/src/registry.ts
@@ -542,11 +542,16 @@ export const TRIGGERS: TriggerSpec[] = [
         ? (cfg["states"] as unknown[]).filter((s): s is string => typeof s === "string")
         : [];
       const validEntityTypes = new Set(["carrier", "broker", "freight-forwarder"]);
+      // Trim before validating AND keep the trimmed value: readiness above
+      // accepts " carrier " because it tests t.trim(), so without the same
+      // normalization here a config reports ready and then starts with no
+      // FMCSA source. Filtering on the trimmed form while passing the raw
+      // one downstream would be the same bug wearing a hat.
       const entityTypes = Array.isArray(cfg["entityTypes"])
-        ? (cfg["entityTypes"] as unknown[]).filter(
-            (t): t is "carrier" | "broker" | "freight-forwarder" =>
-              typeof t === "string" && validEntityTypes.has(t),
-          )
+        ? (cfg["entityTypes"] as unknown[])
+            .filter((t): t is string => typeof t === "string")
+            .map((t) => t.trim())
+            .filter((t): t is "carrier" | "broker" | "freight-forwarder" => validEntityTypes.has(t))
         : [];
       return runLocalRegistryFinder({
         dryRun: false,


### PR DESCRIPTION
Closes the whole open tail of the shipped-findings lane in one PR.

Each finding was checked against current `main` before anything was changed. All four were real — none were stale, none were duplicates of each other.

| issue | from | what was actually wrong |
|---|---|---|
| #516 | PR #510 | max-cost guard ran **above** the duplicate check, so a duplicate — which never reaches `icpFilter` and costs nothing — halted the entire run |
| #517 | PR #512 | the no-ICP test set no `maxCostUsd`, so `expect(out.halted).toBeUndefined()` was vacuous |
| #522 | PR #515 | `pickPoc` threw on a non-iterable `pointOfContact` from SAM.gov, aborting the finder; and STATUS.md still claimed "13 finders" against 15 |
| #524 | PR #521 | readiness accepted `" carrier "` (it trimmed), the runtime filter did not — config reported ready, then ran with no FMCSA source |

**On #516** — the regression test is the point. It asserts `halted === undefined` with `icpCalls` 0 under `maxCostUsd: 0.0005`, and I confirmed it fails against the old ordering rather than assuming: `AssertionError: expected 'max-cost cap (0.0005)' to be undefined`.

**On #524** — trimming only the *check* would have left `" carrier "` flowing downstream to `runLocalRegistryFinder`, which is the same bug moved one line. The value is normalized, not just validated.

**On #522** — `readme-counts.test.ts` derives the finder count from the registry but only guards `README.md`. STATUS.md carries the same claim with nothing checking it, which is why it drifted.

## Why one PR

These four issues each came from a PR that was itself a finding-fix: #509 → #513/#514, #510 → #516, #512 → #517, #515 → #522, #521 → #524. Merging four separate fixes would have produced four more follow-up issues on the same lane. Landing them together stops that.

Verified: `tsc` clean, `oxfmt` clean, 218 files / 2931 tests.

https://claude.ai/code/session_011UAwMEsTQJF1bQCfG3iFtP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Duplicate civic agenda entries are now skipped before cost limits or paid classification, avoiding unnecessary processing and charges.
  - Civic agenda items without an ICP no longer trigger spending or cost-limit halts.
  - Invalid point-of-contact data no longer stops government solicitation searches.
  - Whitespace around FMCSA entity types is now handled correctly, allowing valid searches to proceed.

- **Documentation**
  - Updated the functionality inventory to reflect the current number of finders.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->