### PR TITLE
docs(readme): name the data landscape the finders draw on

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,21 @@ Two ICP gates run per candidate, not one. The **topic gate** judges the source �
 
 The dashboard server runs an in-process scheduler, so enabling a trigger is enough — no separate daemon. `find watch` stays useful for cron and headless boxes. Approved rows ship via the **Drain** button or `find drain <play>`.
 
+### The data underneath
+
+Enrichment, verification and local lookups resolve through OneShot, which maintains a vendor landscape of 50 data sources across six categories. Which source answers a given lookup is chosen per call, so what follows is coverage rather than a list of integrations — a map of who operates in each space, not a claim about what is wired up today.
+
+| Category                      | Sources | Examples                                    |
+| ----------------------------- | ------- | ------------------------------------------- |
+| Contact enrichment            | 13      | Apollo, Clay, Hunter, People Data Labs      |
+| Company & firmographic data   | 7       | Diffbot, Coresignal, PredictLeads           |
+| Email verification            | 6       | ZeroBounce, NeverBounce, Kickbox            |
+| Maps, places & local data     | 6       | Serper, Foursquare, Outscraper              |
+| Browser automation & scraping | 10      | Browserbase, Apify, Bright Data             |
+| Social distribution & data    | 8       | Unipile, TwitterAPI.io, Lix                 |
+
+The other eight categories in the catalogue are things an agent does rather than knows — voice, speech, media, e-signature, mail, shipping, domains, deliverability — and account for the remaining 66 vendors. [The full catalogue](https://docs.oneshotagent.com/vendors).
+
 ### Background monitoring as a service
 
 `find watch --install-service` generates a service file that keeps the watch daemon running in the background — a launchd user agent on macOS, a systemd user unit on Linux. It prints to stdout (redirect-friendly); add `--write` to drop it at the platform-conventional path. Every path is embedded absolute at generation time — the bun binary, the CLI entry, and the active `ONESHOT_GTM_HOME` (so `--workspace acme find watch --install-service` pins the service to that workspace) — because service managers don't source your shell profile. Regenerate with `--write` after moving bun or the checkout.


### PR DESCRIPTION
## What

`## Where targets come from` explains which finder produces a candidate and what each paid lookup costs, but never says where the lookups actually resolve. They go through OneShot, whose catalogue covers **50 data sources across six categories**.

Adds a `### The data underneath` subsection at the end of that section (before `### Background monitoring as a service`) with a short paragraph and this table:

| Category | Sources | Examples |
|---|---|---|
| Contact enrichment | 13 | Apollo, Clay, Hunter, People Data Labs |
| Company & firmographic data | 7 | Diffbot, Coresignal, PredictLeads |
| Email verification | 6 | ZeroBounce, NeverBounce, Kickbox |
| Maps, places & local data | 6 | Serper, Foursquare, Outscraper |
| Browser automation & scraping | 10 | Browserbase, Apify, Bright Data |
| Social distribution & data | 8 | Unipile, TwitterAPI.io, Lix |

plus a line noting the remaining 66 vendors are the eight capability categories, and a link to the full catalogue.

## Framing

Coverage, not integrations. Which source answers a given lookup is chosen per call, so the table is a map of who operates in each space and not a claim about what is wired up today — the same framing the catalogue itself uses.

## Text, no logo images

Embedding a logo CDN in a README fires a third-party request on every repo view for no gain, and this file is table-heavy prose already.

## Verify

- Every count is `grep -c '<V d='` per section of the source catalogue; the six sum to 50, and 50 + 66 = 116, the catalogue total.
- Every vendor named in the Examples column appears in the catalogue (checked programmatically).
- Table rows all pad to the same width, matching the file's existing tables.
- `STATUS.md` untouched — no test or command count changed.

https://claude.ai/code/session_01EjxCc7vemNHo8Y82HuXnyd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a README section describing OneShot’s vendor landscape, including source counts, categories, representative providers, additional categories, and a link to the full catalogue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->