### PR TITLE
fix(setup): credential badges say what the runtime reads, not what the mode selects

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 51 CLI commands, 23 plays, 15 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-04** · Bun 1.3.13 · OneShot SDK 0.22.0 · **3014 tests / 221 files** · typecheck + oxlint + oxfmt clean.
+Last verified **2026-09-04** · Bun 1.3.13 · OneShot SDK 0.22.0 · **3016 tests / 222 files** · typecheck + oxlint + oxfmt clean.
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/apps/web/__tests__/setupWalletKeys.test.ts
+++ b/apps/web/__tests__/setupWalletKeys.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { CDP_KEYS, walletKeysInUse } from "../src/components/setup/constants.ts";
+
+// Mirrors core's initAgent precedence: AGENT_PRIVATE_KEY wins whenever it is
+// set, otherwise the CDP trio. The saved walletMode plays no part — a badge
+// keyed off it said "in use" next to empty CDP fields on an install that runs
+// on a private key.
+describe("walletKeysInUse", () => {
+  it("prefers the private key when it is set, wherever it comes from", () => {
+    expect(walletKeysInUse({ AGENT_PRIVATE_KEY: "file" })).toEqual(["AGENT_PRIVATE_KEY"]);
+    expect(walletKeysInUse({ AGENT_PRIVATE_KEY: "env", CDP_API_KEY_ID: "file" })).toEqual([
+      "AGENT_PRIVATE_KEY",
+    ]);
+  });
+
+  it("falls back to the CDP trio otherwise, even when none of them is set yet", () => {
+    expect(walletKeysInUse({ CDP_API_KEY_ID: "file" })).toEqual(CDP_KEYS);
+    expect(walletKeysInUse({})).toEqual(CDP_KEYS);
+    expect(walletKeysInUse({ AGENT_PRIVATE_KEY: null })).toEqual(CDP_KEYS);
+  });
+});

--- a/apps/web/src/components/setup/CredentialsSection.tsx
+++ b/apps/web/src/components/setup/CredentialsSection.tsx
@@ -3,13 +3,37 @@ import type { XEngine } from "@oneshot-gtm/shared-types";
 import { api } from "../../api/client.ts";
 import { Badge } from "../primitives/Badge.tsx";
 import { Field, Input } from "../primitives/Field.tsx";
-import { hintFor, LLM_KEY, SECRET_LABELS, X_OAUTH_KEYS, type SecretKey } from "./constants.ts";
+import {
+  CDP_KEYS,
+  hintFor,
+  LLM_KEY,
+  SECRET_LABELS,
+  walletKeysInUse,
+  X_OAUTH_KEYS,
+  type SecretKey,
+} from "./constants.ts";
 import { SectionShell } from "./SectionShell.tsx";
 import { useSectionDraft } from "./useSectionDraft.ts";
 import { useSectionSave } from "./useSectionSave.ts";
 import { useReportDirty, type SectionProps } from "./types.ts";
 
 type Secrets = Record<SecretKey, string>;
