### PR TITLE
fix(cli): demo-seed tests need longer than five seconds now

### DIFF
--- a/apps/cli/__tests__/demo-seed.test.ts
+++ b/apps/cli/__tests__/demo-seed.test.ts
@@ -24,6 +24,20 @@ import {
 
 const ANCHOR = new Date("2026-08-17T09:00:00.000Z");
 
+/**
+ * Every test in the two describes below seeds a real ledger in its own body,
+ * and seeding got heavier when the demo install started arriving pre-run
+ * rather than freshly switched on.
+ *
+ * Measured locally: one seed is 640-800ms, and the two tests that seed twice
+ * are 1.3-1.5s. CI runners are roughly 3-4x slower, which puts those two over
+ * vitest's 5s default and leaves the single-seed tests with very little room —
+ * so the timeout is set for the whole group rather than patched onto the two
+ * that happened to cross the line first. These are not five-second unit tests
+ * and should not be held to that budget.
+ */
+const SEED_TIMEOUT_MS = 30_000;
+
 let home: string;
 
 beforeEach(() => {
@@ -46,7 +60,7 @@ function totalSpend(entries: Array<{ spend: number }>): number {
   return entries.reduce((a, r) => a + r.spend, 0);
 }
 
-describe("seedDemoHome", () => {
+describe("seedDemoHome", { timeout: SEED_TIMEOUT_MS }, () => {
   it("writes config, secrets, fixtures and a marker", () => {
     seedDemoHome({ home, anchor: ANCHOR });
 
@@ -322,7 +336,7 @@ describe("scrubInheritedSecrets", () => {
   });
 });
 
-describe("resetDemoHome", () => {
+describe("resetDemoHome", { timeout: SEED_TIMEOUT_MS }, () => {
   it("removes a seeded home", () => {
     seedDemoHome({ home, anchor: ANCHOR });
     resetDemoHome(home);


### PR DESCRIPTION
## Why

`main` has been red since **09:00 UTC today**. Two tests in `apps/cli/__tests__/demo-seed.test.ts` time out on CI at vitest's 5s default:

```
FAIL  seedDemoHome > is deterministic — the same anchor reproduces the same ledger
FAIL  seedDemoHome > re-seeds in place without stacking duplicate rows
Error: Test timed out in 5000ms.
```

Both pass locally, and they are the only two tests in the file that call `seedDemoHome` **twice**.

## Cause

Seeding got heavier in `a429c9c` ("seed an install that has been running, not one that was just switched on") and `e7932d1`. The last green run on main was 00:14 UTC; those landed between it and the first red one.

Measured locally, per test:

| | |
| --- | --- |
| a single seed | 640–800 ms |
| `is deterministic` (2 seeds) | 1486 ms |
| `re-seeds in place` (2 seeds) | 1276 ms |

CI runners are roughly 3–4× slower, which puts the double-seed pair over 5s — and leaves every single-seed test in the file sitting at ~2.5s on CI, with very little room behind them.

## Fix

A timeout for **both seeding describes**, not a patch on the two that happened to cross the line first. `beforeEach` only makes a temp dir; every seed happens in a test body, so the whole group is seed-bound and the next one over would be another red `main` and another bisect. Nothing in these describes is a five-second unit test — each writes a real SQLite ledger.

`scrubInheritedSecrets` is left alone; it seeds nothing and its tests run in 2–4 ms.

## Verify

A passing run proves nothing here, since they passed before the change too. I bound the option to a deliberately impossible value to confirm it actually applies:

```
SEED_TIMEOUT_MS = 50  →  15 × "Test timed out in 50ms"
```

15 failures across both describes, so the `describe`-level option reaches every test in the group rather than silently doing nothing.

Full suite green at the real value: **3026 tests / 223 files** · typecheck · oxfmt · 0 lint errors.

## Note

This unblocks #542 and #544, which both inherit main's red `check`.

https://claude.ai/code/session_011meFPo97LhmTcoNRwyPQeS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased the timeout available for demo seeding and reset test suites to accommodate slower database setup and reseeding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->