### PR TITLE
feat(web): explain GTM concepts and link to the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,14 +236,17 @@ On a headless box, also run `loginctl enable-linger $USER` once so the user unit
 **Windows (Task Scheduler).** There's no user-service template; schedule the cron-style `find watch --once` instead, which runs all due triggers and exits:
 
 ```powershell
-schtasks /Create /TN "oneshot-gtm find watch" /SC MINUTE /MO 15 `
-  /TR "\"C:\Users\you\.bun\bin\bun.exe\" \"C:\path\to\oneshot-gtm\apps\cli\src\main.ts\" find watch --once --quiet"
+$watchAction = New-ScheduledTaskAction -Execute 'C:\Users\you\.bun\bin\bun.exe' `
+  -Argument '"C:\path\to\oneshot-gtm\apps\cli\src\main.ts" find watch --once --quiet'
+$watchTrigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(1) `
+  -RepetitionInterval (New-TimeSpan -Minutes 15)
+Register-ScheduledTask -TaskName 'oneshot-gtm find watch' -Action $watchAction -Trigger $watchTrigger
 
 # uninstall
-schtasks /Delete /TN "oneshot-gtm find watch" /F
+Unregister-ScheduledTask -TaskName 'oneshot-gtm find watch' -Confirm:$false
 ```
 
-The classic cron route works the same way on any platform: `*/15 * * * * ONESHOT_GTM_HOME=$HOME/.oneshot-gtm /path/to/bun /path/to/apps/cli/src/main.ts find watch --once --quiet`.
+The classic cron route works on POSIX hosts; Windows users should use Task Scheduler: `*/15 * * * * ONESHOT_GTM_HOME=$HOME/.oneshot-gtm /path/to/bun /path/to/apps/cli/src/main.ts find watch --once --quiet`.
 
 **Exit codes for scheduled runs.** `find watch --once` exits `1` when a due trigger errored. Add `--fail-on-empty` and a run that worked but produced nothing exits `2` instead of `0`, with one line on stderr naming the triggers and the zero count — enough for a cron wrapper to tell a dry run from a productive one without reading the ledger. `find drain <play>` takes the same flag. Both are opt-in: without it, exit codes are exactly what they were.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > Open-source GTM agent for technical founders. Pay-per-result, signed receipts, founder-led discipline encoded. Terminal CLI + local web dashboard over one SQLite ledger.
 
-**[oneshot-gtm.com](https://oneshot-gtm.com)** · [what a signed receipt is](https://oneshot-gtm.com/receipt) · [docs](https://docs.oneshotagent.com)
+**[oneshot-gtm.com](https://oneshot-gtm.com)** · [what a signed receipt is](https://oneshot-gtm.com/receipt) · [docs](https://docs.oneshotagent.com/oneshot-gtm/introduction)
 
 ```bash
 bunx oneshot-gtm-server     # dashboard only — published, no clone

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 51 CLI commands, 23 plays, 15 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-05** · Bun 1.3.13 · OneShot SDK 0.22.0 · **3081 tests / 230 files** · typecheck + oxlint + oxfmt clean.
+Last verified **2026-09-05** · Bun 1.3.13 · OneShot SDK 0.22.0 · **3088 tests / 233 files** · typecheck + oxlint + oxfmt clean.
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/apps/cli/__tests__/demo-seed.test.ts
+++ b/apps/cli/__tests__/demo-seed.test.ts
@@ -167,6 +167,8 @@ describe("seedDemoHome", { timeout: SEED_TIMEOUT_MS }, () => {
     expect(Number(orphan[0]?.["n"])).toBe(0);
   });
 
