### PR TITLE
perf(setup): cache the provisioned domain pool so /setup loads at once

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 51 CLI commands, 23 plays, 15 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-05** · Bun 1.3.13 · OneShot SDK 0.22.0 · **3020 tests / 223 files** · typecheck + oxlint + oxfmt clean.
+Last verified **2026-09-05** · Bun 1.3.13 · OneShot SDK 0.22.0 · **3024 tests / 223 files** · typecheck + oxlint + oxfmt clean.
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/apps/server/__tests__/setup-domains-route.test.ts
+++ b/apps/server/__tests__/setup-domains-route.test.ts
@@ -18,7 +18,8 @@ vi.mock("@oneshot-gtm/core", async () => {
   };
 });
 
-const { getSetupDomains, getSetupStatus } = await import("../src/api/setup.ts");
+const { getSetupDomains, getSetupStatus, resetDomainCacheForTests } =
+  await import("../src/api/setup.ts");
 
 const ENTRY: DomainPoolEntry = {
   domain: "mail.acme.dev",
@@ -36,6 +37,7 @@ function req(path: string): Request {
 
 beforeEach(() => {
   vi.useFakeTimers();
+  resetDomainCacheForTests();
 });
 afterEach(() => {
   vi.useRealTimers();
@@ -67,6 +69,73 @@ describe("GET /api/setup — provisioned domains are best-effort", () => {
     const body = (await res.json()) as { provisionedDomains: unknown[]; cfg: unknown };
     expect(body.provisionedDomains).toEqual([]);
     expect(body.cfg).toBeTruthy();
+  });
+});
+
+describe("domain pool cache", () => {
+  async function domainsOf(res: Response): Promise<string[]> {
+    const body = (await res.json()) as { provisionedDomains: Array<{ domain: string }> };
+    return body.provisionedDomains.map((d) => d.domain);
+  }
+
+  it("a status call that gave up still fills the cache when the platform finally answers", async () => {
+    let resolve!: (v: DomainPoolEntry[]) => void;
+    let calls = 0;
+    listImpl = () => {
+      calls += 1;
+      return new Promise<DomainPoolEntry[]>((r) => (resolve = r));
+    };
+    const first = getSetupStatus(req("/api/setup"));
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(await domainsOf(await first)).toEqual([]); // gave up at 2.5s
+    resolve([ENTRY]); // ...the platform answers at 70s
+    await vi.advanceTimersByTimeAsync(0);
+    // Next load: instant, from cache, no second platform call.
+    const second = getSetupStatus(req("/api/setup"));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(await domainsOf(await second)).toEqual(["mail.acme.dev"]);
+    expect(calls).toBe(1);
+  });
+
+  it("concurrent status + picker calls share one platform request", async () => {
+    let calls = 0;
+    listImpl = () => {
+      calls += 1;
+      return Promise.resolve([ENTRY]);
+    };
+    const [a, b] = await Promise.all([
+      getSetupStatus(req("/api/setup")),
+      getSetupDomains(req("/api/setup/domains")),
+    ]);
+    expect(await domainsOf(a)).toEqual(["mail.acme.dev"]);
+    expect(await domainsOf(b)).toEqual(["mail.acme.dev"]);
+    expect(calls).toBe(1);
+  });
+
+  it("serves a stale pool immediately and refreshes it in the background", async () => {
+    let calls = 0;
+    listImpl = () => {
+      calls += 1;
+      return Promise.resolve(calls === 1 ? [ENTRY] : [{ ...ENTRY, domain: "new.acme.dev" }]);
+    };
+    await getSetupStatus(req("/api/setup")); // fills the cache
+    await vi.advanceTimersByTimeAsync(61_000); // now stale
+    const stale = getSetupStatus(req("/api/setup"));
+    expect(await domainsOf(await stale)).toEqual(["mail.acme.dev"]); // no wait
+    await vi.advanceTimersByTimeAsync(0); // background refresh lands
+    expect(await domainsOf(await getSetupStatus(req("/api/setup")))).toEqual(["new.acme.dev"]);
+    expect(calls).toBe(2);
+  });
+
+  it("never caches an empty answer — it means unknown, not no domains", async () => {
+    let calls = 0;
+    listImpl = () => {
+      calls += 1;
+      return Promise.resolve(calls === 1 ? [] : [ENTRY]);
+    };
+    expect(await domainsOf(await getSetupStatus(req("/api/setup")))).toEqual([]);
+    expect(await domainsOf(await getSetupStatus(req("/api/setup")))).toEqual(["mail.acme.dev"]);
+    expect(calls).toBe(2);
   });
 });
 

--- a/apps/server/src/api/setup.ts
+++ b/apps/server/src/api/setup.ts
@@ -86,26 +86,79 @@ const SETUP_STATUS_DOMAINS_DEADLINE_MS = 2_500;
 /** The dedicated domain-list route can wait longer; it's off the page's critical path. */
 const SETUP_DOMAINS_DEADLINE_MS = 45_000;
 
+/** A pool this old is served immediately but refreshed in the background. */
+const DOMAIN_CACHE_FRESH_MS = 60_000;
+
+/**
+ * The last pool the platform returned, shared by both routes. `[]` is never
+ * cached — it means "unknown", and a later real answer must replace it. One
+ * underlying `listSendingDomains()` is shared between concurrent callers, and
+ * it keeps running after a caller's deadline fires, so a status call that
+ * gave up at 2.5s still fills the cache for the next load.
+ */
+let domainCache: { views: DomainPoolView[]; at: number } | null = null;
+let domainInflight: Promise<DomainPoolView[]> | null = null;
+
+/** Test seam: forget the cached pool between cases. */
+export function resetDomainCacheForTests(): void {
+  domainCache = null;
+  domainInflight = null;
+}
+
+function refreshDomainViews(): Promise<DomainPoolView[]> {
+  if (domainInflight) return domainInflight;
+  const p = listSendingDomains()
+    .then((entries) => {
+      const views = domainViews(entries);
+      if (views.length > 0) domainCache = { views, at: Date.now() };
+      return views;
+    })
+    .finally(() => {
+      if (domainInflight === p) domainInflight = null;
+    });
+  domainInflight = p;
+  return p;
+}
+
 /**
  * Best-effort provisioned-domain pool for the setup UI. Swallows every failure
- * (transient, auth, OR the deadline) to `[]` so the setup page always renders —
- * a missing domain list degrades the picker, it shouldn't 500 or stall the
- * status call. `[]` means "unknown", not "no domains owned".
+ * (transient, auth, OR the deadline) to the last good pool, or `[]` when there
+ * is none, so the setup page always renders — a missing domain list degrades
+ * the picker, it shouldn't 500 or stall the status call.
  */
 async function provisionedDomainViews(deadlineMs: number): Promise<DomainPoolView[]> {
   try {
-    return domainViews(
-      await withDeadline(listSendingDomains(), deadlineMs, "provisioned domain list"),
-    );
+    return await withDeadline(refreshDomainViews(), deadlineMs, "provisioned domain list");
   } catch {
-    return [];
+    return domainCache?.views ?? [];
   }
+}
+
+/**
+ * What the status call carries: a cached pool is served at once (and
+ * refreshed in the background when stale); only a cold cache waits, briefly.
+ */
+async function cachedDomainViews(): Promise<DomainPoolView[]> {
+  if (domainCache) {
+    if (Date.now() - domainCache.at > DOMAIN_CACHE_FRESH_MS) {
+      refreshDomainViews().catch(() => {
+        // background refresh; the stale pool stays until a real answer lands
+      });
+    }
+    return domainCache.views;
+  }
+  return provisionedDomainViews(SETUP_STATUS_DOMAINS_DEADLINE_MS);
 }
 
 /** GET /api/setup/domains — the provisioned pool alone, for the sender picker. */
 export async function getSetupDomains(req: Request): Promise<Response> {
+  const fresh = domainCache && Date.now() - domainCache.at <= DOMAIN_CACHE_FRESH_MS;
   return jsonResponse(
-    { provisionedDomains: await provisionedDomainViews(SETUP_DOMAINS_DEADLINE_MS) },
+    {
+      provisionedDomains: fresh
+        ? domainCache!.views
+        : await provisionedDomainViews(SETUP_DOMAINS_DEADLINE_MS),
+    },
     200,
     req,
   );
@@ -117,7 +170,7 @@ export async function getSetupStatus(req: Request): Promise<Response> {
     {
       cfg: publicCfg(cfg),
       identities: identityViews(cfg),
-      provisionedDomains: await provisionedDomainViews(SETUP_STATUS_DOMAINS_DEADLINE_MS),
+      provisionedDomains: await cachedDomainViews(),
       secretsPath: secretsPath(),
       sources: {
         OPENROUTER_API_KEY: secretSource("OPENROUTER_API_KEY"),


### PR DESCRIPTION
Follow-up to #537. After deploying it, `GET /api/setup` answers in 2.5 s on both workspaces — exactly the give-up deadline, on every load, because the platform's `listDomains` is still taking over a minute and the result was discarded each time.

## Change

`apps/server/src/api/setup.ts` keeps one in-process cache of the last real domain pool, shared by `/api/setup` and `/api/setup/domains`:

- **Fill after give-up.** One underlying `listSendingDomains()` is shared between concurrent callers and keeps running after a caller's `withDeadline` fires. The status call that gives up at 2.5 s still populates the cache when the platform answers at 70 s, so the next load is instant.
- **Stale-while-revalidate.** A cached pool is served immediately. Older than 60 s it is still served, with a background refresh. Only a cold cache waits, and only for the short deadline.
- **Empty is unknown.** `[]` is never cached; a later real answer replaces it.

## Tests

Four new cases in `setup-domains-route.test.ts` (fake timers): fill-after-give-up with a single platform call; concurrent status + picker share one request; stale served at once then refreshed; empty never cached. 3020 → 3024 tests, STATUS.md updated.

Live effect: first `/setup` after a restart waits ≤ 2.5 s once; every later load answers immediately.

https://claude.ai/code/session_011meFPo97LhmTcoNRwyPQeS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved setup domain loading with shared results for concurrent requests.
  - Setup status now remains responsive when domain checks take longer than expected, using the most recent successful results when available.
  - Previously loaded domain results can be shown immediately while newer results refresh in the background.
  - Empty domain results are no longer retained as cached data.
  - The domains view continues to retrieve up-to-date results with an extended wait period.

- **Documentation**
  - Updated verification status to reflect 3,024 tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->