### PR TITLE
fix(setup): stop /setup waiting on the platform's domain list

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 51 CLI commands, 23 plays, 15 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-04** · Bun 1.3.13 · OneShot SDK 0.22.0 · **3014 tests / 221 files** · typecheck + oxlint + oxfmt clean.
+Last verified **2026-09-04** · Bun 1.3.13 · OneShot SDK 0.22.0 · **3018 tests / 222 files** · typecheck + oxlint + oxfmt clean.
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/apps/server/__tests__/setup-domains-route.test.ts
+++ b/apps/server/__tests__/setup-domains-route.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DomainPoolEntry } from "@oneshot-gtm/core";
+
+// The provisioned-domain list rides GET /api/setup only as a quick
+// best-effort copy: the platform's listDomains has taken 60–80s, and the
+// sectioned /setup page renders nothing until the status call answers. The
+// status call must give up on the list fast (and answer with []), while the
+// dedicated /api/setup/domains route waits longer.
+
+let listImpl: () => Promise<DomainPoolEntry[]> = () => Promise.resolve([]);
+
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    listSendingDomains: () => listImpl(),
+    identityCapacities: () => new Map(),
+  };
+});
+
+const { getSetupDomains, getSetupStatus } = await import("../src/api/setup.ts");
+
+const ENTRY: DomainPoolEntry = {
+  domain: "mail.acme.dev",
+  pool_status: "active",
+  warmup_score: 80,
+  daily_send_limit: 50,
+  daily_sent_count: 3,
+} as DomainPoolEntry;
+
+function req(path: string): Request {
+  return new Request(`http://localhost${path}`, {
+    headers: { host: "127.0.0.1:3030" },
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("GET /api/setup — provisioned domains are best-effort", () => {
+  it("includes the pool when the platform answers promptly", async () => {
+    listImpl = () => Promise.resolve([ENTRY]);
+    const res = await getSetupStatus(req("/api/setup"));
+    const body = (await res.json()) as { provisionedDomains: Array<{ domain: string }> };
+    expect(body.provisionedDomains).toEqual([
+      {
+        domain: "mail.acme.dev",
+        poolStatus: "active",
+        warmupScore: 80,
+        dailySendLimit: 50,
+        dailySentCount: 3,
+      },
+    ]);
+  });
+
+  it("answers with [] once the short deadline passes instead of stalling the page", async () => {
+    listImpl = () => new Promise(() => {}); // hangs forever, like a slow platform
+    const pending = getSetupStatus(req("/api/setup"));
+    await vi.advanceTimersByTimeAsync(3_000);
+    const res = await pending;
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { provisionedDomains: unknown[]; cfg: unknown };
+    expect(body.provisionedDomains).toEqual([]);
+    expect(body.cfg).toBeTruthy();
+  });
+});
+
+describe("GET /api/setup/domains — the dedicated, patient route", () => {
+  it("still waits past the status call's deadline", async () => {
+    let resolve!: (v: DomainPoolEntry[]) => void;
+    listImpl = () => new Promise<DomainPoolEntry[]>((r) => (resolve = r));
+    const pending = getSetupDomains(req("/api/setup/domains"));
+    await vi.advanceTimersByTimeAsync(10_000); // well past 2.5s
+    resolve([ENTRY]);
+    const body = (await (await pending).json()) as {
+      provisionedDomains: Array<{ domain: string }>;
+    };
+    expect(body.provisionedDomains.map((d) => d.domain)).toEqual(["mail.acme.dev"]);
+  });
+
+  it("gives up with [] at its own deadline rather than hanging", async () => {
+    listImpl = () => new Promise(() => {});
+    const pending = getSetupDomains(req("/api/setup/domains"));
+    await vi.advanceTimersByTimeAsync(46_000);
+    const body = (await (await pending).json()) as { provisionedDomains: unknown[] };
+    expect(body.provisionedDomains).toEqual([]);
+  });
+});

--- a/apps/server/src/api/setup.ts
+++ b/apps/server/src/api/setup.ts
@@ -11,6 +11,7 @@ import {
   saveSecrets,
   secretSource,
   secretsPath,
+  withDeadline,
   type DomainPoolEntry,
   type EmailIdentity,
   type OneShotConfig,
@@ -75,16 +76,39 @@ function domainViews(entries: DomainPoolEntry[]): DomainPoolView[] {
 }
 
 /**
- * Best-effort provisioned-domain pool for the setup UI. Swallows every failure
- * (transient OR auth) to `[]` so the setup page always renders — a missing
- * domain list degrades the picker, it shouldn't 500 the whole status call.
+ * How long GET /api/setup waits for the platform's domain list before
+ * answering without it. The sectioned /setup page (issue #451) renders
+ * nothing until this call returns, and `listDomains` has been observed
+ * taking 60–80s — so the status call carries only a quick best-effort copy
+ * and the picker fetches the full list separately via /api/setup/domains.
  */
-async function provisionedDomainViews(): Promise<DomainPoolView[]> {
+const SETUP_STATUS_DOMAINS_DEADLINE_MS = 2_500;
+/** The dedicated domain-list route can wait longer; it's off the page's critical path. */
+const SETUP_DOMAINS_DEADLINE_MS = 45_000;
+
+/**
+ * Best-effort provisioned-domain pool for the setup UI. Swallows every failure
+ * (transient, auth, OR the deadline) to `[]` so the setup page always renders —
+ * a missing domain list degrades the picker, it shouldn't 500 or stall the
+ * status call. `[]` means "unknown", not "no domains owned".
+ */
+async function provisionedDomainViews(deadlineMs: number): Promise<DomainPoolView[]> {
   try {
-    return domainViews(await listSendingDomains());
+    return domainViews(
+      await withDeadline(listSendingDomains(), deadlineMs, "provisioned domain list"),
+    );
   } catch {
     return [];
   }
+}
+
+/** GET /api/setup/domains — the provisioned pool alone, for the sender picker. */
+export async function getSetupDomains(req: Request): Promise<Response> {
+  return jsonResponse(
+    { provisionedDomains: await provisionedDomainViews(SETUP_DOMAINS_DEADLINE_MS) },
+    200,
+    req,
+  );
 }
 
 export async function getSetupStatus(req: Request): Promise<Response> {
@@ -93,7 +117,7 @@ export async function getSetupStatus(req: Request): Promise<Response> {
     {
       cfg: publicCfg(cfg),
       identities: identityViews(cfg),
-      provisionedDomains: await provisionedDomainViews(),
+      provisionedDomains: await provisionedDomainViews(SETUP_STATUS_DOMAINS_DEADLINE_MS),
       secretsPath: secretsPath(),
       sources: {
         OPENROUTER_API_KEY: secretSource("OPENROUTER_API_KEY"),

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -17,7 +17,7 @@ import { listReceipts, getReceipt } from "./api/receipts.ts";
 import { draftReplyRoute, listInboxRoute, saveDraftRoute, sendReplyRoute } from "./api/inbox.ts";
 import { listPlays, setCadenceRoute } from "./api/plays.ts";
 import { measureCac, measureRocs, measureRocsByGoal, recordOutcome } from "./api/measure.ts";
-import { setup, getSetupStatus } from "./api/setup.ts";
+import { setup, getSetupDomains, getSetupStatus } from "./api/setup.ts";
 import { gmailAuthCallbackRoute, startGmailAuthRoute } from "./api/gmail-auth.ts";
 import { smartleadAccountsRoute } from "./api/smartlead.ts";
 import { deriveBriefRoute } from "./api/derive-brief.ts";
@@ -97,6 +97,7 @@ const routes: RouteEntry[] = [
   route("GET", "/api/measure/rocs-by-goal", measureRocsByGoal),
   route("POST", "/api/measure/outcome", recordOutcome),
   route("GET", "/api/setup", getSetupStatus),
+  route("GET", "/api/setup/domains", getSetupDomains),
   route("POST", "/api/setup", setup),
   route("POST", "/api/domains/resume", resumeDomainRoute),
   route("POST", "/api/domains/pause", pauseDomainRoute),

--- a/apps/web/scripts/capture-fixtures.ts
+++ b/apps/web/scripts/capture-fixtures.ts
@@ -63,6 +63,7 @@ const SEEDS = [
   "/plays",
   "/inbox",
   "/setup",
+  "/setup/domains",
 
   // Cadences: the "show all" toggle. `sinceRun` is only reachable from a link a
   // finished run writes, and no run can finish here.

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -221,6 +221,13 @@ export const api = {
       secretsPath: string;
       sources: Record<string, "env" | "file" | null>;
     }>("/setup"),
+  /**
+   * The provisioned OneShot domain pool alone. Off the /setup critical path:
+   * the platform's listDomains has been seen taking 60–80s, so the status
+   * call above carries only a ~2.5s best-effort copy and the sender picker
+   * refines it from this route.
+   */
+  setupDomains: () => getJson<{ provisionedDomains: DomainPoolView[] }>("/setup/domains"),
   setup: (req: SetupRequest) => postJson<{ ok: boolean }>("/setup", req),
   deriveIcp: (domain: string) => postJson<DeriveIcpResult>("/setup/derive-icp", { domain }),
   deriveBrief: (urls: string[]) => postJson<DeriveBriefResult>("/setup/derive-brief", { urls }),

--- a/apps/web/src/components/setup/EmailTransportSection.tsx
+++ b/apps/web/src/components/setup/EmailTransportSection.tsx
@@ -1,4 +1,4 @@
-import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Mail } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
@@ -44,7 +44,18 @@ export function EmailTransportSection({
   const qc = useQueryClient();
   const { cfg, sources } = status;
   const identities = status.identities ?? [];
-  const provisionedDomains = status.provisionedDomains ?? [];
+  // The status call carries only a quick best-effort copy of the domain pool
+  // (the platform's listDomains can take a minute); the dedicated route waits
+  // longer and refines the picker once it lands. Either way the form renders.
+  const domains = useQuery({
+    queryKey: ["setup", "domains"],
+    queryFn: api.setupDomains,
+    staleTime: 60_000,
+  });
+  const provisionedDomains =
+    domains.data?.provisionedDomains && domains.data.provisionedDomains.length > 0
+      ? domains.data.provisionedDomains
+      : (status.provisionedDomains ?? []);
   // Legacy single-identity mode = the pool is auto-derived from emailProvider.
   // Once a real pool exists, the provider select is inert (routing is
   // pool-driven) — hide it instead of misleading.


### PR DESCRIPTION
Follow-up to #536.

## Problem

After the rebuild, `/setup` renders nothing until `GET /api/setup` answers, and that handler awaited `listSendingDomains()`. Against the live platform that call is currently taking **60–80 s** on both workspace servers (measured with curl on 3031 and 3032 after the restart). The old page hid this by rendering empty inputs first and hydrating later; the new page sat on skeletons for over a minute, which reads as "can't see anything".

## Fix

- `GET /api/setup` waits at most **2.5 s** for the domain pool (`withDeadline` from core) and otherwise answers with `provisionedDomains: []`. That is the contract `listSendingDomains` already documents: `[]` means unknown, not "no domains owned".
- New `GET /api/setup/domains` returns the pool alone with a **45 s** deadline. The Email-transport section fetches it as its own query (`["setup", "domains"]`, 60 s stale time) and prefers it once loaded, so the sender picker fills in without holding the page. Pause/resume already invalidates `["setup"]`, which covers the child key.
- The demo capture script enumerates the new route.

## Tests

`apps/server/__tests__/setup-domains-route.test.ts` (fake timers): status call includes the pool when it answers promptly; answers `[]` with the rest of the payload once 2.5 s pass on a hung platform; the dedicated route still waits past that and returns the pool; it gives up with `[]` at 45 s.

Gate clean. 3014 → 3018 tests / 222 files; STATUS.md updated.

Not in scope: why the platform's `listDomains` is that slow right now. Worth a look on the SDK side if it persists.

https://claude.ai/code/session_011meFPo97LhmTcoNRwyPQeS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated setup flow for loading provisioned email domains.
  * Email transport settings now refresh available domains periodically and display the most current options.
  * Added improved handling for domain-list loading, including graceful empty results when retrieval is delayed or unavailable.

* **Tests**
  * Expanded verification coverage for setup domain loading, response timeouts, and provisioned-domain display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->