### PR TITLE
feat(web): rebuild /setup as sectioned settings with per-section save

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 51 CLI commands, 23 plays, 15 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-04** · Bun 1.3.13 · OneShot SDK 0.22.0 · **2919 tests / 218 files** · typecheck + oxlint + oxfmt clean.
+Last verified **2026-09-04** · Bun 1.3.13 · OneShot SDK 0.22.0 · **3014 tests / 221 files** · typecheck + oxlint + oxfmt clean.
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/apps/server/__tests__/setup-public-cfg.test.ts
+++ b/apps/server/__tests__/setup-public-cfg.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { OneShotConfig } from "@oneshot-gtm/core";
-import { mergeSetupConfig, publicCfg } from "../src/api/setup.ts";
+import { mergeSetupConfig, publicCfg, SetupValidationError } from "../src/api/setup.ts";
 
 const FULL_CFG: OneShotConfig = {
   walletMode: "cdp",
@@ -137,6 +137,74 @@ describe("setup config writer", () => {
           FULL_CFG.emailIdentities,
         ),
       ).toThrow(/invalid dailySpendCeilingUsd/);
+    });
+
+    it("throws the typed SetupValidationError so the route can answer 400", () => {
+      expect(() =>
+        mergeSetupConfig(FULL_CFG, { dailySpendCeilingUsd: 0 }, FULL_CFG.emailIdentities),
+      ).toThrow(SetupValidationError);
+    });
+  });
+
+  // Issue #451 surfaced these two keys: real config, no UI, no CLI. The
+  // sectioned /setup now writes them through the same sparse body.
+  describe("queueReviewOrder", () => {
+    it("undefined keeps the stored order", () => {
+      const next = mergeSetupConfig(FULL_CFG, {}, FULL_CFG.emailIdentities);
+      expect(next.queueReviewOrder).toBe("ranked");
+    });
+
+    it("accepts both literals", () => {
+      expect(
+        mergeSetupConfig(FULL_CFG, { queueReviewOrder: "newest" }, FULL_CFG.emailIdentities)
+          .queueReviewOrder,
+      ).toBe("newest");
+      expect(
+        mergeSetupConfig(
+          { ...FULL_CFG, queueReviewOrder: "newest" },
+          { queueReviewOrder: "ranked" },
+          FULL_CFG.emailIdentities,
+        ).queueReviewOrder,
+      ).toBe("ranked");
+    });
+
+    it("ignores an unknown value instead of persisting it", () => {
+      const next = mergeSetupConfig(
+        FULL_CFG,
+        { queueReviewOrder: "sideways" as never },
+        FULL_CFG.emailIdentities,
+      );
+      expect(next.queueReviewOrder).toBe("ranked");
+    });
+  });
+
+  describe("timezone", () => {
+    it("undefined keeps the stored zone", () => {
+      expect(mergeSetupConfig(FULL_CFG, {}, FULL_CFG.emailIdentities).timezone).toBe(
+        "Europe/Vienna",
+      );
+    });
+
+    it("null and blank clear it (runtime zone applies)", () => {
+      expect(
+        mergeSetupConfig(FULL_CFG, { timezone: null }, FULL_CFG.emailIdentities).timezone,
+      ).toBeNull();
+      expect(
+        mergeSetupConfig(FULL_CFG, { timezone: "   " }, FULL_CFG.emailIdentities).timezone,
+      ).toBeNull();
+    });
+
+    it("trims and stores a valid IANA zone", () => {
+      expect(
+        mergeSetupConfig(FULL_CFG, { timezone: " America/New_York " }, FULL_CFG.emailIdentities)
+          .timezone,
+      ).toBe("America/New_York");
+    });
+
+    it("rejects a zone Intl doesn't know", () => {
+      expect(() =>
+        mergeSetupConfig(FULL_CFG, { timezone: "Mars/Olympus" }, FULL_CFG.emailIdentities),
+      ).toThrow(SetupValidationError);
     });
   });
 });

--- a/apps/server/__tests__/setup-route.test.ts
+++ b/apps/server/__tests__/setup-route.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { OneShotConfig } from "@oneshot-gtm/core";
+
+// POST /api/setup as the sectioned /setup page drives it (issue #451): a
+// section posts only its own keys, a rejected body must leave every store
+// untouched and answer 400 (not 500), and a bad cap must never fall open to
+// "uncapped". Core writers are mocked; mergeSetupConfig's own field semantics
+// are covered in setup-public-cfg.test.ts.
+
+const saveConfigMock = vi.fn();
+const saveSecretsMock = vi.fn();
+const deleteGmailTokenMock = vi.fn();
+const registerSmartleadMock = vi.fn().mockReturnValue({ identityId: "smartlead:x", created: true });
+const registerOneShotMock = vi.fn().mockReturnValue({ identityId: "oneshot:x", created: true });
+let current: OneShotConfig;
+
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    loadConfig: () => current,
+    saveConfig: saveConfigMock,
+    saveSecrets: saveSecretsMock,
+    deleteGmailToken: deleteGmailTokenMock,
+    registerSmartleadIdentity: registerSmartleadMock,
+    registerOneShotIdentity: registerOneShotMock,
+  };
+});
+
+const { setup } = await import("../src/api/setup.ts");
+
+function req(body: unknown): Request {
+  return new Request("http://localhost/api/setup", {
+    method: "POST",
+    headers: { "content-type": "application/json", host: "127.0.0.1:3030" },
+    body: JSON.stringify(body),
+  });
+}
+
+async function post(body: unknown): Promise<{ status: number; error?: string }> {
+  const res = await setup(req(body));
+  const json = (await res.json()) as { ok?: boolean; error?: string };
+  return { status: res.status, ...(json.error ? { error: json.error } : {}) };
+}
+
+const BASE: OneShotConfig = {
+  walletMode: "cdp",
+  llmProvider: "openrouter",
+  llmModel: "anthropic/claude-sonnet-4.6",
+  telemetryEnabled: true,
+  founderName: "Jane",
+  founderEmail: "jane@acme.dev",
+  productOneLiner: null,
+  productDomain: null,
+  sendingDomain: null,
+  emailProvider: "oneshot",
+  emailIdentities: [
+    {
+      id: "oneshot:jane@mail.acme.dev",
+      provider: "oneshot",
+      sendingDomain: "mail.acme.dev",
+      mailbox: "jane",
+      maxPerDay: 40,
+      warmup: { startPerDay: 5, incrementPerWeek: 5 },
+    },
+    {
+      id: "gmail:jane@gmail.com",
+      provider: "gmail",
+      address: "jane@gmail.com",
+      maxPerDay: null,
+      warmup: null,
+    },
+  ],
+  icpOneLiner: null,
+  cadenceOverrides: {},
+  queueReviewOrder: "newest",
+  founderCredentials: null,
+  productPortfolio: null,
+  partners: null,
+  founderAdmission: null,
+  productBrief: null,
+  mobileSignature: false,
+  timezone: null,
+  clientId: "11111111-2222-3333-4444-555555555555",
+  dailySpendCeilingUsd: null,
+};
+
+beforeEach(() => {
+  current = structuredClone(BASE);
+  saveConfigMock.mockClear();
+  saveSecretsMock.mockClear();
+  deleteGmailTokenMock.mockClear();
+  registerSmartleadMock.mockClear();
+  registerOneShotMock.mockClear();
+});
+afterEach(() => vi.clearAllMocks());
+
+function savedCfg(): OneShotConfig {
+  expect(saveConfigMock).toHaveBeenCalledTimes(1);
+  return saveConfigMock.mock.calls[0]![0] as OneShotConfig;
+}
+
+describe("POST /api/setup — section-scoped bodies", () => {
+  it("a profile-only body writes config and leaves .env and the identity pool alone", async () => {
+    expect(await post({ founderName: "Janet" })).toEqual({ status: 200 });
+    const cfg = savedCfg();
+    expect(cfg.founderName).toBe("Janet");
+    expect(cfg.emailIdentities).toEqual(BASE.emailIdentities);
+    expect(cfg.llmModel).toBe(BASE.llmModel);
+    expect(saveSecretsMock).not.toHaveBeenCalled();
+    expect(registerOneShotMock).not.toHaveBeenCalled();
+  });
+
+  it("a secrets-only body writes .env and re-saves config unchanged", async () => {
+    expect(await post({ secrets: { OPENROUTER_API_KEY: "sk-new" } })).toEqual({ status: 200 });
+    expect(saveSecretsMock).toHaveBeenCalledWith({ OPENROUTER_API_KEY: "sk-new" });
+    const { clientId: _c, ...rest } = savedCfg();
+    const { clientId: _b, ...base } = BASE;
+    void _c;
+    void _b;
+    expect(rest).toEqual(base);
+  });
+
+  it("an identity-pool body applies caps, removals and adds in one request", async () => {
+    const res = await post({
+      identityUpdates: [{ id: "oneshot:jane@mail.acme.dev", maxPerDay: 25 }],
+      removeIdentityIds: ["gmail:jane@gmail.com"],
+      addIdentities: [{ provider: "oneshot", sendingDomain: "acme.email", maxPerDay: 10 }],
+    });
+    expect(res).toEqual({ status: 200 });
+    const cfg = savedCfg();
+    expect(cfg.emailIdentities).toEqual([{ ...BASE.emailIdentities![0], maxPerDay: 25 }]);
+    expect(deleteGmailTokenMock).toHaveBeenCalledWith("gmail:jane@gmail.com");
+    expect(registerOneShotMock).toHaveBeenCalledWith(
+      expect.objectContaining({ sendingDomain: "acme.email", maxPerDay: 10 }),
+    );
+    // Order matters: the add re-reads config, so the pool write must land first.
+    const saveOrder = saveConfigMock.mock.invocationCallOrder[0]!;
+    const addOrder = registerOneShotMock.mock.invocationCallOrder[0]!;
+    expect(saveOrder).toBeLessThan(addOrder);
+  });
+
+  it("queueReviewOrder and timezone are writable (they had no writer before #451)", async () => {
+    expect(await post({ queueReviewOrder: "ranked", timezone: " Europe/Vienna " })).toEqual({
+      status: 200,
+    });
+    const cfg = savedCfg();
+    expect(cfg.queueReviewOrder).toBe("ranked");
+    expect(cfg.timezone).toBe("Europe/Vienna");
+  });
+
+  it("a blank or null timezone clears back to the runtime zone", async () => {
+    current.timezone = "Europe/Vienna";
+    expect(await post({ timezone: "" })).toEqual({ status: 200 });
+    expect(savedCfg().timezone).toBeNull();
+    saveConfigMock.mockClear();
+    current.timezone = "Europe/Vienna";
+    expect(await post({ timezone: null })).toEqual({ status: 200 });
+    expect(savedCfg().timezone).toBeNull();
+  });
+
+  it("an unknown queueReviewOrder value is ignored, not persisted", async () => {
+    current.queueReviewOrder = "ranked";
+    expect(await post({ queueReviewOrder: "sideways" })).toEqual({ status: 200 });
+    expect(savedCfg().queueReviewOrder).toBe("ranked");
+  });
+});
+
+describe("POST /api/setup — rejected bodies answer 400 and write nothing", () => {
+  const untouched = (): void => {
+    expect(saveConfigMock).not.toHaveBeenCalled();
+    expect(saveSecretsMock).not.toHaveBeenCalled();
+    expect(deleteGmailTokenMock).not.toHaveBeenCalled();
+    expect(registerOneShotMock).not.toHaveBeenCalled();
+    expect(registerSmartleadMock).not.toHaveBeenCalled();
+  };
+
+  it.each([
+    ["a numeric string", "12"],
+    ["NaN (JSON null-in-number smuggle)", "NaN"],
+    ["a negative number", -1],
+    ["a boolean", true],
+  ])("identity cap that is %s → 400, never coerced to uncapped", async (_label, cap) => {
+    const res = await post({
+      identityUpdates: [{ id: "oneshot:jane@mail.acme.dev", maxPerDay: cap }],
+      // Riding along to prove the 400 is atomic: none of these land either.
+      removeIdentityIds: ["gmail:jane@gmail.com"],
+      secrets: { OPENROUTER_API_KEY: "sk-new" },
+    });
+    expect(res.status).toBe(400);
+    expect(res.error).toMatch(/invalid maxPerDay/);
+    expect(res.error).toContain("oneshot:jane@mail.acme.dev");
+    untouched();
+  });
+
+  it("identity cap null → uncapped, cap 0 → 0, cap 7.9 → 7", async () => {
+    const res = await post({
+      identityUpdates: [
+        { id: "oneshot:jane@mail.acme.dev", maxPerDay: null },
+        { id: "gmail:jane@gmail.com", maxPerDay: 7.9 },
+      ],
+    });
+    expect(res).toEqual({ status: 200 });
+    expect(savedCfg().emailIdentities?.map((i) => i.maxPerDay)).toEqual([null, 7]);
+  });
+
+  it("a bad cap on a new sender is rejected before anything is registered", async () => {
+    const res = await post({
+      founderName: "Janet",
+      addIdentities: [{ provider: "oneshot", sendingDomain: "acme.email", maxPerDay: "ramp" }],
+    });
+    expect(res.status).toBe(400);
+    expect(res.error).toMatch(/invalid maxPerDay "ramp" for new oneshot sender acme.email/);
+    untouched();
+  });
+
+  it("a spend ceiling of 0 is a 400 (was a 500 via the generic handler wrapper)", async () => {
+    const res = await post({ dailySpendCeilingUsd: 0, founderName: "Janet" });
+    expect(res.status).toBe(400);
+    expect(res.error).toMatch(/invalid dailySpendCeilingUsd/);
+    untouched();
+  });
+
+  it("an unknown IANA zone is a 400", async () => {
+    const res = await post({ timezone: "Mars/Olympus" });
+    expect(res.status).toBe(400);
+    expect(res.error).toMatch(/invalid timezone 'Mars\/Olympus'/);
+    untouched();
+  });
+
+  it("a non-validation failure still propagates as a throw (→ generic 500)", async () => {
+    saveConfigMock.mockImplementationOnce(() => {
+      throw new Error("disk full");
+    });
+    await expect(setup(req({ founderName: "Janet" }))).rejects.toThrow("disk full");
+  });
+});

--- a/apps/server/src/api/setup.ts
+++ b/apps/server/src/api/setup.ts
@@ -1,6 +1,7 @@
 import {
   deleteGmailToken,
   identityCapacities,
+  isValidTimeZone,
   listSendingDomains,
   loadConfig,
   registerOneShotIdentity,
@@ -121,8 +122,49 @@ export async function getSetupStatus(req: Request): Promise<Response> {
   );
 }
 
