### PR TITLE
Select direct-mail defaults by motion and prospect fit

### DIFF
--- a/README.md
+++ b/README.md
@@ -477,12 +477,12 @@ is the same pipeline that runs there.
 
 **Plays → Direct mail** chooses suitable prospects automatically for selected motions. Founders can choose **Automatic**, **Always include**, or **Off**, and edit the mail step’s position and delay. Each letter still requires individual proof review and approval.
 
-| Motion | Automatic selection | Default placement |
-| --- | --- | --- |
-| New business, free pilot | Named prospect, company, and complete U.S. business address | Step 2, three days after the first email |
-| Design-partner LOI | Same address requirements; enterprise or hardware buyer | Step 2, three days after the first email |
+| Motion                                         | Automatic selection                                                     | Default placement                            |
+| ---------------------------------------------- | ----------------------------------------------------------------------- | -------------------------------------------- |
+| New business, free pilot                       | Named prospect, company, and complete U.S. business address             | Step 2, three days after the first email     |
+| Design-partner LOI                             | Same address requirements; enterprise or hardware buyer                 | Step 2, three days after the first email     |
 | Post-funding, hiring-signal, competitor-switch | Same address requirements; confirmed ICP match and decision-maker title | Step 3, three days after the first follow-up |
-| Other motions | Off by default; founder can choose Always include | Founder-selected |
+| Other motions                                  | Off by default; founder can choose Always include                       | Founder-selected                             |
 
 These are explainable starting rules, not predictions of conversion or account value. Sources labeled as registered-agent, registered-office or residential addresses are excluded from automatic selection. An address still needs review: complete postal fields do not establish that a person works there. Research can add mail to an eligible active cadence when its insertion point is still ahead; completed touches and existing mailpieces retain their plans. Explicit Off overrides survive future default changes.
 

--- a/README.md
+++ b/README.md
@@ -475,10 +475,19 @@ is the same pipeline that runs there.
 
 ### Direct mail
 
-In **Plays**, enable **Include direct mail** only for the motions that need it, and choose its position and delay. Mail adds a touch; it does not replace an email. Eligible active prospects receive the new step, while completed cadences and prospects already past its position keep their existing sequence.
+**Plays → Direct mail** chooses suitable prospects automatically for selected motions. Founders can choose **Automatic**, **Always include**, or **Off**, and edit the mail step’s position and delay. Each letter still requires individual proof review and approval.
+
+| Motion | Automatic selection | Default placement |
+| --- | --- | --- |
+| New business, free pilot | Named prospect, company, and complete U.S. business address | Step 2, three days after the first email |
+| Design-partner LOI | Same address requirements; enterprise or hardware buyer | Step 2, three days after the first email |
+| Post-funding, hiring-signal, competitor-switch | Same address requirements; confirmed ICP match and decision-maker title | Step 3, three days after the first follow-up |
+| Other motions | Off by default; founder can choose Always include | Founder-selected |
+
+These are explainable starting rules, not predictions of conversion or account value. Sources labeled as registered-agent, registered-office or residential addresses are excluded from automatic selection. An address still needs review: complete postal fields do not establish that a person works there. Research can add mail to an eligible active cadence when its insertion point is still ahead; completed touches and existing mailpieces retain their plans. Explicit Off overrides survive future default changes.
 
 Save your return address once under **Setup → Founder → Direct mail return address**. Business addresses are collected from prospect inputs, CSV/registry data, and company research for mail-enabled motions. Missing addresses hold the mail step until you correct them or explicitly skip mail.
 
-On **Cadences**, click a prospect’s **Review mail** button. Both saved addresses are filled automatically. Generate/edit a personalized letter or upload a **PDF/JPEG for that prospect**, review the print proof and price, then **Approve and send**. Replacing content or changing an address requires a fresh proof. The dashboard sends U.S. letters; existing postcard orders and the artwork CLI remain supported. Mail history provides postal status, recovery, and cancellation. Bulk actions never send mailpieces. An accepted order advances the cadence once; postal delivery does not prove readership.
+On **Cadences**, click a prospect’s **Review mail** button. Both saved addresses are filled automatically. Generate/edit a personalized letter or upload a **PDF/JPEG for that prospect**, review the print proof and price, then **Approve and send**. Replacing content or changing an address requires a fresh proof. The dashboard sends U.S. letters; existing postcard orders and the artwork CLI remain supported. Mail history provides postal status, recovery, and cancellation. Bulk actions never send mailpieces. An accepted order advances the cadence once. Its next follow-up allows at least eight business days for printing and transit, plus two calendar days to read; longer configured delays remain in force. This is an estimate, not a delivery guarantee. Skipping mail keeps the normal next-touch delay. Postal delivery does not prove readership.
 
 For this integration branch, both core and the server use the SDK archive in `vendor/`; see its README for the coordinated SDK/GTM release step.