+
+/**
+ * The badge next to a key. "in use" means the runtime reads THIS key today
+ * (selected by the saved preferences AND present). A selected key that is
+ * missing is "needed" when core can't run without it, "optional" otherwise —
+ * never "in use", which read as a contradiction next to an empty field.
+ */
+function keyState(
+  g: Pick<Group, "inUse" | "optional">,
+  k: SecretKey,
+  isSet: boolean,
+): { label: string; tone: "receipt" | "spend" | "neutral" } {
+  if (!g.inUse(k)) return { label: isSet ? "set · not in use" : "not in use", tone: "neutral" };
+  if (isSet) return { label: "in use", tone: "receipt" };
+  return g.optional ? { label: "optional", tone: "neutral" } : { label: "needed", tone: "spend" };
+}
 
 /** Every secret starts blank on screen — the server never echoes a value. */
 const EMPTY: Secrets = Object.fromEntries(
@@ -20,8 +44,13 @@ interface Group {
   title: string;
   caption?: string;
   keys: readonly SecretKey[];
-  /** Keys the saved preferences currently route through, for the "in use" badge. */
+  /** Keys the runtime routes through given the saved preferences (and what is set). */
   inUse: (k: SecretKey) => boolean;
+  /**
+   * Nothing core needs stops working without these (a finder, a channel, an
+   * integration). A missing key is "optional", not "needed".
+   */
+  optional?: boolean;
   /** Extra hint for one key (e.g. the legacy-only refresh token). */
   keyHint?: Partial<Record<SecretKey, string>>;
   placeholder?: Partial<Record<SecretKey, string>>;
@@ -81,9 +110,9 @@ export function CredentialsSection({
       },
       {
         title: "Wallet",
-        caption: `Keys live only in ${homeDir}/.env chmod 600. Nothing leaves your machine.`,
-        keys: ["CDP_API_KEY_ID", "CDP_API_KEY_SECRET", "CDP_WALLET_SECRET", "AGENT_PRIVATE_KEY"],
-        inUse: (k) => (cfg.walletMode === "cdp") === (k !== "AGENT_PRIVATE_KEY"),
+        caption: `Keys live only in ${homeDir}/.env chmod 600. Nothing leaves your machine. The runtime uses AGENT_PRIVATE_KEY whenever it is set, otherwise the three CDP keys — the saved wallet mode only decides which ones the CLI wizard asks for.`,
+        keys: [...CDP_KEYS, "AGENT_PRIVATE_KEY"],
+        inUse: (k) => walletKeysInUse(sources).includes(k),
         placeholder: { AGENT_PRIVATE_KEY: "0x..." },
       },
       {
@@ -93,6 +122,7 @@ export function CredentialsSection({
         keys: ["GMAIL_CLIENT_ID", "GMAIL_CLIENT_SECRET", "GMAIL_REFRESH_TOKEN"],
         inUse: (k) =>
           k === "GMAIL_REFRESH_TOKEN" ? isLegacyPool && cfg.emailProvider === "gmail" : true,
+        optional: true,
         keyHint: {
           GMAIL_REFRESH_TOKEN:
             "Legacy single-identity Gmail mode only. With a rotation pool, Connect Gmail account stores tokens per identity instead.",
@@ -103,12 +133,14 @@ export function CredentialsSection({
         caption: "Smartlead → Settings → API. Then load and pick mailboxes in Email transport.",
         keys: ["SMARTLEAD_API_KEY"],
         inUse: () => true,
+        optional: true,
       },
       {
         title: "X / Twitter",
         caption: `Which set is used follows the engine saved on the x-reposters trigger (${xEngine === "xapi" ? "X API" : "twitterapi.io"}).`,
         keys: [...X_OAUTH_KEYS, "TWITTERAPI_IO_KEY"],
         inUse: (k) => (xEngine === "xapi") === (k !== "TWITTERAPI_IO_KEY"),
+        optional: true,
       },
       {
         title: "LinkedIn replies",
@@ -116,6 +148,7 @@ export function CredentialsSection({
           "Lets LinkedIn automation tools report a real prospect reply so OneShot stops every live email cadence. Connection acceptance alone does nothing.",
         keys: ["LINKEDIN_REPLY_WEBHOOK_SECRET"],
         inUse: () => true,
+        optional: true,
         keyHint: { LINKEDIN_REPLY_WEBHOOK_SECRET: "Use a random 32+ character bearer secret." },
       },
       {
@@ -123,9 +156,10 @@ export function CredentialsSection({
         caption: "Optional credentials for richer GitHub and Luma discovery.",
         keys: ["GITHUB_TOKEN", "LUMA_SESSION_COOKIE"],
         inUse: () => true,
+        optional: true,
       },
     ],
-    [cfg.llmProvider, cfg.walletMode, cfg.emailProvider, homeDir, isLegacyPool, xEngine],
+    [cfg.llmProvider, cfg.emailProvider, sources, homeDir, isLegacyPool, xEngine],
   );
 
   return (
@@ -145,7 +179,7 @@ export function CredentialsSection({
             {g.caption && <p className="clear-both text-[12px] text-ink-faint">{g.caption}</p>}
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               {g.keys.map((k) => {
-                const inUse = g.inUse(k);
+                const state = keyState(g, k, Boolean(sources[k]));
                 const extra = g.keyHint?.[k];
                 return (
                   <Field
@@ -153,15 +187,9 @@ export function CredentialsSection({
                     label={
                       <>
                         {SECRET_LABELS[k]}
-                        {inUse ? (
-                          <Badge tone="receipt" className="ml-2 align-middle">
-                            in use
-                          </Badge>
-                        ) : (
-                          <Badge tone="neutral" className="ml-2 align-middle">
-                            not in use
-                          </Badge>
-                        )}
+                        <Badge tone={state.tone} className="ml-2 align-middle">
+                          {state.label}
+                        </Badge>
                       </>
                     }
                     hint={extra ? `${hintFor(sources[k])} ${extra}` : hintFor(sources[k])}

--- a/apps/web/src/components/setup/WalletSection.tsx
+++ b/apps/web/src/components/setup/WalletSection.tsx
@@ -3,11 +3,10 @@ import type { WalletMode } from "@oneshot-gtm/shared-types";
 import { Field, Input, Select } from "../primitives/Field.tsx";
 import { parseSpendCeiling } from "../../lib/setupValidation.ts";
 import { KeyStatusLine } from "./KeyStatusLine.tsx";
+import { walletKeysInUse } from "./constants.ts";
 import { SectionShell } from "./SectionShell.tsx";
 import { useConfigSection } from "./useConfigSection.ts";
 import type { SectionProps } from "./types.ts";
-
-const CDP_KEYS = ["CDP_API_KEY_ID", "CDP_API_KEY_SECRET", "CDP_WALLET_SECRET"] as const;
 
 export function WalletSection({
   cfg,
@@ -38,13 +37,22 @@ export function WalletSection({
     onDirtyChange,
   });
 
+  // What the runtime will actually pick up (core ignores walletMode).
+  const inUse = walletKeysInUse(sources);
+  const modeMatchesRuntime =
+    (server.walletMode === "private-key") === (inUse[0] === "AGENT_PRIVATE_KEY");
+
   return (
     <SectionShell
       {...s.shell}
       lede={`Keys live only in ${homeDir}/.env chmod 600. Nothing leaves your machine.`}
     >
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-        <Field label="Wallet mode" className="md:col-span-2">
+        <Field
+          label="Wallet mode"
+          className="md:col-span-2"
+          hint="Decides which keys `init` and `config keys` ask for. At runtime AGENT_PRIVATE_KEY is used whenever it is set, otherwise the three CDP keys — regardless of this setting."
+        >
           <Select
             value={s.values.walletMode}
             onChange={(e) => s.set("walletMode", e.target.value as WalletMode)}
@@ -55,12 +63,12 @@ export function WalletSection({
         </Field>
         <KeyStatusLine
           className="md:col-span-2"
-          keys={server.walletMode === "cdp" ? CDP_KEYS : ["AGENT_PRIVATE_KEY"]}
+          keys={inUse}
           sources={sources}
           note={
-            s.values.walletMode !== server.walletMode
-              ? "after saving, add the keys for this mode in Credentials"
-              : undefined
+            modeMatchesRuntime
+              ? undefined
+              : `the runtime is on ${inUse.length === 1 ? "the private key" : "CDP"} because of what is set in Credentials`
           }
         />
         <Field

--- a/apps/web/src/components/setup/constants.ts
+++ b/apps/web/src/components/setup/constants.ts
@@ -44,6 +44,18 @@ export const X_OAUTH_KEYS = [
   "X_ACCESS_SECRET",
 ] as const;
 
+export const CDP_KEYS = ["CDP_API_KEY_ID", "CDP_API_KEY_SECRET", "CDP_WALLET_SECRET"] as const;
+
+/**
+ * Which wallet keys the runtime actually uses. Core's initAgent ignores the
+ * saved `walletMode`: AGENT_PRIVATE_KEY wins whenever it is set, else the CDP
+ * trio. The mode only decides which keys the CLI wizards prompt for, so any
+ * "in use" marker must be derived from what is set, not from the mode.
+ */
+export function walletKeysInUse(sources: Record<string, KeySource>): readonly SecretKey[] {
+  return sources["AGENT_PRIVATE_KEY"] ? ["AGENT_PRIVATE_KEY"] : CDP_KEYS;
+}
+
 export function hintFor(source: KeySource): string {
   if (source === "env") return "Currently from shell env. Leave blank to keep.";
   if (source === "file") return "Currently from this workspace's .env. Leave blank to keep.";


### PR DESCRIPTION
Follow-up to #536, from a founder screenshot: the Wallet group showed three empty CDP fields badged **in use** and the populated `AGENT_PRIVATE_KEY` badged **not in use**.

## Two bugs

1. **The badge trusted `walletMode`, which the runtime ignores.** Core's `initAgent` uses `AGENT_PRIVATE_KEY` whenever it is set and the CDP trio otherwise; `walletMode` only decides which keys `init` / `config keys` prompt for (the only readers are the two CLI wizards). Both workspaces have `walletMode: "cdp"` saved while running on a private key, so the badge was confidently wrong. New `walletKeysInUse(sources)` in `components/setup/constants.ts` mirrors core's precedence and drives both the Credentials badge and the Wallet section's key-status line. The Wallet mode field's hint now says what the setting actually does.
2. **"in use" next to an empty field is a contradiction in every group**, not just wallet. The badge is three-state now:
   - `in use` (receipt): selected by the saved preferences **and** set.
   - `needed` (spend): selected, missing, and core can't run without it (LLM key for the saved provider, wallet keys).
   - `optional` (neutral): selected, missing, but only an integration or finder depends on it (Gmail, Smartlead, X, LinkedIn, GitHub, Luma).
   - `not in use` / `set · not in use` (neutral): the current preference doesn't route through this key.

## Tests

`apps/web/__tests__/setupWalletKeys.test.ts` pins the precedence (private key wins from env or file; CDP trio otherwise, even when unset). Gate clean.

STATUS.md is set to this branch's count (3016 / 222). #537 also touches that line; whichever merges second needs a one-line bump.

https://claude.ai/code/session_011meFPo97LhmTcoNRwyPQeS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Updates**
  - Wallet setup now reflects which credentials are actively used at runtime.
  - Agent private key credentials take precedence over configured wallet mode; otherwise, CDP credentials are used.
  - Wallet settings explain when saved credentials override the selected mode.
  - Credential badges distinguish active, required, optional, and configured-but-unused credentials.
  - Gmail, Smartlead, X/Twitter, LinkedIn, and Finder credentials are identified as optional.

- **Verification**
  - Expanded automated coverage for wallet credential selection.
  - Verification now reports 3,020 tests across 223 files, dated September 5, 2026.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->