+  // Both tests below seed two disk-backed ledgers. CI takes ~6s for two seeds,
+  // above Vitest's default 5s; leave room for runner I/O without changing assertions.
   it("is deterministic — the same anchor reproduces the same ledger", () => {
     const a = seedDemoHome({ home, anchor: ANCHOR });
     const db1 = open(home);
@@ -180,7 +182,7 @@ describe("seedDemoHome", { timeout: SEED_TIMEOUT_MS }, () => {
 
     expect(after).toBe(before);
     expect(b.counts).toEqual(a.counts);
-  });
+  }, 15_000);
 
   it("re-seeds in place without stacking duplicate rows", () => {
     const first = seedDemoHome({ home, anchor: ANCHOR });
@@ -191,7 +193,7 @@ describe("seedDemoHome", { timeout: SEED_TIMEOUT_MS }, () => {
     const n = rows(db, "SELECT COUNT(*) n FROM prospects");
     db.close();
     expect(Number(n[0]?.["n"])).toBe(first.counts["prospects"]);
-  });
+  }, 15_000);
 
   it("refuses to seed into the real install", () => {
     const real = join(homedir(), ".oneshot-gtm");

--- a/apps/cli/__tests__/docs-reference.test.ts
+++ b/apps/cli/__tests__/docs-reference.test.ts
@@ -1,0 +1,51 @@
+import { Command, Option } from "commander";
+import { describe, expect, it } from "vitest";
+import { mdxText, referenceMatches, renderCliReference } from "../src/docs-reference.ts";
+
+const revision = "a".repeat(40);
+describe("CLI documentation", () => {
+  it("renders nested arguments, inherited flags, choices, defaults and MDX safely without actions", () => {
+    let invoked = false;
+    const root = new Command("gtm").option("-w, --workspace <name>", "workspace");
+    root
+      .command("find")
+      .command("drain <play> [files...]")
+      .description("Pass <input> | {value} & `code`")
+      .requiredOption("--target <file>", "target")
+      .option("--no-browser", "Disable browser")
+      .addOption(
+        new Option("--order <mode>", "Order").choices(["ranked", "newest"]).default("newest"),
+      )
+      .action(() => {
+        invoked = true;
+      });
+    const text = renderCliReference(root, revision);
+    expect(text).toContain("## gtm find drain");
+    expect(text).toContain("| play | Yes |");
+    expect(text).toContain("| files... | No |");
+    expect(text).toContain("--workspace &#60;name&#62;");
+    expect(text).toContain("Pass &#60;input&#62; &#124; &#123;value&#125; &#38; &#96;code&#96;");
+    expect(text).toContain("| --target &#60;file&#62; | target | — | Yes |");
+    expect(text).toContain("true (enabled)");
+    expect(text).toContain('Choices: ranked, newest. | "newest"');
+    expect(invoked).toBe(false);
+    expect(renderCliReference(root, revision)).toBe(text);
+    expect(referenceMatches(text, text.replace(revision, "b".repeat(40)))).toBe(true);
+    expect(referenceMatches(text, text.replace("Disable browser", "Changed"))).toBe(false);
+  });
+
+  it("covers every command and flag in the live tree", async () => {
+    process.env["ONESHOT_GTM_CLI_NO_PARSE"] = "1";
+    const { program } = await import("../src/index.ts");
+    const text = renderCliReference(program, revision);
+    function check(cmd: Command, parent = "") {
+      const path = parent ? `${parent} ${cmd.name()}` : cmd.name();
+      expect(text).toContain(`## ${path}\n`);
+      for (const option of cmd.options) {
+        if (!option.hidden) expect(text).toContain(mdxText(option.flags));
+      }
+      for (const child of cmd.commands) check(child, path);
+    }
+    check(program);
+  });
+});

--- a/apps/cli/src/docs-reference.ts
+++ b/apps/cli/src/docs-reference.ts
@@ -84,7 +84,7 @@ export function renderCliReference(program: Command, revision: string): string {
     for (const child of cmd.commands) visit(child, [...ancestors, cmd]);
   }
   visit(program, []);
-  return lines.join("\n") + "\n";
+  return lines.join("\n").trimEnd() + "\n";
 }
 
 /** Ignore provenance only: unrelated source commits must not make content stale. */

--- a/apps/cli/src/docs-reference.ts
+++ b/apps/cli/src/docs-reference.ts
@@ -1,0 +1,97 @@
+import type { Command } from "commander";
+import { homedir } from "node:os";
+
+/** Escape plain help text, including JSX/expression syntax and table delimiters. */
+export function mdxText(value: string): string {
+  return value
+    .split(/(https?:\/\/[^\s]+)/g)
+    .map((part) => {
+      // CLI examples such as localhost:<port> are literal syntax, not live links.
+      if (/^https?:\/\//.test(part))
+        return "`" + part.replaceAll("`", "").replaceAll("|", "\\|") + "`";
+      return part
+        .replace(/[&<>{}|`*_[\]\\]/g, (char) => `&#${char.charCodeAt(0)};`)
+        .replace(/\r?\n/g, "<br />");
+    })
+    .join("");
+}
+
+export function renderCliReference(program: Command, revision: string): string {
+  if (!/^[a-f0-9]{40}$/.test(revision)) throw new Error("Expected a full Git commit SHA");
+  const lines = [
+    "---",
+    'title: "CLI reference"',
+    'description: "Commands, arguments, and options generated from the OneShot GTM CLI."',
+    "---",
+    "",
+    `{/* Generated from oneshot-agent/oneshot-gtm at ${revision}. Do not edit by hand. */}`,
+    "",
+    "Run these commands with `bun run cli --` from the GTM checkout, or with `oneshot-gtm` after linking the CLI. The CLI is not published to npm.",
+    "",
+    "Options below come from Commander. Runtime-dependent defaults are described in the help text. Use `--help` on any command for local help.",
+    "",
+  ];
+  function visit(cmd: Command, ancestors: Command[]) {
+    const path = [...ancestors, cmd].map((c) => c.name()).join(" ");
+    lines.push(`## ${mdxText(path)}`, "", mdxText(cmd.description()), "");
+    if (cmd.aliases().length) lines.push(`Aliases: ${cmd.aliases().map(mdxText).join(", ")}`, "");
+    if (cmd.registeredArguments.length) {
+      lines.push(
+        "### Arguments",
+        "",
+        "| Argument | Required | Description | Default |",
+        "| --- | --- | --- | --- |",
+      );
+      for (const arg of cmd.registeredArguments) {
+        lines.push(
+          `| ${mdxText(arg.name() + (arg.variadic ? "..." : ""))} | ${arg.required ? "Yes" : "No"} | ${mdxText(arg.description)} | ${mdxText(arg.defaultValue === undefined ? "—" : JSON.stringify(arg.defaultValue))} |`,
+        );
+      }
+      lines.push("");
+    }
+    const seen = new Set<string>();
+    const options = [...ancestors, cmd]
+      .toReversed()
+      .flatMap((owner) => owner.options.map((option) => ({ owner, option })))
+      .filter(({ option }) => {
+        if (option.hidden || seen.has(option.attributeName())) return false;
+        seen.add(option.attributeName());
+        return true;
+      });
+    if (options.length) {
+      lines.push(
+        "### Options",
+        "",
+        "| Flag | Description | Default | Required | Defined on |",
+        "| --- | --- | --- | --- | --- |",
+      );
+      for (const { owner, option } of options) {
+        const description =
+          option.description +
+          (option.argChoices ? ` Choices: ${option.argChoices.join(", ")}.` : "");
+        const fallback =
+          option.defaultValue === undefined
+            ? option.negate
+              ? "true (enabled)"
+              : "—"
+            : JSON.stringify(option.defaultValue).replaceAll(homedir(), "~");
+        lines.push(
+          `| ${mdxText(option.flags)} | ${mdxText(description)} | ${mdxText(option.defaultValueDescription ?? fallback)} | ${option.mandatory ? "Yes" : "No"} | ${mdxText(owner.name())} |`,
+        );
+      }
+      lines.push("");
+    }
+    for (const child of cmd.commands) visit(child, [...ancestors, cmd]);
+  }
+  visit(program, []);
+  return lines.join("\n") + "\n";
+}
+
+/** Ignore provenance only: unrelated source commits must not make content stale. */
+export function referenceMatches(actual: string, expected: string): boolean {
+  return normalizeReference(actual) === normalizeReference(expected);
+}
+
+function normalizeReference(text: string): string {
+  return text.replace(/at [a-f0-9]{40}\. Do not edit by hand\./, "at SOURCE. Do not edit by hand.");
+}

--- a/apps/web/__tests__/concepts.test.ts
+++ b/apps/web/__tests__/concepts.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { CONCEPTS, getConcept, PRIORITY_CONCEPTS } from "../src/lib/concepts.ts";
+
+describe("dashboard concept registry", () => {
+  it("resolves known concepts and rejects unknown or inherited keys", () => {
+    expect(getConcept("rocs")?.href).toBe("https://docs.oneshotagent.com/oneshot-gtm/rocs");
+    expect(getConcept("missing")).toBeUndefined();
+    expect(getConcept("toString")).toBeUndefined();
+  });
+  it("supports concepts before a docs page is available", () => {
+    expect(
+      getConcept("local", { local: { title: "Local", body: "Explanation" } })?.href,
+    ).toBeUndefined();
+    expect(
+      getConcept("local", { local: { title: "Local", body: "Explanation", href: null } })?.href,
+    ).toBeNull();
+  });
+  it("covers all priority components and links only to the GTM docs", () => {
+    expect(Object.keys(PRIORITY_CONCEPTS)).toHaveLength(6);
+    for (const id of Object.values(PRIORITY_CONCEPTS)) expect(getConcept(id)?.body).toBeTruthy();
+    for (const entry of Object.values(CONCEPTS)) {
+      expect(entry.title).toBeTruthy();
+      expect(entry.body.length).toBeGreaterThan(20);
+      expect(new URL(entry.href).origin).toBe("https://docs.oneshotagent.com");
+      expect(new URL(entry.href).pathname).toMatch(/^\/oneshot-gtm\/[a-z-]+$/);
+    }
+  });
+});

--- a/apps/web/__tests__/field.test.ts
+++ b/apps/web/__tests__/field.test.ts
@@ -1,0 +1,44 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { Field, Input, Select, Textarea } from "../src/components/primitives/Field.tsx";
+
+describe("Field accessibility", () => {
+  it("keeps help outside labels and renders error and hint together", () => {
+    const html = renderToStaticMarkup(
+      createElement(Field, {
+        label: "Daily cap",
+        explain: "warmup",
+        hint: "Keep this guidance",
+        error: "Invalid number",
+        children: createElement(
+          "div",
+          null,
+          createElement(Input, { id: "cap", "aria-describedby": "existing" }),
+          createElement("button", { type: "button" }, "Helper"),
+        ),
+      }),
+    );
+    expect(html).toContain('for="cap"');
+    expect(html).toContain('id="cap"');
+    expect(html).toContain("Keep this guidance");
+    expect(html).toContain("Invalid number");
+    expect(html).toMatch(/aria-describedby="existing [^"]+-hint [^"]+-error"/);
+    expect(html).toContain('aria-invalid="true"');
+    expect(html).toContain('aria-label="Explain Warm-up ramp"');
+    expect(html.match(/<label[^>]*>[\s\S]*?<\/label>/)?.[0]).not.toContain("button");
+  });
+  it("associates generated labels with native and custom controls", () => {
+    for (const component of [Input, Select, Textarea, "input"] as const) {
+      const html = renderToStaticMarkup(
+        createElement(Field, {
+          label: "Value",
+          children: createElement(component as typeof Input),
+        }),
+      );
+      const id = html.match(/<label[^>]*for="([^"]+)"/)?.[1];
+      expect(id).toBeTruthy();
+      expect(html).toContain(`id="${id}"`);
+    }
+  });
+});

--- a/apps/web/src/components/home/NextStep.tsx
+++ b/apps/web/src/components/home/NextStep.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { ArrowRight } from "lucide-react";
+import { Explain } from "../primitives/Explain.tsx";
 import { api } from "../../api/client.ts";
 import { Button } from "../primitives/Button.tsx";
 import { useLocalStorage } from "../../lib/useLocalStorage.ts";
@@ -91,6 +92,9 @@ export function NextStep() {
             }}
           >
             {step.title}
+            {step.id !== "strategy" && (
+              <Explain concept={step.id === "send" ? "drain" : "icpGate"} />
+            )}
           </h2>
           <p className="mt-1.5 max-w-2xl text-sm leading-relaxed text-ink-cream-2">{step.lede}</p>
         </div>

--- a/apps/web/src/components/home/SchedulerStrip.tsx
+++ b/apps/web/src/components/home/SchedulerStrip.tsx
@@ -9,6 +9,7 @@ import { humanInterval } from "../../lib/humanInterval.ts";
 import { summarizeRun } from "../../lib/summarizeRun.ts";
 import { dueInMs, summarizeTriggers } from "../../lib/triggerSummary.ts";
 import { Badge } from "../primitives/Badge.tsx";
+import { Explain } from "../primitives/Explain.tsx";
 import { EmptyNote } from "../primitives/EmptyNote.tsx";
 import { SkeletonRow } from "../primitives/Skeleton.tsx";
 
@@ -202,6 +203,7 @@ function SchedulerRow({ row, zebra }: { row: Row; zebra: boolean }): React.React
       </td>
       <td className="py-2 font-mono text-[11.5px] text-ink-muted">
         {summarizeRun(trigger.lastRunSummary)}
+        {trigger.lastRunSummary != null && <Explain concept="icpGate" />}
       </td>
       <td className="py-2 text-right font-mono text-[11.5px] text-ink-faint">
         {trigger.lastPolledAt ? timeAgo(trigger.lastPolledAt) : "never"}

--- a/apps/web/src/components/plays/CadenceTimeline.tsx
+++ b/apps/web/src/components/plays/CadenceTimeline.tsx
@@ -1,4 +1,5 @@
 import { cn } from "../../lib/cn.ts";
+import { Explain } from "../primitives/Explain.tsx";
 
 export interface CadenceStep {
   /** Day offset from enrollment (0 = first send). */
@@ -53,7 +54,10 @@ export function CadenceTimeline({
               <span className="whitespace-nowrap font-mono text-[10px] text-ink-faint">
                 d{s.day}
               </span>
-              <span className="whitespace-nowrap text-[10px] text-ink-muted">{s.label}</span>
+              <span className="whitespace-nowrap text-[10px] text-ink-muted">
+                {s.label}
+                {s.breakup && <Explain concept="breakup" />}
+              </span>
             </span>
             {!isLast && (
               <span

--- a/apps/web/src/components/primitives/Explain.tsx
+++ b/apps/web/src/components/primitives/Explain.tsx
@@ -1,0 +1,47 @@
+import { Popover } from "@base-ui/react/popover";
+import { Info } from "lucide-react";
+import { getConcept, type ConceptId } from "../../lib/concepts.ts";
+
+/** Inline, touch- and keyboard-accessible help. Events stay out of row actions. */
+export function Explain({ concept, detail }: { concept: ConceptId; detail?: string }) {
+  const entry = getConcept(concept);
+  if (!entry) return null;
+  return (
+    <Popover.Root>
+      <Popover.Trigger
+        type="button"
+        aria-label={`Explain ${entry.title}`}
+        onClick={(event) => event.stopPropagation()}
+        onKeyDown={(event) => {
+          if (event.key === "Enter" || event.key === " ") event.stopPropagation();
+        }}
+        className="ml-1 inline-flex size-6 shrink-0 items-center justify-center rounded-full align-middle text-ink-muted hover:bg-ink-surface hover:text-ink-cream focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[color:var(--ink-signal)]"
+      >
+        <Info size={13} aria-hidden="true" />
+      </Popover.Trigger>
+      <Popover.Portal>
+        <Popover.Positioner sideOffset={8} className="z-[100]">
+          <Popover.Popup
+            onClick={(event) => event.stopPropagation()}
+            className="max-w-[min(320px,calc(100vw-24px))] rounded-[var(--radius-sm)] border border-ink-rule bg-ink-bg-deep p-4 text-left font-sans text-[13px] normal-case leading-relaxed tracking-normal text-ink-cream shadow-xl"
+          >
+            <Popover.Title className="mb-1 font-semibold">{entry.title}</Popover.Title>
+            <Popover.Description className="text-ink-muted">
+              {detail ?? entry.body}
+            </Popover.Description>
+            {entry.href && (
+              <a
+                href={entry.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mt-3 inline-block underline underline-offset-2"
+              >
+                Read the docs
+              </a>
+            )}
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}

--- a/apps/web/src/components/primitives/Field.tsx
+++ b/apps/web/src/components/primitives/Field.tsx
@@ -1,5 +1,8 @@
 import { ChevronDown } from "lucide-react";
 import type { InputHTMLAttributes, SelectHTMLAttributes, TextareaHTMLAttributes } from "react";
+import { Children, cloneElement, isValidElement, useId, type ReactNode } from "react";
+import type { ConceptId } from "../../lib/concepts.ts";
+import { Explain } from "./Explain.tsx";
 import { cn } from "../../lib/cn.ts";
 import { Toggle } from "./Toggle.tsx";
 
@@ -14,6 +17,7 @@ export function Field({
   error,
   children,
   className,
+  explain,
 }: {
   /** Usually a string; a node lets a caller append a Badge ("in use"). */
   label: React.ReactNode;
@@ -21,17 +25,71 @@ export function Field({
   error?: string | null;
   children: React.ReactNode;
   className?: string;
+  explain?: ConceptId;
 }) {
+  const fieldId = useId();
+  const hintId = `${fieldId}-hint`;
+  const errorId = `${fieldId}-error`;
+  let controlId = fieldId;
+  let bound = false;
+  // Bind the first actual control, including an Input beside a helper button.
+  // Keep interactive help outside the label and retain explicit control ids.
+  function bind(nodes: ReactNode): ReactNode {
+    return Children.map(nodes, (child) => {
+      if (
+        !isValidElement<{
+          id?: string;
+          children?: ReactNode;
+          "aria-describedby"?: string;
+          "aria-invalid"?: boolean | "true" | "false" | "grammar" | "spelling";
+        }>(child)
+      )
+        return child;
+      const control =
+        child.type === Input ||
+        child.type === Select ||
+        child.type === Textarea ||
+        child.type === "input" ||
+        child.type === "select" ||
+        child.type === "textarea";
+      if (control && !bound) {
+        bound = true;
+        controlId = child.props.id ?? fieldId;
+        return cloneElement(child, {
+          id: controlId,
+          "aria-describedby":
+            [child.props["aria-describedby"], hint && hintId, error && errorId]
+              .filter(Boolean)
+              .join(" ") || undefined,
+          "aria-invalid": error ? true : child.props["aria-invalid"],
+        });
+      }
+      return child.props.children && child.type !== Field
+        ? cloneElement(child, { children: bind(child.props.children) })
+        : child;
+    });
+  }
+  const controls = bind(children);
   return (
-    <label className={cn("flex flex-col gap-1.5", className)}>
-      <span className="ln-eyebrow">{label}</span>
-      {children}
-      {error ? (
-        <span className="font-mono text-[11.5px] text-[color:var(--ink-blocked-2)]">{error}</span>
-      ) : hint ? (
-        <span className="text-[12px] text-ink-faint">{hint}</span>
-      ) : null}
-    </label>
+    <div className={cn("flex flex-col gap-1.5", className)}>
+      <div className="flex items-center gap-1">
+        <label htmlFor={controlId} className="ln-eyebrow">
+          {label}
+        </label>
+        {explain && <Explain concept={explain} />}
+      </div>
+      {controls}
+      {error && (
+        <span id={errorId} className="font-mono text-[11.5px] text-[color:var(--ink-blocked-2)]">
+          {error}
+        </span>
+      )}
+      {hint && (
+        <span id={hintId} className="text-[12px] text-ink-faint">
+          {hint}
+        </span>
+      )}
+    </div>
   );
 }
 

--- a/apps/web/src/components/setup/EmailTransportSection.tsx
+++ b/apps/web/src/components/setup/EmailTransportSection.tsx
@@ -1,3 +1,4 @@
+import { Explain } from "../primitives/Explain.tsx";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Mail } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
@@ -193,6 +194,7 @@ export function EmailTransportSection({
           </div>
           <span className="text-[12px] text-ink-faint">
             Removing an identity blocks sends to prospects pinned to it until it's restored.
+            <Explain concept="pinnedRouting" />
           </span>
 
           <ProvisionedDomains
@@ -357,10 +359,17 @@ function IdentityRow({
             : `today ${i.sentToday}/${i.capToday ?? "∞"}`}
           {i.warmup ? ` · warm-up ${i.warmup.startPerDay}+${i.warmup.incrementPerWeek}/wk` : ""}
           {i.legacy ? " · legacy (auto-derived)" : ""}
+          {i.provider === "oneshot" && <Explain concept="domainCaps" />}
+          {i.warmup && <Explain concept="warmup" />}
         </span>
       </div>
       <div className="ml-auto flex items-start gap-2">
-        <Field label="max/day" error={capError} className="w-28 gap-0.5">
+        <Field
+          label="max/day"
+          explain={i.warmup ? "warmup" : undefined}
+          error={capError}
+          className="w-28 gap-0.5"
+        >
           <Input
             className="h-7 text-[12px]"
             placeholder="∞ (no cap)"
@@ -480,6 +489,7 @@ function AddOneShotSender({
                 <span className="truncate text-[13px] text-ink-cream">{key}</span>
                 <span className="ln-mono text-[11px] text-ink-muted">
                   {a.maxPerDay.trim() ? `cap ${a.maxPerDay.trim()}/day` : "warm-up ramp"}
+                  <Explain concept="warmup" />
                 </span>
                 {pendingErrors[key] && (
                   <span className="font-mono text-[11px] text-[color:var(--ink-blocked-2)]">
@@ -526,7 +536,7 @@ function AddOneShotSender({
             aria-label="mailbox local-part"
           />
         </Field>
-        <Field label="Max/day" className="w-28" error={capError}>
+        <Field label="Max/day" explain="warmup" className="w-28" error={capError}>
           <Input
             placeholder="ramp"
             inputMode="numeric"

--- a/apps/web/src/lib/concepts.ts
+++ b/apps/web/src/lib/concepts.ts
@@ -1,0 +1,128 @@
+export interface Concept {
+  title: string;
+  body: string;
+  href?: string | null;
+}
+
+const docs = "https://docs.oneshotagent.com/oneshot-gtm/";
+
+export const CONCEPTS = {
+  rocs: {
+    title: "Return on cognitive spend",
+    body: "Confirmed attributed value divided by OneShot action spend. This is a value-per-dollar ratio, not total profit; unrecorded or pending outcomes can understate it.",
+    href: docs + "rocs",
+  },
+  sql: {
+    title: "Sales-qualified lead",
+    body: "A prospect you have recorded as qualified for a sales conversation. Qualification is an outcome you log, not something a priority score proves.",
+    href: docs + "rocs",
+  },
+  costMeeting: {
+    title: "Cost per meeting",
+    body: "Recorded action spend divided by recorded meetings in this view. A dash means there is no meeting denominator yet.",
+    href: docs + "rocs",
+  },
+  costWon: {
+    title: "Cost per win",
+    body: "Recorded action spend divided by recorded wins in this view. It excludes founder time and costs outside the ledger.",
+    href: docs + "rocs",
+  },
+  shadowScore: {
+    title: "Shadow score",
+    body: "Experimental priority from evidence, not a conversion probability. A shadow badge is informational; ranked review can use priority to order candidates, but never approves or sends them.",
+    href: docs + "shadow-score",
+  },
+  personFit: {
+    title: "Person fit",
+    body: "How the person's role and observed capabilities fit your ICP. Missing evidence is neutral; seniority alone does not establish fit.",
+    href: docs + "shadow-score",
+  },
+  accountFit: {
+    title: "Account fit",
+    body: "Evidence that the organization fits your product, such as company context, funding or hiring signals.",
+    href: docs + "shadow-score",
+  },
+  intentStrength: {
+    title: "Intent strength",
+    body: "How directly the observed activity suggests a relevant need. A star or event appearance is a signal, not a buying commitment.",
+    href: docs + "shadow-score",
+  },
+  timingFreshness: {
+    title: "Timing freshness",
+    body: "How recent the triggering event is. Older evidence usually carries less urgency.",
+    href: docs + "shadow-score",
+  },
+  signalConfidence: {
+    title: "Signal confidence",
+    body: "How much concrete, attributable evidence supports this candidate, such as source URLs and quoted context.",
+    href: docs + "shadow-score",
+  },
+  contactability: {
+    title: "Contactability",
+    body: "Available ways to reach the person, such as email, LinkedIn, phone or open DMs. Availability does not replace deliverability or suppression checks.",
+    href: docs + "shadow-score",
+  },
+  softHold: {
+    title: "Soft hold",
+    body: "A draft paused for human review, for example because an event passed or another workspace contacted the person. Review the stated reason before overriding; other send checks still apply.",
+    href: docs + "sending",
+  },
+  drain: {
+    title: "Drain approved rows",
+    body: "Process approved queue rows for one play. A live drain can draft and send; dry run previews. Pending rows need approval first.",
+    href: docs + "finders",
+  },
+  breakup: {
+    title: "Breakup follow-up",
+    body: "The final touch in an unanswered sequence. It closes the loop and leaves the recipient room to decline or defer.",
+    href: docs + "plays",
+  },
+  warmup: {
+    title: "Warm-up ramp",
+    body: "Blank cap = warm-up ramp: 10/day, +10 a week, max 50. The ramp gradually increases daily sending capacity.",
+    href: docs + "sending",
+  },
+  pinnedRouting: {
+    title: "Pinned sender routing",
+    body: "The first-touch sender stays assigned to that prospect so follow-ups keep the same From address. Removing an identity blocks sends to prospects pinned to it until it's restored.",
+    href: docs + "sending",
+  },
+  domainCaps: {
+    title: "Domain-shared caps",
+    body: "OneShot mailboxes on the same sending domain share a daily ramp and budget. Adding another mailbox does not create another domain allowance.",
+    href: docs + "sending",
+  },
+  dedupe: {
+    title: "Dedupe key",
+    body: "A stable identifier that connects a discovered candidate to its queue row and draft. Retry and send checks use recorded state to avoid repeating an already-sent first touch.",
+    href: docs + "concepts",
+  },
+  icpGate: {
+    title: "ICP gate",
+    body: "The topic gate checks the source; the person gate checks the individual's fit. A relevant repo or event does not make everyone associated with it a fit.",
+    href: docs + "concepts",
+  },
+  enrichment: {
+    title: "Enrichment retry",
+    body: "enrichment failed — drafted from payload context only; retries automatically after ~3 days",
+    href: docs + "finders",
+  },
+} satisfies Record<string, Concept>;
+
+export type ConceptId = keyof typeof CONCEPTS;
+
+export const PRIORITY_CONCEPTS: Readonly<Record<string, ConceptId>> = {
+  "person fit": "personFit",
+  "account fit": "accountFit",
+  intent: "intentStrength",
+  freshness: "timingFreshness",
+  confidence: "signalConfidence",
+  contactability: "contactability",
+};
+
+export function getConcept(
+  id: string,
+  registry: Readonly<Record<string, Concept>> = CONCEPTS,
+): Concept | undefined {
+  return Object.hasOwn(registry, id) ? registry[id] : undefined;
+}

--- a/apps/web/src/routes/measure.tsx
+++ b/apps/web/src/routes/measure.tsx
@@ -1,3 +1,4 @@
+import { Explain } from "../components/primitives/Explain.tsx";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { useMemo, useState } from "react";
@@ -235,7 +236,9 @@ function MeasurePage() {
 
       <section className="border-b border-ink-rule">
         <div className="flex items-baseline justify-between px-6 pb-2 pt-5">
-          <div className="ln-eyebrow">RoCS · return on cognitive spend</div>
+          <div className="ln-eyebrow">
+            RoCS · return on cognitive spend <Explain concept="rocs" />
+          </div>
           <div className="font-mono text-[11px] text-ink-faint">{rangeLabel(sinceDays)}</div>
         </div>
         {rocs.isLoading ? (
@@ -252,10 +255,16 @@ function MeasurePage() {
                 <th className="py-2 text-left font-medium">spend · {sparkDays}d</th>
                 <th className="py-2 text-right font-medium">spend</th>
                 <th className="py-2 text-right font-medium">meetings</th>
-                <th className="py-2 text-right font-medium">SQLs</th>
+                <th className="py-2 text-right font-medium">
+                  SQLs <Explain concept="sql" />
+                </th>
                 <th className="py-2 text-right font-medium">won</th>
-                <th className="py-2 text-right font-medium">$/meeting</th>
-                <th className="px-6 py-2 text-right font-medium">$/won</th>
+                <th className="py-2 text-right font-medium">
+                  $/meeting <Explain concept="costMeeting" />
+                </th>
+                <th className="px-6 py-2 text-right font-medium">
+                  $/won <Explain concept="costWon" />
+                </th>
               </tr>
             </thead>
             <tbody>

--- a/apps/web/src/routes/queue.tsx
+++ b/apps/web/src/routes/queue.tsx
@@ -1,3 +1,5 @@
+import { Explain } from "../components/primitives/Explain.tsx";
+import { PRIORITY_CONCEPTS } from "../lib/concepts.ts";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import {
@@ -682,6 +684,9 @@ function QueuePage() {
       >
         <div className="flex flex-col gap-3">
           {/* A selection IS the limit — never show a second, contradictory number. */}
+          <p className="text-[13px] text-ink-muted">
+            Drain approved rows <Explain concept="drain" />
+          </p>
           {drainModal?.ids ? (
             <p className="text-[13px] text-ink-cream-2">
               Draining the {drainModal.ids.length} approved{" "}
@@ -893,9 +898,13 @@ export function QueueRow({
               </Badge>
             )}
             {prio && (
-              <Badge tone={prio.tone} title={prio.title}>
-                {prio.label}
-              </Badge>
+              <span className="inline-flex items-center">
+                <Badge tone={prio.tone}>{prio.label}</Badge>
+                <Explain
+                  concept="shadowScore"
+                  detail={`${ranked ? "Ranked review uses priority to order candidates; it does not approve or send them." : "Experimental · shadow. Does not affect ordering or sending."} ${prio.title}`}
+                />
+              </span>
             )}
             {eventDate && (
               <span
@@ -948,9 +957,14 @@ export function QueueRow({
                 <div className="rounded-[var(--radius-sm)] border border-ink-rule bg-ink-bg-deep">
                   <div className="flex items-center gap-2 border-b border-ink-rule/60 px-3 py-2 font-mono text-[10px] uppercase tracking-[0.14em] text-ink-faint">
                     <span>priority {row.priority.total}</span>
-                    <Badge tone="neutral">experimental · shadow</Badge>
+                    <Badge tone="neutral">
+                      {ranked ? "ranked review" : "experimental · shadow"}
+                    </Badge>
+                    <Explain concept="shadowScore" />
                     <span className="normal-case tracking-normal">
-                      does not affect ordering or sending
+                      {ranked
+                        ? "affects review order, never approval or sending"
+                        : "does not affect ordering or sending"}
                     </span>
                   </div>
                   <div className="px-3 py-2.5">
@@ -959,6 +973,7 @@ export function QueueRow({
                         <span key={b.component}>
                           {b.component} <span className="text-ink-cream">{b.score}</span>
                           <span className="text-ink-faint"> ·{b.weightPct}%</span>
+                          <Explain concept={PRIORITY_CONCEPTS[b.component] ?? "shadowScore"} />
                         </span>
                       ))}
                     </div>
@@ -1371,10 +1386,21 @@ function DraftSection({
         <span>{headerLabel}</span>
         {draftedAt ? <span className="text-ink-muted">· {timeAgo(draftedAt)}</span> : null}
         <Badge tone={tone}>{stateLabel}</Badge>
+        {softHold && (
+          <Explain
+            concept="softHold"
+            detail={
+              draft.flags.includes("contacted-elsewhere")
+                ? "Held — another workspace emailed this person in the last 7 days. Send the reviewed draft as-is to override."
+                : "Held for review (event has passed) — send the reviewed draft above, as-is"
+            }
+          />
+        )}
         {isStalePostSend && <Badge tone="blocked">post-send regenerate · not sent</Badge>}
         {draft.enrichmentFailed && (
-          <span title="enrichment failed — drafted from payload context only; retries automatically after ~3 days">
+          <span className="inline-flex items-center">
             <Badge tone="spend">no enrichment</Badge>
+            <Explain concept="enrichment" />
           </span>
         )}
         {draft.flags.length > 0 &&

--- a/apps/web/src/routes/run.$playName.tsx
+++ b/apps/web/src/routes/run.$playName.tsx
@@ -1,3 +1,4 @@
+import { Explain } from "../components/primitives/Explain.tsx";
 import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { ArrowLeft, CheckCircle2, Loader2, Play, Plus, RefreshCw, Trash2, X } from "lucide-react";
@@ -496,6 +497,7 @@ function RunPage() {
             {runRecord.targetCount} drafted before the kill. Click <em>Run again</em> below to
             re-fire the remaining targets — already-sent emails won't fire twice (per-prospect
             step-0 dedupe).
+            <Explain concept="dedupe" />
           </div>
         )}
         {mode === "cancelled" && runRecord && (

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -1,0 +1,42 @@
+# Maintaining the GTM docs
+
+The public guides live in `tormine/oneshot`, under `apps/docs/oneshot-gtm/`.
+The GTM README remains a standalone guide; preserve its anchors, especially
+`#watching-whats-happening`, which TELEMETRY.md links to.
+
+## Generate the CLI reference
+
+From the GTM checkout, with the docs repo checked out alongside it:
+
+```bash
+bun run scripts/generate-cli-reference.ts --output ../one-shot/apps/docs/oneshot-gtm/cli-reference.mdx
+bun run scripts/generate-cli-reference.ts --output ../one-shot/apps/docs/oneshot-gtm/cli-reference.mdx --check
+```
+
+Adjust the output path to your actual checkout. The generator imports Commander
+with parsing disabled, isolates its config in a temporary home, and never runs
+command actions. It emits command groups and leaves, positional arguments,
+options and inherited options. Check mode reads without rewriting and exits
+nonzero if content differs. The provenance comment records the source HEAD;
+check mode ignores that SHA so unrelated commits do not cause false drift.
+Generate release artifacts from a clean, committed GTM checkout.
+
+The MDX artifact is committed to the docs repo. A normal docs build needs no
+GTM checkout. Do not hand-edit the generated reference.
+
+## Cross-repo changes
+
+When changing CLI commands, flags, finders, plays, scoring or other documented
+behavior, update the README where relevant and open a linked docs change.
+Use the existing `docs-follow-up` issue label in either repo when the external
+surface cannot be updated in the same release. Name the source PR and affected
+pages so the follow-up has an explicit owner and target.
+
+Avoid hardcoded command/play/finder totals in public prose. Existing README count
+tests remain authoritative for README totals; generated CLI content comes from
+the same command tree. Descriptive guides still need review when behavior changes.
+
+Before a docs release, run generation check against the chosen GTM revision,
+build the docs site, and verify navigation and internal links. Deploy new pages
+before shipping README links to their URLs. Telemetry's authoritative spec stays
+in TELEMETRY.md; link to it instead of duplicating its field whitelist.

--- a/scripts/generate-cli-reference.ts
+++ b/scripts/generate-cli-reference.ts
@@ -1,0 +1,39 @@
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, resolve } from "node:path";
+import { referenceMatches, renderCliReference } from "../apps/cli/src/docs-reference.ts";
+
+const args = process.argv.slice(2);
+const outputIndex = args.indexOf("--output");
+const outputArg = args[outputIndex + 1];
+if (
+  outputIndex < 0 ||
+  !outputArg ||
+  outputArg.startsWith("--") ||
+  args.some((arg, i) => i !== outputIndex && i !== outputIndex + 1 && arg !== "--check")
+) {
+  throw new Error("Usage: bun run scripts/generate-cli-reference.ts --output <file.mdx> [--check]");
+}
+// Imports may initialize config. Keep documentation generation out of real workspaces.
+const home = mkdtempSync(resolve(tmpdir(), "gtm-docs-"));
+process.env["ONESHOT_GTM_HOME"] = home;
+process.env["ONESHOT_GTM_SHARED"] = resolve(home, "shared");
+process.env["ONESHOT_GTM_TELEMETRY"] = "0";
+process.env["ONESHOT_GTM_CLI_NO_PARSE"] = "1";
+const { program } = await import("../apps/cli/src/index.ts");
+const revision = execFileSync("git", ["rev-parse", "HEAD"], {
+  cwd: resolve(import.meta.dirname, ".."),
+  encoding: "utf8",
+}).trim();
+const expected = renderCliReference(program, revision);
+const output = resolve(outputArg);
+if (args.includes("--check")) {
+  if (!referenceMatches(readFileSync(output, "utf8"), expected))
+    throw new Error(`CLI reference is stale: ${output}. Regenerate it from this checkout.`);
+  console.log("CLI reference matches the command tree.");
+} else {
+  mkdirSync(dirname(output), { recursive: true });
+  writeFileSync(output, expected);
+  console.log(`Generated ${output}`);
+}


### PR DESCRIPTION
Dashboard jargon now has keyboard- and touch-accessible “i” explanations, with links to the corresponding OneShot GTM guides. The concept registry covers RoCS and sales metrics, priority components, holds, drain, breakup, sender routing and caps, dedupe, and ICP gates. Field labels retain their control association, help stays outside the label, and hints remain visible alongside errors.

The CLI reference generator walks Commander without invoking actions, renders arguments and inherited options, isolates config in a temporary home, and supports deterministic generation and stale-content checks. The README keeps its existing sections and anchors and links directly to the new documentation tab.

Closes #450. Companion documentation: https://github.com/tormine/oneshot/pull/601 (tormine/oneshot#569). Merge the docs PR first so dashboard links have live targets.

Validation: 3,033 tests across 226 files passed; root and web typechecks, formatting, and dashboard build passed. Lint has existing warnings, no errors; new generator and primitives lint without warnings. Chrome interaction checks passed for keyboard, Escape/focus return, touch, label focus, simultaneous hint/error, docs URLs, and preventing parent row/form actions.

CI exposed repeatable 5-second timeouts in two pre-existing demo tests that each seed two disk-backed ledgers (~6 seconds on the hosted runner). Only those two tests receive a 15-second timeout; their determinism and deduplication assertions are unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added contextual explanations and documentation links for GTM metrics, scoring, sending controls, queues, enrichment, setup fields, and workflow steps.
  * Improved form accessibility with clearer label, hint, error, and validation associations.
  * Added generated CLI reference documentation covering commands, arguments, options, defaults, and choices.
  * Added manual prospect entry and page titles for Measure and Queue.

* **Changes**
  * Scheduler tables no longer expand automatically when overdue triggers load.
  * Removed sender cohort and offer inputs from accelerator-batch drain and run workflows.

* **Documentation**
  * Updated scheduling guidance for PowerShell and POSIX systems.
  * Added documentation-maintenance and CLI reference validation guidance.

* **Tests**
  * Expanded coverage for CLI documentation, dashboard concepts, accessibility, and deterministic test execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->