--- a/apps/server/__tests__/mail-policy-route.test.ts
+++ b/apps/server/__tests__/mail-policy-route.test.ts
@@ -1,0 +1,43 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { Ledger } from "../../../packages/core/src/ledger.ts";
+import type { OneShotConfig } from "@oneshot-gtm/core";
+let ledger: Ledger;
+let config: OneShotConfig;
+vi.mock("@oneshot-gtm/core", async () => ({
+  ...(await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core")),
+  getLedger: () => ledger,
+  loadConfig: () => config,
+  saveConfig: (value: OneShotConfig) => {
+    config = value;
+  },
+}));
+vi.mock("../src/server.ts", () => ({
+  jsonResponse: (data: unknown, status = 200) => Response.json(data, { status }),
+}));
+const { setCadenceRoute, listPlays } = await import("../src/api/plays.ts");
+beforeEach(() => {
+  ledger = new Ledger(":memory:");
+  config = {} as OneShotConfig;
+});
+afterEach(() => ledger.close());
+const save = (directMail: unknown) =>
+  setCadenceRoute(
+    new Request("http://local/api/plays/new-business/cadence", {
+      method: "POST",
+      body: JSON.stringify({ directMail }),
+    }),
+    { name: "new-business" },
+  );
+it("persists off rather than reverting to the default, and allows automatic mode again", async () => {
+  const play = async () => {
+    const result = await listPlays(new Request("http://local/api/plays")).json();
+    return result.plays.find((p: { name: string }) => p.name === "new-business");
+  };
+  expect((await play()).directMail.mode).toBe("automatic");
+  expect((await save(null)).status).toBe(200);
+  expect(config.directMailMotions?.["new-business"]).toBeNull();
+  expect((await play()).directMail).toBeNull();
+  expect((await save({ position: 2, delayDays: 3, mode: "automatic" })).status).toBe(200);
+  expect((await play()).directMail.mode).toBe("automatic");
+  expect((await save({ position: 2, delayDays: 3, mode: "invalid" })).status).toBe(400);
+});

--- a/apps/server/src/api/plays.ts
+++ b/apps/server/src/api/plays.ts
@@ -159,6 +159,7 @@ export function listPlays(req: Request): Response {
       defaultDays: cumulativeDays(defaultSequence(p.name)),
       directMail: motionMailPolicy(loadConfig(), p.name).settings,
       mailRecommendation: motionMailPolicy(loadConfig(), p.name).reason,
+      mailAutomaticSupported: motionMailPolicy(loadConfig(), p.name).recommended,
       mailEligible: !!defaultSequence(p.name),
       baseSteps: (() => {
         const base = defaultSequence(p.name);
@@ -223,7 +224,8 @@ export async function setCadenceRoute(
         !Number.isInteger(mail.delayDays) ||
         mail.delayDays < 1 ||
         mail.delayDays > 120 ||
-        (mail.mode !== undefined && !["automatic", "always"].includes(mail.mode)))
+        (mail.mode !== undefined && !["automatic", "always"].includes(mail.mode)) ||
+        (mail.mode === "automatic" && !motionMailPolicy(cfg, name).recommended))
     )
       return jsonResponse(
         { error: "Choose a valid mail position and a delay of 1–120 days" },

--- a/apps/server/src/api/plays.ts
+++ b/apps/server/src/api/plays.ts
@@ -1,4 +1,9 @@
-import { loadConfig, saveConfig } from "@oneshot-gtm/core";
+import {
+  loadConfig,
+  saveConfig,
+  motionMailPolicy,
+  type MotionMailSettings,
+} from "@oneshot-gtm/core";
 import {
   defaultSequence,
   captureCadencePlans,
@@ -152,7 +157,8 @@ export function listPlays(req: Request): Response {
       cliInvocation: p.cli,
       steps,
       defaultDays: cumulativeDays(defaultSequence(p.name)),
-      directMail: loadConfig().directMailMotions?.[p.name] ?? null,
+      directMail: motionMailPolicy(loadConfig(), p.name).settings,
+      mailRecommendation: motionMailPolicy(loadConfig(), p.name).reason,
       mailEligible: !!defaultSequence(p.name),
       baseSteps: (() => {
         const base = defaultSequence(p.name);
@@ -188,7 +194,7 @@ export async function setCadenceRoute(
     return jsonResponse({ error: `play '${name}' has no editable cadence` }, 400, req);
   }
 
-  let body: { days?: number[] | null; directMail?: { position: number; delayDays: number } | null };
+  let body: { days?: number[] | null; directMail?: MotionMailSettings | null };
   try {
     body = (await req.json()) as { days?: number[] | null };
   } catch {
@@ -216,7 +222,8 @@ export async function setCadenceRoute(
         mail.position > def.steps.length + 2 ||
         !Number.isInteger(mail.delayDays) ||
         mail.delayDays < 1 ||
-        mail.delayDays > 120)
+        mail.delayDays > 120 ||
+        (mail.mode !== undefined && !["automatic", "always"].includes(mail.mode)))
     )
       return jsonResponse(
         { error: "Choose a valid mail position and a delay of 1–120 days" },
@@ -225,7 +232,7 @@ export async function setCadenceRoute(
       );
     const motions = { ...cfg.directMailMotions };
     if (mail) motions[name] = mail;
-    else delete motions[name];
+    else motions[name] = null;
     saveConfig({ ...cfg, directMailMotions: motions });
     applyCadencePlans(name, previous);
     return jsonResponse({ ok: true }, 200, req);

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -163,8 +163,10 @@ export const api = {
   receipt: (id: number) => getJson<{ receipt: ReceiptDetail }>(`/receipts/${id}`),
   plays: () => getJson<{ plays: PlayDescriptor[] }>("/plays"),
   // Timing only (cumulative days from send); null resets to code defaults. Step structure is fixed.
-  setDirectMail: (name: string, directMail: { position: number; delayDays: number } | null) =>
-    postJson<{ ok: boolean }>(`/plays/${name}/cadence`, { directMail }),
+  setDirectMail: (
+    name: string,
+    directMail: { position: number; delayDays: number; mode?: "automatic" | "always" } | null,
+  ) => postJson<{ ok: boolean }>(`/plays/${name}/cadence`, { directMail }),
   setCadence: (name: string, days: number[] | null) =>
     postJson<{ ok: boolean }>(`/plays/${name}/cadence`, { days }),
   measureCac: (sinceDays?: number) =>

--- a/apps/web/src/routes/plays.tsx
+++ b/apps/web/src/routes/plays.tsx
@@ -470,7 +470,9 @@ function MotionMailEditor({ play }: { play: PlayDescriptor }) {
           onChange={(e) => setMode(e.target.value as typeof mode)}
           disabled={readOnly.disabled || save.isPending}
         >
-          <option value="automatic">Automatic — suitable prospects</option>
+          {play.mailAutomaticSupported && (
+            <option value="automatic">Automatic — suitable prospects</option>
+          )}
           <option value="always">Always include</option>
           <option value="off">Off</option>
         </Select>

--- a/apps/web/src/routes/plays.tsx
+++ b/apps/web/src/routes/plays.tsx
@@ -427,19 +427,28 @@ function CadenceEditor({ play: descriptor }: { play: PlayDescriptor }) {
 
 function MotionMailEditor({ play }: { play: PlayDescriptor }) {
   const qc = useQueryClient();
-  const [enabled, setEnabled] = useState(!!play.directMail);
+  const [mode, setMode] = useState<"automatic" | "always" | "off">(
+    play.directMail ? (play.directMail.mode ?? "always") : "off",
+  );
+  const enabled = mode !== "off";
   const [position, setPosition] = useState(play.directMail?.position ?? 2);
   const [delayDays, setDelayDays] = useState(play.directMail?.delayDays ?? 3);
-  const savedEnabled = !!play.directMail,
+  const savedMode = play.directMail ? (play.directMail.mode ?? "always") : "off",
     savedPosition = play.directMail?.position ?? 2,
     savedDelay = play.directMail?.delayDays ?? 3;
   useEffect(() => {
-    setEnabled(savedEnabled);
+    setMode(savedMode);
     setPosition(savedPosition);
     setDelayDays(savedDelay);
-  }, [savedEnabled, savedPosition, savedDelay]);
+  }, [savedMode, savedPosition, savedDelay]);
   const save = useMutation({
-    mutationFn: () => api.setDirectMail(play.name, enabled ? { position, delayDays } : null),
+    mutationFn: () =>
+      api.setDirectMail(
+        play.name,
+        enabled
+          ? { position, delayDays, mode: mode === "automatic" ? "automatic" : "always" }
+          : null,
+      ),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: ["plays"] });
       void qc.invalidateQueries({ queryKey: ["cadences"] });
@@ -448,20 +457,33 @@ function MotionMailEditor({ play }: { play: PlayDescriptor }) {
     onError: (e) => toast.error(e.message),
   });
   const dirty =
-    enabled !== !!play.directMail ||
+    mode !== savedMode ||
     (enabled &&
       (position !== play.directMail?.position || delayDays !== play.directMail?.delayDays));
   return (
     <div className="flex flex-wrap items-center gap-3 text-xs">
       <label className="flex items-center gap-2">
-        <input
-          type="checkbox"
-          checked={enabled}
-          onChange={(e) => setEnabled(e.target.checked)}
+        Direct mail
+        <Select
+          aria-label="Direct mail policy"
+          value={mode}
+          onChange={(e) => setMode(e.target.value as typeof mode)}
           disabled={readOnly.disabled || save.isPending}
-        />
-        Include direct mail
+        >
+          <option value="automatic">Automatic — suitable prospects</option>
+          <option value="always">Always include</option>
+          <option value="off">Off</option>
+        </Select>
       </label>
+      <p className="w-full text-ink-faint">
+        {mode === "automatic"
+          ? play.mailRecommendation
+          : mode === "off"
+            ? "Direct mail is off for this motion."
+            : "Every eligible active prospect gets a mail step; missing addresses pause it."}{" "}
+        Each letter still requires individual approval. Follow-ups allow at least eight business
+        days for printing and transit, plus two days to read.
+      </p>
       {enabled && (
         <>
           <label>

--- a/packages/core/__tests__/mail-enrichment.test.ts
+++ b/packages/core/__tests__/mail-enrichment.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { Ledger } from "../src/ledger.ts";
+let ledger: Ledger;
+vi.mock("../src/ledger.ts", async () => ({
+  ...(await vi.importActual<typeof import("../src/ledger.ts")>("../src/ledger.ts")),
+  getLedger: () => ledger,
+}));
+const { captureSdkBusinessAddress, extractSdkBusinessAddress } =
+  await import("../src/mail-enrichment.ts");
+const address = {
+  name: "Acme",
+  address_line1: "1 Main St",
+  address_city: "Boston",
+  address_state: "MA",
+  address_zip: "02110",
+  address_country: "US" as const,
+};
+beforeEach(() => {
+  ledger = new Ledger(":memory:");
+});
+afterEach(() => ledger.close());
+it("saves SDK company addresses for the company and prospect without overwriting corrections", () => {
+  const id = ledger.upsertProspect({ name: "Jane", email: "jane@acme.test" });
+  const context = {
+    companyDomain: "acme.test",
+    email: "jane@acme.test",
+    source: "sdk:enrich.company",
+  };
+  captureSdkBusinessAddress({ company: { address } }, context);
+  expect(ledger.getMailAddress(`prospect:${id}`)).toMatchObject({ ...address, name: "Jane" });
+  expect(ledger.getMailAddressMetadata(`prospect:${id}`)?.source).toBe(context.source);
+  expect(ledger.getMailAddress("company:acme.test")).toMatchObject(address);
+  ledger.setMailAddress(`prospect:${id}`, { ...address, address_line1: "2 Updated St" });
+  captureSdkBusinessAddress({ company: { address } }, context);
+  expect(ledger.getMailAddress(`prospect:${id}`)?.address_line1).toBe("2 Updated St");
+});
+it("accepts business fields and rejects person addresses and free-text locations", () => {
+  expect(extractSdkBusinessAddress({ profile: { company_address: address } })).toMatchObject(
+    address,
+  );
+  expect(extractSdkBusinessAddress({ profile: { address, location: "Boston, MA" } })).toBeNull();
+  expect(extractSdkBusinessAddress({ company: { location: "Boston, MA" } })).toBeNull();
+  expect(
+    extractSdkBusinessAddress({ company: { address: { ...address, address_country: "GB" } } }),
+  ).toBeNull();
+});

--- a/packages/core/__tests__/mail-policy.test.ts
+++ b/packages/core/__tests__/mail-policy.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { automaticMailEligible, mailFollowupDueAt, motionMailPolicy } from "../src/mail-policy.ts";
+const prospect = {
+  name: "Jane",
+  company: "Acme",
+  businessAddress: {
+    name: "Jane",
+    address_line1: "1 Main St",
+    address_city: "Boston",
+    address_state: "MA",
+    address_zip: "02110",
+    address_country: "US",
+  },
+};
+describe("motion mail defaults", () => {
+  it("inherits selective defaults and preserves explicit off and legacy opt-ins", () => {
+    expect(motionMailPolicy({}, "new-business").settings?.mode).toBe("automatic");
+    expect(motionMailPolicy({}, "demo-no-show").settings).toBeNull();
+    expect(
+      motionMailPolicy({ directMailMotions: { "new-business": null } }, "new-business").settings,
+    ).toBeNull();
+    expect(
+      motionMailPolicy(
+        { directMailMotions: { "new-business": { position: 3, delayDays: 6 } } },
+        "new-business",
+      ).settings,
+    ).toEqual({ position: 3, delayDays: 6 });
+  });
+  it("requires business address and buyer fit", () => {
+    expect(automaticMailEligible("new-business", prospect)).toBe(true);
+    expect(automaticMailEligible("free-pilot", { ...prospect, businessAddress: null })).toBe(false);
+    expect(
+      automaticMailEligible("new-business", {
+        ...prospect,
+        businessAddressSource: "registered agent",
+      }),
+    ).toBe(false);
+    expect(
+      automaticMailEligible("design-partner-loi", { ...prospect, buyerType: "government" }),
+    ).toBe(false);
+    expect(
+      automaticMailEligible("design-partner-loi", { ...prospect, buyerType: "hardware" }),
+    ).toBe(true);
+    expect(automaticMailEligible("post-funding", prospect)).toBe(false);
+    expect(
+      automaticMailEligible("post-funding", { ...prospect, icp_verdict: "pass", title: "CEO" }),
+    ).toBe(true);
+    expect(
+      automaticMailEligible("post-funding", { ...prospect, icp_verdict: "unclear", title: "CEO" }),
+    ).toBe(false);
+  });
+  it("allows printing and transit across weekends and preserves longer delays", () => {
+    const friday = new Date("2026-09-04T12:00:00Z");
+    expect(mailFollowupDueAt(3, friday)).toBe("2026-09-18T12:00:00.000Z");
+    expect(mailFollowupDueAt(30, friday)).toBe("2026-10-04T12:00:00.000Z");
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,3 +30,5 @@ export * from "./daily-spend.ts";
 export * from "./direct-mail.ts";
 export * from "./mail-address.ts";
 export * from "./mail-pdf.ts";
+
+export * from "./mail-policy.ts";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,3 +32,5 @@ export * from "./mail-address.ts";
 export * from "./mail-pdf.ts";
 
 export * from "./mail-policy.ts";
+
+export * from "./mail-enrichment.ts";

--- a/packages/core/src/mail-enrichment.ts
+++ b/packages/core/src/mail-enrichment.ts
@@ -1,0 +1,60 @@
+import { extractBusinessAddress } from "./mail-address.ts";
+import { getLedger } from "./ledger.ts";
+
+/** Company-scoped SDK data only. Never interpret a person's location as a mailing address. */
+export function extractSdkBusinessAddress(value: unknown, name = "") {
+  if (!value || typeof value !== "object") return null;
+  const record = value as Record<string, unknown>;
+  const company =
+    record.company && typeof record.company === "object"
+      ? (record.company as Record<string, unknown>)
+      : null;
+  if (company) {
+    const nested = company.address ?? company.headquarters ?? company.location;
+    return extractBusinessAddress(company, name) ?? extractBusinessAddress(nested, name);
+  }
+  // Profile results may expose a explicitly business-scoped address.
+  const profile =
+    record.profile && typeof record.profile === "object"
+      ? (record.profile as Record<string, unknown>)
+      : record;
+  if (profile.company && typeof profile.company === "object")
+    return extractSdkBusinessAddress({ company: profile.company }, name);
+  return extractBusinessAddress(
+    profile.business_address ??
+      profile.businessAddress ??
+      profile.company_address ??
+      profile.companyAddress,
+    name,
+  );
+}
+
+/** Capture SDK business address evidence without overwriting a founder's saved correction. */
+export function captureSdkBusinessAddress(
+  value: unknown,
+  context: { companyDomain?: string; email?: string; name?: string; source: string },
+) {
+  const address = extractSdkBusinessAddress(value, context.name);
+  if (!address) return;
+  const ledger = getLedger();
+  if (typeof context.companyDomain === "string" && context.companyDomain) {
+    const domain = context.companyDomain
+      .trim()
+      .toLowerCase()
+      .replace(/^https?:\/\//, "")
+      .split("/")[0];
+    if (domain && !ledger.getMailAddress(`company:${domain}`))
+      ledger.setMailAddress(`company:${domain}`, address, context.source);
+  }
+  const match =
+    typeof context.email === "string" && context.email
+      ? ledger.findProspectByEmail(context.email)
+      : null;
+  const prospect = match ? ledger.getProspectById(match.id) : null;
+  if (prospect && !ledger.getMailAddress(`prospect:${prospect.id}`))
+    ledger.setMailAddress(
+      `prospect:${prospect.id}`,
+      { ...address, name: prospect.name ?? address.name },
+      context.source,
+    );
+}

--- a/packages/core/src/mail-policy.ts
+++ b/packages/core/src/mail-policy.ts
@@ -1,0 +1,107 @@
+import type { OneShotConfig } from "./types.ts";
+import { extractBusinessAddress } from "./mail-address.ts";
+
+export interface MotionMailSettings {
+  position: number;
+  delayDays: number;
+  /** Existing settings without a mode remain explicit founder opt-ins. */
+  mode?: "automatic" | "always";
+}
+const defaults: Record<string, MotionMailSettings & { reason: string }> = {
+  "new-business": {
+    position: 2,
+    delayDays: 3,
+    reason: "A relevant opening offer for a reachable business location.",
+  },
+  "free-pilot": {
+    position: 2,
+    delayDays: 3,
+    reason: "A concrete pilot proposal for a reachable business location.",
+  },
+  "design-partner-loi": {
+    position: 2,
+    delayDays: 3,
+    reason: "A shareable proposal for enterprise and hardware buyers.",
+  },
+  "post-funding": {
+    position: 3,
+    delayDays: 3,
+    reason: "An additional touch for an ICP-qualified decision maker with a business address.",
+  },
+  "hiring-signal": {
+    position: 3,
+    delayDays: 3,
+    reason: "An additional touch for an ICP-qualified decision maker with a business address.",
+  },
+  "competitor-switch": {
+    position: 3,
+    delayDays: 3,
+    reason: "An additional touch for an ICP-qualified decision maker with a business address.",
+  },
+};
+
+/** Missing settings inherit the recommendation; explicit null always means off. */
+export function motionMailPolicy(
+  config: Pick<OneShotConfig, "directMailMotions">,
+  playName: string,
+) {
+  const recommended = defaults[playName];
+  const override = config.directMailMotions?.[playName];
+  const settings =
+    override === null
+      ? null
+      : (override ??
+        (recommended
+          ? {
+              position: recommended.position,
+              delayDays: recommended.delayDays,
+              mode: "automatic" as const,
+            }
+          : null));
+  return {
+    settings,
+    reason: recommended?.reason ?? "No automatic mail recommendation for this motion.",
+    recommended: !!recommended,
+  };
+}
+
+/** Conservative eligibility rules, not a conversion or account-value prediction. */
+export function automaticMailEligible(
+  playName: string,
+  prospect: Record<string, unknown>,
+): boolean {
+  const address = extractBusinessAddress(prospect);
+  if (!address?.name || !String(prospect.company ?? "").trim()) return false;
+  const source = String(prospect.businessAddressSource ?? "");
+  if (/registered.agent|registered.office|residential|home.address/i.test(source)) return false;
+  if (prospect.icp_verdict === "reject" || prospect.icpVerdict === "reject") return false;
+  if (playName === "new-business" || playName === "free-pilot") return true;
+  if (playName === "design-partner-loi")
+    return ["enterprise", "hardware"].includes(
+      String(prospect.buyerType ?? "")
+        .trim()
+        .toLowerCase(),
+    );
+  if (["post-funding", "hiring-signal", "competitor-switch"].includes(playName))
+    return (
+      (prospect.icp_verdict ?? prospect.icpVerdict) === "pass" &&
+      /\b(founder|owner|ceo|cto|coo|cfo|chief|president|vp|vice president|head|director)\b/i.test(
+        String(prospect.title ?? ""),
+      )
+    );
+  return false;
+}
+
+/** Printing plus transit allowance. Weekends do not consume the eight business days. */
+export function mailFollowupDueAt(nextDelayDays: number, acceptedAt = new Date()): string {
+  const arrival = new Date(acceptedAt);
+  let days = 0;
+  while (days < 8) {
+    arrival.setUTCDate(arrival.getUTCDate() + 1);
+    if (arrival.getUTCDay() !== 0 && arrival.getUTCDay() !== 6) days++;
+  }
+  // Allow two more days to read the letter; preserve longer founder-configured waits.
+  return new Date(
+    Math.max(arrival.getTime() + 2 * 86400000, acceptedAt.getTime() + nextDelayDays * 86400000),
+  ).toISOString();
+}

--- a/packages/core/src/oneshot.ts
+++ b/packages/core/src/oneshot.ts
@@ -1,3 +1,4 @@
+import { captureSdkBusinessAddress } from "./mail-enrichment.ts";
 import {
   OneShot,
   ValidationError,
@@ -657,6 +658,12 @@ export async function enrichProfile(input: EnrichInput, ctx: CallContext) {
     costUsd: result.cost,
     oneshotRequestId: result.request_id,
   });
+  captureSdkBusinessAddress(result, {
+    email: input.email,
+    name: input.name,
+    companyDomain: input.companyDomain ?? (result.profile?.company_domain as string | undefined),
+    source: "sdk:enrich.profile",
+  });
   return { result, receiptId };
 }
 
@@ -887,6 +894,11 @@ export async function enrichCompany(input: EnrichCompanyInput, ctx: CallContext)
     signedReceipt: result,
     costUsd: result.cost,
     oneshotRequestId: result.request_id,
+  });
+  captureSdkBusinessAddress(result, {
+    name: result.company?.name,
+    companyDomain: input.domain ?? result.company?.domain,
+    source: "sdk:enrich.company",
   });
   return { result, receiptId };
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -261,7 +261,7 @@ export interface OneShotConfig {
    * breakup position) is NOT overridable — timing only.
    */
   cadenceOverrides: Record<string, number[]> | null;
-  directMailMotions?: Record<string, { position: number; delayDays: number }> | null;
+  directMailMotions?: Record<string, import("./mail-policy.ts").MotionMailSettings | null> | null;
   /**
    * Default order of the /queue pending review list. "ranked" interleaves
    * finders with score-within-finder + exploration slots (see find/_rank.ts);

--- a/packages/plays/__tests__/free-pilot.test.ts
+++ b/packages/plays/__tests__/free-pilot.test.ts
@@ -57,7 +57,7 @@ vi.mock("@oneshot-gtm/intel", async () => {
 });
 
 const { runFreePilot } = await import("../src/free-pilot.ts");
-const { getSequence } = await import("../src/_cadence.ts");
+const { defaultSequence: getSequence } = await import("../src/_cadence.ts");
 
 const base = {
   name: "Dave",

--- a/packages/plays/__tests__/mail-cadence.test.ts
+++ b/packages/plays/__tests__/mail-cadence.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Ledger } from "../../core/src/ledger.ts";
 let ledger: Ledger;
-let mailConfig: Record<string, { position: number; delayDays: number }> = {};
+let mailConfig: Record<
+  string,
+  { position: number; delayDays: number; mode?: "automatic" | "always" } | null
+> = {};
 const sendMail = vi.fn();
 vi.mock("@oneshot-gtm/core", async () => {
   const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
@@ -55,6 +58,39 @@ function step(id: number) {
   return nextStepInfo(PLAY, ledger.getCadence(id, PLAY)!.current_step, id);
 }
 describe("optional motion mail steps", () => {
+  it("automatically includes mail only for reachable prospects and honors an off override", () => {
+    registerSequence({
+      playName: "new-business",
+      steps: [{ channel: "email", dayOffset: 5, breakOnReply: true, builder: async () => null }],
+    });
+    const address = {
+      name: "Jane",
+      address_line1: "1 Main St",
+      address_city: "Boston",
+      address_state: "MA",
+      address_zip: "02110",
+      address_country: "US" as const,
+    };
+    const reachable = ledger.upsertProspect({
+      name: "Jane",
+      company: "Acme",
+      businessAddress: address,
+    });
+    const missing = ledger.upsertProspect({ name: "Missing", company: "Acme" });
+    enrollInCadence({ prospectId: reachable, playName: "new-business" });
+    enrollInCadence({ prospectId: missing, playName: "new-business" });
+    expect(effectiveSequence("new-business", reachable)?.steps[0]?.channel).toBe("direct_mail");
+    expect(effectiveSequence("new-business", missing)?.steps[0]?.channel).toBe("email");
+    // Address collection can add mail to an existing cadence whose first step is still ahead.
+    ledger.setMailAddress(`prospect:${missing}`, { ...address, name: "Missing" });
+    applyCadencePlans("new-business", captureCadencePlans("new-business"));
+    expect(effectiveSequence("new-business", missing)?.steps[0]?.channel).toBe("direct_mail");
+    const before = captureCadencePlans("new-business");
+    mailConfig["new-business"] = null;
+    applyCadencePlans("new-business", before);
+    expect(effectiveSequence("new-business", reachable)?.steps[0]?.channel).toBe("email");
+    expect(effectiveSequence("new-business")?.steps).toHaveLength(1);
+  });
   it("moves letter preparation without leaving stale content at the previous index", () => {
     configure(2);
     const id = enroll();
@@ -168,6 +204,9 @@ describe("optional motion mail steps", () => {
     sendMail.mockResolvedValue(draft);
     expect((await sendDirectMailCadenceStep("mail")).action).toBe("step-sent");
     expect(step(id)?.label).toBe("touch 1");
+    expect(Date.parse(ledger.getCadence(id, PLAY)!.next_due_at!) - Date.now()).toBeGreaterThan(
+      10 * 86400000,
+    );
     await sendDirectMailCadenceStep("mail");
     expect(sendMail).toHaveBeenCalledTimes(1);
     expect(

--- a/packages/plays/__tests__/mail-research.test.ts
+++ b/packages/plays/__tests__/mail-research.test.ts
@@ -53,6 +53,18 @@ describe("automatic business address collection", () => {
     expect(ledger.getMailAddress("company:acme.test")).toMatchObject(address);
     expect(read).not.toHaveBeenCalled();
   });
+  it("retains company-page footers when limiting extraction context", async () => {
+    read.mockResolvedValue({
+      result: {
+        markdown: "Intro ".repeat(4000) + "Acme headquarters: 10 Main St, Boston, MA 02110, USA",
+        cost: 0.002,
+      },
+    });
+    expect(
+      (await researchBusinessAddress({ name: "Jane", email: "jane@acme.test" }, "motion")).address,
+    ).toMatchObject(address);
+    expect(llm.mock.calls[0]![0].messages[1].content).toContain("10 Main St");
+  });
   it("stores source evidence and reuses the address for another contact at that business", async () => {
     const first = await researchBusinessAddress(
       { name: "Jane", email: "jane@acme.test" },

--- a/packages/plays/__tests__/mail-research.test.ts
+++ b/packages/plays/__tests__/mail-research.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Ledger } from "../../core/src/ledger.ts";
 let ledger: Ledger;
-const read = vi.fn(),
+const enrich = vi.fn(),
+  read = vi.fn(),
   llm = vi.fn(),
   release = vi.fn();
 let allowed = true;
@@ -11,6 +12,7 @@ vi.mock("@oneshot-gtm/core", async () => {
     ...actual,
     getLedger: () => ledger,
     loadConfig: () => ({ directMailMotions: { motion: { position: 2, delayDays: 3 } } }),
+    enrichCompany: (...args: unknown[]) => enrich(...args),
     webRead: (...args: unknown[]) => read(...args),
     tryReserveDailySpend: () => (allowed ? { granted: true, release } : { granted: false }),
   };
@@ -32,6 +34,7 @@ beforeEach(() => {
   ledger = new Ledger(":memory:");
   vi.clearAllMocks();
   allowed = true;
+  enrich.mockResolvedValue({ result: { company: {}, cost: 0 } });
   read.mockResolvedValue({
     result: { markdown: "Acme headquarters: 10 Main St, Boston, MA 02110, USA", cost: 0.01 },
   });
@@ -39,6 +42,17 @@ beforeEach(() => {
 });
 afterEach(() => ledger.close());
 describe("automatic business address collection", () => {
+  it("captures a complete business address returned by SDK company enrichment", async () => {
+    enrich.mockResolvedValue({ result: { company: { address }, cost: 0.005 } });
+    const result = await researchBusinessAddress(
+      { name: "Jane", email: "jane@acme.test" },
+      "motion",
+    );
+    expect(result.address).toMatchObject({ ...address, name: "Jane" });
+    expect(result.source).toBe("sdk:enrich.company");
+    expect(ledger.getMailAddress("company:acme.test")).toMatchObject(address);
+    expect(read).not.toHaveBeenCalled();
+  });
   it("stores source evidence and reuses the address for another contact at that business", async () => {
     const first = await researchBusinessAddress(
       { name: "Jane", email: "jane@acme.test" },

--- a/packages/plays/__tests__/new-business.test.ts
+++ b/packages/plays/__tests__/new-business.test.ts
@@ -58,7 +58,7 @@ vi.mock("@oneshot-gtm/intel", async () => {
 });
 
 const { runNewBusiness } = await import("../src/new-business.ts");
-const { getSequence } = await import("../src/_cadence.ts");
+const { defaultSequence: getSequence } = await import("../src/_cadence.ts");
 
 const base = {
   name: "Priya",

--- a/packages/plays/src/_cadence.ts
+++ b/packages/plays/src/_cadence.ts
@@ -1,5 +1,8 @@
 import {
   classifyReply,
+  motionMailPolicy,
+  automaticMailEligible,
+  mailFollowupDueAt,
   sendDirectMail,
   getLedger,
   hasAnySendCapacity,
@@ -170,16 +173,17 @@ export function sequencePlan(seq: Sequence): CadencePlanStep[] {
   }));
 }
 
-export function effectiveSequence(playName: string, prospectId?: number): Sequence | undefined {
+export function effectiveSequence(
+  playName: string,
+  prospectId?: number,
+  rebuild = false,
+): Sequence | undefined {
   const base = playSequences.get(playName);
   if (!base) return undefined;
   const cfg = loadConfig();
   const override = cfg.cadenceOverrides?.[playName];
-  if (
-    prospectId === undefined &&
-    !cfg.directMailMotions?.[playName] &&
-    (!override || override.length !== base.steps.length)
-  )
+  const mail = motionMailPolicy(cfg, playName).settings;
+  if (prospectId === undefined && !mail && (!override || override.length !== base.steps.length))
     return base;
   const steps: SequenceStep[] = base.steps.map((step, i) => ({
     id: `base:${i + 1}`,
@@ -193,7 +197,7 @@ export function effectiveSequence(playName: string, prospectId?: number): Sequen
     const ledger = getLedger();
     const cadence = ledger.getCadence(prospectId, playName);
     const saved = cadence && ledger.getCadencePlan(prospectId, playName, cadence.enrolled_at);
-    if (saved)
+    if (saved && !rebuild)
       return {
         playName,
         steps: saved.map((entry) => {
@@ -211,10 +215,22 @@ export function effectiveSequence(playName: string, prospectId?: number): Sequen
         }),
       };
     // Existing enrollments without a snapshot predate configured mail. Reads never mutate them.
-    if (cadence) return { playName, steps };
+    if (cadence && !rebuild) return { playName, steps };
   }
-  const mail = cfg.directMailMotions?.[playName];
-  if (mail) steps.splice(mail.position - 2, 0, mailStep(mail.delayDays));
+  const prospect =
+    prospectId === undefined || mail?.mode !== "automatic"
+      ? null
+      : getLedger().getProspectById(prospectId);
+  const eligible =
+    !mail ||
+    mail.mode !== "automatic" ||
+    prospectId === undefined ||
+    automaticMailEligible(playName, {
+      ...prospect,
+      buyerType: getStep0MetadataField(prospectId, playName, "buyerType"),
+    });
+  if (mail && eligible)
+    steps.splice(Math.min(mail.position - 2, steps.length), 0, mailStep(mail.delayDays));
   return { playName, steps };
 }
 
@@ -234,9 +250,9 @@ export function applyCadencePlans(
   previous: ReturnType<typeof captureCadencePlans>,
 ): void {
   const ledger = getLedger();
-  const desired = sequencePlan(effectiveSequence(playName)!);
   const drafts = ledger.listDirectMail();
   for (const { cadence: c, steps: old } of previous) {
+    const desired = sequencePlan(effectiveSequence(playName, c.prospect_id, true)!);
     let steps = old;
     const pinned =
       ledger.hasSentSequenceEvent(c.prospect_id, playName, c.current_step + 1) ||
@@ -309,7 +325,7 @@ export function skipDirectMailStep(input: { prospectId: number; playName: string
 }
 
 export function enrollInCadence(input: { prospectId: number; playName: string }): void {
-  const seq = effectiveSequence(input.playName);
+  const seq = effectiveSequence(input.playName, input.prospectId);
   if (!seq || seq.steps.length === 0) return;
   const next = seq.steps[0];
   if (!next) return;
@@ -1041,7 +1057,9 @@ export async function runCadenceStepForProspect(
       playName: opts.playName,
       newStep: nextIndex,
       nextDueAt: next
-        ? new Date(Date.now() + next.dayOffset * 24 * 3600 * 1000).toISOString()
+        ? step.channel === "direct_mail"
+          ? mailFollowupDueAt(next.dayOffset)
+          : new Date(Date.now() + next.dayOffset * 24 * 3600 * 1000).toISOString()
         : null,
     });
     if (!next) {
@@ -1188,7 +1206,11 @@ export async function runCadenceStepForProspect(
     prospectId: opts.prospectId,
     playName: opts.playName,
     newStep: nextIndex,
-    nextDueAt: next ? new Date(Date.now() + next.dayOffset * 24 * 3600 * 1000).toISOString() : null,
+    nextDueAt: next
+      ? step.channel === "direct_mail"
+        ? mailFollowupDueAt(next.dayOffset)
+        : new Date(Date.now() + next.dayOffset * 24 * 3600 * 1000).toISOString()
+      : null,
   });
   if (!next) {
     ledger.setCadenceStatus({

--- a/packages/plays/src/_mail-research.ts
+++ b/packages/plays/src/_mail-research.ts
@@ -120,7 +120,12 @@ export async function researchBusinessAddress(
           },
         );
         costUsd += read.result.cost ?? 0;
-        const text = (read.result.markdown ?? "").slice(0, 18000);
+        const markdown = read.result.markdown ?? "";
+        // Company addresses often live in the footer of a long landing page.
+        const text =
+          markdown.length > 18000
+            ? `${markdown.slice(0, 9000)}\n${markdown.slice(-9000)}`
+            : markdown;
         if (!text) continue;
         const result = await complete({
           messages: [

--- a/packages/plays/src/_mail-research.ts
+++ b/packages/plays/src/_mail-research.ts
@@ -1,5 +1,7 @@
 import {
   getLedger,
+  enrichCompany,
+  extractSdkBusinessAddress,
   motionMailPolicy,
   loadConfig,
   extractBusinessAddress,
@@ -53,11 +55,15 @@ export async function researchBusinessAddress(
     };
   let domain = companyDomain(payload);
   const email = payload.email ?? payload.founderEmail;
-  if (!domain && typeof email === "string") {
+  if (typeof email === "string") {
     try {
       const cachedProfile = getLedger().getCachedEnrichment(email.trim().toLowerCase());
-      const profile = cachedProfile ? JSON.parse(cachedProfile.result_json).profile : null;
-      domain = companyDomain({ companyDomain: profile?.company_domain });
+      const cachedResult = cachedProfile ? JSON.parse(cachedProfile.result_json) : null;
+      const cachedAddress = extractSdkBusinessAddress(cachedResult, name);
+      if (cachedAddress)
+        return { address: cachedAddress, source: "sdk:enrich.profile (cached)", costUsd: 0 };
+      const profile = cachedResult?.profile;
+      domain ??= companyDomain({ companyDomain: profile?.company_domain });
     } catch {
       /* Missing/corrupt enrichment is not a usable company source. */
     }
@@ -79,6 +85,28 @@ export async function researchBusinessAddress(
   ledger.setMailAddressMetadata(key, { ...meta, attemptedAt: new Date().toISOString() });
   let costUsd = 0;
   try {
+    try {
+      const enriched = await enrichCompany(
+        { domain },
+        {
+          playName,
+          memo: "Collect business mailing address via SDK",
+          decisionContext: { source: "direct_mail.address", companyDomain: domain },
+        },
+      );
+      costUsd += enriched.result.cost ?? 0;
+      const address = extractSdkBusinessAddress(enriched.result, name);
+      if (address) {
+        ledger.setMailAddress(key, address, "sdk:enrich.company");
+        return { address, source: "sdk:enrich.company", costUsd };
+      }
+    } catch (error) {
+      logEvent(
+        "mail.address.sdk.failed",
+        { domain, message: error instanceof Error ? error.message : String(error) },
+        "warn",
+      );
+    }
     for (const path of ["/", "/contact"]) {
       if (costUsd >= remainingUsd) break;
       const url = `https://${domain}${path}`;

--- a/packages/plays/src/_mail-research.ts
+++ b/packages/plays/src/_mail-research.ts
@@ -1,5 +1,6 @@
 import {
   getLedger,
+  motionMailPolicy,
   loadConfig,
   extractBusinessAddress,
   webRead,
@@ -9,7 +10,7 @@ import {
   type PostalAddress,
 } from "@oneshot-gtm/core";
 import { complete, tryParseJsonObject } from "@oneshot-gtm/intel";
-import { getSequence } from "./_cadence.ts";
+import { getSequence, captureCadencePlans, applyCadencePlans } from "./_cadence.ts";
 
 const DAY = 86400000;
 const personalDomains = new Set([
@@ -142,7 +143,7 @@ export async function collectQueueBusinessAddress(
   if (!row || !["pending", "approved"].includes(row.status) || row.send_started_at) return 0;
   const payload = JSON.parse(row.payload_json) as Record<string, unknown>;
   const known = extractBusinessAddress(payload, String(payload.name ?? payload.founderName ?? ""));
-  if (!known && !loadConfig().directMailMotions?.[row.play_name]) return 0;
+  if (!known && !motionMailPolicy(loadConfig(), row.play_name).settings) return 0;
   const result = known
     ? {
         address: known,
@@ -184,6 +185,7 @@ export async function backfillMailAddresses(): Promise<void> {
   for (const c of ledger.listActiveCadences()) {
     if (attempted >= 5) break;
     if (
+      !motionMailPolicy(loadConfig(), c.play_name).settings &&
       !getSequence(c.play_name, c.prospect_id)
         ?.steps.slice(c.current_step)
         .some((s) => s.channel === "direct_mail")
@@ -204,7 +206,7 @@ export async function backfillMailAddresses(): Promise<void> {
   for (const row of ledger.listQueue({ limit: 500 }).toReversed()) {
     if (attempted >= 5) break;
     if (
-      !loadConfig().directMailMotions?.[row.play_name] ||
+      !motionMailPolicy(loadConfig(), row.play_name).settings ||
       !["pending", "approved"].includes(row.status)
     )
       continue;
@@ -216,5 +218,13 @@ export async function backfillMailAddresses(): Promise<void> {
     attempted++;
     ledger.setMailAddressMetadata(key, { attemptedAt: new Date().toISOString() });
     await collectQueueBusinessAddress(row.id);
+  }
+  // Reconcile eligible active enrollments after address collection; completed prefixes stay pinned.
+  for (const playName of new Set(ledger.listActiveCadences().map((c) => c.play_name))) {
+    if (
+      motionMailPolicy(loadConfig(), playName).settings?.mode === "automatic" &&
+      getSequence(playName)
+    )
+      applyCadencePlans(playName, captureCadencePlans(playName));
   }
 }

--- a/packages/plays/src/_run-play.ts
+++ b/packages/plays/src/_run-play.ts
@@ -24,7 +24,7 @@ import {
   socialProofBlock,
   type SendDraftedOpts,
 } from "./_lib.ts";
-import { enrollInCadence } from "./_cadence.ts";
+import { enrollInCadence, getSequence } from "./_cadence.ts";
 
 type AppConfig = ReturnType<typeof loadConfig>;
 
@@ -257,7 +257,11 @@ export async function runEmailPlay<T, X = Record<string, never>>(
           dryRun: opts.dryRun,
         });
 
-        if (send.sent && (def.enrollCadence || cfg.directMailMotions?.[def.playName])) {
+        if (
+          send.sent &&
+          (def.enrollCadence ||
+            getSequence(def.playName)?.steps.some((s) => s.channel === "direct_mail"))
+        ) {
           const prospect = getLedger().findProspectByEmail(def.toEmail(target));
           if (prospect) enrollInCadence({ prospectId: prospect.id, playName: def.playName });
         }

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -272,7 +272,8 @@ export interface HomeMetrics {
 }
 
 export interface PlayDescriptor {
-  directMail?: { position: number; delayDays: number } | null;
+  directMail?: { position: number; delayDays: number; mode?: "automatic" | "always" } | null;
+  mailRecommendation?: string;
   mailEligible?: boolean;
   baseSteps?: { day: number; label: string; channel: StepChannel; isBreakup: boolean }[];
   name: string;

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -274,6 +274,7 @@ export interface HomeMetrics {
 export interface PlayDescriptor {
   directMail?: { position: number; delayDays: number; mode?: "automatic" | "always" } | null;
   mailRecommendation?: string;
+  mailAutomaticSupported?: boolean;
   mailEligible?: boolean;
   baseSteps?: { day: number; label: string; channel: StepChannel; isBreakup: boolean }[];
   name: string;


### PR DESCRIPTION
Direct mail now starts in Automatic mode for selected motions, and only enters a prospect’s cadence when the available business address and buyer context meet the motion’s rules. Founders can choose Automatic, Always include, or a persistent Off override. Existing explicit opt-ins remain enabled.

New-business/free-pilot use a complete named business address; design-partner LOI additionally requires enterprise/hardware buyers; post-funding/hiring-signal/competitor-switch additionally require an ICP pass and decision-maker title. Other motions default off. These are transparent rules, not predictions of account value or conversion. Automatic address backfill updates eligible active plans while preserving completed prefixes and existing mailpieces.

After postal order acceptance, the following touch waits at least eight business days plus two calendar days for printing, transit, and reading. Longer configured delays remain intact; skipped mail keeps the normal next-touch delay. Individual approval remains required.

Validation: full suite passed (241 files, 3,146 tests), plus the added API regression for Off/Automatic persistence; typecheck, lint (existing warnings only), web production build and diff checks passed. Companion docs: https://github.com/tormine/oneshot/pull/617 (Mintlify validation passed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Configure direct mail per motion as **Automatic**, **Always**, or **Off**.
  - Automatic recommendations consider contactability, business details, buyer fit, motion type, and seniority.
  - Direct-mail sequences adapt to each prospect and refresh when address information changes.
  - Business addresses from supported enrichment data are saved for future mail decisions.
  - Approved direct mail advances follow-ups by at least eight business days plus two reading days; skipped mail keeps the normal cadence.

- **Documentation**
  - Updated direct-mail guidance covering modes, defaults, eligibility, overrides, and cadence timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->