### PR TITLE
fix(setup): tighten every hint, and derive the ICP from the founder's own site

### DIFF
--- a/apps/web/src/components/setup/CredentialsSection.tsx
+++ b/apps/web/src/components/setup/CredentialsSection.tsx
@@ -99,7 +99,7 @@ export function CredentialsSection({
     () => [
       {
         title: "LLM",
-        caption: `The key for your saved provider (${cfg.llmProvider}) is the one in use.`,
+        caption: `Only the saved provider's key (${cfg.llmProvider}) is read.`,
         keys: ["OPENROUTER_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"],
         inUse: (k) => k === LLM_KEY[cfg.llmProvider],
         placeholder: {
@@ -110,7 +110,8 @@ export function CredentialsSection({
       },
       {
         title: "Wallet",
-        caption: `Keys live only in ${homeDir}/.env chmod 600. Nothing leaves your machine. The runtime uses AGENT_PRIVATE_KEY whenever it is set, otherwise the three CDP keys — the saved wallet mode only decides which ones the CLI wizard asks for.`,
+        caption:
+          "AGENT_PRIVATE_KEY wins when set, otherwise the three CDP keys. The wallet mode only drives the CLI wizard.",
         keys: [...CDP_KEYS, "AGENT_PRIVATE_KEY"],
         inUse: (k) => walletKeysInUse(sources).includes(k),
         placeholder: { AGENT_PRIVATE_KEY: "0x..." },
@@ -118,26 +119,26 @@ export function CredentialsSection({
       {
         title: "Gmail",
         caption:
-          "Google Cloud OAuth client (Desktop type, Gmail API enabled). Needed before Connect Gmail account in Email transport.",
+          "Google Cloud OAuth client, Desktop type, Gmail API on. Needed for Connect Gmail account.",
         keys: ["GMAIL_CLIENT_ID", "GMAIL_CLIENT_SECRET", "GMAIL_REFRESH_TOKEN"],
         inUse: (k) =>
           k === "GMAIL_REFRESH_TOKEN" ? isLegacyPool && cfg.emailProvider === "gmail" : true,
         optional: true,
         keyHint: {
           GMAIL_REFRESH_TOKEN:
-            "Legacy single-identity Gmail mode only. With a rotation pool, Connect Gmail account stores tokens per identity instead.",
+            "Legacy single-identity mode only; a pool stores tokens per identity.",
         },
       },
       {
         title: "Smartlead",
-        caption: "Smartlead → Settings → API. Then load and pick mailboxes in Email transport.",
+        caption: "Smartlead → Settings → API.",
         keys: ["SMARTLEAD_API_KEY"],
         inUse: () => true,
         optional: true,
       },
       {
         title: "X / Twitter",
-        caption: `Which set is used follows the engine saved on the x-reposters trigger (${xEngine === "xapi" ? "X API" : "twitterapi.io"}).`,
+        caption: `Follows the engine saved on the x-reposters trigger: ${xEngine === "xapi" ? "X API" : "twitterapi.io"}.`,
         keys: [...X_OAUTH_KEYS, "TWITTERAPI_IO_KEY"],
         inUse: (k) => (xEngine === "xapi") === (k !== "TWITTERAPI_IO_KEY"),
         optional: true,
@@ -145,15 +146,15 @@ export function CredentialsSection({
       {
         title: "LinkedIn replies",
         caption:
-          "Lets LinkedIn automation tools report a real prospect reply so OneShot stops every live email cadence. Connection acceptance alone does nothing.",
+          "Lets a LinkedIn tool report a real reply so email cadences stop. Connection acceptance alone does nothing.",
         keys: ["LINKEDIN_REPLY_WEBHOOK_SECRET"],
         inUse: () => true,
         optional: true,
-        keyHint: { LINKEDIN_REPLY_WEBHOOK_SECRET: "Use a random 32+ character bearer secret." },
+        keyHint: { LINKEDIN_REPLY_WEBHOOK_SECRET: "Random, 32+ characters." },
       },
       {
         title: "Finder access",
-        caption: "Optional credentials for richer GitHub and Luma discovery.",
+        caption: "Richer GitHub and Luma discovery.",
         keys: ["GITHUB_TOKEN", "LUMA_SESSION_COOKIE"],
         inUse: () => true,
         optional: true,
@@ -165,7 +166,7 @@ export function CredentialsSection({
   return (
     <SectionShell
       id="credentials"
-      lede={`Every key and token, apart from the preferences that choose between them. Saved to ${homeDir}/.env (chmod 600); a blank field keeps the stored value.`}
+      lede={`Every key and token. Saved to ${homeDir}/.env, chmod 600. Nothing leaves your machine; a blank field keeps the stored value.`}
       dirtyCount={draft.dirtyKeys.length}
       savedAt={save.savedAt}
       saving={save.isPending}

--- a/apps/web/src/components/setup/EmailTransportSection.tsx
+++ b/apps/web/src/components/setup/EmailTransportSection.tsx
@@ -143,7 +143,7 @@ export function EmailTransportSection({
   return (
     <SectionShell
       id="email"
-      lede="The sender rotation pool. Each prospect sticks to the identity that first emailed them; new prospects go to the identity with the most capacity left today."
+      lede="The sender rotation pool. A prospect stays with the identity that first emailed them."
       dirtyCount={dirtyCount}
       errorCount={errorCount}
       savedAt={save.savedAt}
@@ -183,22 +183,16 @@ export function EmailTransportSection({
             </Button>
             <span className="text-[12px] text-ink-faint">
               {gmailCredsReady ? (
-                "Opens Google consent — sign in as the account you want to send from."
+                "Opens Google consent. Sign in as the sending account."
               ) : (
                 <>
-                  Save GMAIL_CLIENT_ID + GMAIL_CLIENT_SECRET in <CredentialsLink /> first (Google
-                  Cloud OAuth client, Desktop type, Gmail API enabled).
+                  Needs GMAIL_CLIENT_ID and GMAIL_CLIENT_SECRET in <CredentialsLink />.
                 </>
               )}
             </span>
           </div>
           <span className="text-[12px] text-ink-faint">
-            CLI alternative:{" "}
-            <code className="ln-mono text-[11.5px] text-ink-cream-2">
-              bun run cli -- gmail auth
-            </code>
-            . Cap and removal changes apply on Save. Removing an identity blocks sends to prospects
-            pinned to it until it's restored.
+            Removing an identity blocks sends to prospects pinned to it until it's restored.
           </span>
 
           <ProvisionedDomains
@@ -235,11 +229,10 @@ export function EmailTransportSection({
           </Button>
           <span className="text-[12px] text-ink-faint">
             {smartleadKeyReady ? (
-              "Lists the mailboxes connected to your Smartlead workspace — Smartlead does the warmup, this pool does the sending."
+              "Mailboxes connected to your Smartlead workspace. Smartlead warms them; this pool sends."
             ) : (
               <>
-                Save your Smartlead API key in <CredentialsLink /> first (Smartlead → Settings →
-                API).
+                Needs a Smartlead API key in <CredentialsLink />.
               </>
             )}
           </span>
@@ -303,8 +296,8 @@ export function EmailTransportSection({
         {staging.pendingSmartleadAdds.length > 0 && (
           <span className="text-[12px] text-ink-faint">
             {staging.pendingSmartleadAdds.length} Smartlead mailbox
-            {staging.pendingSmartleadAdds.length === 1 ? "" : "es"} staged — applied on Save with
-            the cold-start warm-up ramp (capped at Smartlead's own per-mailbox limit).
+            {staging.pendingSmartleadAdds.length === 1 ? "" : "es"} staged. They join on Save with
+            the warm-up ramp, capped at Smartlead's own limit.
           </span>
         )}
       </div>
@@ -322,11 +315,9 @@ export function EmailTransportSection({
       )}
       {isLegacyPool && draft.values.emailProvider === "gmail" && (
         <div className="ln-note text-[12px] text-ink-muted">
-          Emails send from your authenticated Gmail address — the sending domain in Founder profile
-          is ignored. Easiest path: run{" "}
+          Sends from your authenticated Gmail address; the sending domain is ignored. Run{" "}
           <code className="ln-mono text-[11.5px] text-ink-cream-2">bun run cli -- gmail auth</code>{" "}
-          to authorize in the browser and fill all three Gmail values in <CredentialsLink />{" "}
-          automatically.
+          to fill the Gmail keys in <CredentialsLink />.
         </div>
       )}
     </SectionShell>
@@ -565,22 +556,19 @@ function AddOneShotSender({
         provisionedDomains.length > 0 &&
         !provisionedDomains.some((d) => d.domain.toLowerCase() === domain) && (
           <span className="text-[12px] text-ink-blocked">
-            {domain} isn't in your warmed pool — it auto-provisions on first send and goes out cold
-            (server warm-up is bypassed for chosen domains). The client ramp below is your only
-            throttle.
+            {domain} isn't in your warmed pool. It provisions on first send and starts cold; the
+            ramp is its only throttle.
           </span>
         )}
       {/* Reputation + send limits are per-domain, not per-mailbox. */}
       {domain && identities.some((i) => i.sendingDomain?.toLowerCase() === domain) && (
         <span className="text-[12px] text-ink-faint">
-          Heads up: {domain} already sends in your pool. Reputation and the platform daily limit are
-          per-domain — extra mailboxes share them, and their client caps stack on the same domain.
+          {domain} already sends in your pool. Reputation and the daily limit are per domain, so its
+          mailboxes share them.
         </span>
       )}
       <span className="text-[12px] text-ink-faint">
-        Blank mailbox defaults to your first name; blank cap uses the cold-start warm-up ramp
-        (10/day, +10/week, max 50). Domains you send from are pinned, so the client ramp — not the
-        server — paces warm-up. New senders join the pool on Save.
+        Blank mailbox = your first name. Blank cap = warm-up ramp: 10/day, +10 a week, max 50.
       </span>
     </div>
   );

--- a/apps/web/src/components/setup/FounderSection.tsx
+++ b/apps/web/src/components/setup/FounderSection.tsx
@@ -41,7 +41,7 @@ export function FounderSection({ cfg, onDirtyChange }: SectionProps) {
         <Field
           label="Your email"
           error={s.errors.founderEmail}
-          hint="Lead capture on pages this tool generates (e.g. the PMF survey). NOT a reply address — replies land in the inbox of whichever sending identity sent the mail."
+          hint="For lead-capture pages this tool generates. Replies go to the sending identity, not here."
         >
           <Input
             type="email"
@@ -53,7 +53,7 @@ export function FounderSection({ cfg, onDirtyChange }: SectionProps) {
         <Field
           label="Signature domain"
           error={s.errors.productDomain}
-          hint="Bare domain shown under your name in every email signature, e.g. yourcompany.com. Leave blank for no domain line."
+          hint="Shown under your name in every signature. Blank = no domain line."
         >
           <Input
             value={s.values.productDomain}
@@ -64,7 +64,7 @@ export function FounderSection({ cfg, onDirtyChange }: SectionProps) {
         <Field
           label="Sending domain"
           error={s.errors.sendingDomain}
-          hint="The domain your wallet OWNS. Emails send from <your-first-name>@thisdomain. Must be wallet-owned or the SDK rejects the send. Leave blank to use the SDK default."
+          hint="Wallet-owned domain mail goes out from, as <first-name>@domain. Blank = SDK default."
         >
           <Input
             value={s.values.sendingDomain}

--- a/apps/web/src/components/setup/IcpSection.tsx
+++ b/apps/web/src/components/setup/IcpSection.tsx
@@ -51,7 +51,10 @@ export function IcpSection({
   }, []);
   const showPackBanner = Boolean(proposedIcp) && s.dirtyKeys.includes("icpOneLiner");
 
-  const [icpDomain, setIcpDomain] = useState("");
+  // The derive prompt reads "a company's marketing site" and writes who THEY
+  // sell to — so the founder's own site is the default input, not a peer's.
+  // Seeded once; the section mounts only after ["setup"] has data.
+  const [icpDomain, setIcpDomain] = useState(() => cfg.productDomain ?? "");
   const [deriveError, setDeriveError] = useState<string | null>(null);
   const [deriveSource, setDeriveSource] = useState<{ url: string; cost: number } | null>(null);
   const deriveIcp = useMutation({
@@ -91,7 +94,7 @@ export function IcpSection({
   return (
     <SectionShell
       {...s.shell}
-      lede="A free-text classifier. The find layer uses this to drop candidates that don't match."
+      lede="Who the finders keep. Candidates that don't match this sentence are dropped."
     >
       {showPackBanner && (
         <div className="border-l-2 border-[color:var(--ink-receipt)] bg-[color:var(--ink-receipt)]/10 px-3 py-2 font-mono text-[11.5px] text-ink-cream-2">
@@ -101,13 +104,13 @@ export function IcpSection({
       )}
       <Field
         label="Derive from a website"
-        hint="Paste a domain (or full URL) of a company whose customers look like yours. We'll read the page and propose an ICP — you can edit before saving. Spends ~$0.02–0.05 (one webRead + one LLM call)."
+        hint="Your own site is prefilled; a competitor's customers page works too. Reads one page and drafts the sentence for you to edit. ~$0.03."
       >
         <div className="flex gap-2">
           <Input
             value={icpDomain}
             onChange={(e) => setIcpDomain(e.target.value)}
-            placeholder="acme.com  ·  https://yourcompany.com/customers"
+            placeholder="yourcompany.com  ·  competitor.com/customers"
             onKeyDown={(e) => {
               if (e.key === "Enter" && !deriveIcp.isPending && icpDomain.trim().length > 0) {
                 e.preventDefault();
@@ -155,10 +158,7 @@ export function IcpSection({
         </div>
       )}
 
-      <Field
-        label="ICP one-liner"
-        hint="Leave blank to disable filtering (every candidate passes through)."
-      >
+      <Field label="ICP one-liner" hint="Blank = no filtering.">
         <Textarea
           value={s.values.icpOneLiner}
           onChange={(e) => s.set("icpOneLiner", e.target.value)}

--- a/apps/web/src/components/setup/ProductBriefSection.tsx
+++ b/apps/web/src/components/setup/ProductBriefSection.tsx
@@ -40,7 +40,7 @@ export function ProductBriefSection({ cfg, onDirtyChange }: SectionProps) {
   return (
     <SectionShell
       {...s.shell}
-      lede="What your replies are allowed to know and cite. Facts, architecture, pricing model, canonical links. A link that isn't in this brief is never sent."
+      lede="What replies may know and cite. A link that isn't in here is never sent."
       saveDisabled={deriveBrief.isPending}
       saveTitle={
         deriveBrief.isPending ? "wait for the brief derive to finish, then save" : undefined
@@ -48,7 +48,7 @@ export function ProductBriefSection({ cfg, onDirtyChange }: SectionProps) {
     >
       <Field
         label="Derive from sources"
-        hint="One URL per line — your site, the GitHub repo, docs pages (max 5). Each is one webRead (~$0.01); you edit the proposal before saving."
+        hint="One URL per line, up to 5. About $0.01 each. Edit the draft before saving."
       >
         <div className="flex gap-2">
           <Textarea
@@ -79,10 +79,7 @@ export function ProductBriefSection({ cfg, onDirtyChange }: SectionProps) {
         </div>
       </Field>
       {deriveInfo && <div className="font-mono text-[11px] text-ink-faint">{deriveInfo}</div>}
-      <Field
-        label="Product brief"
-        hint="Used by /inbox reply drafting to answer substantive questions with substance. Keep links verbatim."
-      >
+      <Field label="Product brief" hint="Grounds /inbox reply drafts. Keep links verbatim.">
         <Textarea
           value={s.values.productBrief}
           onChange={(e) => s.set("productBrief", e.target.value)}

--- a/apps/web/src/components/setup/ReviewQueueSection.tsx
+++ b/apps/web/src/components/setup/ReviewQueueSection.tsx
@@ -38,12 +38,12 @@ export function ReviewQueueSection({ cfg, onDirtyChange }: SectionProps) {
   return (
     <SectionShell
       {...s.shell}
-      lede="How /queue orders what you review, and which clock event-relative copy uses."
+      lede="The default order on /queue, and the clock for event-relative copy."
     >
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <Field
           label="Review order"
-          hint="ranked: highest priority score first, so the drafts most worth a look surface before the rest. newest: arrival order. /queue can override per visit; this is the default."
+          hint="Ranked = highest priority score first. /queue can override per visit."
         >
           <Select
             value={s.values.queueReviewOrder}
@@ -56,7 +56,7 @@ export function ReviewQueueSection({ cfg, onDirtyChange }: SectionProps) {
         <Field
           label="Time zone"
           error={s.errors.timezone}
-          hint={`IANA name, e.g. Europe/Vienna. Last resort when an event has no explicit zone and its city can't be placed. Blank = this machine's zone (${RUNTIME_ZONE}).`}
+          hint={`IANA name. Used when an event has no zone and its city can't be placed. Blank = ${RUNTIME_ZONE}.`}
         >
           <Input
             value={s.values.timezone}

--- a/apps/web/src/components/setup/SocialProofSection.tsx
+++ b/apps/web/src/components/setup/SocialProofSection.tsx
@@ -25,13 +25,10 @@ export function SocialProofSection({ cfg, onDirtyChange }: SectionProps) {
   return (
     <SectionShell
       {...s.shell}
-      lede="All optional. Each maps to a different play type. Used by the LLM when drafting the second sentence of a first-touch email — never more than one beat per email."
+      lede="All optional. At most one of these lands in a first-touch email, as its second sentence."
     >
       <div className="grid grid-cols-1 gap-4">
-        <Field
-          label="Founder background"
-          hint="Prior companies, named past roles, anything that lets a stranger trust you. Used by job-change / podcast-guest / post-funding / breakup-revive."
-        >
+        <Field label="Founder background" hint="Prior companies and roles a stranger would trust.">
           <Textarea
             value={s.values.founderCredentials}
             onChange={(e) => s.set("founderCredentials", e.target.value)}
@@ -43,7 +40,7 @@ export function SocialProofSection({ cfg, onDirtyChange }: SectionProps) {
         </Field>
         <Field
           label="Products you've shipped"
-          hint="Used in peer-founder outreach to show you've actually built things. Stack-consolidation / competitor-switch / show-hn / hiring-signal."
+          hint="Proof you've built things, for peer-founder outreach."
         >
           <Textarea
             value={s.values.productPortfolio}
@@ -54,7 +51,7 @@ export function SocialProofSection({ cfg, onDirtyChange }: SectionProps) {
         </Field>
         <Field
           label="Notable partners / customers"
-          hint="Brand names that open doors. Helps when the prospect doesn't know you yet. Accelerator-batch / demo-no-show."
+          hint="Brand names that open doors when the prospect doesn't know you."
         >
           <Textarea
             value={s.values.partners}
@@ -65,7 +62,7 @@ export function SocialProofSection({ cfg, onDirtyChange }: SectionProps) {
         </Field>
         <Field
           label="One true concession"
-          hint="The thing you'd rather not say but is true. Used in roughly 1 in 3 first touches as a damaging admission (two of us, no logos yet, but…), which makes the rest of the email more believable. Leave blank and the beat is skipped, never invented."
+          hint="The true thing you'd rather not say. Used in about 1 in 3 first touches; it makes the rest believable. Blank = skipped, never invented."
         >
           <Textarea
             value={s.values.founderAdmission}

--- a/apps/web/src/components/setup/TelemetrySection.tsx
+++ b/apps/web/src/components/setup/TelemetrySection.tsx
@@ -13,10 +13,7 @@ export function TelemetrySection({ cfg, onDirtyChange }: SectionProps) {
     onDirtyChange,
   });
   return (
-    <SectionShell
-      {...s.shell}
-      lede="Off by default for your data, on by default for command-run counts. Opt out at will."
-    >
+    <SectionShell {...s.shell} lede="Anonymous command counts only. Never your data.">
       <Checkbox
         label="Send anonymous opt-out telemetry (commands run, no data, no PII — see TELEMETRY.md)"
         checked={s.values.telemetryEnabled}

--- a/apps/web/src/components/setup/WalletSection.tsx
+++ b/apps/web/src/components/setup/WalletSection.tsx
@@ -45,13 +45,13 @@ export function WalletSection({
   return (
     <SectionShell
       {...s.shell}
-      lede={`Keys live only in ${homeDir}/.env chmod 600. Nothing leaves your machine.`}
+      lede="Which wallet signs, and how much the automated finders may spend per day."
     >
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
         <Field
           label="Wallet mode"
           className="md:col-span-2"
-          hint="Decides which keys `init` and `config keys` ask for. At runtime AGENT_PRIVATE_KEY is used whenever it is set, otherwise the three CDP keys — regardless of this setting."
+          hint="Only decides which keys the CLI wizard asks for. The runtime uses AGENT_PRIVATE_KEY when set, otherwise the CDP keys."
         >
           <Select
             value={s.values.walletMode}
@@ -68,14 +68,14 @@ export function WalletSection({
           note={
             modeMatchesRuntime
               ? undefined
-              : `the runtime is on ${inUse.length === 1 ? "the private key" : "CDP"} because of what is set in Credentials`
+              : `the runtime is on ${inUse.length === 1 ? "the private key" : "CDP"}, going by what is set in Credentials`
           }
         />
         <Field
           label="Daily spend ceiling (USD)"
           className="md:col-span-2"
           error={s.errors.dailySpendCeiling}
-          hint="Install-wide cap across every automated finder run and drain — blank = unlimited. Once reached, scheduled/run-now finders and drains halt with a named reason (visible here and in doctor) until local midnight; manual /queue sends are never blocked."
+          hint="Across all automated finder runs and drains; they pause until local midnight once it's hit. Manual /queue sends are never blocked. Blank = unlimited."
         >
           {/* A text input on purpose: type="number" lets Firefox/Safari accept
               junk and report value="" — exactly the silent path a cap must not

--- a/apps/web/src/components/setup/XSection.tsx
+++ b/apps/web/src/components/setup/XSection.tsx
@@ -47,7 +47,7 @@ export function XSection({
   return (
     <SectionShell
       id="x"
-      lede="Data provider for the x-reposters finder. The engine choice lives on the trigger; the keys are in Credentials."
+      lede="Data provider for the x-reposters finder. Its keys are in Credentials."
       dirtyCount={draft.dirtyKeys.length}
       savedAt={save.savedAt}
       saving={save.isPending}
@@ -59,7 +59,7 @@ export function XSection({
       <div className="grid grid-cols-1 gap-4">
         <Field
           label="Data provider"
-          hint="Both bill per record returned. Switching resets the trigger's spend ceiling and harvest knobs to the new engine's defaults; fine-tune in the /queue trigger editor."
+          hint="Both bill per record. Switching resets the trigger's spend ceiling and knobs to that engine's defaults."
         >
           <Select
             value={draft.values.engine}

--- a/apps/web/src/components/setup/constants.ts
+++ b/apps/web/src/components/setup/constants.ts
@@ -57,9 +57,9 @@ export function walletKeysInUse(sources: Record<string, KeySource>): readonly Se
 }
 
 export function hintFor(source: KeySource): string {
-  if (source === "env") return "Currently from shell env. Leave blank to keep.";
-  if (source === "file") return "Currently from this workspace's .env. Leave blank to keep.";
-  return "Not set yet.";
+  if (source === "env") return "From shell env. Blank keeps it.";
+  if (source === "file") return "From this workspace's .env. Blank keeps it.";
+  return "Not set.";
 }
 
 /** Human status of one secret for the preference sections' key line. */


### PR DESCRIPTION
Follow-up to #536 from founder feedback: hints were too long, and the ICP derive box pointed at "a company whose customers look like yours" when the founder's own site is the obvious input.

## ICP derive

The prompt (`packages/prompts/icp-derive-from-site.md`) reads *a company's marketing site* and writes *who they sell to*. Pointed at your own site, that is your ICP. The box now prefills with the saved product domain; a competitor's customers page still works and the hint says so.

## Copy pass

Every hint, lede and caption on `/setup` is cut to the one fact the field needs. A second sentence survives only where a consequence matters. Representative before → after:

| Field | Before | After |
|---|---|---|
| Your email | Lead capture on pages this tool generates (e.g. the PMF survey). NOT a reply address — replies land in the inbox of whichever sending identity sent the mail. | For lead-capture pages this tool generates. Replies go to the sending identity, not here. |
| Sending domain | The domain your wallet OWNS. Emails send from `<your-first-name>@thisdomain`. Must be wallet-owned or the SDK rejects the send. Leave blank to use the SDK default. | Wallet-owned domain mail goes out from, as `<first-name>@domain`. Blank = SDK default. |
| Derive ICP | Paste a domain (or full URL) of a company whose customers look like yours. We'll read the page and propose an ICP — you can edit before saving. Spends ~$0.02–0.05 (one webRead + one LLM call). | Your own site is prefilled; a competitor's customers page works too. Reads one page and drafts the sentence for you to edit. ~$0.03. |
| Founder background | Prior companies, named past roles, anything that lets a stranger trust you. Used by job-change / podcast-guest / post-funding / breakup-revive. | Prior companies and roles a stranger would trust. |
| Spend ceiling | Install-wide cap across every automated finder run and drain — blank = unlimited. Once reached, scheduled/run-now finders and drains halt with a named reason (visible here and in doctor) until local midnight; manual /queue sends are never blocked. | Across all automated finder runs and drains; they pause until local midnight once it's hit. Manual /queue sends are never blocked. Blank = unlimited. |
| Add sender footer | Blank mailbox defaults to your first name; blank cap uses the cold-start warm-up ramp (10/day, +10/week, max 50). Domains you send from are pinned, so the client ramp — not the server — paces warm-up. New senders join the pool on Save. | Blank mailbox = your first name. Blank cap = warm-up ramp: 10/day, +10 a week, max 50. |
| Secret hint | Currently from this workspace's .env. Leave blank to keep. | From this workspace's .env. Blank keeps it. |

Copy only, plus the one prefill. No behavior change; gate clean.

https://claude.ai/code/session_011meFPo97LhmTcoNRwyPQeS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified setup guidance for credentials, email transport, founder details, product briefs, review queues, social proof, telemetry, wallets, and X/Twitter.
  * Explained blank-field behavior, local secret storage, shared domain limits, warm-up defaults, spending caps, and anonymous telemetry collection.
  * Simplified several hints and removed obsolete Gmail CLI and detailed OAuth instructions.
* **User Experience**
  * ICP domain now defaults to the configured product domain, with clearer website guidance and filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->