+/**
+ * Thrown for a body the caller can fix (bad cap, bad ceiling, unknown time
+ * zone). The handler maps it to a 400 so the /setup form can show the message
+ * inline; anything else still surfaces as the generic 500.
+ */
+export class SetupValidationError extends Error {
+  override readonly name = "SetupValidationError";
+}
+
+/**
+ * Per-identity daily cap as submitted by the web form or a raw API client:
+ * `null` = uncapped, a finite number >= 0 = that cap (floored). Anything else
+ * — a string, NaN, a negative — is rejected instead of being coerced to
+ * "uncapped": the old fail-open coercion turned a typo in the cap box into
+ * unlimited sends for that identity.
+ */
+export function validateIdentityCap(value: unknown, where: string): number | null {
+  if (value === null) return null;
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) return Math.floor(value);
+  throw new SetupValidationError(
+    `invalid maxPerDay ${JSON.stringify(value)} for ${where} — must be a whole number of sends per day (0 or more), or null for no cap`,
+  );
+}
+
 export async function setup(req: Request): Promise<Response> {
   const body = (await req.json()) as SetupRequest;
+  try {
+    applySetup(body);
+  } catch (err) {
+    if (err instanceof SetupValidationError) {
+      return jsonResponse({ error: err.message }, 400, req);
+    }
+    throw err;
+  }
+  return jsonResponse({ ok: true }, 200, req);
+}
+
+/**
+ * Validate everything first, then write. A SetupValidationError thrown from
+ * any check below leaves config.json, the identity pool and .env exactly as
+ * they were — a partial write behind a 400 would make the 400 a lie.
+ */
+function applySetup(body: SetupRequest): void {
   const current = loadConfig();
   const llmProvider: LlmProvider = body.llmProvider ?? current.llmProvider;
   const walletMode: WalletMode = body.walletMode ?? current.walletMode;
@@ -137,32 +179,26 @@ export async function setup(req: Request): Promise<Response> {
   // client-side warm-up ramp is the only throttle — hence new identities
   // default to it.
   const adds = body.addIdentities ?? [];
+  for (const add of adds) {
+    if ("maxPerDay" in add && add.maxPerDay !== undefined) {
+      const where = add.provider === "smartlead" ? add.address : add.sendingDomain;
+      validateIdentityCap(add.maxPerDay, `new ${add.provider} sender ${where}`);
+    }
+  }
 
   // Identity-pool edits (cap changes / removals). The first edit materializes
   // the pool from legacy config so the change has somewhere to persist.
   let emailIdentities = current.emailIdentities;
   const hasIdentityEdits =
     (body.identityUpdates?.length ?? 0) > 0 || (body.removeIdentityIds?.length ?? 0) > 0;
+  const remove = new Set(body.removeIdentityIds ?? []);
   if (hasIdentityEdits) {
     let pool: EmailIdentity[] = current.emailIdentities ?? resolveIdentities(current);
     for (const upd of body.identityUpdates ?? []) {
-      const cap =
-        typeof upd.maxPerDay === "number" && Number.isFinite(upd.maxPerDay) && upd.maxPerDay >= 0
-          ? Math.floor(upd.maxPerDay)
-          : null;
+      const cap = validateIdentityCap(upd.maxPerDay, upd.id);
       pool = pool.map((i) => (i.id === upd.id ? { ...i, maxPerDay: cap } : i));
     }
-    const remove = new Set(body.removeIdentityIds ?? []);
-    if (remove.size > 0) {
-      pool = pool.filter((i) => !remove.has(i.id));
-      for (const id of remove) {
-        try {
-          deleteGmailToken(id);
-        } catch {
-          // token-store cleanup is best-effort; the identity is gone either way.
-        }
-      }
-    }
+    if (remove.size > 0) pool = pool.filter((i) => !remove.has(i.id));
     emailIdentities = pool;
   }
 
@@ -170,7 +206,18 @@ export async function setup(req: Request): Promise<Response> {
   // ignored so a malicious or accidental web POST can't rotate the anonymous
   // install id. saveConfig writes the entire cfg, so omitting clientId here
   // would silently drop it from disk.
-  saveConfig(mergeSetupConfig(current, body, emailIdentities, llmProvider, walletMode));
+  // mergeSetupConfig is the last validator (ceiling, time zone): nothing
+  // below this line runs if it throws.
+  const merged = mergeSetupConfig(current, body, emailIdentities, llmProvider, walletMode);
+  saveConfig(merged);
+
+  for (const id of remove) {
+    try {
+      deleteGmailToken(id);
+    } catch {
+      // token-store cleanup is best-effort; the identity is gone either way.
+    }
+  }
 
   // Adds run AFTER the main saveConfig: registerOneShotIdentity reloads the
   // freshly-persisted config (so it sees the cap/removal edits above and any
@@ -198,8 +245,6 @@ export async function setup(req: Request): Promise<Response> {
   if (body.secrets && Object.keys(body.secrets).length > 0) {
     saveSecrets(body.secrets);
   }
-
-  return jsonResponse({ ok: true }, 200, req);
 }
 
 export function mergeSetupConfig(
@@ -232,6 +277,11 @@ export function mergeSetupConfig(
     founderAdmission: mergeString(body.founderAdmission, current.founderAdmission),
     productBrief: mergeString(body.productBrief, current.productBrief),
     mobileSignature: body.mobileSignature ?? current.mobileSignature,
+    queueReviewOrder:
+      body.queueReviewOrder === "ranked" || body.queueReviewOrder === "newest"
+        ? body.queueReviewOrder
+        : current.queueReviewOrder,
+    timezone: mergeTimeZone(body.timezone, current.timezone),
     dailySpendCeilingUsd:
       body.dailySpendCeilingUsd === undefined
         ? current.dailySpendCeilingUsd
@@ -265,9 +315,27 @@ function mergeString(incoming: string | undefined, current: string | null): stri
 function validateSpendCeiling(value: number | null): number | null {
   if (value === null) return null;
   if (!Number.isFinite(value) || value <= 0) {
-    throw new Error(
+    throw new SetupValidationError(
       `invalid dailySpendCeilingUsd '${value}' — must be a positive number of USD, or null to clear`,
     );
   }
   return value;
+}
+
+/**
+ * Time zone merge: undefined keeps the stored zone, null/blank clears it back
+ * to the runtime default (installTimeZone in core), anything else must be an
+ * IANA name Intl recognises — "Mars/Olympus" is a 400, not a saved string that
+ * later makes every Luma slot resolve to UTC.
+ */
+function mergeTimeZone(incoming: string | null | undefined, current: string | null): string | null {
+  if (incoming === undefined) return current;
+  if (incoming === null || incoming.trim().length === 0) return null;
+  const zone = incoming.trim();
+  if (!isValidTimeZone(zone)) {
+    throw new SetupValidationError(
+      `invalid timezone '${zone}' — must be an IANA zone such as Europe/Vienna, or blank to use this machine's zone`,
+    );
+  }
+  return zone;
 }

--- a/apps/web/__tests__/setupValidation.test.ts
+++ b/apps/web/__tests__/setupValidation.test.ts
@@ -1,0 +1,257 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildIdentityPoolRequest,
+  CAP_ERROR,
+  capText,
+  parseCap,
+  parseSpendCeiling,
+  validateBareDomain,
+  validateEmail,
+  validateRequired,
+  validateTimeZone,
+  type IdentityPoolStaging,
+} from "../src/lib/setupValidation.ts";
+
+describe("validateEmail", () => {
+  it("is optional", () => {
+    expect(validateEmail("")).toBeNull();
+    expect(validateEmail("   ")).toBeNull();
+  });
+  it("accepts a plain address and trims", () => {
+    expect(validateEmail(" jane@acme.com ")).toBeNull();
+    expect(validateEmail("jane+gtm@sub.acme.co.uk")).toBeNull();
+  });
+  it.each(["jane", "jane@", "@acme.com", "jane@acme", "jane @acme.com", "a@b@c.com"])(
+    "rejects %s",
+    (v) => {
+      expect(validateEmail(v)).toMatch(/enter an email/);
+    },
+  );
+});
+
+describe("validateBareDomain", () => {
+  it("is optional", () => {
+    expect(validateBareDomain("")).toBeNull();
+  });
+  it("accepts bare hosts", () => {
+    expect(validateBareDomain("acme.com")).toBeNull();
+    expect(validateBareDomain(" mail.acme-corp.io ")).toBeNull();
+    expect(validateBareDomain("ACME.COM")).toBeNull();
+  });
+  it("names the scheme as the problem when one is present", () => {
+    expect(validateBareDomain("https://acme.com")).toMatch(/drop the https/);
+  });
+  it.each(["acme.com/", "acme.com:8080", "jane@acme.com", "acme com"])(
+    "rejects path/port/mailbox/whitespace: %s",
+    (v) => {
+      expect(validateBareDomain(v)).toMatch(/no path, port or mailbox/);
+    },
+  );
+  it("rejects a bare word with no dot", () => {
+    expect(validateBareDomain("localhost")).toMatch(/like acme.com/);
+  });
+});
+
+describe("parseCap", () => {
+  it("blank → null (uncapped) for identity rows", () => {
+    expect(parseCap("", { blank: "uncapped" })).toEqual({ ok: true, value: null });
+    expect(parseCap("  ", { blank: "uncapped" })).toEqual({ ok: true, value: null });
+  });
+  it("blank → undefined (omit → warm-up ramp) for the add-sender form", () => {
+    expect(parseCap("", { blank: "omit" })).toEqual({ ok: true, value: undefined });
+  });
+  it("digits → integer, including 0", () => {
+    expect(parseCap("40", { blank: "uncapped" })).toEqual({ ok: true, value: 40 });
+    expect(parseCap(" 0 ", { blank: "omit" })).toEqual({ ok: true, value: 0 });
+  });
+  // The fail-open bug: every one of these used to become "uncapped".
+  it.each(["abc", "-1", "1.5", "40/day", "∞", "1e3", "0x10", "99999999999999999999"])(
+    "rejects %s instead of treating it as uncapped",
+    (v) => {
+      expect(parseCap(v, { blank: "uncapped" })).toEqual({ ok: false, error: CAP_ERROR });
+    },
+  );
+});
+
+describe("parseSpendCeiling", () => {
+  it("blank → null (unlimited)", () => {
+    expect(parseSpendCeiling("")).toEqual({ ok: true, value: null });
+  });
+  it("accepts a positive decimal", () => {
+    expect(parseSpendCeiling(" 12.5 ")).toEqual({ ok: true, value: 12.5 });
+  });
+  it.each(["0", "-5", "abc", "2usd", "$2", "Infinity", "NaN"])("rejects %s", (v) => {
+    expect(parseSpendCeiling(v).ok).toBe(false);
+  });
+});
+
+describe("validateTimeZone", () => {
+  it("is optional", () => {
+    expect(validateTimeZone("")).toBeNull();
+  });
+  it("accepts IANA zones", () => {
+    expect(validateTimeZone("Europe/Vienna")).toBeNull();
+    expect(validateTimeZone(" America/New_York ")).toBeNull();
+    expect(validateTimeZone("UTC")).toBeNull();
+  });
+  it("rejects made-up zones", () => {
+    expect(validateTimeZone("Mars/Olympus")).toMatch(/unknown time zone/);
+    expect(validateTimeZone("CEST")).toMatch(/unknown time zone/);
+  });
+});
+
+describe("validateRequired", () => {
+  it("names what is missing", () => {
+    expect(validateRequired("  ", "a model")).toBe("enter a model");
+    expect(validateRequired("gpt-4o-mini", "a model")).toBeNull();
+  });
+});
+
+describe("capText", () => {
+  it("renders null as blank and numbers verbatim", () => {
+    expect(capText(null)).toBe("");
+    expect(capText(0)).toBe("0");
+    expect(capText(40)).toBe("40");
+  });
+});
+
+describe("buildIdentityPoolRequest", () => {
+  const base: IdentityPoolStaging = {
+    identities: [
+      { id: "oneshot:jane@mail.acme.dev", maxPerDay: 40 },
+      { id: "gmail:jane@gmail.com", maxPerDay: null },
+    ],
+    capEdits: {},
+    removedIds: [],
+    pendingAdds: [],
+    pendingSmartleadAdds: [],
+  };
+
+  it("nothing staged → an empty request", () => {
+    expect(buildIdentityPoolRequest(base)).toEqual({ ok: true, request: {}, empty: true });
+  });
+
+  it("a cap edit equal to the stored cap is not an update", () => {
+    const r = buildIdentityPoolRequest({
+      ...base,
+      capEdits: { "oneshot:jane@mail.acme.dev": " 40 ", "gmail:jane@gmail.com": "" },
+    });
+    expect(r).toEqual({ ok: true, request: {}, empty: true });
+  });
+
+  it("cap edits: number → cap, blank → null (uncapped)", () => {
+    const r = buildIdentityPoolRequest({
+      ...base,
+      capEdits: { "oneshot:jane@mail.acme.dev": "", "gmail:jane@gmail.com": "25" },
+    });
+    expect(r).toEqual({
+      ok: true,
+      empty: false,
+      request: {
+        identityUpdates: [
+          { id: "oneshot:jane@mail.acme.dev", maxPerDay: null },
+          { id: "gmail:jane@gmail.com", maxPerDay: 25 },
+        ],
+      },
+    });
+  });
+
+  it("a garbage cap fails the whole build with a per-row error", () => {
+    const r = buildIdentityPoolRequest({
+      ...base,
+      capEdits: { "oneshot:jane@mail.acme.dev": "lots", "gmail:jane@gmail.com": "25" },
+      removedIds: [],
+    });
+    expect(r).toEqual({
+      ok: false,
+      errors: { caps: { "oneshot:jane@mail.acme.dev": CAP_ERROR }, adds: {} },
+    });
+  });
+
+  it("drops edits and removals for ids that no longer exist, and edits on removed rows", () => {
+    const r = buildIdentityPoolRequest({
+      ...base,
+      capEdits: { "oneshot:gone@x.dev": "5", "gmail:jane@gmail.com": "nonsense" },
+      removedIds: ["gmail:jane@gmail.com", "oneshot:gone@x.dev"],
+    });
+    // The nonsense edit is on a removed row, so it neither errors nor ships.
+    expect(r).toEqual({
+      ok: true,
+      empty: false,
+      request: { removeIdentityIds: ["gmail:jane@gmail.com"] },
+    });
+  });
+
+  it("OneShot adds: blank cap omits maxPerDay (ramp), a number sets it, mailbox optional", () => {
+    const r = buildIdentityPoolRequest({
+      ...base,
+      pendingAdds: [
+        { sendingDomain: "acme.email", mailbox: "", maxPerDay: "" },
+        { sendingDomain: "acme.email", mailbox: " jane ", maxPerDay: "10" },
+      ],
+    });
+    expect(r).toEqual({
+      ok: true,
+      empty: false,
+      request: {
+        addIdentities: [
+          { provider: "oneshot", sendingDomain: "acme.email" },
+          { provider: "oneshot", sendingDomain: "acme.email", mailbox: "jane", maxPerDay: 10 },
+        ],
+      },
+    });
+  });
+
+  it("a bad add cap is reported under its address", () => {
+    const r = buildIdentityPoolRequest({
+      ...base,
+      pendingAdds: [{ sendingDomain: "acme.email", mailbox: "", maxPerDay: "ramp" }],
+    });
+    expect(r).toEqual({ ok: false, errors: { caps: {}, adds: { "agent@acme.email": CAP_ERROR } } });
+  });
+
+  it("Smartlead adds carry the provider cap for the server-side clamp", () => {
+    const r = buildIdentityPoolRequest({
+      ...base,
+      pendingSmartleadAdds: [
+        { address: "jane@acme.com", label: " Jane ", providerMessagePerDay: 30 },
+        { address: "ops@acme.com", label: "", providerMessagePerDay: null },
+      ],
+    });
+    expect(r).toEqual({
+      ok: true,
+      empty: false,
+      request: {
+        addIdentities: [
+          {
+            provider: "smartlead",
+            address: "jane@acme.com",
+            label: "Jane",
+            providerMessagePerDay: 30,
+          },
+          { provider: "smartlead", address: "ops@acme.com", providerMessagePerDay: null },
+        ],
+      },
+    });
+  });
+
+  it("everything staged ships in ONE request (atomic section save)", () => {
+    const r = buildIdentityPoolRequest({
+      ...base,
+      capEdits: { "oneshot:jane@mail.acme.dev": "30" },
+      removedIds: ["gmail:jane@gmail.com"],
+      pendingAdds: [{ sendingDomain: "acme.email", mailbox: "", maxPerDay: "" }],
+      pendingSmartleadAdds: [{ address: "x@y.com", label: "", providerMessagePerDay: null }],
+      emailProvider: "gmail",
+    });
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    expect(Object.keys(r.request).toSorted()).toEqual([
+      "addIdentities",
+      "emailProvider",
+      "identityUpdates",
+      "removeIdentityIds",
+    ]);
+    expect(r.request.addIdentities).toHaveLength(2);
+  });
+});

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -53,23 +53,30 @@ const BASE = "/api";
  * the 36 mutation sites behind it and all nine routes stay untouched. That is
  * why the seam is worth keeping narrow.
  */
+/**
+ * Error message for a non-2xx response: the server's `{ error }` string when
+ * the body carries one (every 4xx we emit does — e.g. the /setup 400s that a
+ * section form shows inline), else `status statusText: fallback`.
+ */
+async function errorMessage(res: Response, fallback: string): Promise<string> {
+  let message = `${res.status} ${res.statusText}: ${fallback}`;
+  try {
+    const text = await res.text();
+    if (text) {
+      const body = JSON.parse(text) as { error?: unknown };
+      if (typeof body.error === "string" && body.error) message = body.error;
+      else message = `${res.status} ${res.statusText}: ${text.slice(0, 200)}`;
+    }
+  } catch {
+    // body absent, empty, or not JSON — keep the fallback message
+  }
+  return message;
+}
+
 async function getJson<T>(path: string): Promise<T> {
   if (IS_DEMO) return demoGet<T>(path);
   const res = await fetch(BASE + path);
-  if (!res.ok) {
-    const fallback = `${res.status} ${res.statusText}: ${path}`;
-    let message = fallback;
-    try {
-      const text = await res.text();
-      if (text) {
-        const body = JSON.parse(text) as { error?: unknown };
-        if (typeof body.error === "string" && body.error) message = body.error;
-      }
-    } catch {
-      // body absent, empty, or not JSON — keep the fallback message
-    }
-    throw new Error(message);
-  }
+  if (!res.ok) throw new Error(await errorMessage(res, path));
   return (await res.json()) as T;
 }
 
@@ -80,10 +87,7 @@ async function postJson<T>(path: string, body: unknown): Promise<T> {
     headers: { "content-type": "application/json" },
     body: JSON.stringify(body),
   });
-  if (!res.ok) {
-    const text = await res.text();
-    throw new Error(`${res.status} ${res.statusText}: ${text.slice(0, 200)}`);
-  }
+  if (!res.ok) throw new Error(await errorMessage(res, path));
   return (await res.json()) as T;
 }
 
@@ -209,6 +213,10 @@ export const api = {
         llmModel: string;
         telemetryEnabled: boolean;
         walletMode: "cdp" | "private-key";
+        // Optional: older servers / the demo fixture may omit them; the
+        // server has always returned them (publicCfg spreads the whole cfg).
+        queueReviewOrder?: "ranked" | "newest";
+        timezone?: string | null;
       };
       secretsPath: string;
       sources: Record<string, "env" | "file" | null>;

--- a/apps/web/src/components/primitives/Field.tsx
+++ b/apps/web/src/components/primitives/Field.tsx
@@ -15,7 +15,8 @@ export function Field({
   children,
   className,
 }: {
-  label: string;
+  /** Usually a string; a node lets a caller append a Badge ("in use"). */
+  label: React.ReactNode;
   hint?: string;
   error?: string | null;
   children: React.ReactNode;

--- a/apps/web/src/components/setup/CredentialsSection.tsx
+++ b/apps/web/src/components/setup/CredentialsSection.tsx
@@ -1,0 +1,186 @@
+import { useMemo } from "react";
+import type { XEngine } from "@oneshot-gtm/shared-types";
+import { api } from "../../api/client.ts";
+import { Badge } from "../primitives/Badge.tsx";
+import { Field, Input } from "../primitives/Field.tsx";
+import { hintFor, LLM_KEY, SECRET_LABELS, X_OAUTH_KEYS, type SecretKey } from "./constants.ts";
+import { SectionShell } from "./SectionShell.tsx";
+import { useSectionDraft } from "./useSectionDraft.ts";
+import { useSectionSave } from "./useSectionSave.ts";
+import { useReportDirty, type SectionProps } from "./types.ts";
+
+type Secrets = Record<SecretKey, string>;
+
+/** Every secret starts blank on screen — the server never echoes a value. */
+const EMPTY: Secrets = Object.fromEntries(
+  (Object.keys(SECRET_LABELS) as SecretKey[]).map((k) => [k, ""]),
+) as Secrets;
+
+interface Group {
+  title: string;
+  caption?: string;
+  keys: readonly SecretKey[];
+  /** Keys the saved preferences currently route through, for the "in use" badge. */
+  inUse: (k: SecretKey) => boolean;
+  /** Extra hint for one key (e.g. the legacy-only refresh token). */
+  keyHint?: Partial<Record<SecretKey, string>>;
+  placeholder?: Partial<Record<SecretKey, string>>;
+}
+
+/**
+ * Every `type="password"` input on the page, in one place (issue #451 scope
+ * item 4). Preferences stay in their own sections; this one posts only
+ * `{ secrets }`. A blank field means "keep what's there" — there is no
+ * delete path for a secret from the web UI, same as before.
+ */
+export function CredentialsSection({
+  cfg,
+  sources,
+  homeDir,
+  isLegacyPool,
+  xEngine,
+  onDirtyChange,
+  onSmartleadKeySaved,
+}: SectionProps & {
+  homeDir: string;
+  isLegacyPool: boolean;
+  xEngine: XEngine;
+  /** A new Smartlead key = a different workspace; the email section drops its loaded list. */
+  onSmartleadKeySaved: () => void;
+}) {
+  const draft = useSectionDraft(EMPTY);
+  const save = useSectionSave<Partial<Secrets>>({
+    save: async (sent) => {
+      const secrets: Partial<Secrets> = {};
+      for (const [k, v] of Object.entries(sent) as [SecretKey, string][]) {
+        if (v.trim().length > 0) secrets[k] = v.trim();
+      }
+      await api.setup({ secrets });
+    },
+    refetch: [["setup"]],
+    alsoInvalidate: [["doctor"], ["home"]],
+    onCommitted: (sent) => {
+      draft.commit(sent);
+      if (sent.SMARTLEAD_API_KEY?.trim()) onSmartleadKeySaved();
+    },
+  });
+  useReportDirty("credentials", draft.dirty, onDirtyChange);
+
+  const groups = useMemo<Group[]>(
+    () => [
+      {
+        title: "LLM",
+        caption: `The key for your saved provider (${cfg.llmProvider}) is the one in use.`,
+        keys: ["OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"],
+        inUse: (k) => k === LLM_KEY[cfg.llmProvider],
+        placeholder: {
+          OPENROUTER_API_KEY: "sk-or-...",
+          OPENAI_API_KEY: "sk-...",
+          ANTHROPIC_API_KEY: "sk-ant-...",
+        },
+      },
+      {
+        title: "Wallet",
+        caption: `Keys live only in ${homeDir}/.env chmod 600. Nothing leaves your machine.`,
+        keys: ["CDP_API_KEY_ID", "CDP_API_KEY_SECRET", "CDP_WALLET_SECRET", "AGENT_PRIVATE_KEY"],
+        inUse: (k) => (cfg.walletMode === "cdp") === (k !== "AGENT_PRIVATE_KEY"),
+        placeholder: { AGENT_PRIVATE_KEY: "0x..." },
+      },
+      {
+        title: "Gmail",
+        caption:
+          "Google Cloud OAuth client (Desktop type, Gmail API enabled). Needed before Connect Gmail account in Email transport.",
+        keys: ["GMAIL_CLIENT_ID", "GMAIL_CLIENT_SECRET", "GMAIL_REFRESH_TOKEN"],
+        inUse: (k) =>
+          k === "GMAIL_REFRESH_TOKEN" ? isLegacyPool && cfg.emailProvider === "gmail" : true,
+        keyHint: {
+          GMAIL_REFRESH_TOKEN:
+            "Legacy single-identity Gmail mode only. With a rotation pool, Connect Gmail account stores tokens per identity instead.",
+        },
+      },
+      {
+        title: "Smartlead",
+        caption: "Smartlead → Settings → API. Then load and pick mailboxes in Email transport.",
+        keys: ["SMARTLEAD_API_KEY"],
+        inUse: () => true,
+      },
+      {
+        title: "X / Twitter",
+        caption: `Which set is used follows the engine saved on the x-reposters trigger (${xEngine === "xapi" ? "X API" : "twitterapi.io"}).`,
+        keys: [...X_OAUTH_KEYS, "TWITTERAPI_IO_KEY"],
+        inUse: (k) => (xEngine === "xapi") === (k !== "TWITTERAPI_IO_KEY"),
+      },
+      {
+        title: "LinkedIn replies",
+        caption:
+          "Lets LinkedIn automation tools report a real prospect reply so OneShot stops every live email cadence. Connection acceptance alone does nothing.",
+        keys: ["LINKEDIN_REPLY_WEBHOOK_SECRET"],
+        inUse: () => true,
+        keyHint: { LINKEDIN_REPLY_WEBHOOK_SECRET: "Use a random 32+ character bearer secret." },
+      },
+      {
+        title: "Finder access",
+        caption: "Optional credentials for richer GitHub and Luma discovery.",
+        keys: ["GITHUB_TOKEN", "LUMA_SESSION_COOKIE"],
+        inUse: () => true,
+      },
+    ],
+    [cfg.llmProvider, cfg.walletMode, cfg.emailProvider, homeDir, isLegacyPool, xEngine],
+  );
+
+  return (
+    <SectionShell
+      id="credentials"
+      lede={`Every key and token, apart from the preferences that choose between them. Saved to ${homeDir}/.env (chmod 600); a blank field keeps the stored value.`}
+      dirtyCount={draft.dirtyKeys.length}
+      savedAt={save.savedAt}
+      saving={save.isPending}
+      onSubmit={() => save.run(draft.snapshot)}
+      saveLabel="Save credentials"
+    >
+      <div className="flex flex-col gap-6">
+        {groups.map((g) => (
+          <fieldset key={g.title} className="flex flex-col gap-3 border-t border-ink-rule/60 pt-4">
+            <legend className="ln-eyebrow float-left pr-2">{g.title}</legend>
+            {g.caption && <p className="clear-both text-[12px] text-ink-faint">{g.caption}</p>}
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+              {g.keys.map((k) => {
+                const inUse = g.inUse(k);
+                const extra = g.keyHint?.[k];
+                return (
+                  <Field
+                    key={k}
+                    label={
+                      <>
+                        {SECRET_LABELS[k]}
+                        {inUse ? (
+                          <Badge tone="receipt" className="ml-2 align-middle">
+                            in use
+                          </Badge>
+                        ) : (
+                          <Badge tone="neutral" className="ml-2 align-middle">
+                            not in use
+                          </Badge>
+                        )}
+                      </>
+                    }
+                    hint={extra ? `${hintFor(sources[k])} ${extra}` : hintFor(sources[k])}
+                  >
+                    <Input
+                      type="password"
+                      placeholder={sources[k] ? "(unchanged)" : (g.placeholder?.[k] ?? "")}
+                      value={draft.values[k]}
+                      onChange={(e) => draft.set(k, e.target.value)}
+                      autoComplete="new-password"
+                      spellCheck={false}
+                    />
+                  </Field>
+                );
+              })}
+            </div>
+          </fieldset>
+        ))}
+      </div>
+    </SectionShell>
+  );
+}

--- a/apps/web/src/components/setup/EmailTransportSection.tsx
+++ b/apps/web/src/components/setup/EmailTransportSection.tsx
@@ -1,0 +1,576 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Mail } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
+import type {
+  DomainPoolView,
+  SenderIdentityView,
+  SetupRequest,
+  SmartleadAccountView,
+} from "@oneshot-gtm/shared-types";
+import { api } from "../../api/client.ts";
+import { readOnly } from "../../lib/readOnly.ts";
+import {
+  buildIdentityPoolRequest,
+  capText,
+  parseCap,
+  type PendingOneShotAdd,
+} from "../../lib/setupValidation.ts";
+import { Badge } from "../primitives/Badge.tsx";
+import { Button } from "../primitives/Button.tsx";
+import { Field, Input, Select } from "../primitives/Field.tsx";
+import { CredentialsLink } from "./KeyStatusLine.tsx";
+import { SectionShell } from "./SectionShell.tsx";
+import { useIdentityStaging } from "./useIdentityStaging.ts";
+import { useSectionDraft } from "./useSectionDraft.ts";
+import { useSectionSave } from "./useSectionSave.ts";
+import { useReportDirty, type SectionProps, type SetupStatus } from "./types.ts";
+
+/**
+ * The sender rotation pool. Cap edits, removals, new OneShot senders and
+ * picked Smartlead mailboxes are STAGED and commit together in one POST on
+ * this section's Save — never as a side effect of saving another section.
+ * Pause/resume of a provisioned domain is the one immediate action here.
+ */
+export function EmailTransportSection({
+  status,
+  smartleadKeyEpoch,
+  onDirtyChange,
+}: Pick<SectionProps, "onDirtyChange"> & {
+  status: SetupStatus;
+  /** Bumped when Credentials saves a new Smartlead key: the loaded list belongs to the old one. */
+  smartleadKeyEpoch: number;
+}) {
+  const qc = useQueryClient();
+  const { cfg, sources } = status;
+  const identities = status.identities ?? [];
+  const provisionedDomains = status.provisionedDomains ?? [];
+  // Legacy single-identity mode = the pool is auto-derived from emailProvider.
+  // Once a real pool exists, the provider select is inert (routing is
+  // pool-driven) — hide it instead of misleading.
+  const isLegacyPool = identities[0]?.legacy ?? true;
+  const gmailCredsReady = Boolean(sources["GMAIL_CLIENT_ID"] && sources["GMAIL_CLIENT_SECRET"]);
+  const smartleadKeyReady = Boolean(sources["SMARTLEAD_API_KEY"]);
+  // Default mailbox shown as a placeholder — founder's first name, normalized.
+  const founderLocalpart = ((cfg.founderName ?? "").trim().split(/\s+/)[0] ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "");
+
+  const server = useMemo(() => ({ emailProvider: cfg.emailProvider }), [cfg.emailProvider]);
+  const draft = useSectionDraft(server);
+  const staging = useIdentityStaging();
+
+  const build = buildIdentityPoolRequest({
+    identities: identities.map((i) => ({ id: i.id, maxPerDay: i.maxPerDay })),
+    capEdits: staging.capEdits,
+    removedIds: staging.removedIds,
+    pendingAdds: staging.pendingAdds,
+    pendingSmartleadAdds: staging.pendingSmartleadAdds,
+    emailProvider: draft.snapshot.emailProvider,
+  });
+  const capErrors = build.ok ? {} : build.errors.caps;
+  const addErrors = build.ok ? {} : build.errors.adds;
+  const errorCount = Object.keys(capErrors).length + Object.keys(addErrors).length;
+  const liveIds = new Set(identities.map((i) => i.id));
+  const removed = staging.removedIds.filter((id) => liveIds.has(id));
+  const capDirty = identities.filter(
+    (i) =>
+      !removed.includes(i.id) &&
+      staging.capEdits[i.id] !== undefined &&
+      staging.capEdits[i.id] !== capText(i.maxPerDay),
+  ).length;
+  const dirtyCount =
+    capDirty +
+    removed.length +
+    staging.pendingAdds.length +
+    staging.pendingSmartleadAdds.length +
+    draft.dirtyKeys.length;
+
+  const save = useSectionSave<SetupRequest>({
+    save: async (req) => {
+      await api.setup(req);
+    },
+    refetch: [["setup"]],
+    alsoInvalidate: [["doctor"], ["home"]],
+    onCommitted: (sent) => {
+      staging.clear();
+      if (sent.emailProvider !== undefined) draft.commit({ emailProvider: sent.emailProvider });
+    },
+  });
+  useReportDirty("email", dirtyCount > 0, onDirtyChange);
+
+  // Resume / pause a provisioned sending domain in the OneShot pool. Refetches
+  // the setup status (and doctor) so the status badge + warning update. Errors
+  // surface verbatim — incl. the OneShot HTTP status during a platform outage.
+  const domainAction = useMutation({
+    mutationFn: (vars: { domain: string; action: "resume" | "pause" }) =>
+      vars.action === "resume" ? api.resumeDomain(vars.domain) : api.pauseDomain(vars.domain),
+    onSuccess: (res) => {
+      void qc.invalidateQueries({ queryKey: ["setup"] });
+      void qc.invalidateQueries({ queryKey: ["doctor"] });
+      toast.success(`${res.domain} → ${res.poolStatus}`);
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
+
+  // Smartlead workspace mailboxes — loaded with the SAVED key (the input now
+  // lives in Credentials). A saved key change invalidates the list and any
+  // staged picks: they'd register mailboxes the new key can't send as.
+  const [smartleadAccounts, setSmartleadAccounts] = useState<SmartleadAccountView[] | null>(null);
+  const loadSmartlead = useMutation({
+    mutationFn: () => api.smartleadAccounts(undefined),
+    onSuccess: (res) => setSmartleadAccounts(res.accounts),
+    onError: (err: Error) => toast.error(`Smartlead: ${err.message}`),
+  });
+  const { clearSmartlead } = staging;
+  useEffect(() => {
+    if (smartleadKeyEpoch === 0) return;
+    setSmartleadAccounts(null);
+    clearSmartlead();
+  }, [smartleadKeyEpoch, clearSmartlead]);
+
+  return (
+    <SectionShell
+      id="email"
+      lede="The sender rotation pool. Each prospect sticks to the identity that first emailed them; new prospects go to the identity with the most capacity left today."
+      dirtyCount={dirtyCount}
+      errorCount={errorCount}
+      savedAt={save.savedAt}
+      saving={save.isPending}
+      onSubmit={() => {
+        if (build.ok && !build.empty) save.run(build.request);
+      }}
+      saveLabel="Save pool changes"
+      footerNote="cap, removal and sender changes apply together on save"
+    >
+      {identities.length > 0 && (
+        <div className="flex flex-col gap-2">
+          <span className="ln-eyebrow">Sender identities</span>
+          {identities
+            .filter((i) => !removed.includes(i.id))
+            .map((i) => (
+              <IdentityRow
+                key={i.id}
+                identity={i}
+                capValue={staging.capEdits[i.id] ?? capText(i.maxPerDay)}
+                capError={capErrors[i.id]}
+                onCap={(raw) => staging.setCap(i.id, raw)}
+                onRemove={() => staging.remove(i.id)}
+              />
+            ))}
+          <div className="mt-1 flex flex-wrap items-center gap-3">
+            <Button
+              type="button"
+              variant="secondary"
+              disabled={!gmailCredsReady}
+              onClick={() => {
+                window.location.href = "/api/gmail/auth/start";
+              }}
+            >
+              <Mail size={12} />
+              Connect Gmail account
+            </Button>
+            <span className="text-[12px] text-ink-faint">
+              {gmailCredsReady ? (
+                "Opens Google consent — sign in as the account you want to send from."
+              ) : (
+                <>
+                  Save GMAIL_CLIENT_ID + GMAIL_CLIENT_SECRET in <CredentialsLink /> first (Google
+                  Cloud OAuth client, Desktop type, Gmail API enabled).
+                </>
+              )}
+            </span>
+          </div>
+          <span className="text-[12px] text-ink-faint">
+            CLI alternative:{" "}
+            <code className="ln-mono text-[11.5px] text-ink-cream-2">
+              bun run cli -- gmail auth
+            </code>
+            . Cap and removal changes apply on Save. Removing an identity blocks sends to prospects
+            pinned to it until it's restored.
+          </span>
+
+          <ProvisionedDomains
+            domains={provisionedDomains}
+            busyDomain={domainAction.isPending ? domainAction.variables?.domain : undefined}
+            onToggle={(domain, action) => domainAction.mutate({ domain, action })}
+          />
+
+          <AddOneShotSender
+            identities={identities}
+            provisionedDomains={provisionedDomains}
+            founderLocalpart={founderLocalpart}
+            pending={staging.pendingAdds}
+            pendingErrors={addErrors}
+            onStage={staging.stageAdd}
+            onUnstage={staging.unstageAdd}
+          />
+        </div>
+      )}
+
+      {/* Smartlead lives OUTSIDE the identities guard — connecting it is how an
+          empty pool gets rebuilt. */}
+      <div className="mt-3 flex flex-col gap-2">
+        <span className="ln-eyebrow">Smartlead accounts</span>
+        <div className="flex flex-wrap items-center gap-3">
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={!smartleadKeyReady || loadSmartlead.isPending}
+            onClick={() => loadSmartlead.mutate()}
+            {...readOnly}
+          >
+            {loadSmartlead.isPending ? "Loading…" : "Load Smartlead accounts"}
+          </Button>
+          <span className="text-[12px] text-ink-faint">
+            {smartleadKeyReady ? (
+              "Lists the mailboxes connected to your Smartlead workspace — Smartlead does the warmup, this pool does the sending."
+            ) : (
+              <>
+                Save your Smartlead API key in <CredentialsLink /> first (Smartlead → Settings →
+                API).
+              </>
+            )}
+          </span>
+        </div>
+        {smartleadAccounts && smartleadAccounts.length === 0 && (
+          <span className="text-[12px] text-ink-faint">
+            No email accounts connected in Smartlead yet.
+          </span>
+        )}
+        {smartleadAccounts?.map((a) => {
+          const staged = staging.pendingSmartleadAdds.some((p) => p.address === a.fromEmail);
+          const blocked = !a.isSmtpSuccess;
+          return (
+            <div
+              key={a.id}
+              className="flex items-center gap-3 border border-ink-rule rounded-[var(--radius-sm)] px-3 py-2"
+            >
+              <div className="flex min-w-0 flex-col">
+                <span className="truncate text-[13px] text-ink-cream">{a.fromEmail}</span>
+                <span className="ln-mono text-[11px] text-ink-muted">
+                  {a.messagePerDay != null ? `${a.messagePerDay}/day` : "no cap"}
+                  {a.warmupStatus
+                    ? ` · warmup ${a.warmupStatus.toLowerCase()}${a.warmupReputation ? ` (${a.warmupReputation})` : ""}`
+                    : ""}
+                  {blocked ? " · SMTP broken — reconnect in Smartlead" : ""}
+                </span>
+              </div>
+              <div className="ml-auto">
+                {a.alreadyRegistered ? (
+                  <span className="ln-mono text-[11px] text-ink-faint">in pool</span>
+                ) : staged ? (
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    className="h-7 px-2 text-[11px]"
+                    onClick={() => staging.unstageSmartlead(a.fromEmail)}
+                  >
+                    Undo
+                  </Button>
+                ) : (
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    className="h-7 px-2 text-[11px]"
+                    disabled={blocked}
+                    onClick={() =>
+                      staging.stageSmartlead({
+                        address: a.fromEmail,
+                        label: a.fromName ?? "",
+                        providerMessagePerDay: a.messagePerDay,
+                      })
+                    }
+                  >
+                    Add
+                  </Button>
+                )}
+              </div>
+            </div>
+          );
+        })}
+        {staging.pendingSmartleadAdds.length > 0 && (
+          <span className="text-[12px] text-ink-faint">
+            {staging.pendingSmartleadAdds.length} Smartlead mailbox
+            {staging.pendingSmartleadAdds.length === 1 ? "" : "es"} staged — applied on Save with
+            the cold-start warm-up ramp (capped at Smartlead's own per-mailbox limit).
+          </span>
+        )}
+      </div>
+
+      {isLegacyPool && (
+        <Field label="Provider" className="mt-3">
+          <Select
+            value={draft.values.emailProvider}
+            onChange={(e) => draft.set("emailProvider", e.target.value as "oneshot" | "gmail")}
+          >
+            <option value="oneshot">OneShot SDK (wallet-owned sending domain)</option>
+            <option value="gmail">Gmail / Google Workspace (your own account)</option>
+          </Select>
+        </Field>
+      )}
+      {isLegacyPool && draft.values.emailProvider === "gmail" && (
+        <div className="ln-note text-[12px] text-ink-muted">
+          Emails send from your authenticated Gmail address — the sending domain in Founder profile
+          is ignored. Easiest path: run{" "}
+          <code className="ln-mono text-[11.5px] text-ink-cream-2">bun run cli -- gmail auth</code>{" "}
+          to authorize in the browser and fill all three Gmail values in <CredentialsLink />{" "}
+          automatically.
+        </div>
+      )}
+    </SectionShell>
+  );
+}
+
+function IdentityRow({
+  identity: i,
+  capValue,
+  capError,
+  onCap,
+  onRemove,
+}: {
+  identity: SenderIdentityView;
+  capValue: string;
+  capError: string | undefined;
+  onCap: (raw: string) => void;
+  onRemove: () => void;
+}) {
+  return (
+    <div className="flex items-start gap-3 border border-ink-rule rounded-[var(--radius-sm)] px-3 py-2">
+      <Badge
+        tone={i.provider === "gmail" ? "signal" : i.provider === "smartlead" ? "spend" : "receipt"}
+        className="mt-1.5"
+      >
+        {i.provider}
+      </Badge>
+      <div className="flex min-w-0 flex-col pt-1">
+        <span className="truncate text-[13px] text-ink-cream">
+          {i.mailbox && i.sendingDomain
+            ? `${i.mailbox}@${i.sendingDomain}`
+            : (i.address ?? i.sendingDomain ?? i.label ?? i.id)}
+        </span>
+        <span className="ln-mono text-[11px] text-ink-muted">
+          {i.domainSentToday !== i.sentToday
+            ? `today ${i.sentToday} · domain ${i.domainSentToday}/${i.capToday ?? "∞"} shared`
+            : `today ${i.sentToday}/${i.capToday ?? "∞"}`}
+          {i.warmup ? ` · warm-up ${i.warmup.startPerDay}+${i.warmup.incrementPerWeek}/wk` : ""}
+          {i.legacy ? " · legacy (auto-derived)" : ""}
+        </span>
+      </div>
+      <div className="ml-auto flex items-start gap-2">
+        <Field label="max/day" error={capError} className="w-28 gap-0.5">
+          <Input
+            className="h-7 text-[12px]"
+            placeholder="∞ (no cap)"
+            inputMode="numeric"
+            value={capValue}
+            onChange={(e) => onCap(e.target.value)}
+            aria-label={`max sends per day for ${i.id}`}
+          />
+        </Field>
+        {!i.legacy && (
+          <Button
+            type="button"
+            variant="secondary"
+            className="mt-[18px] h-7 px-2 text-[11px]"
+            onClick={onRemove}
+          >
+            Remove
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Provisioned OneShot domains — a paused domain sends nothing until resumed. */
+function ProvisionedDomains({
+  domains,
+  busyDomain,
+  onToggle,
+}: {
+  domains: DomainPoolView[];
+  busyDomain: string | undefined;
+  onToggle: (domain: string, action: "resume" | "pause") => void;
+}) {
+  if (domains.length === 0) return null;
+  return (
+    <div className="mt-3 flex flex-col gap-2 border-t border-ink-rule pt-3">
+      <span className="ln-eyebrow">Provisioned domains</span>
+      {domains.map((d) => {
+        const paused = d.poolStatus === "paused" || d.poolStatus === "removed";
+        const tone =
+          d.poolStatus === "active" ? "receipt" : d.poolStatus === "warming" ? "spend" : "blocked";
+        const busy = busyDomain === d.domain;
+        return (
+          <div
+            key={d.domain}
+            className="flex items-center gap-3 border border-ink-rule rounded-[var(--radius-sm)] px-3 py-2"
+          >
+            <Badge tone={tone}>{d.poolStatus}</Badge>
+            <span className="truncate text-[13px] text-ink-cream">{d.domain}</span>
+            <span className="ln-mono text-[11px] text-ink-muted">
+              sent {d.dailySentCount}/{d.dailySendLimit}/day
+              {d.warmupScore != null ? ` · warmth ${d.warmupScore}` : ""}
+            </span>
+            <Button
+              type="button"
+              variant="secondary"
+              disabled={busy}
+              className="ml-auto h-7 px-2 text-[11px]"
+              onClick={() => onToggle(d.domain, paused ? "resume" : "pause")}
+              {...readOnly}
+            >
+              {busy ? "…" : paused ? "Resume" : "Pause"}
+            </Button>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+/** Add OneShot sender — domain + mailbox join the rotation pool on Save. */
+function AddOneShotSender({
+  identities,
+  provisionedDomains,
+  founderLocalpart,
+  pending,
+  pendingErrors,
+  onStage,
+  onUnstage,
+}: {
+  identities: SenderIdentityView[];
+  provisionedDomains: DomainPoolView[];
+  founderLocalpart: string;
+  pending: PendingOneShotAdd[];
+  pendingErrors: Record<string, string>;
+  onStage: (a: PendingOneShotAdd) => void;
+  onUnstage: (a: PendingOneShotAdd) => void;
+}) {
+  const [addDomain, setAddDomain] = useState("");
+  const [addMailbox, setAddMailbox] = useState("");
+  const [addCap, setAddCap] = useState("");
+  // Validated at Add time so a bad cap never even reaches the staged list.
+  const capParsed = parseCap(addCap, { blank: "omit" });
+  const capError = addCap.trim() && !capParsed.ok ? capParsed.error : null;
+  const domain = addDomain.trim().toLowerCase();
+  const stage = (): void => {
+    if (!domain || !capParsed.ok) return;
+    onStage({ sendingDomain: domain, mailbox: addMailbox, maxPerDay: addCap });
+    setAddDomain("");
+    setAddMailbox("");
+    setAddCap("");
+  };
+  return (
+    <div className="mt-3 flex flex-col gap-2 border-t border-ink-rule pt-3">
+      <span className="ln-eyebrow">Add OneShot sender</span>
+      {pending.length > 0 && (
+        <div className="flex flex-col gap-1.5">
+          {pending.map((a) => {
+            const key = `${a.mailbox.trim() || "agent"}@${a.sendingDomain}`;
+            return (
+              <div
+                key={key}
+                className="flex items-center gap-3 border border-dashed border-ink-rule rounded-[var(--radius-sm)] px-3 py-1.5"
+              >
+                <Badge tone="receipt">oneshot</Badge>
+                <span className="truncate text-[13px] text-ink-cream">{key}</span>
+                <span className="ln-mono text-[11px] text-ink-muted">
+                  {a.maxPerDay.trim() ? `cap ${a.maxPerDay.trim()}/day` : "warm-up ramp"}
+                </span>
+                {pendingErrors[key] && (
+                  <span className="font-mono text-[11px] text-[color:var(--ink-blocked-2)]">
+                    {pendingErrors[key]}
+                  </span>
+                )}
+                <Button
+                  type="button"
+                  variant="secondary"
+                  className="ml-auto h-7 px-2 text-[11px]"
+                  onClick={() => onUnstage(a)}
+                >
+                  Remove
+                </Button>
+              </div>
+            );
+          })}
+        </div>
+      )}
+      <div className="flex flex-wrap items-end gap-2">
+        <Field label="Domain" className="min-w-[200px]">
+          {/* Pick a warmed domain or type a new one (auto-provisions on first send). */}
+          <Input
+            list="oneshot-domains"
+            placeholder="acme.com"
+            value={addDomain}
+            onChange={(e) => setAddDomain(e.target.value)}
+            aria-label="sending domain"
+          />
+          <datalist id="oneshot-domains">
+            {provisionedDomains.map((d) => (
+              <option key={d.domain} value={d.domain}>
+                {d.poolStatus !== "active" ? d.poolStatus : ""}
+                {d.warmupScore != null ? ` warmth ${d.warmupScore}` : ""}
+              </option>
+            ))}
+          </datalist>
+        </Field>
+        <Field label="Mailbox" className="w-32">
+          <Input
+            placeholder={founderLocalpart || "agent"}
+            value={addMailbox}
+            onChange={(e) => setAddMailbox(e.target.value)}
+            aria-label="mailbox local-part"
+          />
+        </Field>
+        <Field label="Max/day" className="w-28" error={capError}>
+          <Input
+            placeholder="ramp"
+            inputMode="numeric"
+            value={addCap}
+            onChange={(e) => setAddCap(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                stage();
+              }
+            }}
+            aria-label="max sends per day"
+          />
+        </Field>
+        <Button
+          type="button"
+          variant="secondary"
+          className="mb-[2px]"
+          disabled={!domain || !capParsed.ok}
+          onClick={stage}
+        >
+          Add
+        </Button>
+      </div>
+      {/* A domain outside the warmed pool goes out cold — pinned sends bypass warm-up. */}
+      {domain &&
+        provisionedDomains.length > 0 &&
+        !provisionedDomains.some((d) => d.domain.toLowerCase() === domain) && (
+          <span className="text-[12px] text-ink-blocked">
+            {domain} isn't in your warmed pool — it auto-provisions on first send and goes out cold
+            (server warm-up is bypassed for chosen domains). The client ramp below is your only
+            throttle.
+          </span>
+        )}
+      {/* Reputation + send limits are per-domain, not per-mailbox. */}
+      {domain && identities.some((i) => i.sendingDomain?.toLowerCase() === domain) && (
+        <span className="text-[12px] text-ink-faint">
+          Heads up: {domain} already sends in your pool. Reputation and the platform daily limit are
+          per-domain — extra mailboxes share them, and their client caps stack on the same domain.
+        </span>
+      )}
+      <span className="text-[12px] text-ink-faint">
+        Blank mailbox defaults to your first name; blank cap uses the cold-start warm-up ramp
+        (10/day, +10/week, max 50). Domains you send from are pinned, so the client ramp — not the
+        server — paces warm-up. New senders join the pool on Save.
+      </span>
+    </div>
+  );
+}

--- a/apps/web/src/components/setup/FounderSection.tsx
+++ b/apps/web/src/components/setup/FounderSection.tsx
@@ -1,0 +1,92 @@
+import { useMemo } from "react";
+import { Field, Input, Textarea } from "../primitives/Field.tsx";
+import { validateBareDomain, validateEmail } from "../../lib/setupValidation.ts";
+import { SectionShell } from "./SectionShell.tsx";
+import { useConfigSection } from "./useConfigSection.ts";
+import type { SectionProps } from "./types.ts";
+
+export function FounderSection({ cfg, onDirtyChange }: SectionProps) {
+  const server = useMemo(
+    () => ({
+      founderName: cfg.founderName ?? "",
+      founderEmail: cfg.founderEmail ?? "",
+      productDomain: cfg.productDomain ?? "",
+      sendingDomain: cfg.sendingDomain ?? "",
+      productOneLiner: cfg.productOneLiner ?? "",
+    }),
+    [cfg],
+  );
+  const s = useConfigSection({
+    id: "profile",
+    server,
+    toRequest: (sent) => sent,
+    validate: (v) => ({
+      founderEmail: validateEmail(v.founderEmail),
+      productDomain: validateBareDomain(v.productDomain),
+      sendingDomain: validateBareDomain(v.sendingDomain),
+    }),
+    onDirtyChange,
+  });
+
+  return (
+    <SectionShell {...s.shell} lede="How prospects see you on the other side of the inbox.">
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <Field label="Name">
+          <Input
+            value={s.values.founderName}
+            onChange={(e) => s.set("founderName", e.target.value)}
+            placeholder="Jane Doe"
+          />
+        </Field>
+        <Field
+          label="Your email"
+          error={s.errors.founderEmail}
+          hint="Lead capture on pages this tool generates (e.g. the PMF survey). NOT a reply address — replies land in the inbox of whichever sending identity sent the mail."
+        >
+          <Input
+            type="email"
+            value={s.values.founderEmail}
+            onChange={(e) => s.set("founderEmail", e.target.value)}
+            placeholder="jane@yourcompany.com"
+          />
+        </Field>
+        <Field
+          label="Signature domain"
+          error={s.errors.productDomain}
+          hint="Bare domain shown under your name in every email signature, e.g. yourcompany.com. Leave blank for no domain line."
+        >
+          <Input
+            value={s.values.productDomain}
+            onChange={(e) => s.set("productDomain", e.target.value)}
+            placeholder="yourcompany.com"
+          />
+        </Field>
+        <Field
+          label="Sending domain"
+          error={s.errors.sendingDomain}
+          hint="The domain your wallet OWNS. Emails send from <your-first-name>@thisdomain. Must be wallet-owned or the SDK rejects the send. Leave blank to use the SDK default."
+        >
+          <Input
+            value={s.values.sendingDomain}
+            onChange={(e) => s.set("sendingDomain", e.target.value)}
+            placeholder="yourcompany-mail.com"
+          />
+        </Field>
+        <Field
+          label="Product one-liner"
+          hint="What you're building, in one sentence."
+          className="md:col-span-2"
+        >
+          <Textarea
+            value={s.values.productOneLiner}
+            onChange={(e) => s.set("productOneLiner", e.target.value)}
+            placeholder={
+              'e.g. "Stripe for freight" · "AI bookkeeping for restaurants" · "scheduling for dog groomers"'
+            }
+            rows={2}
+          />
+        </Field>
+      </div>
+    </SectionShell>
+  );
+}

--- a/apps/web/src/components/setup/IcpSection.tsx
+++ b/apps/web/src/components/setup/IcpSection.tsx
@@ -1,0 +1,173 @@
+import { useMutation } from "@tanstack/react-query";
+import { Wand2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { api } from "../../api/client.ts";
+import { readOnly } from "../../lib/readOnly.ts";
+import { Button } from "../primitives/Button.tsx";
+import { Field, Input, Textarea } from "../primitives/Field.tsx";
+import { SectionShell } from "./SectionShell.tsx";
+import { useConfigSection } from "./useConfigSection.ts";
+import type { SectionProps } from "./types.ts";
+
+export function IcpSection({
+  cfg,
+  proposedIcp,
+  packLabel,
+  onDirtyChange,
+}: SectionProps & {
+  /** A pack's proposed ICP, deep-linked from /queue's "Accept in Setup". */
+  proposedIcp?: string;
+  packLabel?: string;
+}) {
+  const server = useMemo(() => ({ icpOneLiner: cfg.icpOneLiner ?? "" }), [cfg]);
+  // The pack proposal seeds the DRAFT, never config.json — the founder still
+  // has to Save. Being a draft it also survives every ["setup"] refetch.
+  const s = useConfigSection({
+    id: "icp",
+    server,
+    initialDraft: proposedIcp ? { icpOneLiner: proposedIcp } : undefined,
+    toRequest: (sent) => sent,
+    onDirtyChange,
+  });
+
+  // Clear proposedIcp/packLabel from the URL once consumed so a later reload
+  // of /setup doesn't re-seed — and re-save — the stale proposal over the
+  // founder's own edits. Preserve window.history.state: TanStack Router's
+  // __TSR_index/__TSR_key live there, and replacing it with {} desyncs the
+  // router's history index (next back/forward becomes a generic GO).
+  useEffect(() => {
+    if (!proposedIcp) return;
+    const params = new URLSearchParams(window.location.search);
+    params.delete("proposedIcp");
+    params.delete("packLabel");
+    const qs = params.toString();
+    window.history.replaceState(
+      window.history.state,
+      "",
+      `${window.location.pathname}${qs ? `?${qs}` : ""}${window.location.hash}`,
+    );
+    // Seeded once, on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  const showPackBanner = Boolean(proposedIcp) && s.dirtyKeys.includes("icpOneLiner");
+
+  const [icpDomain, setIcpDomain] = useState("");
+  const [deriveError, setDeriveError] = useState<string | null>(null);
+  const [deriveSource, setDeriveSource] = useState<{ url: string; cost: number } | null>(null);
+  const deriveIcp = useMutation({
+    mutationFn: (domain: string) => api.deriveIcp(domain),
+    onSuccess: (res) => {
+      s.set("icpOneLiner", res.proposedIcp);
+      setDeriveSource({ url: res.sourceUrl, cost: res.costUsd });
+      setDeriveError(null);
+    },
+    onError: (err: Error) => {
+      setDeriveError(err.message);
+      setDeriveSource(null);
+    },
+  });
+
+  // Elapsed counter so the ~30–60s derive feels alive instead of frozen.
+  // Server doesn't stream progress; we cycle a phase label by elapsed time.
+  const [deriveElapsed, setDeriveElapsed] = useState(0);
+  useEffect(() => {
+    if (!deriveIcp.isPending) {
+      setDeriveElapsed(0);
+      return;
+    }
+    const started = Date.now();
+    const t = setInterval(() => {
+      setDeriveElapsed(Math.floor((Date.now() - started) / 1000));
+    }, 250);
+    return () => clearInterval(t);
+  }, [deriveIcp.isPending]);
+  const derivePhase =
+    deriveElapsed < 15
+      ? `Reading the page · ${deriveElapsed}s`
+      : deriveElapsed < 35
+        ? `Still reading — slow pages take a moment · ${deriveElapsed}s`
+        : `Asking the LLM to extract an ICP · ${deriveElapsed}s`;
+
+  return (
+    <SectionShell
+      {...s.shell}
+      lede="A free-text classifier. The find layer uses this to drop candidates that don't match."
+    >
+      {showPackBanner && (
+        <div className="border-l-2 border-[color:var(--ink-receipt)] bg-[color:var(--ink-receipt)]/10 px-3 py-2 font-mono text-[11.5px] text-ink-cream-2">
+          Proposed by {packLabel ?? "an industry pack"} — never written until you Save below. Edit
+          or clear it first if it's not right.
+        </div>
+      )}
+      <Field
+        label="Derive from a website"
+        hint="Paste a domain (or full URL) of a company whose customers look like yours. We'll read the page and propose an ICP — you can edit before saving. Spends ~$0.02–0.05 (one webRead + one LLM call)."
+      >
+        <div className="flex gap-2">
+          <Input
+            value={icpDomain}
+            onChange={(e) => setIcpDomain(e.target.value)}
+            placeholder="acme.com  ·  https://yourcompany.com/customers"
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !deriveIcp.isPending && icpDomain.trim().length > 0) {
+                e.preventDefault();
+                deriveIcp.mutate(icpDomain.trim());
+              }
+            }}
+          />
+          <Button
+            type="button"
+            variant="secondary"
+            className="shrink-0 whitespace-nowrap"
+            disabled={deriveIcp.isPending || icpDomain.trim().length === 0}
+            onClick={() => deriveIcp.mutate(icpDomain.trim())}
+            {...readOnly}
+          >
+            <Wand2 size={12} className={deriveIcp.isPending ? "animate-pulse" : undefined} />
+            {deriveIcp.isPending ? `Working · ${deriveElapsed}s` : "Derive ICP"}
+          </Button>
+        </div>
+      </Field>
+
+      {deriveIcp.isPending && (
+        <div className="flex items-center gap-2 font-mono text-[11px] text-ink-muted">
+          <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-ink-cream-2" />
+          {derivePhase}
+        </div>
+      )}
+      {deriveError && (
+        <div className="border-l-2 border-[color:var(--ink-blocked)] bg-[color:var(--ink-blocked)]/10 px-3 py-2 font-mono text-[11.5px] text-[color:var(--ink-blocked-2)]">
+          {deriveError}
+        </div>
+      )}
+      {deriveSource && !deriveError && (
+        <div className="font-mono text-[11px] text-ink-muted">
+          drafted from{" "}
+          <a
+            href={deriveSource.url}
+            target="_blank"
+            rel="noreferrer"
+            className="text-ink-cream-2 underline decoration-ink-faint decoration-1 underline-offset-2 hover:decoration-ink-cream"
+          >
+            {deriveSource.url}
+          </a>{" "}
+          · spent ${deriveSource.cost.toFixed(3)} · edit below before saving.
+        </div>
+      )}
+
+      <Field
+        label="ICP one-liner"
+        hint="Leave blank to disable filtering (every candidate passes through)."
+      >
+        <Textarea
+          value={s.values.icpOneLiner}
+          onChange={(e) => s.set("icpOneLiner", e.target.value)}
+          placeholder={
+            'e.g. "CFOs at Series-B SaaS" · "Shopify stores doing $1M+/yr" · "indie iOS devs"'
+          }
+          rows={3}
+        />
+      </Field>
+    </SectionShell>
+  );
+}

--- a/apps/web/src/components/setup/KeyStatusLine.tsx
+++ b/apps/web/src/components/setup/KeyStatusLine.tsx
@@ -1,0 +1,62 @@
+import { cn } from "../../lib/cn.ts";
+import { keyStatus, SECRET_LABELS, type SecretKey } from "./constants.ts";
+import { jumpToSection } from "./SectionNav.tsx";
+import type { Sources } from "./types.ts";
+
+/**
+ * "OPENROUTER_API_KEY · from .env" — the one-line bridge from a preference
+ * section to the Credentials section that now owns every secret input.
+ */
+export function KeyStatusLine({
+  keys,
+  sources,
+  note,
+  className,
+}: {
+  keys: readonly SecretKey[];
+  sources: Sources;
+  note?: string;
+  className?: string;
+}) {
+  const missing = keys.filter((k) => !sources[k]);
+  return (
+    <p className={cn("font-mono text-[11px] text-ink-muted", className)}>
+      {keys.map((k, i) => (
+        <span key={k}>
+          {i > 0 && " · "}
+          <span className={sources[k] ? "text-ink-cream-2" : "text-[color:var(--ink-spend-2)]"}>
+            {SECRET_LABELS[k]}
+          </span>{" "}
+          {keyStatus(sources[k])}
+        </span>
+      ))}
+      {(missing.length > 0 || note) && (
+        <>
+          {" — "}
+          {note ?? "add it in"}
+          {!note && (
+            <>
+              {" "}
+              <CredentialsLink />
+            </>
+          )}
+        </>
+      )}
+    </p>
+  );
+}
+
+export function CredentialsLink({ children = "Credentials" }: { children?: React.ReactNode }) {
+  return (
+    <a
+      href="#credentials"
+      onClick={(e) => {
+        e.preventDefault();
+        jumpToSection("credentials");
+      }}
+      className="text-ink-cream-2 underline decoration-ink-faint decoration-1 underline-offset-2 hover:decoration-ink-cream"
+    >
+      {children}
+    </a>
+  );
+}

--- a/apps/web/src/components/setup/LlmSection.tsx
+++ b/apps/web/src/components/setup/LlmSection.tsx
@@ -1,0 +1,72 @@
+import { useMemo } from "react";
+import type { LlmProvider } from "@oneshot-gtm/shared-types";
+import { Field, Input, Select } from "../primitives/Field.tsx";
+import { validateRequired } from "../../lib/setupValidation.ts";
+import { KeyStatusLine } from "./KeyStatusLine.tsx";
+import { LLM_DEFAULTS, LLM_KEY } from "./constants.ts";
+import { SectionShell } from "./SectionShell.tsx";
+import { useConfigSection } from "./useConfigSection.ts";
+import type { SectionProps } from "./types.ts";
+
+export function LlmSection({ cfg, sources, onDirtyChange }: SectionProps) {
+  const server = useMemo(
+    () => ({ llmProvider: cfg.llmProvider as LlmProvider, llmModel: cfg.llmModel }),
+    [cfg],
+  );
+  const s = useConfigSection({
+    id: "llm",
+    server,
+    toRequest: (sent) => sent,
+    validate: (v) => ({ llmModel: validateRequired(v.llmModel, "a model id") }),
+    onDirtyChange,
+  });
+
+  const onProvider = (next: LlmProvider): void => {
+    const prev = s.values.llmProvider;
+    s.set("llmProvider", next);
+    // Follow the provider with its default model unless the founder typed
+    // their own — a model id from the old provider is never valid on the new one.
+    const model = s.values.llmModel.trim();
+    if (model.length === 0 || model === LLM_DEFAULTS[prev]) {
+      s.set("llmModel", LLM_DEFAULTS[next] ?? "");
+    }
+  };
+
+  return (
+    <SectionShell
+      {...s.shell}
+      lede="Bring your own key. Swap providers freely; nothing is locked in."
+    >
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <Field label="Provider">
+          <Select
+            value={s.values.llmProvider}
+            onChange={(e) => onProvider(e.target.value as LlmProvider)}
+          >
+            <option value="openrouter">OpenRouter (recommended)</option>
+            <option value="openai">OpenAI</option>
+            <option value="anthropic">Anthropic</option>
+          </Select>
+        </Field>
+        <Field label="Model" error={s.errors.llmModel}>
+          <Input
+            value={s.values.llmModel}
+            onChange={(e) => s.set("llmModel", e.target.value)}
+            placeholder={LLM_DEFAULTS[s.values.llmProvider]}
+            spellCheck={false}
+          />
+        </Field>
+        <KeyStatusLine
+          className="md:col-span-2"
+          keys={[LLM_KEY[server.llmProvider]]}
+          sources={sources}
+          note={
+            s.values.llmProvider !== server.llmProvider
+              ? `after saving, add the ${s.values.llmProvider} key in Credentials`
+              : undefined
+          }
+        />
+      </div>
+    </SectionShell>
+  );
+}

--- a/apps/web/src/components/setup/ProductBriefSection.tsx
+++ b/apps/web/src/components/setup/ProductBriefSection.tsx
@@ -1,0 +1,95 @@
+import { useMutation } from "@tanstack/react-query";
+import { Wand2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import { api } from "../../api/client.ts";
+import { readOnly } from "../../lib/readOnly.ts";
+import { Button } from "../primitives/Button.tsx";
+import { Field, Textarea } from "../primitives/Field.tsx";
+import { SectionShell } from "./SectionShell.tsx";
+import { useConfigSection } from "./useConfigSection.ts";
+import type { SectionProps } from "./types.ts";
+
+export function ProductBriefSection({ cfg, onDirtyChange }: SectionProps) {
+  const server = useMemo(() => ({ productBrief: cfg.productBrief ?? "" }), [cfg]);
+  const s = useConfigSection({
+    id: "brief",
+    server,
+    toRequest: (sent) => sent,
+    onDirtyChange,
+  });
+
+  // Seeded once from the saved signature domain; the section mounts only
+  // after ["setup"] has data, so the initializer sees the real value.
+  const [briefSources, setBriefSources] = useState(() =>
+    cfg.productDomain ? `https://${cfg.productDomain}` : "",
+  );
+  const [deriveInfo, setDeriveInfo] = useState<string | null>(null);
+  const deriveBrief = useMutation({
+    mutationFn: (urls: string[]) => api.deriveBrief(urls),
+    onSuccess: (res) => {
+      s.set("productBrief", res.proposedBrief);
+      const skipped = res.skipped.length > 0 ? ` · ${res.skipped.length} source(s) unreadable` : "";
+      setDeriveInfo(
+        `derived from ${res.sourceUrls.length} source(s) · $${res.costUsd.toFixed(2)}${skipped} — edit before saving`,
+      );
+    },
+    onError: (err) => toast.error((err as Error).message),
+  });
+
+  return (
+    <SectionShell
+      {...s.shell}
+      lede="What your replies are allowed to know and cite. Facts, architecture, pricing model, canonical links. A link that isn't in this brief is never sent."
+      saveDisabled={deriveBrief.isPending}
+      saveTitle={
+        deriveBrief.isPending ? "wait for the brief derive to finish, then save" : undefined
+      }
+    >
+      <Field
+        label="Derive from sources"
+        hint="One URL per line — your site, the GitHub repo, docs pages (max 5). Each is one webRead (~$0.01); you edit the proposal before saving."
+      >
+        <div className="flex gap-2">
+          <Textarea
+            value={briefSources}
+            onChange={(e) => setBriefSources(e.target.value)}
+            placeholder={"yourproduct.com\ngithub.com/you/your-repo\ndocs.yourproduct.com/pricing"}
+            rows={3}
+          />
+          <Button
+            type="button"
+            variant="secondary"
+            className="shrink-0 self-start whitespace-nowrap"
+            disabled={deriveBrief.isPending || briefSources.trim().length === 0}
+            onClick={() =>
+              deriveBrief.mutate(
+                briefSources
+                  .split("\n")
+                  .map((u) => u.trim())
+                  .filter((u) => u.length > 0)
+                  .slice(0, 5),
+              )
+            }
+            {...readOnly}
+          >
+            <Wand2 size={12} className={deriveBrief.isPending ? "animate-pulse" : undefined} />
+            {deriveBrief.isPending ? "Reading sources…" : "Derive brief"}
+          </Button>
+        </div>
+      </Field>
+      {deriveInfo && <div className="font-mono text-[11px] text-ink-faint">{deriveInfo}</div>}
+      <Field
+        label="Product brief"
+        hint="Used by /inbox reply drafting to answer substantive questions with substance. Keep links verbatim."
+      >
+        <Textarea
+          value={s.values.productBrief}
+          onChange={(e) => s.set("productBrief", e.target.value)}
+          placeholder="How it works: … settled per call in USDC on Base …\nPricing: …\nLinks:\nhttps://docs.yourproduct.com/payments"
+          rows={8}
+        />
+      </Field>
+    </SectionShell>
+  );
+}

--- a/apps/web/src/components/setup/ReviewQueueSection.tsx
+++ b/apps/web/src/components/setup/ReviewQueueSection.tsx
@@ -1,0 +1,71 @@
+import { useMemo } from "react";
+import { Field, Input, Select } from "../primitives/Field.tsx";
+import { validateTimeZone } from "../../lib/setupValidation.ts";
+import { SectionShell } from "./SectionShell.tsx";
+import { useConfigSection } from "./useConfigSection.ts";
+import type { SectionProps } from "./types.ts";
+
+const RUNTIME_ZONE = (() => {
+  try {
+    return Intl.DateTimeFormat().resolvedOptions().timeZone;
+  } catch {
+    return "UTC";
+  }
+})();
+
+/**
+ * Two config keys that existed with no UI and no CLI (issue #451): the
+ * /queue default order, and the install's time zone for event-relative
+ * plays (Luma slots, "tomorrow morning").
+ */
+export function ReviewQueueSection({ cfg, onDirtyChange }: SectionProps) {
+  const server = useMemo(
+    () => ({
+      queueReviewOrder: cfg.queueReviewOrder ?? "newest",
+      timezone: cfg.timezone ?? "",
+    }),
+    [cfg],
+  );
+  const s = useConfigSection({
+    id: "review",
+    server,
+    // "" reaches the server as timezone: "" → cleared (runtime zone).
+    toRequest: (sent) => sent,
+    validate: (v) => ({ timezone: validateTimeZone(v.timezone) }),
+    onDirtyChange,
+  });
+
+  return (
+    <SectionShell
+      {...s.shell}
+      lede="How /queue orders what you review, and which clock event-relative copy uses."
+    >
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <Field
+          label="Review order"
+          hint="ranked: highest priority score first, so the drafts most worth a look surface before the rest. newest: arrival order. /queue can override per visit; this is the default."
+        >
+          <Select
+            value={s.values.queueReviewOrder}
+            onChange={(e) => s.set("queueReviewOrder", e.target.value as "ranked" | "newest")}
+          >
+            <option value="newest">newest first (default)</option>
+            <option value="ranked">ranked by priority score</option>
+          </Select>
+        </Field>
+        <Field
+          label="Time zone"
+          error={s.errors.timezone}
+          hint={`IANA name, e.g. Europe/Vienna. Last resort when an event has no explicit zone and its city can't be placed. Blank = this machine's zone (${RUNTIME_ZONE}).`}
+        >
+          <Input
+            value={s.values.timezone}
+            onChange={(e) => s.set("timezone", e.target.value)}
+            placeholder={RUNTIME_ZONE}
+            spellCheck={false}
+          />
+        </Field>
+      </div>
+    </SectionShell>
+  );
+}

--- a/apps/web/src/components/setup/SectionNav.tsx
+++ b/apps/web/src/components/setup/SectionNav.tsx
@@ -1,0 +1,77 @@
+import { cn } from "../../lib/cn.ts";
+import { SECTIONS, type SectionId } from "./constants.ts";
+
+/**
+ * Jump list for the settings sections. A sticky rail on wide screens, a
+ * horizontal chip row above the fold on narrow ones. Each item is a real
+ * `#id` anchor for copy-link, but the click is handled by hand: a native
+ * hash navigation pushes a history entry without TanStack's `__TSR_key`,
+ * which desyncs the router's back/forward index (see the proposedIcp strip
+ * in IcpSection for the same constraint).
+ */
+export function SectionNav({
+  dirty,
+  active,
+}: {
+  dirty: Partial<Record<SectionId, boolean>>;
+  active: SectionId | null;
+}) {
+  const unsaved = SECTIONS.filter((s) => dirty[s.id]).length;
+  return (
+    <nav
+      aria-label="Setup sections"
+      className={cn(
+        "border-b border-ink-rule bg-ink-bg/95 backdrop-blur-[2px]",
+        "sticky top-0 z-10 flex gap-1 overflow-x-auto px-4 py-2",
+        "lg:static lg:top-auto lg:z-auto lg:flex-col lg:gap-0.5 lg:overflow-visible lg:border-b-0 lg:border-r lg:px-3 lg:py-5",
+      )}
+    >
+      {SECTIONS.map((s) => (
+        <a
+          key={s.id}
+          href={`#${s.id}`}
+          aria-current={active === s.id ? "location" : undefined}
+          onClick={(e) => {
+            e.preventDefault();
+            jumpToSection(s.id);
+          }}
+          className={cn(
+            "flex shrink-0 items-center gap-2 rounded-[var(--radius-sm)] px-2.5 py-1.5",
+            "font-sans text-[12.5px] whitespace-nowrap transition-colors duration-[var(--dur-stamp)]",
+            active === s.id
+              ? "bg-ink-surface text-ink-cream"
+              : "text-ink-muted hover:bg-ink-surface/60 hover:text-ink-cream-2",
+          )}
+        >
+          <span
+            aria-hidden
+            className={cn(
+              "inline-block h-1.5 w-1.5 rounded-full",
+              dirty[s.id] ? "bg-[color:var(--ink-spend)]" : "bg-transparent",
+            )}
+          />
+          {s.label}
+          {dirty[s.id] && <span className="sr-only"> (unsaved changes)</span>}
+        </a>
+      ))}
+      <div
+        className={cn(
+          "hidden lg:block lg:mt-3 lg:px-2.5 font-mono text-[10.5px]",
+          unsaved > 0 ? "text-[color:var(--ink-spend-2)]" : "text-ink-faint",
+        )}
+      >
+        {unsaved > 0 ? `${unsaved} section${unsaved === 1 ? "" : "s"} unsaved` : "all saved"}
+      </div>
+    </nav>
+  );
+}
+
+/**
+ * Scroll a section into view and record the hash without adding a history
+ * entry. `<main>` is the scroll container, so scrollIntoView (nearest
+ * scrollable ancestor) is the right primitive — not window.scrollTo.
+ */
+export function jumpToSection(id: SectionId, behavior: ScrollBehavior = "smooth"): void {
+  document.getElementById(id)?.scrollIntoView({ behavior, block: "start" });
+  window.history.replaceState(window.history.state, "", `#${id}`);
+}

--- a/apps/web/src/components/setup/SectionShell.tsx
+++ b/apps/web/src/components/setup/SectionShell.tsx
@@ -1,0 +1,115 @@
+import { Save } from "lucide-react";
+import { useEffect, useState, type FormEvent, type ReactNode } from "react";
+import { Button } from "../primitives/Button.tsx";
+import { readOnly } from "../../lib/readOnly.ts";
+import { sectionMeta, type SectionId } from "./constants.ts";
+
+/**
+ * One settings section: eyebrow + lede in the left column, the fields in the
+ * right, and its own footer with the dirty count and a Save that submits only
+ * this section's `<form>` (Enter in any of its inputs does the same).
+ */
+export function SectionShell({
+  id,
+  lede,
+  children,
+  dirtyCount,
+  errorCount = 0,
+  savedAt,
+  saving,
+  onSubmit,
+  saveDisabled,
+  saveTitle,
+  saveLabel = "Save",
+  footerNote,
+}: {
+  id: SectionId;
+  lede?: ReactNode;
+  children: ReactNode;
+  dirtyCount: number;
+  errorCount?: number;
+  savedAt: number | null;
+  saving: boolean;
+  onSubmit: () => void;
+  saveDisabled?: boolean;
+  saveTitle?: string;
+  saveLabel?: string;
+  /** Extra footer text shown when nothing is dirty (e.g. "applies on the trigger"). */
+  footerNote?: ReactNode;
+}) {
+  const meta = sectionMeta(id);
+  const dirty = dirtyCount > 0;
+  const blocked = errorCount > 0;
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (saving || blocked || !dirty) return;
+    onSubmit();
+  };
+  return (
+    <section
+      id={id}
+      // scroll-margin so a #hash jump doesn't hide the eyebrow under the
+      // horizontal chip row on narrow screens.
+      className="scroll-mt-14 border-b border-ink-rule lg:scroll-mt-0"
+      aria-labelledby={`${id}-eyebrow`}
+    >
+      <form
+        onSubmit={handleSubmit}
+        className="grid grid-cols-1 gap-6 px-6 py-6 lg:grid-cols-[220px_1fr]"
+      >
+        <div>
+          <div id={`${id}-eyebrow`} className="ln-eyebrow">
+            {meta.eyebrow}
+          </div>
+          {lede && <p className="ln-note mt-2 max-w-[32ch] text-[13px] text-ink-cream-2">{lede}</p>}
+        </div>
+        <div className="flex flex-col gap-4">
+          {children}
+          <div className="mt-2 flex items-center justify-between gap-4 border-t border-ink-rule/60 pt-3">
+            <div className="font-mono text-[11px]">
+              {blocked ? (
+                <span className="text-[color:var(--ink-blocked-2)]">
+                  fix {errorCount} field{errorCount === 1 ? "" : "s"} to save
+                </span>
+              ) : dirty ? (
+                <span className="text-[color:var(--ink-spend-2)]">
+                  {dirtyCount} unsaved change{dirtyCount === 1 ? "" : "s"}
+                </span>
+              ) : savedAt != null ? (
+                <span className="text-[color:var(--ink-receipt-2)]">
+                  saved · <Ago at={savedAt} />
+                </span>
+              ) : (
+                <span className="text-ink-faint">{footerNote ?? "no unsaved changes"}</span>
+              )}
+            </div>
+            <Button
+              type="submit"
+              size="sm"
+              variant={dirty ? "primary" : "secondary"}
+              disabled={saving || blocked || !dirty || saveDisabled}
+              title={saveTitle}
+              {...readOnly}
+            >
+              <Save size={12} />
+              {saving ? "Saving…" : saveLabel}
+            </Button>
+          </div>
+        </div>
+      </form>
+    </section>
+  );
+}
+
+/** "just now" → "2m ago", ticking, without pulling a date library in. */
+function Ago({ at }: { at: number }) {
+  const [, tick] = useState(0);
+  useEffect(() => {
+    const t = setInterval(() => tick((n) => n + 1), 15_000);
+    return () => clearInterval(t);
+  }, []);
+  const s = Math.floor((Date.now() - at) / 1000);
+  if (s < 45) return <>just now</>;
+  if (s < 3600) return <>{Math.floor(s / 60)}m ago</>;
+  return <>{Math.floor(s / 3600)}h ago</>;
+}

--- a/apps/web/src/components/setup/SocialProofSection.tsx
+++ b/apps/web/src/components/setup/SocialProofSection.tsx
@@ -1,0 +1,85 @@
+import { useMemo } from "react";
+import { Checkbox, Field, Textarea } from "../primitives/Field.tsx";
+import { SectionShell } from "./SectionShell.tsx";
+import { useConfigSection } from "./useConfigSection.ts";
+import type { SectionProps } from "./types.ts";
+
+export function SocialProofSection({ cfg, onDirtyChange }: SectionProps) {
+  const server = useMemo(
+    () => ({
+      founderCredentials: cfg.founderCredentials ?? "",
+      productPortfolio: cfg.productPortfolio ?? "",
+      partners: cfg.partners ?? "",
+      founderAdmission: cfg.founderAdmission ?? "",
+      mobileSignature: cfg.mobileSignature,
+    }),
+    [cfg],
+  );
+  const s = useConfigSection({
+    id: "proof",
+    server,
+    toRequest: (sent) => sent,
+    onDirtyChange,
+  });
+
+  return (
+    <SectionShell
+      {...s.shell}
+      lede="All optional. Each maps to a different play type. Used by the LLM when drafting the second sentence of a first-touch email — never more than one beat per email."
+    >
+      <div className="grid grid-cols-1 gap-4">
+        <Field
+          label="Founder background"
+          hint="Prior companies, named past roles, anything that lets a stranger trust you. Used by job-change / podcast-guest / post-funding / breakup-revive."
+        >
+          <Textarea
+            value={s.values.founderCredentials}
+            onChange={(e) => s.set("founderCredentials", e.target.value)}
+            placeholder={
+              'e.g. "ex-Stripe eng" · "VP Sales at Salesforce" · "ran a $2M Shopify store"'
+            }
+            rows={2}
+          />
+        </Field>
+        <Field
+          label="Products you've shipped"
+          hint="Used in peer-founder outreach to show you've actually built things. Stack-consolidation / competitor-switch / show-hn / hiring-signal."
+        >
+          <Textarea
+            value={s.values.productPortfolio}
+            onChange={(e) => s.set("productPortfolio", e.target.value)}
+            placeholder="Comma-separated list of products or projects you've shipped."
+            rows={2}
+          />
+        </Field>
+        <Field
+          label="Notable partners / customers"
+          hint="Brand names that open doors. Helps when the prospect doesn't know you yet. Accelerator-batch / demo-no-show."
+        >
+          <Textarea
+            value={s.values.partners}
+            onChange={(e) => s.set("partners", e.target.value)}
+            placeholder="Comma-separated brand-name integrations or customers."
+            rows={2}
+          />
+        </Field>
+        <Field
+          label="One true concession"
+          hint="The thing you'd rather not say but is true. Used in roughly 1 in 3 first touches as a damaging admission (two of us, no logos yet, but…), which makes the rest of the email more believable. Leave blank and the beat is skipped, never invented."
+        >
+          <Textarea
+            value={s.values.founderAdmission}
+            onChange={(e) => s.set("founderAdmission", e.target.value)}
+            placeholder="e.g. two people, no enterprise logos yet"
+            rows={2}
+          />
+        </Field>
+        <Checkbox
+          checked={s.values.mobileSignature}
+          onChange={(e) => s.set("mobileSignature", e.target.checked)}
+          label={'Append "Sent from my iPhone" to every email signature'}
+        />
+      </div>
+    </SectionShell>
+  );
+}

--- a/apps/web/src/components/setup/TelemetrySection.tsx
+++ b/apps/web/src/components/setup/TelemetrySection.tsx
@@ -1,0 +1,27 @@
+import { useMemo } from "react";
+import { Checkbox } from "../primitives/Field.tsx";
+import { SectionShell } from "./SectionShell.tsx";
+import { useConfigSection } from "./useConfigSection.ts";
+import type { SectionProps } from "./types.ts";
+
+export function TelemetrySection({ cfg, onDirtyChange }: SectionProps) {
+  const server = useMemo(() => ({ telemetryEnabled: cfg.telemetryEnabled }), [cfg]);
+  const s = useConfigSection({
+    id: "telemetry",
+    server,
+    toRequest: (sent) => sent,
+    onDirtyChange,
+  });
+  return (
+    <SectionShell
+      {...s.shell}
+      lede="Off by default for your data, on by default for command-run counts. Opt out at will."
+    >
+      <Checkbox
+        label="Send anonymous opt-out telemetry (commands run, no data, no PII — see TELEMETRY.md)"
+        checked={s.values.telemetryEnabled}
+        onChange={(e) => s.set("telemetryEnabled", e.target.checked)}
+      />
+    </SectionShell>
+  );
+}

--- a/apps/web/src/components/setup/WalletSection.tsx
+++ b/apps/web/src/components/setup/WalletSection.tsx
@@ -1,0 +1,92 @@
+import { useMemo } from "react";
+import type { WalletMode } from "@oneshot-gtm/shared-types";
+import { Field, Input, Select } from "../primitives/Field.tsx";
+import { parseSpendCeiling } from "../../lib/setupValidation.ts";
+import { KeyStatusLine } from "./KeyStatusLine.tsx";
+import { SectionShell } from "./SectionShell.tsx";
+import { useConfigSection } from "./useConfigSection.ts";
+import type { SectionProps } from "./types.ts";
+
+const CDP_KEYS = ["CDP_API_KEY_ID", "CDP_API_KEY_SECRET", "CDP_WALLET_SECRET"] as const;
+
+export function WalletSection({
+  cfg,
+  sources,
+  homeDir,
+  onDirtyChange,
+}: SectionProps & { homeDir: string }) {
+  const server = useMemo(
+    () => ({
+      walletMode: cfg.walletMode as WalletMode,
+      dailySpendCeiling: cfg.dailySpendCeilingUsd == null ? "" : String(cfg.dailySpendCeilingUsd),
+    }),
+    [cfg],
+  );
+  const s = useConfigSection({
+    id: "wallet",
+    server,
+    toRequest: (sent) => ({
+      ...(sent.walletMode !== undefined ? { walletMode: sent.walletMode } : {}),
+      ...(sent.dailySpendCeiling !== undefined
+        ? { dailySpendCeilingUsd: ceilingValue(sent.dailySpendCeiling) }
+        : {}),
+    }),
+    validate: (v) => {
+      const parsed = parseSpendCeiling(v.dailySpendCeiling);
+      return { dailySpendCeiling: parsed.ok ? null : parsed.error };
+    },
+    onDirtyChange,
+  });
+
+  return (
+    <SectionShell
+      {...s.shell}
+      lede={`Keys live only in ${homeDir}/.env chmod 600. Nothing leaves your machine.`}
+    >
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <Field label="Wallet mode" className="md:col-span-2">
+          <Select
+            value={s.values.walletMode}
+            onChange={(e) => s.set("walletMode", e.target.value as WalletMode)}
+          >
+            <option value="cdp">Coinbase CDP server wallet</option>
+            <option value="private-key">Raw private key</option>
+          </Select>
+        </Field>
+        <KeyStatusLine
+          className="md:col-span-2"
+          keys={server.walletMode === "cdp" ? CDP_KEYS : ["AGENT_PRIVATE_KEY"]}
+          sources={sources}
+          note={
+            s.values.walletMode !== server.walletMode
+              ? "after saving, add the keys for this mode in Credentials"
+              : undefined
+          }
+        />
+        <Field
+          label="Daily spend ceiling (USD)"
+          className="md:col-span-2"
+          error={s.errors.dailySpendCeiling}
+          hint="Install-wide cap across every automated finder run and drain — blank = unlimited. Once reached, scheduled/run-now finders and drains halt with a named reason (visible here and in doctor) until local midnight; manual /queue sends are never blocked."
+        >
+          {/* A text input on purpose: type="number" lets Firefox/Safari accept
+              junk and report value="" — exactly the silent path a cap must not
+              have. parseSpendCeiling is the validator. */}
+          <Input
+            inputMode="decimal"
+            placeholder="unlimited"
+            value={s.values.dailySpendCeiling}
+            onChange={(e) => s.set("dailySpendCeiling", e.target.value)}
+          />
+        </Field>
+      </div>
+    </SectionShell>
+  );
+}
+
+/** Only called after validate passed, so the throw is a programming error. */
+function ceilingValue(raw: string): number | null {
+  const parsed = parseSpendCeiling(raw);
+  if (!parsed.ok) throw new Error(parsed.error);
+  return parsed.value;
+}

--- a/apps/web/src/components/setup/XSection.tsx
+++ b/apps/web/src/components/setup/XSection.tsx
@@ -1,0 +1,95 @@
+import { useMemo } from "react";
+import { withXEngine, type TriggerView, type XEngine } from "@oneshot-gtm/shared-types";
+import { api } from "../../api/client.ts";
+import { Field, Select } from "../primitives/Field.tsx";
+import { KeyStatusLine } from "./KeyStatusLine.tsx";
+import { X_OAUTH_KEYS } from "./constants.ts";
+import { SectionShell } from "./SectionShell.tsx";
+import { useSectionDraft } from "./useSectionDraft.ts";
+import { useSectionSave } from "./useSectionSave.ts";
+import { useReportDirty, type SectionProps } from "./types.ts";
+
+/** Engine choice as stored on the x-reposters trigger (not in config.json). */
+export function storedXEngine(xTrigger: TriggerView | undefined): XEngine {
+  return (
+    (xTrigger?.config?.["engine"] as XEngine | undefined) ??
+    (xTrigger?.defaultConfig?.["engine"] as XEngine | undefined) ??
+    "xapi"
+  );
+}
+
+/**
+ * The one section whose save doesn't go to /api/setup: the engine rides the
+ * x-reposters trigger config. withXEngine drops the maxSpendPerRun/knobs
+ * overrides on an actual flip so the per-engine defaults re-apply.
+ */
+export function XSection({
+  sources,
+  xTrigger,
+  onDirtyChange,
+}: Pick<SectionProps, "sources" | "onDirtyChange"> & { xTrigger: TriggerView | undefined }) {
+  const stored = storedXEngine(xTrigger);
+  const server = useMemo(() => ({ engine: stored }), [stored]);
+  const draft = useSectionDraft(server);
+  const save = useSectionSave<{ engine: XEngine }>({
+    save: async (sent) => {
+      if (!xTrigger) throw new Error("x-reposters trigger not loaded yet");
+      await api.setTriggerConfig(
+        "x-reposters",
+        withXEngine(xTrigger.config ?? xTrigger.defaultConfig, sent.engine),
+      );
+    },
+    refetch: [["triggers"]],
+    onCommitted: (sent) => draft.commit(sent),
+  });
+  useReportDirty("x", draft.dirty, onDirtyChange);
+
+  return (
+    <SectionShell
+      id="x"
+      lede="Data provider for the x-reposters finder. The engine choice lives on the trigger; the keys are in Credentials."
+      dirtyCount={draft.dirtyKeys.length}
+      savedAt={save.savedAt}
+      saving={save.isPending}
+      onSubmit={() => save.run({ engine: draft.values.engine })}
+      saveDisabled={!xTrigger}
+      saveTitle={!xTrigger ? "trigger list still loading" : undefined}
+      footerNote="applies to the x-reposters trigger"
+    >
+      <div className="grid grid-cols-1 gap-4">
+        <Field
+          label="Data provider"
+          hint="Both bill per record returned. Switching resets the trigger's spend ceiling and harvest knobs to the new engine's defaults; fine-tune in the /queue trigger editor."
+        >
+          <Select
+            value={draft.values.engine}
+            onChange={(e) => draft.set("engine", e.target.value as XEngine)}
+          >
+            <option value="twitterapiio">twitterapi.io — ~$0.25/run, third-party scraper</option>
+            <option value="xapi">X API (first-party) — ~$5/run, licensed, OAuth1</option>
+          </Select>
+        </Field>
+        <KeyStatusLine
+          keys={stored === "xapi" ? X_OAUTH_KEYS : ["TWITTERAPI_IO_KEY"]}
+          sources={sources}
+          note={
+            draft.values.engine !== stored
+              ? "after saving, add this engine's keys in Credentials"
+              : undefined
+          }
+        />
+        {xTrigger && (
+          <p className="font-mono text-[11px] text-ink-muted">
+            x-reposters: {xTrigger.enabled ? "enabled" : "disabled"} ·{" "}
+            {xTrigger.ready ? (
+              <span className="text-ink-cream-2">ready</span>
+            ) : (
+              <span>not ready — {xTrigger.notReadyReason}</span>
+            )}
+            {draft.dirty && " · engine change applies on Save"}
+          </p>
+        )}
+      </div>
+    </SectionShell>
+  );
+}

--- a/apps/web/src/components/setup/constants.ts
+++ b/apps/web/src/components/setup/constants.ts
@@ -1,0 +1,82 @@
+import type { SetupRequest } from "@oneshot-gtm/shared-types";
+
+export type SecretKey = keyof NonNullable<SetupRequest["secrets"]>;
+export type KeySource = "env" | "file" | null | undefined;
+
+export const LLM_DEFAULTS: Record<string, string> = {
+  openrouter: "anthropic/claude-sonnet-4.6",
+  openai: "gpt-4o-mini",
+  anthropic: "claude-sonnet-4-6",
+};
+
+export const LLM_KEY: Record<"openrouter" | "openai" | "anthropic", SecretKey> = {
+  openrouter: "OPENROUTER_API_KEY",
+  openai: "OPENAI_API_KEY",
+  anthropic: "ANTHROPIC_API_KEY",
+};
+
+export const SECRET_LABELS: Record<SecretKey, string> = {
+  OPENROUTER_API_KEY: "OpenRouter API key",
+  OPENAI_API_KEY: "OpenAI API key",
+  ANTHROPIC_API_KEY: "Anthropic API key",
+  CDP_API_KEY_ID: "CDP_API_KEY_ID",
+  CDP_API_KEY_SECRET: "CDP_API_KEY_SECRET",
+  CDP_WALLET_SECRET: "CDP_WALLET_SECRET",
+  AGENT_PRIVATE_KEY: "AGENT_PRIVATE_KEY",
+  GMAIL_CLIENT_ID: "GMAIL_CLIENT_ID",
+  GMAIL_CLIENT_SECRET: "GMAIL_CLIENT_SECRET",
+  GMAIL_REFRESH_TOKEN: "GMAIL_REFRESH_TOKEN",
+  SMARTLEAD_API_KEY: "Smartlead API key",
+  X_API_KEY: "X_API_KEY",
+  X_API_SECRET: "X_API_SECRET",
+  X_ACCESS_TOKEN: "X_ACCESS_TOKEN",
+  X_ACCESS_SECRET: "X_ACCESS_SECRET",
+  TWITTERAPI_IO_KEY: "twitterapi.io API key",
+  GITHUB_TOKEN: "GitHub token",
+  LUMA_SESSION_COOKIE: "Luma session cookie",
+  LINKEDIN_REPLY_WEBHOOK_SECRET: "LinkedIn reply webhook secret",
+};
+
+export const X_OAUTH_KEYS = [
+  "X_API_KEY",
+  "X_API_SECRET",
+  "X_ACCESS_TOKEN",
+  "X_ACCESS_SECRET",
+] as const;
+
+export function hintFor(source: KeySource): string {
+  if (source === "env") return "Currently from shell env. Leave blank to keep.";
+  if (source === "file") return "Currently from this workspace's .env. Leave blank to keep.";
+  return "Not set yet.";
+}
+
+/** Human status of one secret for the preference sections' key line. */
+export function keyStatus(source: KeySource): string {
+  if (source === "env") return "from shell env";
+  if (source === "file") return "from .env";
+  return "not set";
+}
+
+/**
+ * The page's sections in render order. `id` doubles as the anchor
+ * (`/setup#credentials`) and the key in the page-level dirty registry.
+ */
+export const SECTIONS = [
+  { id: "profile", eyebrow: "01 · Founder profile", label: "Founder profile" },
+  { id: "icp", eyebrow: "02 · Ideal customer profile", label: "ICP" },
+  { id: "proof", eyebrow: "03 · Social proof", label: "Social proof" },
+  { id: "brief", eyebrow: "04 · Product brief", label: "Product brief" },
+  { id: "llm", eyebrow: "05 · LLM provider", label: "LLM provider" },
+  { id: "wallet", eyebrow: "06 · Wallet & spend", label: "Wallet & spend" },
+  { id: "x", eyebrow: "07 · X / Twitter", label: "X / Twitter" },
+  { id: "email", eyebrow: "08 · Email transport", label: "Email transport" },
+  { id: "review", eyebrow: "09 · Review queue & time zone", label: "Queue & time zone" },
+  { id: "telemetry", eyebrow: "10 · Telemetry", label: "Telemetry" },
+  { id: "credentials", eyebrow: "11 · Credentials", label: "Credentials" },
+] as const;
+
+export type SectionId = (typeof SECTIONS)[number]["id"];
+
+export function sectionMeta(id: SectionId): (typeof SECTIONS)[number] {
+  return SECTIONS.find((s) => s.id === id)!;
+}

--- a/apps/web/src/components/setup/types.ts
+++ b/apps/web/src/components/setup/types.ts
@@ -1,0 +1,24 @@
+import { useEffect } from "react";
+import type { api } from "../../api/client.ts";
+import type { SectionId } from "./constants.ts";
+
+export type SetupStatus = Awaited<ReturnType<typeof api.setupStatus>>;
+export type SetupCfg = SetupStatus["cfg"];
+export type Sources = SetupStatus["sources"];
+
+/** How a section tells the page (rail dots, leave guard) that it has unsaved edits. */
+export type DirtyReporter = (id: SectionId, dirty: boolean) => void;
+
+export interface SectionProps {
+  cfg: SetupCfg;
+  sources: Sources;
+  onDirtyChange: DirtyReporter;
+}
+
+/** Report this section's dirty flag upward whenever it changes; clear it on unmount. */
+export function useReportDirty(id: SectionId, dirty: boolean, report: DirtyReporter): void {
+  useEffect(() => {
+    report(id, dirty);
+  }, [id, dirty, report]);
+  useEffect(() => () => report(id, false), [id, report]);
+}

--- a/apps/web/src/components/setup/useConfigSection.ts
+++ b/apps/web/src/components/setup/useConfigSection.ts
@@ -1,0 +1,80 @@
+import type { SetupRequest } from "@oneshot-gtm/shared-types";
+import { api } from "../../api/client.ts";
+import type { SectionId } from "./constants.ts";
+import { useSectionDraft, type SectionDraft } from "./useSectionDraft.ts";
+import { useSectionSave } from "./useSectionSave.ts";
+import { useReportDirty, type DirtyReporter } from "./types.ts";
+
+type Primitive = string | number | boolean;
+
+/**
+ * Draft + validation + save for a section whose fields live in config.json
+ * and go out through `POST /api/setup`. Errors are only reported for dirty
+ * keys — a value the server already holds isn't the founder's to fix until
+ * they touch it, and Save is inert while nothing is dirty anyway.
+ */
+export function useConfigSection<T extends Record<string, Primitive>>(opts: {
+  id: SectionId;
+  server: T;
+  initialDraft?: Partial<T>;
+  /** Map the dirty keys onto the sparse request. Omitted keys stay untouched. */
+  toRequest: (sent: Partial<T>) => SetupRequest;
+  validate?: (values: T) => Partial<Record<keyof T, string | null>>;
+  onDirtyChange: DirtyReporter;
+}): SectionDraft<T> & {
+  errors: Partial<Record<keyof T, string>>;
+  errorCount: number;
+  submit: () => void;
+  saving: boolean;
+  savedAt: number | null;
+  /** Spread into `<SectionShell>`; add `saveDisabled`/`saveTitle` per section. */
+  shell: {
+    id: SectionId;
+    dirtyCount: number;
+    errorCount: number;
+    savedAt: number | null;
+    saving: boolean;
+    onSubmit: () => void;
+  };
+} {
+  const draft = useSectionDraft(opts.server, opts.initialDraft);
+  const all: Partial<Record<keyof T, string | null>> = opts.validate?.(draft.values) ?? {};
+  const errors: Partial<Record<keyof T, string>> = {};
+  for (const k of draft.dirtyKeys) {
+    const e = all[k];
+    if (e) errors[k] = e;
+  }
+  const errorCount = Object.keys(errors).length;
+
+  const save = useSectionSave<Partial<T>>({
+    save: async (sent) => {
+      await api.setup(opts.toRequest(sent));
+    },
+    refetch: [["setup"]],
+    alsoInvalidate: [["doctor"], ["home"]],
+    onCommitted: (sent) => draft.commit(sent),
+  });
+  useReportDirty(opts.id, draft.dirty, opts.onDirtyChange);
+
+  const submit = (): void => {
+    if (errorCount > 0 || !draft.dirty || save.isPending) return;
+    save.run(draft.snapshot);
+  };
+
+  return {
+    ...draft,
+    errors,
+    errorCount,
+    submit,
+    saving: save.isPending,
+    savedAt: save.savedAt,
+    shell: {
+      id: opts.id,
+      dirtyCount: draft.dirtyKeys.length,
+      errorCount,
+      savedAt: save.savedAt,
+      saving: save.isPending,
+      onSubmit: submit,
+    },
+  };
+}

--- a/apps/web/src/components/setup/useIdentityStaging.ts
+++ b/apps/web/src/components/setup/useIdentityStaging.ts
@@ -1,0 +1,56 @@
+import { useCallback, useState } from "react";
+import type { PendingOneShotAdd, PendingSmartleadAdd } from "../../lib/setupValidation.ts";
+
+/**
+ * The Email-transport section's pending operations — cap edits, removals and
+ * new senders — held until its Save commits them in ONE request. Unlike the
+ * draft overlay these are operations, not field values, so they get their
+ * own store; `clear()` runs after the post-save refetch has landed.
+ */
+export function useIdentityStaging() {
+  const [capEdits, setCapEdits] = useState<Record<string, string>>({});
+  const [removedIds, setRemovedIds] = useState<string[]>([]);
+  const [pendingAdds, setPendingAdds] = useState<PendingOneShotAdd[]>([]);
+  const [pendingSmartleadAdds, setPendingSmartleadAdds] = useState<PendingSmartleadAdd[]>([]);
+
+  const setCap = useCallback((id: string, raw: string) => {
+    setCapEdits((m) => ({ ...m, [id]: raw }));
+  }, []);
+  const remove = useCallback((id: string) => {
+    setRemovedIds((ids) => (ids.includes(id) ? ids : [...ids, id]));
+  }, []);
+  const stageAdd = useCallback((a: PendingOneShotAdd) => {
+    setPendingAdds((p) => [...p, a]);
+  }, []);
+  const unstageAdd = useCallback((a: PendingOneShotAdd) => {
+    setPendingAdds((p) => p.filter((x) => x !== a));
+  }, []);
+  const stageSmartlead = useCallback((a: PendingSmartleadAdd) => {
+    setPendingSmartleadAdds((p) => (p.some((x) => x.address === a.address) ? p : [...p, a]));
+  }, []);
+  const unstageSmartlead = useCallback((address: string) => {
+    setPendingSmartleadAdds((p) => p.filter((x) => x.address !== address));
+  }, []);
+  const clearSmartlead = useCallback(() => setPendingSmartleadAdds([]), []);
+  const clear = useCallback(() => {
+    setCapEdits({});
+    setRemovedIds([]);
+    setPendingAdds([]);
+    setPendingSmartleadAdds([]);
+  }, []);
+
+  return {
+    capEdits,
+    setCap,
+    removedIds,
+    remove,
+    pendingAdds,
+    stageAdd,
+    unstageAdd,
+    pendingSmartleadAdds,
+    stageSmartlead,
+    unstageSmartlead,
+    clearSmartlead,
+    clear,
+  };
+}

--- a/apps/web/src/components/setup/useSectionDraft.ts
+++ b/apps/web/src/components/setup/useSectionDraft.ts
@@ -1,0 +1,73 @@
+import { useCallback, useMemo, useState } from "react";
+
+type Primitive = string | number | boolean;
+
+export interface SectionDraft<T extends Record<string, Primitive>> {
+  /** What the inputs render: the server value overlaid with the draft. */
+  values: T;
+  /** Only the keys the founder touched (may equal the server value again). */
+  draft: Partial<T>;
+  set<K extends keyof T>(key: K, value: T[K]): void;
+  /** Keys whose draft value differs from the server value right now. */
+  dirtyKeys: (keyof T)[];
+  dirty: boolean;
+  /** The draft restricted to dirtyKeys — what a section save posts. */
+  snapshot: Partial<T>;
+  /**
+   * After a successful save + refetch: forget the keys whose CURRENT draft
+   * value still equals what was sent. A keystroke that landed during the
+   * in-flight save differs from `sent` and therefore survives.
+   */
+  commit(sent: Partial<T>): void;
+  reset(): void;
+}
+
+/**
+ * Draft overlay for one settings section (issue #451).
+ *
+ * Nothing is ever copied from the server into local state. Inputs read
+ * `draft[k]` when the founder has touched `k`, else `server[k]`, so a
+ * background `["setup"]` refetch can only ever change untouched keys — the
+ * old hydrate-into-useState pattern silently reverted unsaved edits on every
+ * refetch unless a field had its own hand-rolled dirty ref.
+ *
+ * `server` must be a normalized projection (nulls → "", numbers → text for
+ * text inputs) so every value is a comparable primitive.
+ */
+export function useSectionDraft<T extends Record<string, Primitive>>(
+  server: T,
+  initialDraft?: Partial<T>,
+): SectionDraft<T> {
+  const [draft, setDraft] = useState<Partial<T>>(() => initialDraft ?? {});
+
+  const values = useMemo(() => ({ ...server, ...draft }) as T, [server, draft]);
+
+  const dirtyKeys = useMemo(
+    () => (Object.keys(draft) as (keyof T)[]).filter((k) => draft[k] !== server[k]),
+    [draft, server],
+  );
+
+  const snapshot = useMemo(() => {
+    const out: Partial<T> = {};
+    for (const k of dirtyKeys) out[k] = draft[k];
+    return out;
+  }, [dirtyKeys, draft]);
+
+  const set = useCallback(<K extends keyof T>(key: K, value: T[K]) => {
+    setDraft((d) => ({ ...d, [key]: value }));
+  }, []);
+
+  const commit = useCallback((sent: Partial<T>) => {
+    setDraft((d) => {
+      const next: Partial<T> = { ...d };
+      for (const k of Object.keys(sent) as (keyof T)[]) {
+        if (Object.hasOwn(next, k) && next[k] === sent[k]) delete next[k];
+      }
+      return next;
+    });
+  }, []);
+
+  const reset = useCallback(() => setDraft({}), []);
+
+  return { values, draft, set, dirtyKeys, dirty: dirtyKeys.length > 0, snapshot, commit, reset };
+}

--- a/apps/web/src/components/setup/useSectionSave.ts
+++ b/apps/web/src/components/setup/useSectionSave.ts
@@ -1,0 +1,52 @@
+import { useMutation, useQueryClient, type QueryKey } from "@tanstack/react-query";
+import { useState } from "react";
+import { toast } from "sonner";
+
+/**
+ * One section's save cycle: post, refetch what the page reads, then let the
+ * section forget the draft keys it just sent — in that order, so an input
+ * never flashes the stale server value between "saved" and "refetched".
+ *
+ * `refetch` keys are awaited; `alsoInvalidate` keys are fire-and-forget (the
+ * doctor / home widgets that mirror setup state, same as the old global save).
+ */
+export function useSectionSave<S>(opts: {
+  save: (sent: S) => Promise<void>;
+  refetch: QueryKey[];
+  alsoInvalidate?: QueryKey[];
+  /** Called only when every awaited refetch succeeded. */
+  onCommitted: (sent: S) => void;
+  /** Success toast; defaults to none (the footer tick is the signal). */
+  successMessage?: string;
+}) {
+  const qc = useQueryClient();
+  const [savedAt, setSavedAt] = useState<number | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: async (sent: S): Promise<{ sent: S; refreshed: boolean }> => {
+      await opts.save(sent);
+      for (const key of opts.refetch) await qc.invalidateQueries({ queryKey: key });
+      // invalidateQueries resolves even when the refetch failed; only commit
+      // the draft when the data on screen is actually the post-save truth.
+      const refreshed = opts.refetch.every((key) => !qc.getQueryState(key)?.error);
+      return { sent, refreshed };
+    },
+    onSuccess: ({ sent, refreshed }) => {
+      setSavedAt(Date.now());
+      for (const key of opts.alsoInvalidate ?? []) void qc.invalidateQueries({ queryKey: key });
+      if (refreshed) {
+        opts.onCommitted(sent);
+        if (opts.successMessage) toast.success(opts.successMessage);
+      } else {
+        toast.warning("saved · couldn't refresh — reload to confirm");
+      }
+    },
+    onError: (err: Error) => toast.error(`couldn't save · ${err.message}`),
+  });
+
+  return {
+    run: (sent: S) => mutation.mutate(sent),
+    isPending: mutation.isPending,
+    savedAt,
+  };
+}

--- a/apps/web/src/lib/setupValidation.ts
+++ b/apps/web/src/lib/setupValidation.ts
@@ -1,0 +1,187 @@
+/**
+ * Field validators + request builders for the sectioned /setup page. Pure and
+ * DOM-free so the rules that used to live inline in the form (and the two
+ * that silently failed open — identity caps and the add-sender cap) are unit
+ * tested. Every validator returns `null` for "fine" and a short lowercase
+ * message for `Field error=`.
+ */
+import type { SetupRequest } from "@oneshot-gtm/shared-types";
+
+export type Parsed<T> = { ok: true; value: T } | { ok: false; error: string };
+
+/** Optional field; when present must look like `local@host.tld`. */
+export function validateEmail(raw: string): string | null {
+  const v = raw.trim();
+  if (v.length === 0) return null;
+  // Deliberately loose: one @, no whitespace, a dot in the host part.
+  if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(v)) return "enter an email address like jane@acme.com";
+  return null;
+}
+
+/**
+ * Optional field; when present must be a bare host name — no scheme, path,
+ * port, mailbox or whitespace. Both the signature domain and the sending
+ * domain are interpolated verbatim (signature line, `from_domain`), so
+ * `https://acme.com/` would ship as-is.
+ */
+export function validateBareDomain(raw: string): string | null {
+  const v = raw.trim();
+  if (v.length === 0) return null;
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(v)) return "bare domain only — drop the https://";
+  if (/[/@:\s]/.test(v)) return "bare domain only — no path, port or mailbox";
+  if (!/^[a-z0-9-]+(\.[a-z0-9-]+)+$/i.test(v)) return "enter a domain like acme.com";
+  return null;
+}
+
+export const CAP_ERROR = "enter a whole number of sends per day";
+
+/**
+ * A per-day send cap typed into a text box.
+ *   blank → `null` when `blank: "uncapped"` (identity rows: no cap)
+ *         → `undefined` when `blank: "omit"` (add-sender form: warm-up ramp)
+ *   digits only → that integer
+ *   anything else → error (never "uncapped" — that was the fail-open bug)
+ */
+export function parseCap(
+  raw: string,
+  opts: { blank: "uncapped" | "omit" },
+): Parsed<number | null | undefined> {
+  const v = raw.trim();
+  if (v.length === 0) return { ok: true, value: opts.blank === "uncapped" ? null : undefined };
+  if (!/^\d+$/.test(v)) return { ok: false, error: CAP_ERROR };
+  const n = Number(v);
+  if (!Number.isSafeInteger(n)) return { ok: false, error: CAP_ERROR };
+  return { ok: true, value: n };
+}
+
+export const SPEND_CEILING_ERROR = "enter a positive number of USD, or leave blank for unlimited";
+
+/**
+ * Install-wide daily spend ceiling. Blank = unlimited (`null`). Uses
+ * `Number()` rather than `parseFloat` — the same choice the CLI's
+ * `configSpendCeiling` makes — so "2usd" is rejected instead of read as 2.
+ */
+export function parseSpendCeiling(raw: string): Parsed<number | null> {
+  const v = raw.trim();
+  if (v.length === 0) return { ok: true, value: null };
+  const n = Number(v);
+  if (!Number.isFinite(n) || n <= 0) return { ok: false, error: SPEND_CEILING_ERROR };
+  return { ok: true, value: n };
+}
+
+/** Optional; when present must be an IANA zone the runtime's Intl knows. */
+export function validateTimeZone(raw: string): string | null {
+  const v = raw.trim();
+  if (v.length === 0) return null;
+  try {
+    // The constructor is the check: an unknown zone throws a RangeError.
+    Intl.DateTimeFormat("en-US", { timeZone: v }).format(0);
+    return null;
+  } catch {
+    return "unknown time zone — use an IANA name like Europe/Vienna";
+  }
+}
+
+/** Required text field (used for the LLM model so `""` never persists). */
+export function validateRequired(raw: string, what: string): string | null {
+  return raw.trim().length === 0 ? `enter ${what}` : null;
+}
+
+// ---------------------------------------------------------------------------
+// Email-transport section: staging → one atomic SetupRequest
+
+export interface PendingOneShotAdd {
+  sendingDomain: string;
+  mailbox: string;
+  /** Raw text from the Max/day box; blank = warm-up ramp. Validated here. */
+  maxPerDay: string;
+}
+
+export interface PendingSmartleadAdd {
+  address: string;
+  label: string;
+  providerMessagePerDay: number | null;
+}
+
+export interface IdentityPoolStaging {
+  /** Live identity ids + their stored cap, so stale edits can be dropped. */
+  identities: Array<{ id: string; maxPerDay: number | null }>;
+  /** Raw cap text per identity id, only for rows the founder touched. */
+  capEdits: Record<string, string>;
+  removedIds: string[];
+  pendingAdds: PendingOneShotAdd[];
+  pendingSmartleadAdds: PendingSmartleadAdd[];
+  /** Legacy single-identity provider select; undefined = untouched. */
+  emailProvider?: "oneshot" | "gmail";
+}
+
+export type IdentityPoolBuild =
+  | { ok: true; request: SetupRequest; empty: boolean }
+  | { ok: false; errors: { caps: Record<string, string>; adds: Record<string, string> } };
+
+/** The stored cap as the text box shows it: blank = uncapped. */
+export function capText(maxPerDay: number | null): string {
+  return maxPerDay == null ? "" : String(maxPerDay);
+}
+
+/**
+ * Turn the section's staging into the single POST that commits it. A cap edit
+ * only counts when the row still exists AND the text differs from the stored
+ * cap; a removal only when the id still exists. Any invalid cap fails the
+ * whole build — nothing partial goes out.
+ */
+export function buildIdentityPoolRequest(s: IdentityPoolStaging): IdentityPoolBuild {
+  const capErrors: Record<string, string> = {};
+  const addErrors: Record<string, string> = {};
+  const live = new Map(s.identities.map((i) => [i.id, i.maxPerDay]));
+  const removed = new Set(s.removedIds.filter((id) => live.has(id)));
+
+  const identityUpdates: NonNullable<SetupRequest["identityUpdates"]> = [];
+  for (const [id, raw] of Object.entries(s.capEdits)) {
+    if (!live.has(id) || removed.has(id)) continue;
+    if (raw.trim() === capText(live.get(id) ?? null)) continue;
+    const parsed = parseCap(raw, { blank: "uncapped" });
+    if (!parsed.ok) {
+      capErrors[id] = parsed.error;
+      continue;
+    }
+    identityUpdates.push({ id, maxPerDay: parsed.value ?? null });
+  }
+
+  const addIdentities: NonNullable<SetupRequest["addIdentities"]> = [];
+  for (const a of s.pendingAdds) {
+    const parsed = parseCap(a.maxPerDay, { blank: "omit" });
+    const key = `${a.mailbox.trim() || "agent"}@${a.sendingDomain}`;
+    if (!parsed.ok) {
+      addErrors[key] = parsed.error;
+      continue;
+    }
+    addIdentities.push({
+      provider: "oneshot",
+      sendingDomain: a.sendingDomain,
+      ...(a.mailbox.trim() ? { mailbox: a.mailbox.trim() } : {}),
+      // Blank cap = omit → cold-start ramp; a number = explicit cap.
+      ...(parsed.value !== undefined ? { maxPerDay: parsed.value } : {}),
+    });
+  }
+  for (const a of s.pendingSmartleadAdds) {
+    addIdentities.push({
+      provider: "smartlead",
+      address: a.address,
+      ...(a.label.trim() ? { label: a.label.trim() } : {}),
+      providerMessagePerDay: a.providerMessagePerDay,
+    });
+  }
+
+  if (Object.keys(capErrors).length > 0 || Object.keys(addErrors).length > 0) {
+    return { ok: false, errors: { caps: capErrors, adds: addErrors } };
+  }
+
+  const request: SetupRequest = {
+    ...(identityUpdates.length > 0 ? { identityUpdates } : {}),
+    ...(addIdentities.length > 0 ? { addIdentities } : {}),
+    ...(removed.size > 0 ? { removeIdentityIds: [...removed] } : {}),
+    ...(s.emailProvider !== undefined ? { emailProvider: s.emailProvider } : {}),
+  };
+  return { ok: true, request, empty: Object.keys(request).length === 0 };
+}

--- a/apps/web/src/routes/queue.tsx
+++ b/apps/web/src/routes/queue.tsx
@@ -1600,6 +1600,8 @@ function PackPicker() {
                 navigate({
                   to: "/setup",
                   search: { proposedIcp: result.proposedIcpOneLiner, packLabel: selected.label },
+                  // Land on the ICP section — the seeded field is the point.
+                  hash: "icp",
                 })
               }
             >

--- a/apps/web/src/routes/setup.tsx
+++ b/apps/web/src/routes/setup.tsx
@@ -1,19 +1,24 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { createFileRoute } from "@tanstack/react-router";
-import { Mail, Save, Wand2 } from "lucide-react";
-import { useEffect, useState, type ReactNode, useRef } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute, useBlocker } from "@tanstack/react-router";
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { toast } from "sonner";
-import {
-  withXEngine,
-  type SetupRequest,
-  type SmartleadAccountView,
-  type XEngine,
-} from "@oneshot-gtm/shared-types";
+import type { TriggerView } from "@oneshot-gtm/shared-types";
 import { api } from "../api/client.ts";
-import { Badge } from "../components/primitives/Badge.tsx";
-import { Button } from "../components/primitives/Button.tsx";
-import { Checkbox, Field, Input, Select, Textarea } from "../components/primitives/Field.tsx";
-import { readOnly } from "../lib/readOnly.ts";
+import { Skeleton } from "../components/primitives/Skeleton.tsx";
+import { CredentialsSection } from "../components/setup/CredentialsSection.tsx";
+import { EmailTransportSection } from "../components/setup/EmailTransportSection.tsx";
+import { FounderSection } from "../components/setup/FounderSection.tsx";
+import { IcpSection } from "../components/setup/IcpSection.tsx";
+import { LlmSection } from "../components/setup/LlmSection.tsx";
+import { ProductBriefSection } from "../components/setup/ProductBriefSection.tsx";
+import { ReviewQueueSection } from "../components/setup/ReviewQueueSection.tsx";
+import { SectionNav, jumpToSection } from "../components/setup/SectionNav.tsx";
+import { SocialProofSection } from "../components/setup/SocialProofSection.tsx";
+import { TelemetrySection } from "../components/setup/TelemetrySection.tsx";
+import { WalletSection } from "../components/setup/WalletSection.tsx";
+import { storedXEngine, XSection } from "../components/setup/XSection.tsx";
+import { SECTIONS, type SectionId } from "../components/setup/constants.ts";
+import type { DirtyReporter, SetupStatus } from "../components/setup/types.ts";
 
 interface SetupSearch {
   /**
@@ -34,363 +39,38 @@ export const Route = createFileRoute("/setup")({
   component: SetupPage,
 });
 
-const LLM_DEFAULTS: Record<string, string> = {
-  openrouter: "anthropic/claude-sonnet-4.6",
-  openai: "gpt-4o-mini",
-  anthropic: "claude-sonnet-4-6",
-};
-
-const SECRET_LABELS: Record<string, string> = {
-  OPENROUTER_API_KEY: "OpenRouter API key",
-  OPENAI_API_KEY: "OpenAI API key",
-  ANTHROPIC_API_KEY: "Anthropic API key",
-  CDP_API_KEY_ID: "CDP_API_KEY_ID",
-  CDP_API_KEY_SECRET: "CDP_API_KEY_SECRET",
-  CDP_WALLET_SECRET: "CDP_WALLET_SECRET",
-  AGENT_PRIVATE_KEY: "AGENT_PRIVATE_KEY",
-  GMAIL_CLIENT_ID: "GMAIL_CLIENT_ID",
-  GMAIL_CLIENT_SECRET: "GMAIL_CLIENT_SECRET",
-  GMAIL_REFRESH_TOKEN: "GMAIL_REFRESH_TOKEN",
-  SMARTLEAD_API_KEY: "Smartlead API key",
-  X_API_KEY: "X_API_KEY",
-  X_API_SECRET: "X_API_SECRET",
-  X_ACCESS_TOKEN: "X_ACCESS_TOKEN",
-  X_ACCESS_SECRET: "X_ACCESS_SECRET",
-  TWITTERAPI_IO_KEY: "twitterapi.io API key",
-  GITHUB_TOKEN: "GitHub token",
-  LUMA_SESSION_COOKIE: "Luma session cookie",
-};
-
-const X_OAUTH_KEYS = ["X_API_KEY", "X_API_SECRET", "X_ACCESS_TOKEN", "X_ACCESS_SECRET"] as const;
+const SECTION_IDS = new Set<string>(SECTIONS.map((s) => s.id));
 
 /**
- * Blank = unlimited (null). Otherwise must parse to a positive finite
- * number — matches the CLI path's validation (`configSpendCeiling`) and
- * the server's own re-check (`mergeSetupConfig` → `validateSpendCeiling`).
- * A submitted 0/negative/NaN throws here instead of silently reaching the
- * API, where a ceiling of 0 would halt every automated finder and drain
- * install-wide immediately.
+ * /setup (issue #451): eleven sections, each with its own draft, validation
+ * and Save. The page owns only what spans sections — the query, the dirty
+ * registry behind the rail dots and the leave guard, the Smartlead-key epoch,
+ * and the two URL round-trips (Gmail OAuth outcome, #section deep links).
  */
-function parseDailySpendCeiling(raw: string): number | null {
-  if (raw.trim() === "") return null;
-  const n = Number.parseFloat(raw);
-  if (!Number.isFinite(n) || n <= 0) {
-    throw new Error(
-      `invalid daily spend ceiling '${raw}' — enter a positive number of USD, or leave blank`,
-    );
-  }
-  return n;
-}
-
 function SetupPage() {
   const qc = useQueryClient();
   const status = useQuery({ queryKey: ["setup"], queryFn: api.setupStatus });
   const triggers = useQuery({ queryKey: ["triggers"], queryFn: api.triggers });
   const { proposedIcp, packLabel } = Route.useSearch();
 
-  const [founderName, setFounderName] = useState("");
-  const [founderEmail, setFounderEmail] = useState("");
-  const [productOneLiner, setProductOneLiner] = useState("");
-  const [productDomain, setProductDomain] = useState("");
-  const [sendingDomain, setSendingDomain] = useState("");
-  const [icpOneLiner, setIcpOneLiner] = useState("");
-  const [icpDomain, setIcpDomain] = useState("");
-  const [icpDeriveError, setIcpDeriveError] = useState<string | null>(null);
-  const [icpDeriveSource, setIcpDeriveSource] = useState<{ url: string; cost: number } | null>(
-    null,
-  );
-  const [llmProvider, setLlmProvider] = useState<"openrouter" | "openai" | "anthropic">(
-    "openrouter",
-  );
-  const [llmModel, setLlmModel] = useState("");
-  const [telemetryEnabled, setTelemetryEnabled] = useState(true);
-  const [walletMode, setWalletMode] = useState<"cdp" | "private-key">("cdp");
-  const [emailProvider, setEmailProvider] = useState<"oneshot" | "gmail">("oneshot");
-  // Sender-rotation pool edits, applied on Save: per-identity cap inputs
-  // (string so the field can be temporarily empty) + pending removals.
-  const [capEdits, setCapEdits] = useState<Record<string, string>>({});
-  const [removedIdentityIds, setRemovedIdentityIds] = useState<string[]>([]);
-  // Pending OneShot sender identities to add on Save. Each is a wallet-owned
-  // domain + mailbox local-part; cap blank = cold-start warm-up ramp.
-  const [pendingAdds, setPendingAdds] = useState<
-    Array<{ sendingDomain: string; mailbox: string; maxPerDay: string }>
-  >([]);
-  // Pending Smartlead mailboxes to add on Save (picked from the loaded account
-  // list; providerMessagePerDay clamps the default warm-up ceiling server-side).
-  const [pendingSmartleadAdds, setPendingSmartleadAdds] = useState<
-    Array<{ address: string; label: string; providerMessagePerDay: number | null }>
-  >([]);
-  const [addDomain, setAddDomain] = useState("");
-  const [addMailbox, setAddMailbox] = useState("");
-  const [addCap, setAddCap] = useState("");
-  const [founderCredentials, setFounderCredentials] = useState("");
-  const [productPortfolio, setProductPortfolio] = useState("");
-  const [partners, setPartners] = useState("");
-  const [founderAdmission, setFounderAdmission] = useState("");
-  const [productBrief, setProductBrief] = useState("");
-  // Unsaved edits/derives must survive ["setup"] refetches (pause/resume and
-  // save all invalidate it) — the hydrate effect only overwrites a clean field.
-  // A ref, not state: the hydrate effect must read the CURRENT flag without
-  // re-running when it flips.
-  const briefDirty = useRef(false);
-  const [briefSources, setBriefSources] = useState("");
-  const [briefDeriveInfo, setBriefDeriveInfo] = useState<string | null>(null);
-  const [mobileSignature, setMobileSignature] = useState(false);
-  // "" = unlimited (no ceiling). A positive-number string is the ceiling in
-  // USD; kept as a string so the field can be temporarily empty while typing.
-  // Same dirty-flag pattern as briefDirty: a pause/resume action invalidates
-  // ["setup"] mid-edit, and without this the hydrate effect below would
-  // silently overwrite whatever the founder just typed with the persisted
-  // value.
-  const [dailySpendCeiling, setDailySpendCeiling] = useState("");
-  const spendCeilingDirty = useRef(false);
-  const [secrets, setSecrets] = useState<Record<string, string>>({});
-  const [savedAt, setSavedAt] = useState<number | null>(null);
-
-  // A pack's proposed ICP arrives via ?proposedIcp= from /queue's "Accept in
-  // Setup" action (PackRow). Seed it into the field once on arrival — same
-  // one-shot-then-hands-off-to-the-founder pattern as briefDirty above — so a
-  // background ["setup"] refetch doesn't clobber the founder's edits after.
-  // Clear proposedIcp/packLabel from the URL once consumed (same pattern as
-  // the gmailAuth outcome below) so a later reload of /setup doesn't reset
-  // icpFromPack and silently re-seed — and re-save — the stale pack proposal
-  // over the founder's own edits.
-  const icpFromPack = useRef(false);
-  useEffect(() => {
-    if (!proposedIcp || icpFromPack.current) return;
-    icpFromPack.current = true;
-    setIcpOneLiner(proposedIcp);
-    const params = new URLSearchParams(window.location.search);
-    params.delete("proposedIcp");
-    params.delete("packLabel");
-    const qs = params.toString();
-    // Preserve window.history.state (TanStack Router's __TSR_index/__TSR_key
-    // live there) — replacing it with {} desyncs the router's history index
-    // and turns the next back/forward into a generic GO instead of BACK/FORWARD.
-    window.history.replaceState(
-      window.history.state,
-      "",
-      `${window.location.pathname}${qs ? `?${qs}` : ""}`,
-    );
-  }, [proposedIcp]);
-
-  // X channel: engine choice lives in the x-reposters trigger config, not in
-  // config.json. Seed local state once from the stored trigger; after that the
-  // select is the founder's — a background refetch must not clobber it.
-  const [xEngine, setXEngine] = useState<XEngine>("xapi");
-  const xEngineSeeded = useRef(false);
-  const xTrigger = triggers.data?.triggers.find((t) => t.name === "x-reposters");
-  const storedXEngine: XEngine =
-    (xTrigger?.config?.["engine"] as XEngine | undefined) ??
-    (xTrigger?.defaultConfig?.["engine"] as XEngine | undefined) ??
-    "xapi";
-  useEffect(() => {
-    if (!xTrigger || xEngineSeeded.current) return;
-    xEngineSeeded.current = true;
-    setXEngine(storedXEngine);
-  }, [xTrigger, storedXEngine]);
-
-  useEffect(() => {
-    if (!status.data?.cfg) return;
-    const c = status.data.cfg;
-    setFounderName(c.founderName ?? "");
-    setFounderEmail(c.founderEmail ?? "");
-    setProductOneLiner(c.productOneLiner ?? "");
-    setProductDomain(c.productDomain ?? "");
-    setSendingDomain(c.sendingDomain ?? "");
-    setIcpOneLiner((prev) => (icpFromPack.current ? prev : (c.icpOneLiner ?? "")));
-    setFounderCredentials(c.founderCredentials ?? "");
-    setProductPortfolio(c.productPortfolio ?? "");
-    setPartners(c.partners ?? "");
-    setFounderAdmission(c.founderAdmission ?? "");
-    if (!briefDirty.current) setProductBrief(c.productBrief ?? "");
-    setBriefSources((prev) => prev || (c.productDomain ? `https://${c.productDomain}` : ""));
-    setMobileSignature(c.mobileSignature ?? false);
-    setDailySpendCeiling((prev) =>
-      spendCeilingDirty.current
-        ? prev
-        : c.dailySpendCeilingUsd != null
-          ? String(c.dailySpendCeilingUsd)
-          : "",
-    );
-    setLlmProvider(c.llmProvider);
-    setLlmModel(c.llmModel || LLM_DEFAULTS[c.llmProvider] || "");
-    setTelemetryEnabled(c.telemetryEnabled);
-    setWalletMode(c.walletMode);
-    setEmailProvider(c.emailProvider);
-  }, [status.data?.cfg]);
-
-  // Load the Smartlead workspace's connected mailboxes. Uses the just-typed
-  // key when present (browse before saving), else the server falls back to the
-  // stored SMARTLEAD_API_KEY. The key rides the POST body, never a URL.
-  const [smartleadAccounts, setSmartleadAccounts] = useState<SmartleadAccountView[] | null>(null);
-  const loadSmartlead = useMutation({
-    mutationFn: () => api.smartleadAccounts(secrets["SMARTLEAD_API_KEY"]),
-    onSuccess: (res) => setSmartleadAccounts(res.accounts),
-    onError: (err: Error) => toast.error(`Smartlead: ${err.message}`),
+  // Which sections have unsaved edits — reported by each section, read by
+  // the rail and the leave guard. A ref mirrors it for the blocker callbacks.
+  const [dirty, setDirty] = useState<Partial<Record<SectionId, boolean>>>({});
+  const anyDirty = Object.values(dirty).some(Boolean);
+  const anyDirtyRef = useRef(false);
+  anyDirtyRef.current = anyDirty;
+  const onDirtyChange = useCallback<DirtyReporter>((id, flag) => {
+    setDirty((d) => (Boolean(d[id]) === flag ? d : { ...d, [id]: flag }));
+  }, []);
+  useBlocker({
+    shouldBlockFn: () =>
+      anyDirtyRef.current && !window.confirm("Unsaved changes on this page — leave anyway?"),
+    enableBeforeUnload: () => anyDirtyRef.current,
   });
 
-  const deriveIcp = useMutation({
-    mutationFn: (domain: string) => api.deriveIcp(domain),
-    onSuccess: (res) => {
-      setIcpOneLiner(res.proposedIcp);
-      setIcpDeriveSource({ url: res.sourceUrl, cost: res.costUsd });
-      setIcpDeriveError(null);
-    },
-    onError: (err: Error) => {
-      setIcpDeriveError(err.message);
-      setIcpDeriveSource(null);
-    },
-  });
-
-  // Resume / pause a provisioned sending domain in the OneShot pool. Refetches
-  // the setup status (and doctor) so the status badge + warning update. Errors
-  // surface verbatim — incl. the OneShot HTTP status during a platform outage.
-  const domainAction = useMutation({
-    mutationFn: (vars: { domain: string; action: "resume" | "pause" }) =>
-      vars.action === "resume" ? api.resumeDomain(vars.domain) : api.pauseDomain(vars.domain),
-    onSuccess: (res) => {
-      void qc.invalidateQueries({ queryKey: ["setup"] });
-      void qc.invalidateQueries({ queryKey: ["doctor"] });
-      toast.success(`${res.domain} → ${res.poolStatus}`);
-    },
-    onError: (err: Error) => toast.error(err.message),
-  });
-
-  // Elapsed counter so the ~30–60s derive feels alive instead of frozen.
-  // Server doesn't stream progress; we cycle a phase label by elapsed time.
-  const [deriveElapsed, setDeriveElapsed] = useState(0);
-  useEffect(() => {
-    if (!deriveIcp.isPending) {
-      setDeriveElapsed(0);
-      return;
-    }
-    const started = Date.now();
-    const t = setInterval(() => {
-      setDeriveElapsed(Math.floor((Date.now() - started) / 1000));
-    }, 250);
-    return () => clearInterval(t);
-  }, [deriveIcp.isPending]);
-  const derivePhase =
-    deriveElapsed < 15
-      ? `Reading the page · ${deriveElapsed}s`
-      : deriveElapsed < 35
-        ? `Still reading — slow pages take a moment · ${deriveElapsed}s`
-        : `Asking the LLM to extract an ICP · ${deriveElapsed}s`;
-
-  const deriveBrief = useMutation({
-    mutationFn: (urls: string[]) => api.deriveBrief(urls),
-    onSuccess: (res) => {
-      setProductBrief(res.proposedBrief);
-      briefDirty.current = true;
-      const skipped = res.skipped.length > 0 ? ` · ${res.skipped.length} source(s) unreadable` : "";
-      setBriefDeriveInfo(
-        `derived from ${res.sourceUrls.length} source(s) · $${res.costUsd.toFixed(2)}${skipped} — edit before saving`,
-      );
-    },
-    onError: (err) => toast.error((err as Error).message),
-  });
-
-  const save = useMutation({
-    mutationFn: async () => {
-      const filteredSecrets: Record<string, string> = {};
-      for (const [k, v] of Object.entries(secrets)) {
-        if (v.trim().length > 0) filteredSecrets[k] = v.trim();
-      }
-      const identityUpdates = Object.entries(capEdits).map(([id, raw]) => {
-        const n = Number.parseInt(raw, 10);
-        return { id, maxPerDay: Number.isFinite(n) && n >= 0 ? n : null };
-      });
-      const addIdentities: NonNullable<SetupRequest["addIdentities"]> = pendingAdds.map((a) => {
-        const n = Number.parseInt(a.maxPerDay, 10);
-        return {
-          provider: "oneshot" as const,
-          sendingDomain: a.sendingDomain,
-          ...(a.mailbox.trim() ? { mailbox: a.mailbox.trim() } : {}),
-          // Blank cap = omit → cold-start ramp; a number = explicit cap.
-          ...(a.maxPerDay.trim() && Number.isFinite(n) && n >= 0 ? { maxPerDay: n } : {}),
-        };
-      });
-      for (const a of pendingSmartleadAdds) {
-        addIdentities.push({
-          provider: "smartlead" as const,
-          address: a.address,
-          ...(a.label.trim() ? { label: a.label.trim() } : {}),
-          providerMessagePerDay: a.providerMessagePerDay,
-        });
-      }
-      await api.setup({
-        ...(identityUpdates.length > 0 ? { identityUpdates } : {}),
-        ...(addIdentities.length > 0 ? { addIdentities } : {}),
-        ...(removedIdentityIds.length > 0 ? { removeIdentityIds: removedIdentityIds } : {}),
-        founderName,
-        founderEmail,
-        productOneLiner,
-        productDomain,
-        sendingDomain,
-        icpOneLiner,
-        founderCredentials,
-        productPortfolio,
-        partners,
-        founderAdmission,
-        productBrief,
-        mobileSignature,
-        dailySpendCeilingUsd: parseDailySpendCeiling(dailySpendCeiling),
-        llmProvider,
-        llmModel,
-        telemetryEnabled,
-        walletMode,
-        emailProvider,
-        secrets: filteredSecrets as never,
-      });
-      // Engine choice rides the x-reposters trigger config (not config.json).
-      // withXEngine drops the maxSpendPerRun/knobs overrides on an actual
-      // flip so the per-engine defaults re-apply.
-      if (xTrigger && xEngine !== storedXEngine) {
-        await api.setTriggerConfig(
-          "x-reposters",
-          withXEngine(xTrigger.config ?? xTrigger.defaultConfig, xEngine),
-        );
-      }
-    },
-    onSuccess: () => {
-      setSecrets({});
-      setCapEdits({});
-      setRemovedIdentityIds([]);
-      setPendingAdds([]);
-      setPendingSmartleadAdds([]);
-      setAddDomain("");
-      setAddMailbox("");
-      setAddCap("");
-      briefDirty.current = false;
-      spendCeilingDirty.current = false;
-      setSavedAt(Date.now());
-      // Re-seed the engine select from the refetched trigger row.
-      xEngineSeeded.current = false;
-      void qc.invalidateQueries({ queryKey: ["setup"] });
-      void qc.invalidateQueries({ queryKey: ["doctor"] });
-      void qc.invalidateQueries({ queryKey: ["home"] });
-      void qc.invalidateQueries({ queryKey: ["triggers"] });
-    },
-  });
-
-  const sources = status.data?.sources ?? {};
-  // Workspace-aware: the server already reports the real secrets path.
-  const homeDir = status.data?.secretsPath?.replace(/\/\.env$/, "") ?? "~/.oneshot-gtm";
-  const provisionedDomains = status.data?.provisionedDomains ?? [];
-  // Default mailbox shown as a placeholder — founder's first name, normalized.
-  const founderLocalpart =
-    (founderName.trim().split(/\s+/)[0] ?? "").toLowerCase().replace(/[^a-z0-9]/g, "") || "";
-  // Legacy single-identity mode = the pool is auto-derived from emailProvider.
-  // Once a real pool exists, the provider select / manual Gmail secrets are
-  // inert (routing is pool-driven) — hide them instead of misleading.
-  const isLegacyPool = status.data?.identities?.[0]?.legacy ?? true;
-  // The Connect button needs the shared OAuth-app creds saved first.
-  const gmailCredsReady = Boolean(sources["GMAIL_CLIENT_ID"] && sources["GMAIL_CLIENT_SECRET"]);
-  // Smartlead can be browsed with a just-typed key before it's ever saved.
-  const smartleadKeyReady = Boolean(
-    sources["SMARTLEAD_API_KEY"] || (secrets["SMARTLEAD_API_KEY"] ?? "").trim(),
-  );
+  // Credentials saved a new Smartlead key → the email section's loaded
+  // account list (and staged picks) belong to the old workspace.
+  const [smartleadKeyEpoch, bumpSmartleadKey] = useReducer((n: number) => n + 1, 0);
 
   // Round-trip result from the browser OAuth flow (/api/gmail/auth/callback
   // redirects back here with ?gmailAuth=ok:<address> | error:<reason>).
@@ -405,24 +85,60 @@ function SetupPage() {
     }
     params.delete("gmailAuth");
     const qs = params.toString();
-    window.history.replaceState({}, "", `${window.location.pathname}${qs ? `?${qs}` : ""}`);
+    // Preserve history.state — TanStack Router keeps its index/key there.
+    window.history.replaceState(
+      window.history.state,
+      "",
+      `${window.location.pathname}${qs ? `?${qs}` : ""}${window.location.hash}`,
+    );
     void qc.invalidateQueries({ queryKey: ["setup"] });
     void qc.invalidateQueries({ queryKey: ["doctor"] });
   }, [qc]);
-  const llmSecretKey =
-    llmProvider === "openrouter"
-      ? "OPENROUTER_API_KEY"
-      : llmProvider === "openai"
-        ? "OPENAI_API_KEY"
-        : "ANTHROPIC_API_KEY";
 
-  const setSecret = (key: string, value: string): void => {
-    setSecrets((s) => ({ ...s, [key]: value }));
-  };
-
+  // #section deep link. The router's own hash scroll runs when the route
+  // resolves — before ["setup"] has data, so the target doesn't exist yet —
+  // and the root layout then resets <main> to the top. Jump once the
+  // sections have rendered.
+  const hashJumped = useRef(false);
+  const loaded = Boolean(status.data);
   useEffect(() => {
-    if (save.isError) toast.error(`couldn't save · ${save.error.message}`);
-  }, [save.isError, save.error]);
+    if (!loaded || hashJumped.current) return;
+    hashJumped.current = true;
+    const id = window.location.hash.slice(1);
+    if (!SECTION_IDS.has(id)) return;
+    const raf = requestAnimationFrame(() => jumpToSection(id as SectionId, "auto"));
+    return () => cancelAnimationFrame(raf);
+  }, [loaded]);
+
+  // Active rail item: the first section (in page order) currently on screen.
+  const [visible, setVisible] = useState<Set<SectionId>>(() => new Set());
+  useEffect(() => {
+    if (!loaded) return;
+    const els = SECTIONS.map((s) => document.getElementById(s.id)).filter(
+      (el): el is HTMLElement => el != null,
+    );
+    const io = new IntersectionObserver(
+      (entries) => {
+        setVisible((prev) => {
+          const next = new Set(prev);
+          for (const e of entries) {
+            const id = e.target.id as SectionId;
+            if (e.isIntersecting) next.add(id);
+            else next.delete(id);
+          }
+          return next;
+        });
+      },
+      { rootMargin: "-10% 0px -60% 0px" },
+    );
+    for (const el of els) io.observe(el);
+    return () => io.disconnect();
+  }, [loaded]);
+  const active = SECTIONS.find((s) => visible.has(s.id))?.id ?? null;
+
+  // Workspace-aware: the server already reports the real secrets path.
+  const homeDir = status.data?.secretsPath?.replace(/\/\.env$/, "") ?? "~/.oneshot-gtm";
+  const xTrigger = triggers.data?.triggers.find((t) => t.name === "x-reposters");
 
   return (
     <div className="-mx-6 -my-6 flex flex-col">
@@ -444,998 +160,88 @@ function SetupPage() {
         </div>
         <span className="text-[11px] text-ink-faint ln-mono">
           saved to <span className="text-ink-muted">{homeDir}/config.json</span> ·{" "}
-          <span className="text-ink-muted">.env</span> · chmod 600
+          <span className="text-ink-muted">.env</span> · chmod 600 · each section saves on its own
         </span>
       </section>
 
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          save.mutate();
-        }}
-        className="flex flex-col"
-      >
-        <LedgerSection
-          eyebrow="01 · Founder profile"
-          lede="How prospects see you on the other side of the inbox."
-        >
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-            <Field label="Name">
-              <Input
-                value={founderName}
-                onChange={(e) => setFounderName(e.target.value)}
-                placeholder="Jane Doe"
-              />
-            </Field>
-            <Field
-              label="Your email"
-              hint="Lead capture on pages this tool generates (e.g. the PMF survey). NOT a reply address — replies land in the inbox of whichever sending identity sent the mail."
-            >
-              <Input
-                type="email"
-                value={founderEmail}
-                onChange={(e) => setFounderEmail(e.target.value)}
-                placeholder="jane@yourcompany.com"
-              />
-            </Field>
-            <Field
-              label="Signature domain"
-              hint="Bare domain shown under your name in every email signature, e.g. yourcompany.com. Leave blank for no domain line."
-            >
-              <Input
-                value={productDomain}
-                onChange={(e) => setProductDomain(e.target.value)}
-                placeholder="yourcompany.com"
-              />
-            </Field>
-            <Field
-              label="Sending domain"
-              hint="The domain your wallet OWNS. Emails send from <your-first-name>@thisdomain. Must be wallet-owned or the SDK rejects the send. Leave blank to use the SDK default."
-            >
-              <Input
-                value={sendingDomain}
-                onChange={(e) => setSendingDomain(e.target.value)}
-                placeholder="yourcompany-mail.com"
-              />
-            </Field>
-            <Field
-              label="Product one-liner"
-              hint="What you're building, in one sentence."
-              className="md:col-span-2"
-            >
-              <Textarea
-                value={productOneLiner}
-                onChange={(e) => setProductOneLiner(e.target.value)}
-                placeholder={
-                  'e.g. "Stripe for freight" · "AI bookkeeping for restaurants" · "scheduling for dog groomers"'
-                }
-                rows={2}
-              />
-            </Field>
-          </div>
-        </LedgerSection>
-
-        <LedgerSection
-          eyebrow="02 · Ideal customer profile"
-          lede="A free-text classifier. The find layer uses this to drop candidates that don't match."
-        >
-          <div className="flex flex-col gap-4">
-            {proposedIcp && icpFromPack.current && (
-              <div className="border-l-2 border-[color:var(--ink-receipt)] bg-[color:var(--ink-receipt)]/10 px-3 py-2 font-mono text-[11.5px] text-ink-cream-2">
-                Proposed by {packLabel ?? "an industry pack"} — never written until you Save below.
-                Edit or clear it first if it's not right.
-              </div>
-            )}
-            <Field
-              label="Derive from a website"
-              hint="Paste a domain (or full URL) of a company whose customers look like yours. We'll read the page and propose an ICP — you can edit before saving. Spends ~$0.02–0.05 (one webRead + one LLM call)."
-            >
-              <div className="flex gap-2">
-                <Input
-                  value={icpDomain}
-                  onChange={(e) => setIcpDomain(e.target.value)}
-                  placeholder="acme.com  ·  https://yourcompany.com/customers"
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter" && !deriveIcp.isPending && icpDomain.trim().length > 0) {
-                      e.preventDefault();
-                      deriveIcp.mutate(icpDomain.trim());
-                    }
-                  }}
-                />
-                <Button
-                  type="button"
-                  variant="secondary"
-                  className="shrink-0 whitespace-nowrap"
-                  disabled={deriveIcp.isPending || icpDomain.trim().length === 0}
-                  onClick={() => deriveIcp.mutate(icpDomain.trim())}
-                  {...readOnly}
-                >
-                  <Wand2 size={12} className={deriveIcp.isPending ? "animate-pulse" : undefined} />
-                  {deriveIcp.isPending ? `Working · ${deriveElapsed}s` : "Derive ICP"}
-                </Button>
-              </div>
-            </Field>
-
-            {deriveIcp.isPending && (
-              <div className="flex items-center gap-2 font-mono text-[11px] text-ink-muted">
-                <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-ink-cream-2" />
-                {derivePhase}
-              </div>
-            )}
-
-            {icpDeriveError && (
-              <div className="border-l-2 border-[color:var(--ink-blocked)] bg-[color:var(--ink-blocked)]/10 px-3 py-2 font-mono text-[11.5px] text-[color:var(--ink-blocked-2)]">
-                {icpDeriveError}
-              </div>
-            )}
-            {icpDeriveSource && !icpDeriveError && (
-              <div className="font-mono text-[11px] text-ink-muted">
-                drafted from{" "}
-                <a
-                  href={icpDeriveSource.url}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-ink-cream-2 underline decoration-ink-faint decoration-1 underline-offset-2 hover:decoration-ink-cream"
-                >
-                  {icpDeriveSource.url}
-                </a>{" "}
-                · spent ${icpDeriveSource.cost.toFixed(3)} · edit below before saving.
-              </div>
-            )}
-
-            <Field
-              label="ICP one-liner"
-              hint="Leave blank to disable filtering (every candidate passes through)."
-            >
-              <Textarea
-                value={icpOneLiner}
-                onChange={(e) => setIcpOneLiner(e.target.value)}
-                placeholder={
-                  'e.g. "CFOs at Series-B SaaS" · "Shopify stores doing $1M+/yr" · "indie iOS devs"'
-                }
-                rows={3}
-              />
-            </Field>
-          </div>
-        </LedgerSection>
-
-        <LedgerSection
-          eyebrow="03 · Social proof"
-          lede="All optional. Each maps to a different play type. Used by the LLM when drafting the second sentence of a first-touch email — never more than one beat per email."
-        >
-          <div className="grid grid-cols-1 gap-4">
-            <Field
-              label="Founder background"
-              hint="Prior companies, named past roles, anything that lets a stranger trust you. Used by job-change / podcast-guest / post-funding / breakup-revive."
-            >
-              <Textarea
-                value={founderCredentials}
-                onChange={(e) => setFounderCredentials(e.target.value)}
-                placeholder={
-                  'e.g. "ex-Stripe eng" · "VP Sales at Salesforce" · "ran a $2M Shopify store"'
-                }
-                rows={2}
-              />
-            </Field>
-            <Field
-              label="Products you've shipped"
-              hint="Used in peer-founder outreach to show you've actually built things. Stack-consolidation / competitor-switch / show-hn / hiring-signal."
-            >
-              <Textarea
-                value={productPortfolio}
-                onChange={(e) => setProductPortfolio(e.target.value)}
-                placeholder="Comma-separated list of products or projects you've shipped."
-                rows={2}
-              />
-            </Field>
-            <Field
-              label="Notable partners / customers"
-              hint="Brand names that open doors. Helps when the prospect doesn't know you yet. Accelerator-batch / demo-no-show."
-            >
-              <Textarea
-                value={partners}
-                onChange={(e) => setPartners(e.target.value)}
-                placeholder="Comma-separated brand-name integrations or customers."
-                rows={2}
-              />
-            </Field>
-            <Field
-              label="One true concession"
-              hint="The thing you'd rather not say but is true. Used in roughly 1 in 3 first touches as a damaging admission (two of us, no logos yet, but…), which makes the rest of the email more believable. Leave blank and the beat is skipped, never invented."
-            >
-              <Textarea
-                value={founderAdmission}
-                onChange={(e) => setFounderAdmission(e.target.value)}
-                placeholder="e.g. two people, no enterprise logos yet"
-                rows={2}
-              />
-            </Field>
-            <Checkbox
-              checked={mobileSignature}
-              onChange={(e) => setMobileSignature(e.target.checked)}
-              label={'Append "Sent from my iPhone" to every email signature'}
-            />
-          </div>
-        </LedgerSection>
-
-        <LedgerSection
-          eyebrow="03.5 · Product brief"
-          lede="What your replies are allowed to know and cite. Facts, architecture, pricing model, canonical links. A link that isn't in this brief is never sent."
-        >
-          <div className="flex flex-col gap-4">
-            <Field
-              label="Derive from sources"
-              hint="One URL per line — your site, the GitHub repo, docs pages (max 5). Each is one webRead (~$0.01); you edit the proposal before saving."
-            >
-              <div className="flex gap-2">
-                <Textarea
-                  value={briefSources}
-                  onChange={(e) => setBriefSources(e.target.value)}
-                  placeholder={
-                    "yourproduct.com\ngithub.com/you/your-repo\ndocs.yourproduct.com/pricing"
-                  }
-                  rows={3}
-                />
-                <Button
-                  type="button"
-                  variant="secondary"
-                  className="shrink-0 self-start whitespace-nowrap"
-                  disabled={deriveBrief.isPending || briefSources.trim().length === 0}
-                  onClick={() =>
-                    deriveBrief.mutate(
-                      briefSources
-                        .split("\n")
-                        .map((u) => u.trim())
-                        .filter((u) => u.length > 0)
-                        .slice(0, 5),
-                    )
-                  }
-                  {...readOnly}
-                >
-                  <Wand2
-                    size={12}
-                    className={deriveBrief.isPending ? "animate-pulse" : undefined}
-                  />
-                  {deriveBrief.isPending ? "Reading sources…" : "Derive brief"}
-                </Button>
-              </div>
-            </Field>
-            {briefDeriveInfo && (
-              <div className="font-mono text-[11px] text-ink-faint">{briefDeriveInfo}</div>
-            )}
-            <Field
-              label="Product brief"
-              hint="Used by /inbox reply drafting to answer substantive questions with substance. Keep links verbatim."
-            >
-              <Textarea
-                value={productBrief}
-                onChange={(e) => {
-                  setProductBrief(e.target.value);
-                  briefDirty.current = true;
-                }}
-                placeholder="How it works: … settled per call in USDC on Base …\nPricing: …\nLinks:\nhttps://docs.yourproduct.com/payments"
-                rows={8}
-              />
-            </Field>
-          </div>
-        </LedgerSection>
-
-        <LedgerSection
-          eyebrow="04 · LLM provider"
-          lede="Bring your own key. Swap providers freely; nothing is locked in."
-        >
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-            <Field label="Provider">
-              <Select
-                value={llmProvider}
-                onChange={(e) => {
-                  const v = e.target.value as typeof llmProvider;
-                  setLlmProvider(v);
-                  if (!llmModel) setLlmModel(LLM_DEFAULTS[v] ?? "");
-                }}
-              >
-                <option value="openrouter">OpenRouter (recommended)</option>
-                <option value="openai">OpenAI</option>
-                <option value="anthropic">Anthropic</option>
-              </Select>
-            </Field>
-            <Field label="Model">
-              <Input
-                value={llmModel}
-                onChange={(e) => setLlmModel(e.target.value)}
-                placeholder={LLM_DEFAULTS[llmProvider]}
-              />
-            </Field>
-            <Field
-              label={SECRET_LABELS[llmSecretKey] ?? llmSecretKey}
-              hint={
-                sources[llmSecretKey] === "env"
-                  ? "Currently from shell env. Leaving blank keeps the env value."
-                  : sources[llmSecretKey] === "file"
-                    ? "Currently from this workspace's .env. Leave blank to keep."
-                    : "Not set. Paste it here to save (chmod 600)."
-              }
-              className="md:col-span-2"
-            >
-              <Input
-                type="password"
-                placeholder={sources[llmSecretKey] ? "(unchanged)" : "sk-..."}
-                value={secrets[llmSecretKey] ?? ""}
-                onChange={(e) => setSecret(llmSecretKey, e.target.value)}
-                autoComplete="new-password"
-              />
-            </Field>
-          </div>
-        </LedgerSection>
-
-        <LedgerSection
-          eyebrow="05 · Wallet"
-          lede={`Keys live only in ${homeDir}/.env chmod 600. Nothing leaves your machine.`}
-        >
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-            <Field label="Wallet mode" className="md:col-span-2">
-              <Select
-                value={walletMode}
-                onChange={(e) => setWalletMode(e.target.value as typeof walletMode)}
-              >
-                <option value="cdp">Coinbase CDP server wallet</option>
-                <option value="private-key">Raw private key</option>
-              </Select>
-            </Field>
-            {walletMode === "cdp" ? (
-              <>
-                <Field label="CDP_API_KEY_ID" hint={hintFor(sources["CDP_API_KEY_ID"])}>
-                  <Input
-                    type="password"
-                    placeholder={sources["CDP_API_KEY_ID"] ? "(unchanged)" : ""}
-                    value={secrets["CDP_API_KEY_ID"] ?? ""}
-                    onChange={(e) => setSecret("CDP_API_KEY_ID", e.target.value)}
-                    autoComplete="new-password"
-                  />
-                </Field>
-                <Field label="CDP_API_KEY_SECRET" hint={hintFor(sources["CDP_API_KEY_SECRET"])}>
-                  <Input
-                    type="password"
-                    placeholder={sources["CDP_API_KEY_SECRET"] ? "(unchanged)" : ""}
-                    value={secrets["CDP_API_KEY_SECRET"] ?? ""}
-                    onChange={(e) => setSecret("CDP_API_KEY_SECRET", e.target.value)}
-                    autoComplete="new-password"
-                  />
-                </Field>
-                <Field
-                  label="CDP_WALLET_SECRET"
-                  hint={hintFor(sources["CDP_WALLET_SECRET"])}
-                  className="md:col-span-2"
-                >
-                  <Input
-                    type="password"
-                    placeholder={sources["CDP_WALLET_SECRET"] ? "(unchanged)" : ""}
-                    value={secrets["CDP_WALLET_SECRET"] ?? ""}
-                    onChange={(e) => setSecret("CDP_WALLET_SECRET", e.target.value)}
-                    autoComplete="new-password"
-                  />
-                </Field>
-              </>
-            ) : (
-              <Field
-                label="AGENT_PRIVATE_KEY"
-                hint={hintFor(sources["AGENT_PRIVATE_KEY"])}
-                className="md:col-span-2"
-              >
-                <Input
-                  type="password"
-                  placeholder={sources["AGENT_PRIVATE_KEY"] ? "(unchanged)" : "0x..."}
-                  value={secrets["AGENT_PRIVATE_KEY"] ?? ""}
-                  onChange={(e) => setSecret("AGENT_PRIVATE_KEY", e.target.value)}
-                  autoComplete="new-password"
-                />
-              </Field>
-            )}
-            <Field
-              label="Daily spend ceiling (USD)"
-              className="md:col-span-2"
-              hint="Install-wide cap across every automated finder run and drain — blank = unlimited. Once reached, scheduled/run-now finders and drains halt with a named reason (visible here and in doctor) until local midnight; manual /queue sends are never blocked."
-            >
-              <Input
-                type="number"
-                min="0.01"
-                step="0.01"
-                placeholder="unlimited"
-                value={dailySpendCeiling}
-                onChange={(e) => {
-                  setDailySpendCeiling(e.target.value);
-                  spendCeilingDirty.current = true;
-                }}
-              />
-            </Field>
-          </div>
-        </LedgerSection>
-
-        <LedgerSection
-          eyebrow="05.5 · X / Twitter"
-          lede="Credentials and data provider for the x-reposters finder. Keys land in the same .env (chmod 600); the engine choice lives on the trigger."
-        >
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-            <Field
-              label="Data provider"
-              className="md:col-span-2"
-              hint="Both bill per record returned. Switching resets the trigger's spend ceiling and harvest knobs to the new engine's defaults; fine-tune in the /queue trigger editor."
-            >
-              <Select value={xEngine} onChange={(e) => setXEngine(e.target.value as XEngine)}>
-                <option value="twitterapiio">
-                  twitterapi.io — ~$0.25/run, third-party scraper
-                </option>
-                <option value="xapi">X API (first-party) — ~$5/run, licensed, OAuth1</option>
-              </Select>
-            </Field>
-            {xEngine === "xapi" ? (
-              X_OAUTH_KEYS.map((k) => (
-                <Field key={k} label={k} hint={hintFor(sources[k])}>
-                  <Input
-                    type="password"
-                    placeholder={sources[k] ? "(unchanged)" : ""}
-                    value={secrets[k] ?? ""}
-                    onChange={(e) => setSecret(k, e.target.value)}
-                    autoComplete="new-password"
-                  />
-                </Field>
-              ))
-            ) : (
-              <Field
-                label="TWITTERAPI_IO_KEY"
-                hint={hintFor(sources["TWITTERAPI_IO_KEY"])}
-                className="md:col-span-2"
-              >
-                <Input
-                  type="password"
-                  placeholder={sources["TWITTERAPI_IO_KEY"] ? "(unchanged)" : ""}
-                  value={secrets["TWITTERAPI_IO_KEY"] ?? ""}
-                  onChange={(e) => setSecret("TWITTERAPI_IO_KEY", e.target.value)}
-                  autoComplete="new-password"
-                />
-              </Field>
-            )}
-            {xTrigger && (
-              <p className="md:col-span-2 font-mono text-[11px] text-ink-muted">
-                x-reposters: {xTrigger.enabled ? "enabled" : "disabled"} ·{" "}
-                {xTrigger.ready ? (
-                  <span className="text-ink-cream-2">ready</span>
-                ) : (
-                  <span>not ready — {xTrigger.notReadyReason}</span>
-                )}
-                {xEngine !== storedXEngine && " · engine change applies on Save"}
-              </p>
-            )}
-          </div>
-        </LedgerSection>
-
-        <LedgerSection
-          eyebrow="05.6 · LinkedIn replies"
-          lede="Let LinkedIn automation tools report a real prospect reply so OneShot stops every live email cadence. Connection acceptance alone does nothing."
-        >
-          <Field
-            label="LINKEDIN_REPLY_WEBHOOK_SECRET"
-            hint={`${hintFor(sources["LINKEDIN_REPLY_WEBHOOK_SECRET"])} Use a random 32+ character bearer secret.`}
-          >
-            <Input
-              type="password"
-              placeholder={sources["LINKEDIN_REPLY_WEBHOOK_SECRET"] ? "(unchanged)" : ""}
-              value={secrets["LINKEDIN_REPLY_WEBHOOK_SECRET"] ?? ""}
-              onChange={(e) => setSecret("LINKEDIN_REPLY_WEBHOOK_SECRET", e.target.value)}
-              autoComplete="new-password"
-            />
-          </Field>
-        </LedgerSection>
-
-        <LedgerSection
-          eyebrow="05.75 · Finder access"
-          lede="Optional credentials for richer GitHub and Luma discovery. They are stored in the same local .env."
-        >
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-            {(["GITHUB_TOKEN", "LUMA_SESSION_COOKIE"] as const).map((key) => (
-              <Field key={key} label={SECRET_LABELS[key] ?? key} hint={hintFor(sources[key])}>
-                <Input
-                  type="password"
-                  placeholder={sources[key] ? "(unchanged)" : ""}
-                  value={secrets[key] ?? ""}
-                  onChange={(e) => setSecret(key, e.target.value)}
-                  autoComplete="new-password"
-                />
-              </Field>
-            ))}
-          </div>
-        </LedgerSection>
-
-        <LedgerSection
-          eyebrow="06 · Email transport"
-          lede="The sender rotation pool. Each prospect sticks to the identity that first emailed them; new prospects go to the identity with the most capacity left today."
-        >
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-            {(status.data?.identities?.length ?? 0) > 0 && (
-              <div className="md:col-span-2 flex flex-col gap-2">
-                <span className="ln-eyebrow">Sender identities</span>
-                {status
-                  .data!.identities.filter((i) => !removedIdentityIds.includes(i.id))
-                  .map((i) => (
-                    <div
-                      key={i.id}
-                      className="flex items-center gap-3 border border-ink-rule rounded-[var(--radius-sm)] px-3 py-2"
-                    >
-                      <Badge
-                        tone={
-                          i.provider === "gmail"
-                            ? "signal"
-                            : i.provider === "smartlead"
-                              ? "spend"
-                              : "receipt"
-                        }
-                      >
-                        {i.provider}
-                      </Badge>
-                      <div className="flex min-w-0 flex-col">
-                        <span className="truncate text-[13px] text-ink-cream">
-                          {i.mailbox && i.sendingDomain
-                            ? `${i.mailbox}@${i.sendingDomain}`
-                            : (i.address ?? i.sendingDomain ?? i.label ?? i.id)}
-                        </span>
-                        <span className="ln-mono text-[11px] text-ink-muted">
-                          {i.domainSentToday !== i.sentToday
-                            ? `today ${i.sentToday} · domain ${i.domainSentToday}/${i.capToday ?? "∞"} shared`
-                            : `today ${i.sentToday}/${i.capToday ?? "∞"}`}
-                          {i.warmup
-                            ? ` · warm-up ${i.warmup.startPerDay}+${i.warmup.incrementPerWeek}/wk`
-                            : ""}
-                          {i.legacy ? " · legacy (auto-derived)" : ""}
-                        </span>
-                      </div>
-                      <div className="ml-auto flex items-center gap-2">
-                        <Input
-                          className="h-7 w-20 text-[12px]"
-                          placeholder={i.maxPerDay == null ? "∞" : String(i.maxPerDay)}
-                          value={capEdits[i.id] ?? ""}
-                          onChange={(e) => setCapEdits((m) => ({ ...m, [i.id]: e.target.value }))}
-                          aria-label={`max sends per day for ${i.id}`}
-                        />
-                        <span className="ln-mono text-[10.5px] text-ink-faint">max/day</span>
-                        {!i.legacy && (
-                          <Button
-                            type="button"
-                            variant="secondary"
-                            className="h-7 px-2 text-[11px]"
-                            onClick={() => setRemovedIdentityIds((ids) => [...ids, i.id])}
-                          >
-                            Remove
-                          </Button>
-                        )}
-                      </div>
-                    </div>
-                  ))}
-                <div className="mt-1 flex flex-wrap items-center gap-3">
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    disabled={!gmailCredsReady}
-                    onClick={() => {
-                      window.location.href = "/api/gmail/auth/start";
-                    }}
-                  >
-                    <Mail size={12} />
-                    Connect Gmail account
-                  </Button>
-                  <span className="text-[12px] text-ink-faint">
-                    {gmailCredsReady
-                      ? "Opens Google consent — sign in as the account you want to send from."
-                      : "Save GMAIL_CLIENT_ID + GMAIL_CLIENT_SECRET below first (Google Cloud OAuth client, Desktop type, Gmail API enabled)."}
-                  </span>
-                </div>
-                <span className="text-[12px] text-ink-faint">
-                  CLI alternative:{" "}
-                  <code className="ln-mono text-[11.5px] text-ink-cream-2">
-                    bun run cli -- gmail auth
-                  </code>
-                  . Cap and removal changes apply on Save. Removing an identity blocks sends to
-                  prospects pinned to it until it's restored.
-                </span>
-
-                {/* Provisioned OneShot domains — a paused domain sends nothing until resumed. */}
-                {provisionedDomains.length > 0 && (
-                  <div className="mt-3 flex flex-col gap-2 border-t border-ink-rule pt-3">
-                    <span className="ln-eyebrow">Provisioned domains</span>
-                    {provisionedDomains.map((d) => {
-                      const paused = d.poolStatus === "paused" || d.poolStatus === "removed";
-                      const tone =
-                        d.poolStatus === "active"
-                          ? "receipt"
-                          : d.poolStatus === "warming"
-                            ? "spend"
-                            : "blocked";
-                      const busy =
-                        domainAction.isPending && domainAction.variables?.domain === d.domain;
-                      return (
-                        <div
-                          key={d.domain}
-                          className="flex items-center gap-3 border border-ink-rule rounded-[var(--radius-sm)] px-3 py-2"
-                        >
-                          <Badge tone={tone}>{d.poolStatus}</Badge>
-                          <span className="truncate text-[13px] text-ink-cream">{d.domain}</span>
-                          <span className="ln-mono text-[11px] text-ink-muted">
-                            sent {d.dailySentCount}/{d.dailySendLimit}/day
-                            {d.warmupScore != null ? ` · warmth ${d.warmupScore}` : ""}
-                          </span>
-                          <Button
-                            type="button"
-                            variant="secondary"
-                            disabled={busy}
-                            className="ml-auto h-7 px-2 text-[11px]"
-                            onClick={() =>
-                              domainAction.mutate({
-                                domain: d.domain,
-                                action: paused ? "resume" : "pause",
-                              })
-                            }
-                            {...readOnly}
-                          >
-                            {busy ? "…" : paused ? "Resume" : "Pause"}
-                          </Button>
-                        </div>
-                      );
-                    })}
-                  </div>
-                )}
-
-                {/* Add OneShot sender — domain + mailbox join the rotation pool on Save. */}
-                <div className="mt-3 flex flex-col gap-2 border-t border-ink-rule pt-3">
-                  <span className="ln-eyebrow">Add OneShot sender</span>
-                  {pendingAdds.length > 0 && (
-                    <div className="flex flex-col gap-1.5">
-                      {pendingAdds.map((a) => (
-                        <div
-                          key={`${a.mailbox || "agent"}@${a.sendingDomain}`}
-                          className="flex items-center gap-3 border border-dashed border-ink-rule rounded-[var(--radius-sm)] px-3 py-1.5"
-                        >
-                          <Badge tone="receipt">oneshot</Badge>
-                          <span className="truncate text-[13px] text-ink-cream">
-                            {a.mailbox.trim() || "agent"}@{a.sendingDomain}
-                          </span>
-                          <span className="ln-mono text-[11px] text-ink-muted">
-                            {a.maxPerDay.trim() ? `cap ${a.maxPerDay.trim()}/day` : "warm-up ramp"}
-                          </span>
-                          <Button
-                            type="button"
-                            variant="secondary"
-                            className="ml-auto h-7 px-2 text-[11px]"
-                            onClick={() => setPendingAdds((p) => p.filter((x) => x !== a))}
-                          >
-                            Remove
-                          </Button>
-                        </div>
-                      ))}
-                    </div>
-                  )}
-                  <div className="flex flex-wrap items-end gap-2">
-                    <Field label="Domain" className="min-w-[200px]">
-                      {/* Pick a warmed domain or type a new one (auto-provisions on first send). */}
-                      <Input
-                        list="oneshot-domains"
-                        placeholder="acme.com"
-                        value={addDomain}
-                        onChange={(e) => setAddDomain(e.target.value)}
-                        aria-label="sending domain"
-                      />
-                      <datalist id="oneshot-domains">
-                        {provisionedDomains.map((d) => (
-                          <option key={d.domain} value={d.domain}>
-                            {d.poolStatus !== "active" ? d.poolStatus : ""}
-                            {d.warmupScore != null ? ` warmth ${d.warmupScore}` : ""}
-                          </option>
-                        ))}
-                      </datalist>
-                    </Field>
-                    <Field label="Mailbox" className="w-32">
-                      <Input
-                        placeholder={founderLocalpart || "agent"}
-                        value={addMailbox}
-                        onChange={(e) => setAddMailbox(e.target.value)}
-                        aria-label="mailbox local-part"
-                      />
-                    </Field>
-                    <Field label="Max/day" className="w-24">
-                      <Input
-                        placeholder="ramp"
-                        value={addCap}
-                        onChange={(e) => setAddCap(e.target.value)}
-                        aria-label="max sends per day"
-                      />
-                    </Field>
-                    <Button
-                      type="button"
-                      variant="secondary"
-                      className="mb-[2px]"
-                      disabled={!addDomain.trim()}
-                      onClick={() => {
-                        const d = addDomain.trim().toLowerCase();
-                        if (!d) return;
-                        setPendingAdds((p) => [
-                          ...p,
-                          { sendingDomain: d, mailbox: addMailbox, maxPerDay: addCap },
-                        ]);
-                        setAddDomain("");
-                        setAddMailbox("");
-                        setAddCap("");
-                      }}
-                    >
-                      Add
-                    </Button>
-                  </div>
-                  {/* A domain outside the warmed pool goes out cold — pinned sends bypass warm-up. */}
-                  {addDomain.trim() &&
-                    provisionedDomains.length > 0 &&
-                    !provisionedDomains.some(
-                      (d) => d.domain.toLowerCase() === addDomain.trim().toLowerCase(),
-                    ) && (
-                      <span className="text-[12px] text-ink-blocked">
-                        {addDomain.trim()} isn't in your warmed pool — it auto-provisions on first
-                        send and goes out cold (server warm-up is bypassed for chosen domains). The
-                        client ramp below is your only throttle.
-                      </span>
-                    )}
-                  {/* Reputation + send limits are per-domain, not per-mailbox. */}
-                  {addDomain.trim() &&
-                    (status.data?.identities ?? []).some(
-                      (i) => i.sendingDomain?.toLowerCase() === addDomain.trim().toLowerCase(),
-                    ) && (
-                      <span className="text-[12px] text-ink-faint">
-                        Heads up: {addDomain.trim()} already sends in your pool. Reputation and the
-                        platform daily limit are per-domain — extra mailboxes share them, and their
-                        client caps stack on the same domain.
-                      </span>
-                    )}
-                  <span className="text-[12px] text-ink-faint">
-                    Blank mailbox defaults to your first name; blank cap uses the cold-start warm-up
-                    ramp (10/day, +10/week, max 50). Domains you send from are pinned, so the client
-                    ramp — not the server — paces warm-up. New senders join the pool on Save.
-                  </span>
-                </div>
-              </div>
-            )}
-            {/* Smartlead lives OUTSIDE the identities guard — connecting it is how an
-                empty pool gets rebuilt. */}
-            <div className="md:col-span-2 flex flex-col gap-2">
-              {/* Smartlead accounts — send-only; replies live in Smartlead's own UI. */}
-              <div className="mt-3 flex flex-col gap-2">
-                <span className="ln-eyebrow">Smartlead accounts</span>
-                <Field
-                  label="SMARTLEAD_API_KEY"
-                  hint={hintFor(sources["SMARTLEAD_API_KEY"])}
-                  className="max-w-md"
-                >
-                  <Input
-                    type="password"
-                    placeholder={sources["SMARTLEAD_API_KEY"] ? "(unchanged)" : ""}
-                    value={secrets["SMARTLEAD_API_KEY"] ?? ""}
-                    onChange={(e) => {
-                      setSecret("SMARTLEAD_API_KEY", e.target.value);
-                      // A different key = a different Smartlead workspace: the
-                      // loaded list and any staged picks belong to the OLD key
-                      // and would register mailboxes the new key can't send as.
-                      setSmartleadAccounts(null);
-                      setPendingSmartleadAdds([]);
-                    }}
-                    autoComplete="new-password"
-                  />
-                </Field>
-                <div className="flex flex-wrap items-center gap-3">
-                  <Button
-                    type="button"
-                    variant="secondary"
-                    disabled={!smartleadKeyReady || loadSmartlead.isPending}
-                    onClick={() => loadSmartlead.mutate()}
-                    {...readOnly}
-                  >
-                    {loadSmartlead.isPending ? "Loading…" : "Load Smartlead accounts"}
-                  </Button>
-                  <span className="text-[12px] text-ink-faint">
-                    {smartleadKeyReady
-                      ? "Lists the mailboxes connected to your Smartlead workspace — Smartlead does the warmup, this pool does the sending."
-                      : "Paste your Smartlead API key first (Smartlead → Settings → API)."}
-                  </span>
-                </div>
-                {smartleadAccounts && smartleadAccounts.length === 0 && (
-                  <span className="text-[12px] text-ink-faint">
-                    No email accounts connected in Smartlead yet.
-                  </span>
-                )}
-                {smartleadAccounts?.map((a) => {
-                  const staged = pendingSmartleadAdds.some((p) => p.address === a.fromEmail);
-                  const blocked = !a.isSmtpSuccess;
-                  return (
-                    <div
-                      key={a.id}
-                      className="flex items-center gap-3 border border-ink-rule rounded-[var(--radius-sm)] px-3 py-2"
-                    >
-                      <div className="flex min-w-0 flex-col">
-                        <span className="truncate text-[13px] text-ink-cream">{a.fromEmail}</span>
-                        <span className="ln-mono text-[11px] text-ink-muted">
-                          {a.messagePerDay != null ? `${a.messagePerDay}/day` : "no cap"}
-                          {a.warmupStatus
-                            ? ` · warmup ${a.warmupStatus.toLowerCase()}${a.warmupReputation ? ` (${a.warmupReputation})` : ""}`
-                            : ""}
-                          {blocked ? " · SMTP broken — reconnect in Smartlead" : ""}
-                        </span>
-                      </div>
-                      <div className="ml-auto">
-                        {a.alreadyRegistered ? (
-                          <span className="ln-mono text-[11px] text-ink-faint">in pool</span>
-                        ) : staged ? (
-                          <Button
-                            type="button"
-                            variant="secondary"
-                            className="h-7 px-2 text-[11px]"
-                            onClick={() =>
-                              setPendingSmartleadAdds((p) =>
-                                p.filter((x) => x.address !== a.fromEmail),
-                              )
-                            }
-                          >
-                            Undo
-                          </Button>
-                        ) : (
-                          <Button
-                            type="button"
-                            variant="secondary"
-                            className="h-7 px-2 text-[11px]"
-                            disabled={blocked}
-                            onClick={() =>
-                              setPendingSmartleadAdds((p) => [
-                                ...p,
-                                {
-                                  address: a.fromEmail,
-                                  label: a.fromName ?? "",
-                                  providerMessagePerDay: a.messagePerDay,
-                                },
-                              ])
-                            }
-                          >
-                            Add
-                          </Button>
-                        )}
-                      </div>
-                    </div>
-                  );
-                })}
-                {pendingSmartleadAdds.length > 0 && (
-                  <span className="text-[12px] text-ink-faint">
-                    {pendingSmartleadAdds.length} Smartlead mailbox
-                    {pendingSmartleadAdds.length === 1 ? "" : "es"} staged — applied on Save with
-                    the cold-start warm-up ramp (capped at Smartlead's own per-mailbox limit).
-                  </span>
-                )}
-              </div>
-            </div>
-            {!gmailCredsReady && (
-              <>
-                <Field label="GMAIL_CLIENT_ID" hint={hintFor(sources["GMAIL_CLIENT_ID"])}>
-                  <Input
-                    type="password"
-                    placeholder={sources["GMAIL_CLIENT_ID"] ? "(unchanged)" : ""}
-                    value={secrets["GMAIL_CLIENT_ID"] ?? ""}
-                    onChange={(e) => setSecret("GMAIL_CLIENT_ID", e.target.value)}
-                    autoComplete="new-password"
-                  />
-                </Field>
-                <Field label="GMAIL_CLIENT_SECRET" hint={hintFor(sources["GMAIL_CLIENT_SECRET"])}>
-                  <Input
-                    type="password"
-                    placeholder={sources["GMAIL_CLIENT_SECRET"] ? "(unchanged)" : ""}
-                    value={secrets["GMAIL_CLIENT_SECRET"] ?? ""}
-                    onChange={(e) => setSecret("GMAIL_CLIENT_SECRET", e.target.value)}
-                    autoComplete="new-password"
-                  />
-                </Field>
-              </>
-            )}
-            {isLegacyPool && (
-              <Field label="Provider" className="md:col-span-2">
-                <Select
-                  value={emailProvider}
-                  onChange={(e) => setEmailProvider(e.target.value as typeof emailProvider)}
-                >
-                  <option value="oneshot">OneShot SDK (wallet-owned sending domain)</option>
-                  <option value="gmail">Gmail / Google Workspace (your own account)</option>
-                </Select>
-              </Field>
-            )}
-            {isLegacyPool && emailProvider === "gmail" && (
-              <>
-                <div className="ln-note text-[12px] text-ink-muted md:col-span-2">
-                  Emails send from your authenticated Gmail address — the sending domain above is
-                  ignored. Easiest path: run{" "}
-                  <code className="ln-mono text-[11.5px] text-ink-cream-2">
-                    bun run cli -- gmail auth
-                  </code>{" "}
-                  to authorize in the browser and fill all three values automatically.
-                </div>
-                <Field
-                  label="GMAIL_REFRESH_TOKEN"
-                  hint={hintFor(sources["GMAIL_REFRESH_TOKEN"])}
-                  className="md:col-span-2"
-                >
-                  <Input
-                    type="password"
-                    placeholder={sources["GMAIL_REFRESH_TOKEN"] ? "(unchanged)" : ""}
-                    value={secrets["GMAIL_REFRESH_TOKEN"] ?? ""}
-                    onChange={(e) => setSecret("GMAIL_REFRESH_TOKEN", e.target.value)}
-                    autoComplete="new-password"
-                  />
-                </Field>
-              </>
-            )}
-          </div>
-        </LedgerSection>
-
-        <LedgerSection
-          eyebrow="07 · Telemetry"
-          lede="Off by default for your data, on by default for command-run counts. Opt out at will."
-        >
-          <Checkbox
-            label="Send anonymous opt-out telemetry (commands run, no data, no PII — see TELEMETRY.md)"
-            checked={telemetryEnabled}
-            onChange={(e) => setTelemetryEnabled(e.target.checked)}
-          />
-        </LedgerSection>
-
-        <div
-          className="sticky bottom-0 z-10 flex items-center justify-between gap-4 border-b border-t border-ink-rule bg-ink-bg/90 px-6 py-3 backdrop-blur-[2px]"
-          data-foot-bar
-        >
-          <div className="font-mono text-[11px] text-ink-muted">
-            {save.isSuccess && savedAt != null ? (
-              <span className="text-[color:var(--ink-receipt-2)]">
-                · saved to <span className="text-ink-cream-2">.env</span>
-              </span>
-            ) : (
-              <span className="text-ink-faint">changes apply on save</span>
-            )}
-          </div>
-          <Button
-            type="submit"
-            disabled={save.isPending || deriveBrief.isPending}
-            {...readOnly}
-            title={
-              deriveBrief.isPending ? "wait for the brief derive to finish, then save" : undefined
-            }
-          >
-            <Save size={14} />
-            {save.isPending ? "Saving…" : "Save changes"}
-          </Button>
+      <div className="grid grid-cols-1 lg:grid-cols-[200px_1fr]">
+        <div className="lg:sticky lg:top-0 lg:self-start">
+          <SectionNav dirty={dirty} active={active} />
         </div>
-      </form>
+        <div className="min-w-0">
+          {status.data ? (
+            <Sections
+              status={status.data}
+              xTrigger={xTrigger}
+              homeDir={homeDir}
+              proposedIcp={proposedIcp}
+              packLabel={packLabel}
+              smartleadKeyEpoch={smartleadKeyEpoch}
+              onSmartleadKeySaved={bumpSmartleadKey}
+              onDirtyChange={onDirtyChange}
+            />
+          ) : status.error ? (
+            <div className="px-6 py-8 font-mono text-[12px] text-[color:var(--ink-blocked-2)]">
+              couldn't load setup · {status.error.message}
+            </div>
+          ) : (
+            <div className="flex flex-col gap-8 px-6 py-8">
+              {SECTIONS.slice(0, 4).map((s) => (
+                <Skeleton key={s.id} lines={3} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   );
 }
 
-function LedgerSection({
-  eyebrow,
-  lede,
-  children,
+function Sections({
+  status,
+  xTrigger,
+  homeDir,
+  proposedIcp,
+  packLabel,
+  smartleadKeyEpoch,
+  onSmartleadKeySaved,
+  onDirtyChange,
 }: {
-  eyebrow: string;
-  lede?: string;
-  children: ReactNode;
+  status: SetupStatus;
+  xTrigger: TriggerView | undefined;
+  homeDir: string;
+  proposedIcp?: string;
+  packLabel?: string;
+  smartleadKeyEpoch: number;
+  onSmartleadKeySaved: () => void;
+  onDirtyChange: DirtyReporter;
 }) {
+  const { cfg, sources } = status;
+  const common = { cfg, sources, onDirtyChange };
+  const isLegacyPool = status.identities?.[0]?.legacy ?? true;
   return (
-    <section className="grid grid-cols-1 gap-6 border-b border-ink-rule px-6 py-6 lg:grid-cols-[220px_1fr]">
-      <div>
-        <div className="ln-eyebrow">{eyebrow}</div>
-        {lede && <p className="ln-note mt-2 max-w-[32ch] text-[13px] text-ink-cream-2">{lede}</p>}
-      </div>
-      <div>{children}</div>
-    </section>
+    <>
+      <FounderSection {...common} />
+      <IcpSection {...common} proposedIcp={proposedIcp} packLabel={packLabel} />
+      <SocialProofSection {...common} />
+      <ProductBriefSection {...common} />
+      <LlmSection {...common} />
+      <WalletSection {...common} homeDir={homeDir} />
+      <XSection sources={sources} xTrigger={xTrigger} onDirtyChange={onDirtyChange} />
+      <EmailTransportSection
+        status={status}
+        smartleadKeyEpoch={smartleadKeyEpoch}
+        onDirtyChange={onDirtyChange}
+      />
+      <ReviewQueueSection {...common} />
+      <TelemetrySection {...common} />
+      <CredentialsSection
+        {...common}
+        homeDir={homeDir}
+        isLegacyPool={isLegacyPool}
+        xEngine={storedXEngine(xTrigger)}
+        onSmartleadKeySaved={onSmartleadKeySaved}
+      />
+    </>
   );
-}
-
-function hintFor(source: "env" | "file" | null | undefined): string {
-  if (source === "env") return "Currently from shell env. Leave blank to keep.";
-  if (source === "file") return "Currently from this workspace's .env. Leave blank to keep.";
-  return "Not set yet.";
 }

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -340,6 +340,17 @@ export interface SetupRequest {
   llmModel?: string;
   telemetryEnabled?: boolean;
   walletMode?: WalletMode;
+  /**
+   * Default /queue review order. `undefined` = leave unchanged. Anything but
+   * the two literals is ignored (keeps the current value).
+   */
+  queueReviewOrder?: "ranked" | "newest";
+  /**
+   * Install-wide IANA time zone (issue #451 surfaced it — no other writer
+   * exists). `undefined` = leave unchanged; `null` or blank = clear back to the
+   * runtime zone; otherwise must be a valid IANA name or the request is 400.
+   */
+  timezone?: string | null;
   secrets?: Partial<
     Record<
       | "OPENROUTER_API_KEY"


### PR DESCRIPTION
Closes #451.

## What

`/setup` is rebuilt as eleven sections, each with its own draft, validation and Save. The monolithic form (1,441 lines, 35 `useState`, one submit that wrote prose + LLM + wallet + sender pool + staged Smartlead mailboxes + the X trigger config in one go) is gone.

| Section | Saves |
|---|---|
| Founder profile · ICP · Social proof · Product brief · LLM provider · Wallet & spend · Telemetry | only that section's dirty keys via the existing sparse `POST /api/setup` |
| X / Twitter | the engine on the x-reposters trigger config |
| Email transport | caps, removals, OneShot + Smartlead adds and the legacy provider in **one** request (pause/resume stays immediate) |
| Review queue & time zone (**new**) | `queueReviewOrder`, `timezone` — real config keys that had no UI and no CLI |
| Credentials | every secret, grouped by service, "in use" badges keyed off the saved provider / wallet mode / X engine |

## The three defects from the issue

1. **Refetch clobbering.** `useSectionDraft` overlays a draft on a normalized projection of the server value; nothing is ever copied into local state, so a `["setup"]` refetch can only change keys the founder hasn't touched. Save posts dirty keys, awaits the refetch, then drops only the draft keys whose current value still equals what was sent — a keystroke during the in-flight save survives. The `briefDirty` / `spendCeilingDirty` / `icpFromPack` / `xEngineSeeded` refs are gone.
2. **No validation.** `apps/web/src/lib/setupValidation.ts` (pure, tested): email, bare domain, spend ceiling (`Number()` like the CLI, so `2usd` is rejected), IANA time zone, identity caps. Errors render through `Field`'s existing `error` prop for dirty keys; Save is disabled while any exist.
3. **Caps failed open.** Client: `parseCap` accepts digits only; blank means uncapped on an identity row and warm-up ramp on the add-sender form. Server: `identityUpdates[].maxPerDay` / `addIdentities[].maxPerDay` must be `null` or a finite number ≥ 0, else `400` — the old coercion to `null` is removed. `validateSpendCeiling` and the new time-zone check also answer `400` instead of the generic `500`, and every check runs before any write.

## Other changes

- `SetupRequest` + `mergeSetupConfig` gain `queueReviewOrder` and `timezone`; the client cfg type declares both (optional).
- `postJson` surfaces the server's `{ error }` string like `getJson` already did, so a 400 toasts the real message.
- `Field.label` accepts a node (for the "in use" badge). No call-site changes.
- `/queue`'s "Accept in Setup" navigates to `/setup#icp`.
- Smartlead account loading uses the **saved** key only, since the key input now lives in Credentials; the button's caption links there. Saving a new Smartlead key clears the loaded list and staged picks (same invariant as before).
- Leave guard via TanStack `useBlocker` (window + in-app navigation) while any section is dirty.

## Verified

Gate: `bun run fmt:check && bun run typecheck && bun run lint && bun run test` clean. 2919 → 3014 tests / 221 files; STATUS.md updated in this commit.

In a browser, against a scratch `ONESHOT_GTM_HOME` (never the real config):

- Typed into Founder name, saved Telemetry (invalidates `["setup"]`): the edit survived, rail showed the section dirty, server had only the telemetry change.
- Typed `abc` into an identity cap: inline error, Save disabled. Cleared it and saved: identity uncapped.
- Staged a Gmail identity removal, then saved **LLM provider** only: server pool unchanged, staging still on screen. Saved Email transport: removal + cap applied in one POST.
- Raw `POST /api/setup` with `maxPerDay: "x"` plus `founderName: "HACKED"`: `400` with the message, config untouched.
- Credentials-only save: `.env` written chmod 600, config content unchanged.
- `Mars/Olympus` time zone: inline error; `Europe/Vienna` + ranked order: persisted.
- Cold load of `/setup#credentials`: scrolled to the section after data arrived.
- With a dirty section, clicking Queue was blocked.

## Notes for the reviewer

- The issue says #435 shipped section status badges on `/setup`. PR #437 never touched `setup.tsx`; there was nothing to preserve.
- Saving any section still rewrites `config.json` (the server always calls `saveConfig`), so its mtime changes on a credentials-only save even though the content doesn't. Same as before; out of scope.
- No component tests exist in this repo (node env, no DOM), so the browser checks above are manual; the pure helpers and the route are unit-tested.

https://claude.ai/code/session_011meFPo97LhmTcoNRwyPQeS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Redesigned setup experience with navigable sections, deep links, unsaved-change protection, and per-section save status.
  - Added configuration for credentials, email identities, wallets, AI providers, founder details, social proof, product briefs, ICP, telemetry, and X integrations.
  - Added review-queue ordering and installation time-zone settings.
  - Added validation and clearer error messages for domains, emails, caps, spending limits, and time zones.
  - Added support for deriving product briefs and ICP suggestions from URLs or domains.
- **Bug Fixes**
  - Setup changes now validate before saving, preventing partial updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->