### PR TITLE
perf(setup): only the first cold load waits for the domain pool

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 51 CLI commands, 23 plays, 15 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-05** · Bun 1.3.13 · OneShot SDK 0.22.0 · **3024 tests / 223 files** · typecheck + oxlint + oxfmt clean.
+Last verified **2026-09-05** · Bun 1.3.13 · OneShot SDK 0.22.0 · **3026 tests / 223 files** · typecheck + oxlint + oxfmt clean.
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/apps/server/__tests__/setup-domains-route.test.ts
+++ b/apps/server/__tests__/setup-domains-route.test.ts
@@ -72,12 +72,12 @@ describe("GET /api/setup — provisioned domains are best-effort", () => {
   });
 });
 
-describe("domain pool cache", () => {
-  async function domainsOf(res: Response): Promise<string[]> {
-    const body = (await res.json()) as { provisionedDomains: Array<{ domain: string }> };
-    return body.provisionedDomains.map((d) => d.domain);
-  }
+async function domainsOf(res: Response): Promise<string[]> {
+  const body = (await res.json()) as { provisionedDomains: Array<{ domain: string }> };
+  return body.provisionedDomains.map((d) => d.domain);
+}
 
+describe("domain pool cache", () => {
   it("a status call that gave up still fills the cache when the platform finally answers", async () => {
     let resolve!: (v: DomainPoolEntry[]) => void;
     let calls = 0;
@@ -127,14 +127,46 @@ describe("domain pool cache", () => {
     expect(calls).toBe(2);
   });
 
-  it("never caches an empty answer — it means unknown, not no domains", async () => {
+  it("never caches an empty answer, but doesn't re-ask on every load either", async () => {
     let calls = 0;
     listImpl = () => {
       calls += 1;
       return Promise.resolve(calls === 1 ? [] : [ENTRY]);
     };
     expect(await domainsOf(await getSetupStatus(req("/api/setup")))).toEqual([]);
+    // Within a minute of an empty answer the status call answers at once
+    // with [] — the picker route is the one that retries.
+    expect(await domainsOf(await getSetupStatus(req("/api/setup")))).toEqual([]);
+    expect(calls).toBe(1);
+    await vi.advanceTimersByTimeAsync(61_000);
     expect(await domainsOf(await getSetupStatus(req("/api/setup")))).toEqual(["mail.acme.dev"]);
+    expect(calls).toBe(2);
+  });
+
+  it("only the first cold call waits; later calls answer at once while it is in flight", async () => {
+    listImpl = () => new Promise(() => {}); // the ~70s platform
+    const first = getSetupStatus(req("/api/setup"));
+    await vi.advanceTimersByTimeAsync(100);
+    const startedAt = Date.now();
+    const second = await getSetupStatus(req("/api/setup")); // must not wait its own 2.5s
+    expect(Date.now() - startedAt).toBe(0);
+    expect(await domainsOf(second)).toEqual([]);
+    await vi.advanceTimersByTimeAsync(3_000);
+    expect(await domainsOf(await first)).toEqual([]);
+  });
+
+  it("a failed answer counts as empty: no re-ask for a minute, and the picker route still tries", async () => {
+    let calls = 0;
+    listImpl = () => {
+      calls += 1;
+      return calls === 1 ? Promise.reject(new Error("401 unauthorized")) : Promise.resolve([ENTRY]);
+    };
+    expect(await domainsOf(await getSetupStatus(req("/api/setup")))).toEqual([]);
+    expect(await domainsOf(await getSetupStatus(req("/api/setup")))).toEqual([]);
+    expect(calls).toBe(1);
+    expect(await domainsOf(await getSetupDomains(req("/api/setup/domains")))).toEqual([
+      "mail.acme.dev",
+    ]);
     expect(calls).toBe(2);
   });
 });

--- a/apps/server/src/api/setup.ts
+++ b/apps/server/src/api/setup.ts
@@ -98,11 +98,14 @@ const DOMAIN_CACHE_FRESH_MS = 60_000;
  */
 let domainCache: { views: DomainPoolView[]; at: number } | null = null;
 let domainInflight: Promise<DomainPoolView[]> | null = null;
+/** When the platform last answered empty (or failed) — "unknown", not cached, but not re-asked on every page load either. */
+let lastEmptyAt = 0;
 
 /** Test seam: forget the cached pool between cases. */
 export function resetDomainCacheForTests(): void {
   domainCache = null;
   domainInflight = null;
+  lastEmptyAt = 0;
 }
 
 function refreshDomainViews(): Promise<DomainPoolView[]> {
@@ -111,7 +114,12 @@ function refreshDomainViews(): Promise<DomainPoolView[]> {
     .then((entries) => {
       const views = domainViews(entries);
       if (views.length > 0) domainCache = { views, at: Date.now() };
+      else lastEmptyAt = Date.now();
       return views;
+    })
+    .catch((err: unknown) => {
+      lastEmptyAt = Date.now();
+      throw err;
     })
     .finally(() => {
       if (domainInflight === p) domainInflight = null;
@@ -136,7 +144,11 @@ async function provisionedDomainViews(deadlineMs: number): Promise<DomainPoolVie
 
 /**
  * What the status call carries: a cached pool is served at once (and
- * refreshed in the background when stale); only a cold cache waits, briefly.
+ * refreshed in the background when stale). With a cold cache, only the FIRST
+ * call waits, briefly: while that fetch is still in flight, or after it came
+ * back empty within the last minute, later calls answer at once with `[]`
+ * rather than each paying the deadline again — that was the live pattern
+ * after #540 (platform answers empty after ~70s, so every load waited 2.5s).
  */
 async function cachedDomainViews(): Promise<DomainPoolView[]> {
   if (domainCache) {
@@ -147,6 +159,8 @@ async function cachedDomainViews(): Promise<DomainPoolView[]> {
     }
     return domainCache.views;
   }
+  if (domainInflight) return [];
+  if (Date.now() - lastEmptyAt < DOMAIN_CACHE_FRESH_MS) return [];
   return provisionedDomainViews(SETUP_STATUS_DOMAINS_DEADLINE_MS);
 }
 


### PR DESCRIPTION
Follow-up to #540, measured live: `/api/setup` still took 2.5 s on every load after the restart, and `provisionedDomains` was `[]` every time.

## Why the cache never engaged

The platform answers the domain list **empty** after ~70 s (no transient-failure log line, just an empty pool). Empty is deliberately not cached, since it means "unknown". So each page load started a fresh fetch and paid the full give-up deadline.

## Change

`cachedDomainViews` waits only when nothing is known **and** nothing is in flight:

- first fetch still running → answer at once with `[]`
- empty or failed answer within the last minute → answer at once with `[]`, no re-ask
- otherwise → start the fetch and wait at most 2.5 s (the first cold load only)

`/api/setup/domains` is unchanged and remains the route that retries, so the picker still fills in if the platform recovers.

Net effect after a restart: one load waits up to 2.5 s, every later load is immediate.

## Tests

Two new cases in `setup-domains-route.test.ts`: a second status call during the in-flight fetch does not wait; an empty or rejected answer is not re-asked for a minute while the picker route still tries. 3024 → 3026 tests, STATUS.md updated.

https://claude.ai/code/session_011meFPo97LhmTcoNRwyPQeS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved domain status requests when no domains are available, returning promptly instead of repeatedly waiting for a response.
  - Empty or unsuccessful platform responses are now temporarily reused, reducing repeated delays and requests.
  - Domain fetching can retry after a failed response and refresh results when domains become available.
  - Expanded verification coverage for domain caching, concurrent requests, and recovery scenarios.
- **Documentation**
  - Updated verification status to reflect 3,026 completed tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->