### PR TITLE
docs: shorten the README and split operational detail into docs/

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ https://github.com/user-attachments/assets/bba2fb2d-35c3-4171-a358-fd3a987c24bc
 
 [OneShot](https://docs.oneshotagent.com) is a pay-per-use API toolbox — email, SMS, voice, deep research, person enrichment, browser automation, website build — settled per call in USDC on Base, with a cryptographically signed receipt for every action.
 
-`oneshot-gtm` is the strategy wrapper. It encodes the canonical PMF and founder-led-sales playbook — Mom Test, Sean Ellis 40%, Predictable Revenue, do-things-that-don't-scale, multichannel cadence, signed-receipt CAC — as named **plays** you run from the terminal or the dashboard.
+`oneshot-gtm` is the strategy wrapper. It encodes the founder-led-sales playbook — Mom Test, Sean Ellis 40%, Predictable Revenue, do-things-that-don't-scale, multichannel cadence, signed-receipt CAC — as named **plays** you run from the terminal or the dashboard. Finders watch public signals, an ICP gate filters what they find, you approve rows in a queue, plays draft and send, cadences follow up, and every dollar lands in a receipt you can attribute to an outcome.
 
 MIT, so you can read every prompt, fork every play, and trust what's running.
 
@@ -35,13 +35,13 @@ MIT, so you can read every prompt, fork every play, and trust what's running.
 | LLM               | Built-in, opaque                     | BYO key (OpenRouter / OpenAI / Anthropic) |
 | State             | Vendor cloud                         | Local SQLite + chmod-600 dotfile          |
 
-Most GTM tools assume you have product-market fit and optimize sends. Most pre-PMF founders don't, and end up scaling a broken motion because the tool said "send more" — which the [Startup Genome Report](https://startupgenome.com) cites as the top documented cause of startup death. So the discipline is built in:
+Most GTM tools assume you have product-market fit and optimize sends. Most pre-PMF founders don't, and end up scaling a broken motion because the tool said "send more" — the [Startup Genome Report](https://startupgenome.com)'s top documented cause of startup death. So the discipline is built in:
 
 - Plays default to founder-to-founder voice, low volume (≤50/day), one touch unless you invoke the cadence engine.
-- Every first touch is Hook → Identity → Offer → CTA. The Offer says the useful thing in the email, for free; the CTA asks for one line the reader can answer from their own experience, or asks for nothing. It never asks a stranger for a meeting — "open to compare notes?" is banned, because it needs the reader to already believe a conversation with you is worth their time. Optionally, one true concession you write in config (`founderAdmission`) is worked into roughly a third of first touches as a damaging admission; leave it blank and the beat is skipped, never invented.
-- Every draft passes a lint pass built on the Wikipedia "Signs of AI writing" canon — banned phrases, em dashes, AI vocabulary, three-item lists, sycophantic openers.
+- Every first touch is Hook → Identity → Offer → CTA. The Offer says the useful thing in the email, for free; the CTA asks for one line the reader can answer from their own experience, or asks for nothing. It never asks a stranger for a meeting. One true concession you write in config (`founderAdmission`) is worked into roughly a third of first touches; leave it blank and the beat is skipped, never invented.
+- Every draft passes a lint built on the Wikipedia "Signs of AI writing" canon — banned phrases, em dashes, AI vocabulary, three-item lists, sycophantic openers.
 - Scale-move commands (`handoff templatize`, `first-ae`, `readiness`) print soft-gate checklists and default to "not yet, fix this first" until the signals earn the move. `--force` overrides.
-- Every paid action emits a signed receipt carrying a **memo** (why the call happened), structured `decisionContext`, and a `goalId` grouping a cadence's spend. When a reply or deal outcome lands, that value is tagged back — so CAC and RoCS on the Measure page are attestable and outcome-attributed, not estimated.
+- Every paid action emits a signed receipt carrying a **memo** (why the call happened), structured `decisionContext`, and a `goalId` grouping a cadence's spend. When a reply or deal outcome lands, that value is tagged back, so CAC and RoCS on the Measure page are attestable and outcome-attributed, not estimated.
 
 ---
 
@@ -59,13 +59,11 @@ bun run --cwd apps/web build                    # one-time: build the SPA
 bun run cli -- ui                               # http://127.0.0.1:3030
 ```
 
-`init` also asks for the founder profile the prompts draw on: background that builds trust, products you've shipped, notable partners or customers, and one true concession. All optional — when a field is blank, the beat that uses it is skipped rather than improvised. Edit any of them later from `/setup` or `config founder`.
+`init` asks for the founder profile the prompts draw on: background that builds trust, products you've shipped, notable partners or customers, and one true concession. All optional — a blank field skips the beat that uses it rather than improvising. Edit any of them later from `/setup` or `config founder`. [What reaches the model, and when](./docs/prompt-inputs.md) maps each field to the surfaces it shapes.
 
-Some credentials are env-only — `init` never asks about them, but `/setup` and `config keys` can store them in the workspace-aware secrets file (the path returned internally by `secretsPath()`). The `x-reposters` finder's keys live here too: four OAuth1 values for the first-party X API, or `TWITTERAPI_IO_KEY` for the cheaper third-party engine — pick the provider on `/setup` or with `config x-engine`. `GITHUB_TOKEN` is the one most people need: without it the two GitHub finders share GitHub's unauthenticated ceiling of 60 requests/hour per IP and halt on a `403`, so a classic token with **no scopes** is worth creating before you enable them. `LUMA_SESSION_COOKIE` is optional, and only buys authed Luma guest lists. `doctor` warns about a missing `GITHUB_TOKEN` once a GitHub finder is on.
+Some finders need keys `init` never asks about — most people want `GITHUB_TOKEN` (a classic token with no scopes) before enabling the GitHub finders. `/setup` and `config keys` store them; [finders](./docs/finders.md#finder-specific-keys) lists them.
 
-To call it from anywhere: `cd apps/cli && bun link && bun link oneshot-gtm && cd -`. If you linked before workspaces landed, re-run that — the bin target moved to the bootstrap shim (`src/main.ts`).
-
-Prefer the dashboard without cloning? `bunx oneshot-gtm-server` downloads and boots it. Bun is still required — the bundle uses `bun:sqlite` and `Bun.serve`, and fails loudly with an install hint under plain `node`. The CLI itself is not published to npm.
+To call it from anywhere: `cd apps/cli && bun link && bun link oneshot-gtm && cd -`. Prefer the dashboard without cloning? `bunx oneshot-gtm-server` downloads and boots it. Bun is still required — the bundle uses `bun:sqlite` and `Bun.serve`, and fails loudly under plain `node`. The CLI itself is not published to npm.
 
 ---
 
@@ -82,20 +80,20 @@ bun run cli -- find drain podcast-guest --dry-run  # preview approved /queue row
 bun run cli -- cadence advance                     # daily tick: poll inbox, fire follow-ups
 ```
 
-65 commands — fifteen groups, plus `init`, `doctor` and `ui` at the top level. `bun run cli -- --help` (or `oneshot-gtm --help` once linked) is the reference:
+`bun run cli -- --help` (or `oneshot-gtm --help` once linked) is the reference:
 
 | Group                    | Commands                                                                                                                                                                                                                                                                                            |
 | ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `init` · `doctor` · `ui` | setup wizard · health check · open the dashboard                                                                                                                                                                                                                                                    |
-| `direct-mail`            | `list` · `upload` · `preview` · `refresh` · `approve` · `send` · `cancel` — individual physical-mail approvals                                                                                                                                                                                      |
 | `config`                 | `llm` · `founder` · `keys` · `telemetry on\|off` · `x-engine [engine]` · `spend-ceiling [amount\|off]`                                                                                                                                                                                              |
-| `gmail`                  | `auth` (OAuth a sending account) · `placement` (inbox-placement canary)                                                                                                                                                                                                                             |
 | `identities`             | `list` · `add` · `remove <id>` — the sender pool                                                                                                                                                                                                                                                    |
+| `gmail`                  | `auth` (OAuth a sending account) · `placement` (inbox-placement canary)                                                                                                                                                                                                                             |
 | `smartlead`              | `connect` — API key + pick Smartlead mailboxes into the pool (send-only)                                                                                                                                                                                                                            |
 | `domains`                | `list` · `pause <domain>` · `resume <domain>` — provisioned OneShot domains                                                                                                                                                                                                                         |
 | `find`                   | `watch` · `drain <play>` · `import --csv <file> --play <name>` · `enrich-linkedin` · `research-prospects` · `research-products` · `score-prospects` · `calibrate` — `--fail-on-empty` makes `watch --once` and `drain` [exit 2 on a run that produced nothing](#background-monitoring-as-a-service) |
 | `motion`                 | `post-funding` `concierge` `demo-no-show` `competitor-switch` `hiring-signal` `podcast-guest` `discovery-interview` `free-pilot` — each takes `--target <file>`; `breakup-revive` reads the ledger                                                                                                  |
 | `cadence`                | `advance` — poll inbound, fire due steps                                                                                                                                                                                                                                                            |
+| `direct-mail`            | `list` · `upload` · `preview` · `refresh` · `approve` · `send` · `cancel` — individual physical-mail approvals                                                                                                                                                                                      |
 | `discover`               | `icp interview-prep` · `icp synthesize` · `pmf classify` · `pmf survey` · `pmf survey-collect`                                                                                                                                                                                                      |
 | `measure`                | `benchmark` — compare this install's command activity with the opt-in telemetry cohort; supports `--json`                                                                                                                                                                                           |
 | `intel`                  | `advise` · `personalize` · `triage-replies` · `weekly-review`                                                                                                                                                                                                                                       |
@@ -103,7 +101,7 @@ bun run cli -- cadence advance                     # daily tick: poll inbox, fir
 | `demo`                   | `seed` · `ui` · `reset` — a fictional install for screenshots and video                                                                                                                                                                                                                             |
 | `workspace`              | `list` · `create <name>` · `use <name>` · `current` · `path <name>` · `remove <name>` — one isolated install per product; `--workspace <name>` on any command                                                                                                                                       |
 
-Spend, CAC, RoCS and outcome logging remain in the dashboard's Measure and Cadences pages so there's one source of truth. The CLI's `measure benchmark` surface is limited to anonymous telemetry comparisons. The `/api/measure/*` routes are there if you'd rather script local ledger metrics, or add `--json` to a read-only command (`doctor`, `identities list`, `domains list`, `workspace list`) for machine-readable output.
+Spend, CAC, RoCS and outcome logging live in the dashboard's Measure and Cadences pages so there's one source of truth. Add `--json` to a read-only command (`doctor`, `identities list`, `domains list`, `workspace list`) for machine-readable output, or script the `/api/measure/*` routes.
 
 ### Dashboard
 
@@ -114,225 +112,83 @@ bun run cli -- ui [--dev] [--port 4000] [--no-browser]
 Nine pages plus a run form:
 
 - **Home** — spend, reply-rate trend, in-flight cadences, and a scheduler strip showing each trigger's state, last run and next due
-- **Queue** — triggers table (enable, edit config, fire) plus the target queue with bulk approve and per-play **Drain**; the pending review list can be ordered `newest` or `ranked` (finder-interleaved priority score with exploration slots — a toggle on the page, defaulted by `queueReviewOrder` in config)
-- **Add Prospect** — paste a LinkedIn / X / GitHub URL; `deepResearchPerson` builds a dossier, the LLM picks an angle against your ICP and drafts an intro, and the row lands in the queue
-- **Replies** — every reply matched to its prospect, play and cadence status across all sender identities; answer in place, by hand or LLM-drafted. Drafting is research-grounded: known prospects reuse their stored dossier, unknown senders get enriched + their site read (~$0.06, cached 30 days, receipted under `inbox-reply`), and replies may cite links from your product brief — never invented ones
+- **Queue** — triggers table (enable, edit config, fire) plus the target queue with bulk approve and per-play **Drain**
+- **Add Prospect** — paste a LinkedIn / X / GitHub URL; deep research builds a dossier, the LLM picks an angle against your ICP and drafts an intro, and the row lands in the queue
+- **Replies** — every reply matched to its prospect, play and cadence status across all sender identities; answer in place, by hand or LLM-drafted and research-grounded
 - **Cadences** — stop, log outcome, preview the next step, batch send email, and [review/send direct mail](#direct-mail) per prospect
 - **Receipts** — paginated, with the memo and value chip per call; click through to the signed payload
-- **Plays** — cards with channel badges, a Run button, Copy CLI, and optional [direct-mail steps](#direct-mail) with editable position and delay
+- **Plays** — cards with channel badges, a Run button, Copy CLI, and optional [direct-mail steps](#direct-mail)
 - **Measure** — CAC and RoCS by time range, plus per-cadence spend vs tagged value grouped by goal
-- **Setup** — founder profile, ICP, product brief (facts + the only links replies may cite, derivable from your site/repo/docs), LLM provider, wallet keys, sender identities, telemetry toggle
+- **Setup** — founder profile, ICP, product brief, LLM provider, wallet keys, sender identities, telemetry toggle
 - **Run a play** (`/run/$playName`) — editable target rows, dry-run toggle, drafts streamed back over SSE with lint flags and receipt links
 
-A floating strategist dock sits on every page: it reads your ICP and product one-liner and proposes trigger configs as confirmation chips (`POST /api/strategist/stream`, SSE).
-
-Next to it is a **privacy toggle**. Flip it on and names, emails, companies and phone numbers render partially masked everywhere — enough to screenshot a receipt or a cadence without exposing a real contact. Costs, receipt IDs and every other figure stay untouched, since the numbers are the reason to show a receipt in the first place. Off by default, remembered per browser. It's readable obfuscation for screenshots, not secure redaction.
-
-### Direct mail
-
-**Plays → Direct mail** chooses suitable prospects automatically for selected motions. Founders can choose **Automatic**, **Always include**, or **Off**, and edit the mail step’s position and delay. Each letter still requires individual proof review and approval.
-
-| Motion                                         | Automatic selection                                                     | Default placement                            |
-| ---------------------------------------------- | ----------------------------------------------------------------------- | -------------------------------------------- |
-| New business, free pilot                       | Named prospect, company, and complete U.S. business address             | Step 2, three days after the first email     |
-| Design-partner LOI                             | Same address requirements; enterprise or hardware buyer                 | Step 2, three days after the first email     |
-| Post-funding, hiring-signal, competitor-switch | Same address requirements; confirmed ICP match and decision-maker title | Step 3, three days after the first follow-up |
-| Other motions                                  | Off by default; founder can choose Always include                       | Founder-selected                             |
-
-These are explainable starting rules, not predictions of conversion or account value. Sources labeled as registered-agent, registered-office or residential addresses are excluded from automatic selection. An address still needs review: complete postal fields do not establish that a person works there. Research can add mail to an eligible active cadence when its insertion point is still ahead; completed touches and existing mailpieces retain their plans. Explicit Off overrides survive future default changes.
-
-Save your return address once under **Setup → Founder → Direct mail return address**. Business addresses are collected from prospect inputs, CSV/registry data, and company research for mail-enabled motions. Missing addresses hold the mail step until you correct them or explicitly skip mail.
-
-On **Cadences**, click a prospect’s **Review mail** button. Both saved addresses are filled automatically. Generate/edit a personalized letter or upload a **PDF/JPEG for that prospect**, review the print proof and price, then **Approve and send**. Replacing content or changing an address requires a fresh proof. The dashboard sends U.S. letters; existing postcard orders and the artwork CLI remain supported. Mail history provides postal status, recovery, and cancellation. Bulk actions never send mailpieces. An accepted order advances the cadence once. Its next follow-up allows at least eight business days for printing and transit, plus two calendar days to read; longer configured delays remain in force. This is an estimate, not a delivery guarantee. Skipping mail keeps the normal next-touch delay. Postal delivery does not prove readership.
-
-For this integration branch, both core and the server use the SDK archive in `vendor/`; see its README for the coordinated SDK/GTM release step.
-
-### Demo mode
-
-A fresh install is nine empty states, which makes it hard to show anyone what this looks like in use. `demo` builds a fictional, fully-populated install in its own home and opens the dashboard against it.
-
-```bash
-bun run cli -- demo seed      # → ~/.oneshot-gtm-demo
-bun run cli -- demo ui        # dashboard, pointed at the demo install
-bun run cli -- demo reset     # delete it
-```
-
-The cast is invented (it extends the one in `examples/`) and the numbers are internally consistent: ~24 prospects across eight plays and 30 days, 147 signed receipts totalling $2.94, cadences in all five states, replies matched to their prospects, two closed deals. Everything is anchored to a timestamp, so `--now` reproduces a ledger exactly and a re-shoot matches the first take.
-
-What demo mode changes, and nothing else:
-
-- Four **read-only** calls that fetch at request time rather than reading the ledger — the reply list, the platform RoCS rollup, the domain pool, the wallet balance — are served from JSON fixtures in the demo home. Without that, Replies is blank no matter what's in SQLite.
-- The in-process **scheduler idles**, so enabled triggers don't fire against the demo install and overwrite its state mid-screenshot.
-
-Nothing that sends, drafts or spends is faked. Under the flag, the demo home's `.env` is the **sole** source of secrets — real credentials inherited from your shell, your install, or a repo-root `.env` are overwritten or deleted — so a stray click on Run or Send fails at auth rather than doing something real. `demo seed` refuses to touch `~/.oneshot-gtm`, and `demo reset` only removes a directory it marked as its own.
-
----
-
-## Workspaces
-
-One install is one product: one founder voice, one ICP, one product brief, one ledger, one sender pool. Selling two things — or running the OneShot motion _and_ the oneshot-gtm adoption motion — means two workspaces:
-
-```bash
-bun run cli -- workspace create gtm          # ~/.oneshot-gtm-workspaces/gtm, dashboard :3031
-bun run cli -- --workspace gtm init          # its own profile, keys, identities
-bun run cli -- --workspace gtm ui            # runs side by side with the default on :3030
-bun run cli -- workspace use gtm             # make it the default for runs without the flag
-```
-
-`--workspace` (or `ONESHOT_GTM_WORKSPACE`) is resolved by a bootstrap shim before anything else loads, so every command and the spawned dashboard see the right home. An explicit `ONESHOT_GTM_HOME` still wins — it's the escape hatch, and `workspace path <name>` prints a home for scripting (`ops/expandi-sync` reads it that way).
-
-What stays **shared** across workspaces lives in `~/.oneshot-gtm-shared/shared.sqlite`: the paid lookup caches (enrichment, LinkedIn — the same person is never bought twice) and contact touches. A workspace never first-touches someone another workspace emailed in the last 7 days: the draft holds with a `contacted-elsewhere` flag you can override on a manual send, while drain and cadence steps wait the window out.
-
-`doctor` warns when two workspaces share a sending domain (warm-up caps are per-workspace, so the domain's real budget silently doubles) or a Gmail account (both inbox pollers would see both products' replies).
-
-The dashboard always knows where it is: a masthead chip names the workspace and its port (each name gets a stable colour, so `gtm` always looks like `gtm`). Clicking the chip — or `⌘K → Workspaces` — lists every registered workspace with a live status dot: running ones open in a new tab, stopped ones **start and then open** (the server is spawned detached with no supervisor; the status dots are the truth about what's up, and a launch that doesn't come up within 15s falls back to a copyable `--workspace <name> ui` command).
+A floating strategist dock on every page reads your ICP and product one-liner and proposes trigger configs as confirmation chips. Next to it, a privacy toggle masks names, emails, companies and phone numbers for screenshots. [Demo mode](./docs/demo-mode.md) seeds a fictional, fully-populated install for the same purpose.
 
 ---
 
 ## Where targets come from
 
-Fifteen **finders** discover prospects, ICP-filter them, and enqueue into `/queue` for one-click approve or reject. Each runs as a trigger with its own interval and spend cap.
+Finders discover prospects, ICP-filter them, and enqueue into `/queue` for one-click approve or reject. Each runs as a trigger with its own interval and spend cap; the dashboard server runs the scheduler in-process, so enabling a trigger is enough.
 
-| Finder              | Signal                                                                                                                                                                                                                                                                                                                                             |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `show-hn`           | same-day Show HN posts, via the HN Algolia API                                                                                                                                                                                                                                                                                                     |
-| `post-funding-auto` | funding announcements by ICP-derived industry × round                                                                                                                                                                                                                                                                                              |
-| `accelerator-batch` | new cohorts — yc-oss directory, websearch fallback for Techstars / Antler / 500 / AI Grant                                                                                                                                                                                                                                                         |
-| `job-change`        | `joined as <persona>` announcements, filtered by persona and company                                                                                                                                                                                                                                                                               |
-| `hiring-signal`     | open roles on Greenhouse / Lever / Workable / Ashby implying a need                                                                                                                                                                                                                                                                                |
-| `podcast-guest`     | recent guests across Latent Space, Lenny's, 20VC, Acquired, Invest Like the Best                                                                                                                                                                                                                                                                   |
-| `github-topics`     | repos by topic, then a manifest scan (`package.json`, `pyproject.toml`, `requirements.txt`) that detects the vendor stack deterministically — needs `GITHUB_TOKEN`                                                                                                                                                                                 |
-| `github-stars`      | recent stargazers of repos you watch; tag each repo `competitor` or `adjacent` to route the play — needs `GITHUB_TOKEN`                                                                                                                                                                                                                            |
-| `luma-events`       | upcoming events from Luma's own city pages, gated per event by a topic + ICP check before any spend; pitches the hosts and featured guests Luma exposes publicly                                                                                                                                                                                   |
-| `gov-solicitation`  | SAM.gov Sources Sought / Presolicitation notices by NAICS code — pitches the notice's own published point of contact, no `findEmail`/`verifyEmail` spend at all — needs `SAM_GOV_API_KEY`                                                                                                                                                          |
-| `civic-agenda`      | city/county council agenda items via the Legistar/Granicus Web API, keyword-gated free before any paid call; pitches the meeting body's own published contact                                                                                                                                                                                      |
-| `breakup-revive`    | your own ledger — prospects cold for 60–90 days. No LLM or OneShot spend                                                                                                                                                                                                                                                                           |
-| `x-reposters`       | people who repost/quote X accounts you watch, in two lanes: builders who'd adopt (founder lane → email cadence) and dev accounts with reach who'd boost a launch (amplifier lane → one-touch email, or a hand-sent DM draft when no email is found) — needs X API OAuth1 keys, or `TWITTERAPI_IO_KEY` for the ~55x cheaper engine                  |
-| `local-business`    | main-street businesses via `peopleSearch`/`companySearch` (job title × industry × location × company size) — routed to the `free-pilot` play; a candidate carrying `best_work_email` skips `findEmail`/`verifyEmail` entirely, but `qualifyPostEnrich` may still perform paid `enrichProfile` lookups when `fillGaps` is enabled                   |
-| `local-registry`    | newly-licensed/enumerated main-street businesses over free, keyless public registries (Socrata business licenses, NPPES NPI, FMCSA Company Census, Socrata health inspections) — recent matches route to `new-business`, older ones to `free-pilot`; fmcsa carries a published email on the record, so it skips `findEmail`/`verifyEmail` entirely |
+| Finder              | Signal                                                                                                                                                                                                                                 |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `show-hn`           | same-day Show HN posts, via the HN Algolia API                                                                                                                                                                                         |
+| `post-funding-auto` | funding announcements by ICP-derived industry × round                                                                                                                                                                                  |
+| `accelerator-batch` | new cohorts — yc-oss directory, websearch fallback for Techstars / Antler / 500 / AI Grant                                                                                                                                             |
+| `job-change`        | `joined as <persona>` announcements, filtered by persona and company                                                                                                                                                                   |
+| `hiring-signal`     | open roles on Greenhouse / Lever / Workable / Ashby implying a need                                                                                                                                                                    |
+| `podcast-guest`     | recent guests across Latent Space, Lenny's, 20VC, Acquired, Invest Like the Best                                                                                                                                                       |
+| `github-topics`     | repos by topic, then a manifest scan that detects the vendor stack deterministically — needs `GITHUB_TOKEN`                                                                                                                            |
+| `github-stars`      | recent stargazers of repos you watch; tag each repo `competitor` or `adjacent` to route the play — needs `GITHUB_TOKEN`                                                                                                                |
+| `luma-events`       | upcoming events from Luma's city pages, gated per event by a topic + ICP check before any spend; pitches the hosts and featured guests                                                                                                 |
+| `gov-solicitation`  | SAM.gov Sources Sought / Presolicitation notices by NAICS code; pitches the notice's published point of contact, no lookup spend — needs `SAM_GOV_API_KEY`                                                                             |
+| `civic-agenda`      | city/county council agenda items via the Legistar/Granicus API, keyword-gated free before any paid call; pitches the meeting body's published contact                                                                                  |
+| `breakup-revive`    | your own ledger — prospects cold for 60–90 days. No LLM or OneShot spend                                                                                                                                                               |
+| `x-reposters`       | people who repost/quote X accounts you watch, in two lanes: builders who'd adopt (email cadence) and dev accounts with reach who'd boost a launch (one-touch email, or a hand-sent DM draft) — needs X API keys or `TWITTERAPI_IO_KEY` |
+| `local-business`    | main-street businesses via `peopleSearch`/`companySearch` (job title × industry × location × company size) — routed to the `free-pilot` play                                                                                           |
+| `local-registry`    | newly-licensed main-street businesses over free public registries (Socrata business licenses, NPPES NPI, FMCSA Company Census, health inspections) — recent matches route to `new-business`, older ones to `free-pilot`                |
 
-Only `show-hn` and `post-funding-auto` are on by default; enable the rest from `/queue`. A trigger missing required config reads as **not ready** — the toggle and Run button disable with the reason, and the API returns `409`, so scripted callers can't bypass the gate either.
-
-Per-run caps (`maxCostUsd` on a finder, `maxSpendPerRun` on x-reposters) bound one call; they don't stop fifteen independently-scheduled finders and automatic drains from collectively overspending across a day. `config spend-ceiling <amount>` (or the Wallet card on `/setup`) sets an install-wide daily USD ceiling, checked before every automated finder run and drain — a reservation held for the call's duration closes the race between two concurrent automated paths, so they can't both slip under the ceiling before either one's spend has posted. Once reached, scheduled/run-now finders and drains halt with a named reason (`daily spend ceiling reached ($X.XX/$Y.YY spent today)`) visible on the trigger cards and in `doctor`; manual `/queue` sends (approve, reject, mark-sent, send-draft) are never gated by it — a founder reviewing and sending one email by hand is a deliberate decision the ceiling should never block. The counter resets at local midnight, same boundary the per-identity send caps use. Unset (the default) is unlimited, matching the historical behavior.
-
-Qualified first-touch rows receive a product dossier before the trigger completes: up to two known first-party pages plus quick external research covering the product, ecosystem, architecture, and business model. Set `productResearch: false` on a trigger to disable it. Research counts toward that trigger's `maxCostUsd`; a failure or exhausted cap leaves the row reviewable with an explicit warning. `find research-products` backfills the same context onto active/replied prospects and pending queue rows (`--dry-run`, `--limit`, and `--refresh` are supported). Use `--first-party-only` for a resilient bulk backfill when the external research provider is unavailable.
-
-Before any paid `findEmail`, a prescreen skips dud domains (`*.vercel.app`, social hosts, link aggregators, personal email providers) and inputs whose "name" is obviously a username. LinkedIn URLs are captured on every finder path and verified to belong to the person before they're stored.
-
-Two ICP gates run per candidate, not one. The **topic gate** judges the source — the repo, event, or announcement — and keeps whole categories of noise out before any spend. The **person gate** judges the human's role, staged by cost: free role text the finder already holds (an event bio, an extracted title), then the job title off the enrichment every verified email already pays for, then — only when still ambiguous and a LinkedIn URL exists — one extra ~$0.005 lookup. It judges capability to build and self-adopt, not job-title seniority: students shipping hackathon projects and consultants building agent systems for clients pass; a Marketing Manager at a brilliant AI company doesn't. Only a _positive_ reject drops a candidate — ambiguity escalates or proceeds, never silently discards. Rejections land in `/queue` as auditable `auto: role — <reason>` rows you can override, count as `role-drop` on trigger cards, and a prospect judged off-ICP after contact stops receiving cadence follow-ups (terminal status `off-icp`).
-
-The dashboard server runs an in-process scheduler, so enabling a trigger is enough — no separate daemon. `find watch` stays useful for cron and headless boxes. Approved rows ship via the **Drain** button or `find drain <play>`.
-
-### The data underneath
-
-Enrichment, verification and local lookups resolve through OneShot, which maintains a vendor landscape of 50 data sources across six categories. Which source answers a given lookup is chosen per call, so what follows is coverage rather than a list of integrations — a map of who operates in each space, not a claim about what is wired up today.
-
-| Category                      | Sources | Examples                               |
-| ----------------------------- | ------- | -------------------------------------- |
-| Contact enrichment            | 13      | Apollo, Clay, Hunter, People Data Labs |
-| Company & firmographic data   | 7       | Diffbot, Coresignal, PredictLeads      |
-| Email verification            | 6       | ZeroBounce, NeverBounce, Kickbox       |
-| Maps, places & local data     | 6       | Serper, Foursquare, Outscraper         |
-| Browser automation & scraping | 10      | Browserbase, Apify, Bright Data        |
-| Social distribution & data    | 8       | Unipile, TwitterAPI.io, Lix            |
-
-The other eight categories in the catalogue are things an agent does rather than knows — voice, speech, media, e-signature, mail, shipping, domains, deliverability — and account for the remaining 66 vendors. [The full catalogue](https://docs.oneshotagent.com/vendors).
-
-### Background monitoring as a service
-
-`find watch --install-service` generates a service file that keeps the watch daemon running in the background — a launchd user agent on macOS, a systemd user unit on Linux. It prints to stdout (redirect-friendly); add `--write` to drop it at the platform-conventional path. Every path is embedded absolute at generation time — the bun binary, the CLI entry, and the active `ONESHOT_GTM_HOME` (so `--workspace acme find watch --install-service` pins the service to that workspace) — because service managers don't source your shell profile. Regenerate with `--write` after moving bun or the checkout.
-
-**macOS (launchd).** Logs go to `<home>/find-watch.log`; the agent restarts on crash and survives reboots.
-
-```bash
-oneshot-gtm find watch --install-service            # inspect the plist
-oneshot-gtm find watch --install-service --write    # → ~/Library/LaunchAgents/com.oneshot-gtm.find-watch.plist
-launchctl load ~/Library/LaunchAgents/com.oneshot-gtm.find-watch.plist
-
-# uninstall
-launchctl unload ~/Library/LaunchAgents/com.oneshot-gtm.find-watch.plist
-rm ~/Library/LaunchAgents/com.oneshot-gtm.find-watch.plist
-```
-
-**Linux (systemd user unit).** Logs go to the user journal: `journalctl --user -u oneshot-gtm-find-watch`.
-
-```bash
-oneshot-gtm find watch --install-service --write    # → ~/.config/systemd/user/oneshot-gtm-find-watch.service
-systemctl --user daemon-reload
-systemctl --user enable --now oneshot-gtm-find-watch
-
-# uninstall
-systemctl --user disable --now oneshot-gtm-find-watch
-rm ~/.config/systemd/user/oneshot-gtm-find-watch.service
-```
-
-On a headless box, also run `loginctl enable-linger $USER` once so the user unit starts at boot rather than at first login.
-
-**Windows (Task Scheduler).** There's no user-service template; schedule the cron-style `find watch --once` instead, which runs all due triggers and exits:
-
-```powershell
-$watchAction = New-ScheduledTaskAction -Execute 'C:\Users\you\.bun\bin\bun.exe' `
-  -Argument '"C:\path\to\oneshot-gtm\apps\cli\src\main.ts" find watch --once --quiet'
-$watchTrigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(1) `
-  -RepetitionInterval (New-TimeSpan -Minutes 15)
-Register-ScheduledTask -TaskName 'oneshot-gtm find watch' -Action $watchAction -Trigger $watchTrigger
-
-# uninstall
-Unregister-ScheduledTask -TaskName 'oneshot-gtm find watch' -Confirm:$false
-```
-
-The classic cron route works on POSIX hosts; Windows users should use Task Scheduler: `*/15 * * * * ONESHOT_GTM_HOME=$HOME/.oneshot-gtm /path/to/bun /path/to/apps/cli/src/main.ts find watch --once --quiet`.
-
-**Exit codes for scheduled runs.** `find watch --once` exits `1` when a due trigger errored. Add `--fail-on-empty` and a run that worked but produced nothing exits `2` instead of `0`, with one line on stderr naming the triggers and the zero count — enough for a cron wrapper to tell a dry run from a productive one without reading the ledger. `find drain <play>` takes the same flag. Both are opt-in: without it, exit codes are exactly what they were.
-
-|       | `find watch --once`                                | `find drain <play>`                                     |
-| ----- | -------------------------------------------------- | ------------------------------------------------------- |
-| **0** | candidates queued, or `--fail-on-empty` not passed | rows drained, or `--fail-on-empty` not passed           |
-| **1** | a due trigger errored (with or without the flag)   | with the flag: a row errored, or the drain itself threw |
-| **2** | with the flag: ran clean, queued nothing           | with the flag: no approved rows to drain                |
-
-Errors win over emptiness: a run that both errored and produced nothing exits `1`, not `2`. "Queued nothing" counts candidates that reached the queue, not raw hits scanned — a poll whose every hit was a duplicate or off-ICP left the ledger untouched and reads as empty. `--fail-on-empty` needs `--once`; on the daemon (which never ends on its own) it's rejected rather than ignored.
-
-```bash
-oneshot-gtm find watch --once --quiet --fail-on-empty
-case $? in
-  0) ;;                                  # candidates queued
-  2) echo "nothing found this tick" ;;   # idle, not broken
-  *) echo "watch failed" >&2 ;;
-esac
-```
+Only `show-hn` and `post-funding-auto` are on by default. Two ICP gates run per candidate: a **topic gate** on the source, before any spend, and a **person gate** on the human's role, staged by cost and judging capability to build and self-adopt rather than seniority. Only a positive reject drops a candidate; rejections land in `/queue` as auditable rows you can override. [Finders](./docs/finders.md) covers the prescreen, the gates, product research and review ordering.
 
 ### The plays
 
-Twenty-three of them. Thirteen have a **Run** page in the dashboard and drain from the queue:
+Twenty-three. Thirteen have a **Run** page in the dashboard and drain from the queue:
 
 `show-hn` · `job-change` · `post-funding` · `accelerator-batch` · `hiring-signal` · `podcast-guest` · `competitor-switch` · `stack-consolidation` · `repo-interest` · `luma-events` · `sources-sought` · `civic-pilot` · `design-partner-loi`
 
-The last three are the institutional counterparts to the founder-to-founder register above: `sources-sought` cites a specific SAM.gov Sources Sought / Presolicitation notice number and agency, `civic-pilot` cites a council/county agenda item, meeting date, and a cooperative purchasing vehicle (Sourcewell, NASPO ValuePoint, OMNIA), and `design-partner-loi` walks an ask ladder — conversation, then a scoped pilot, then a non-binding LOI — for enterprise, government and hardware buyers. `design-partner-loi` refuses to draft (before any paid call) when its target's `buyerType` names an owner-operator; that guard is asserted in code rather than left to finder-config convention, since a future pack could route the wrong lane at it.
+The last three are the institutional counterparts to the founder-to-founder register: `sources-sought` cites a specific SAM.gov notice and agency, `civic-pilot` cites a council agenda item, meeting date and a cooperative purchasing vehicle, and `design-partner-loi` walks an ask ladder — conversation, scoped pilot, non-binding LOI — for enterprise, government and hardware buyers, and refuses to draft at an owner-operator.
 
-Six more drain from the queue without a Run form — `profile-intro` (what Add Prospect enqueues), `breakup-revive`, `free-pilot` (fed by the `local-business` finder), and the three the `x-reposters` finder feeds: `x-repost-intro` (founder-lane email + cadence), `x-amplify` (one-touch launch-day repost ask), and `x-amplify-dm` — the one play that never auto-sends: it drafts X DM/reply text you copy and send by hand from the X app, then **Mark sent** records it as a channel-`x` touch. The last two, `concierge` and `demo-no-show`, are CLI-only because they open with a voice call and an SMS respectively.
+Six more drain from the queue without a Run form — `profile-intro` (what Add Prospect enqueues), `breakup-revive`, `free-pilot`, and the three `x-reposters` feeds: `x-repost-intro`, `x-amplify`, and `x-amplify-dm`, the one play that never auto-sends (it drafts DM text you send by hand, then **Mark sent** records the touch). `concierge` and `demo-no-show` are CLI-only because they open with a voice call and an SMS respectively; both are fed by [trigger webhooks](./docs/webhooks.md).
 
-Most carry a cadence — a value follow-up, then a breakup, spread over roughly three to nine days and editable per play from `/plays`. Any email reply stops every live cadence for that prospect — and is recorded whether the sequence is still running, already finished, or never existed (one-touch plays like `luma-events`), credited to the play whose subject it threads on. You can also stop one cadence deliberately from `/cadences`, with a reason and note: bad-timing/other stops become breakup-revive candidates after the configured 60–90 day cold window, while not-a-fit/do-not-contact remain excluded.
+Most carry a cadence — a value follow-up, then a breakup, over roughly three to nine days, editable per play from `/plays`. Any reply, email or LinkedIn, stops every live cadence for that prospect. You can also stop one deliberately from `/cadences` with a reason: bad-timing stops become breakup-revive candidates after the cold window, not-a-fit and do-not-contact stay excluded.
+
+### Direct mail
+
+An optional, individually approved physical-letter step. **Plays → Direct mail** picks eligible prospects per motion (a named person, a company, and a complete U.S. business address); **Cadences → Review mail** generates or uploads the letter, shows the print proof and price, and sends on approval. Bulk actions never send mailpieces. [Direct mail](./docs/direct-mail.md) has the selection rules and timing.
+
+### Background monitoring as a service
+
+`find watch --install-service` generates a launchd agent (macOS) or systemd user unit (Linux) that keeps the watch daemon running; Windows schedules `find watch --once`. `--fail-on-empty` makes a clean-but-empty run exit `2`, so a cron wrapper can tell idle from broken. `config spend-ceiling` caps what all finders and drains may spend per day; manual sends are never gated by it. [Background monitoring](./docs/background-monitoring.md) has the service files, exit codes and ceiling semantics.
 
 ---
 
 ## Sending
 
-Outbound ships through a **sender identity pool** — any mix of OneShot wallet-owned sending domains (several domains, several mailboxes per domain), your own Gmail / Workspace accounts, and Smartlead-hosted mailboxes (bring-your-own cold-email infra at scale).
+Outbound ships through a **sender identity pool** — any mix of OneShot wallet-owned sending domains, your own Gmail / Workspace accounts, and Smartlead-hosted mailboxes (send-only). Every email to a prospect comes from the identity that sent their first touch. New identities ramp 10/day, +10/week, to a 50 ceiling, per domain; when every identity is at cap, nothing sends over it — steps stay due until midnight. The inbox poll merges the OneShot inbox with every authorized Gmail account, so stop-on-reply works whichever identity sent, and replies from `/inbox` thread on both transports.
 
-- **Sticky threads.** Every email to a prospect comes from the identity that sent their first touch, across plays and cadence steps. In-flight conversations never switch From address.
-- **Warm-up caps, per domain.** A new identity ramps 10/day, +10/week, to a 50 ceiling — editable per identity on `/setup`. OneShot reputation is per-domain, so every mailbox on a domain shares one ramp and budget. Gmail accounts ramp per account.
-- **Defer, never exceed.** When every identity is at cap, cadence steps stay due and queue rows stay approved until midnight. Nothing sends over cap.
-- **Two products, one founder, one inbox.** A workspace (see Workspaces) never first-touches someone another workspace emailed in the last 7 days: the draft is held with a `contacted-elsewhere` flag that you can override on a manual send, and auto paths (drain, cadence steps) wait the window out. Touches and the paid lookup caches live in one shared SQLite (`~/.oneshot-gtm-shared/`), so the same person is never researched twice across products.
-- **Replies follow the pool.** The inbox poll merges the OneShot inbox with every authorized Gmail account, so stop-on-reply works whichever identity sent. It walks everything since its last clean poll — a persisted watermark with an hour of overlap, paged newest-first, parking anything beyond one poll's page budget as a backlog the next ticks drain — so a reply is delayed by an outage, never lost to it. A reply you've already read and archived still counts. Answering from `/inbox` records the reply too, replies from the receiving identity, and threads on both transports — Gmail via `In-Reply-To`/`References`, OneShot via `reply_to_email_id`. Sends carry an idempotency key, so a retry after a timeout can't double-send.
-- **LinkedIn replies stop email too.** On `/cadences`, **Mark LinkedIn reply** records the cross-channel reply and stops every active or paused cadence for that prospect. Automation tools can call the authenticated webhook below. Connection acceptance alone does nothing, message text is not retained, and an email already handed to a sender cannot be recalled. A LinkedIn reply resets breakup-revive's cold clock just like an email reply; it does not receive fake email-play attribution.
+Bounces are harvested from Gmail mailboxes and classified; a hard bounce stops the cadence and suppresses the address. `gmail placement` sends one real canary between two of your mailboxes and reports where it landed, with the SPF/DKIM/DMARC verdicts — no DNS tooling. [Sending and deliverability](./docs/sending.md) has the full rules.
 
-Add a OneShot domain and mailbox from `/setup` or `identities add` — pick a provisioned domain or type a new one to auto-provision on first send. Add a Gmail account with `gmail auth` (one-time OAuth; needs a Google Cloud _Desktop_ client with the Gmail API on). Add Smartlead mailboxes with `smartlead connect` (paste the workspace API key, pick from your connected accounts) or from `/setup` — Smartlead does the warmup and hosts the inboxes; the default ramp ceiling clamps to each mailbox's own Smartlead limit. **Send-only for now**: replies to Smartlead-sent mail appear in Smartlead's inbox, not `/inbox`, and its bounces aren't harvested — like OneShot identities, `doctor` reports them as not bounce-covered. With no pool configured, behavior is the classic single OneShot identity.
+## Workspaces
 
-### Deliverability
+One install is one product: one founder voice, one ICP, one product brief, one ledger, one sender pool. A fresh install is a single workspace named `default`. Selling a second product means a second workspace with its own profile, keys, identities and dashboard port:
 
-- **Bounces.** Delivery status notifications are harvested from connected Gmail mailboxes on a 30-minute sweep, parsed per RFC 3464, and classified hard / block / soft. A hard bounce stops the cadence and suppresses the address at both draft and send time; a `5.7.x` policy block never suppresses, being a verdict on the message rather than the mailbox. `doctor` reports a per-identity rate — warn above 2%, fail above 5%, 20-send minimum. Gmail-only for now.
-- **Inbox placement.** `gmail placement` sends one real message between two authorized mailboxes and reads back where the receiving account filed it, plus the SPF/DKIM/DMARC verdicts that server recorded — a verdict on the real send path, needing no DNS tooling. It's never run automatically, since repeated canaries train the seed mailbox's filter.
+```bash
+bun run cli -- workspace create acme          # its own home under ~/.oneshot-gtm-workspaces
+bun run cli -- --workspace acme init          # profile, keys, identities
+bun run cli -- --workspace acme ui            # side by side with the default dashboard
+```
+
+Workspaces share one thing: `~/.oneshot-gtm-shared/shared.sqlite`, holding the paid lookup caches and contact touches, so the same person is never bought twice and never first-touched by two workspaces within 7 days. [Workspaces](./docs/workspaces.md) covers resolution order, the shared DB, `doctor`'s cross-workspace checks and the dashboard switcher.
 
 ---
 
@@ -361,46 +217,13 @@ Add a OneShot domain and mailbox from `/setup` or `identities add` — pick a pr
 
 **Secrets** — `~/.oneshot-gtm/.env`, chmod 600, auto-loaded on first import.
 
-**Server** — single-user, local-first, binds `127.0.0.1` only. Dashboard routes rely on that local boundary. Keep unsigned intake endpoints private or protect them at your reverse proxy; the LinkedIn reply endpoint has its own bearer authentication.
+**Server** — single-user, local-first, binds `127.0.0.1` only. Dashboard routes rely on that local boundary. Two [webhook](./docs/webhooks.md) families accept outside input: signed trigger intake (signup, demo no-show) and a bearer-authenticated LinkedIn reply endpoint.
 
-### Trigger webhooks
-
-Two JSON endpoints feed warm product signals through the normal ICP filter and review queue:
-
-- `POST /api/triggers/signup` requires `name`, `email`, and `phone`; optional fields are `signupContext`, `callWindow`, and `linkedinUrl`. Accepted ICP matches enqueue the `concierge` play.
-- `POST /api/triggers/cal-no-show` requires `name`, `email`, `company`, `missedAt`, and `rescheduleLink`; optional fields are `phone`, `whatTheyWanted`, and `linkedinUrl`. Accepted ICP matches enqueue `demo-no-show`.
-
-Valid matches return `202`; ICP rejections return `200` with `accepted: false`; malformed JSON or fields return `400`. Signup deliveries deduplicate by lowercase email, while no-shows deduplicate by lowercase `email + missedAt`.
-
-Set `WEBHOOK_SECRET` to authenticate both endpoints. Send `X-Webhook-Signature: t=<unix-seconds>,v1=<hex>` where the hex value is an HMAC-SHA256 of `<timestamp>.<raw JSON body>`. Signed deliveries are accepted for five minutes and may be used only once. When the secret is unset, intake remains unsigned for backwards-compatible local use.
-
-### LinkedIn reply webhook
-
-Public LinkedIn inbox APIs require partner approval, so OneShot exposes a provider-neutral intake that Expandi, Zapier, Make, n8n, or another automation can map into. Set a random bearer secret in `/setup` or `~/.oneshot-gtm/.env`:
-
-```bash
-LINKEDIN_REPLY_WEBHOOK_SECRET=<random-32+-character-secret>
-```
-
-Then send one stable event ID per actual reply. At least one of `linkedinUrl` or `email` is required; when both match different prospects the request is rejected.
-
-```bash
-curl -X POST http://127.0.0.1:3000/api/triggers/linkedin-reply \
-  -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer <secret>' \
-  -d '{
-    "source": "expandi",
-    "eventId": "provider-event-123",
-    "occurredAt": "2026-09-01T12:00:00Z",
-    "linkedinUrl": "https://www.linkedin.com/in/example-person"
-  }'
-```
-
-Successful responses include `duplicate`, `prospectId`, `cadencesStopped`, and `inFlightSends`. Retries of the same `source + eventId` succeed without applying the event twice. The endpoint stops OneShot email; the source tool remains responsible for stopping its own LinkedIn automation.
+**Data underneath** — enrichment, verification and local lookups resolve through OneShot, which maintains a vendor landscape of 50 data sources across six categories (contact enrichment, company data, email verification, maps and places, browser automation, social). Which source answers a given lookup is chosen per call. [The full catalogue](https://docs.oneshotagent.com/vendors).
 
 ```
 apps/
-  cli/        65-command CLI (commander); src/demo/ seeds the demo install, src/main.ts picks the workspace
+  cli/        commander CLI; src/demo/ seeds the demo install, src/main.ts picks the workspace
   server/     Bun.serve + SSE; tsdown bundle published as `oneshot-gtm-server`
   web/        Vite + React 19 + TanStack + Base UI — 9 pages, run form, strategist dock, privacy mode
 packages/
@@ -411,16 +234,12 @@ packages/
   prompts/    Markdown prompts — humanizer canon, per-play, per-extract
   doctor/     Wallet, ledger, key and deliverability health checks
   shared-types/  Wire types shared across CLI / server / web
+docs/         Guides: workspaces, finders, sending, direct mail, background monitoring, webhooks, demo mode, prompt inputs
 examples/     Sample target files for nine plays
-launch/       Draft launch posts (unpublished)
-docs/         The built-with badge
+vendor/       The pinned SDK archive core and server install from
 ```
 
-### Stack
-
-Bun 1.3+ · Turborepo with a Bun catalog · Vitest 4 · oxlint + oxfmt · TypeScript 6 (`verbatimModuleSyntax`, `noUncheckedIndexedAccess`, `noImplicitOverride`) · Vite 8 + React 19 + TanStack Router/Query + Base UI + Tailwind 4 · tsdown for the server bundle · `bun:sqlite` · BYO LLM via OpenRouter, OpenAI or Anthropic.
-
-Plain `async`/`await` throughout — no monadic abstractions to learn before reading the code. Keeps it forkable.
+**Stack** — Bun 1.3+ · Turborepo with a Bun catalog · Vitest 4 · oxlint + oxfmt · TypeScript 6 (`verbatimModuleSyntax`, `noUncheckedIndexedAccess`, `noImplicitOverride`) · Vite 8 + React 19 + TanStack Router/Query + Base UI + Tailwind 4 · tsdown for the server bundle · `bun:sqlite` · BYO LLM via OpenRouter, OpenAI or Anthropic. Plain `async`/`await` throughout — no monadic abstractions to learn before reading the code.
 
 ---
 
@@ -431,7 +250,7 @@ bun install
 bun run typecheck                  # tsc --noEmit across cli + server + packages
 bun run lint                       # oxlint
 bun run fmt                        # oxfmt --write   (fmt:check in CI)
-bun run test                       # vitest — 1621 cases across 126 files
+bun run test                       # vitest — current totals in STATUS.md
 bun run cli -- doctor              # smoke check
 ```
 
@@ -443,25 +262,23 @@ bun run --cwd apps/web build       # → apps/web/dist/
 bun run --cwd apps/server build    # → apps/server/dist/bin.mjs + dist/web/
 ```
 
-Tests set `ONESHOT_GTM_HOME` to a temp dir, so they never touch your real ledger. CI runs `bun --bun run test` — the flag matters, since `bun:sqlite` doesn't exist under Node.
+Tests set `ONESHOT_GTM_HOME` to a temp dir, so they never touch your real ledger. CI runs `bun --bun run test` — the flag matters, since `bun:sqlite` doesn't exist under Node. Core and server install the SDK from the archive in `vendor/`; its README has the coordinated release step.
 
 ### Watching what's happening
 
-Every install writes a structured event log to `~/.oneshot-gtm/events.jsonl` — one line per LLM call, ICP decision, finder lifecycle event and swallowed `catch`. Local-only, never transmitted.
+Every install writes a structured event log to `~/.oneshot-gtm/events.jsonl` — one line per LLM call, ICP decision, finder lifecycle event and swallowed `catch`. Local-only, never transmitted; the `ctx` payload is primitives, counters, durations and hostnames only.
 
 ```bash
-tail -f ~/.oneshot-gtm/events.jsonl | jq -c '{t:.ts, k:.kind, ctx:.ctx}'          # condensed
-tail -f ~/.oneshot-gtm/events.jsonl | jq -c 'select(.kind|startswith("llm."))'    # LLM calls
-tail -f ~/.oneshot-gtm/events.jsonl | jq -c 'select(.kind=="icp.decision")'       # topic-gate rejects
-tail -f ~/.oneshot-gtm/events.jsonl | jq -c 'select(.kind=="icp.person_decision")' # person-gate verdicts
-tail -f ~/.oneshot-gtm/events.jsonl | jq -c 'select(.level=="error" or .level=="warn")'
+tail -F ~/.oneshot-gtm/events.jsonl | jq -c '{t:.ts, k:.kind, ctx:.ctx}'          # condensed
+tail -F ~/.oneshot-gtm/events.jsonl | jq -c 'select(.kind|startswith("llm."))'    # LLM calls
+tail -F ~/.oneshot-gtm/events.jsonl | jq -c 'select(.kind=="icp.decision")'       # topic-gate rejects
+tail -F ~/.oneshot-gtm/events.jsonl | jq -c 'select(.kind=="icp.person_decision")' # person-gate verdicts
+tail -F ~/.oneshot-gtm/events.jsonl | jq -c 'select(.level=="error" or .level=="warn")'
 tail -2000 ~/.oneshot-gtm/events.jsonl | jq -c 'select(.run_id=="PASTE-HERE")'    # one run
 DEBUG=oneshot:* oneshot-gtm find watch --once                                     # mirror to stderr
 ```
 
-The live file uses 10 MB as a pre-append rotation threshold, so it may exceed that size by one complete event (including a large `ctx`) before rotating to `events.1.jsonl` … `events.3.jsonl` (oldest dropped). `tail -f` follows the path, not the file, so it goes quiet after a rotation — use `tail -F` if you're watching a long-running install. Override the threshold with `ONESHOT_GTM_MAX_EVENT_LOG_BYTES`, and grep the rotated generations with `cat ~/.oneshot-gtm/events*.jsonl | jq …`.
-
-The `ctx` payload is bound by a strict privacy boundary — primitives, counters, durations and hostnames only.
+The file rotates at about 10 MB into `events.1.jsonl` … `events.3.jsonl` (override with `ONESHOT_GTM_MAX_EVENT_LOG_BYTES`); `tail -F` survives the rotation, `tail -f` doesn't.
 
 ---
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -17,7 +17,7 @@ while `reports.test.ts` covers `triageEmails`, `synthesizeInterviews`, `adviseOn
 **Dependency pins.** The root `package.json` carries `overrides` for `seroval`, `seroval-plugins`
 (CVE-2026-59940) and `ws`. Forks inherit these.
 
-The person-level ICP gate (#45) was calibrated against 84 real LinkedIn titles (all 13 known off-ICP prospects caught, zero false rejects among 44 builders) and the history audit ran live `enrichProfile` for 111 titles. The workspace switcher's auto-start was live-verified in both directions (default ↔ gtm).
+The person-level ICP gate (#45) was calibrated against 84 real LinkedIn titles (all 13 known off-ICP prospects caught, zero false rejects among 44 builders) and the history audit ran live `enrichProfile` for 111 titles. The workspace switcher's auto-start was live-verified in both directions (default ↔ a named workspace).
 
 Reply detection was verified on 2026-08-23 against the real mailboxes: a sliced sweep of all four inboxes from the first send onward (4,833 inbound, every slice fully covered) found exactly the replies the live poll then recorded on restart. Since 2026-08-28 every inbound is also classified (#63) — out-of-office autoresponders, dead-mailbox notices and unsubscribes are recorded for the conversation history but never count as replies, and the latter two durably suppress the address at the send funnel.
 

--- a/apps/cli/src/commands/workspace.ts
+++ b/apps/cli/src/commands/workspace.ts
@@ -81,7 +81,7 @@ export async function commandWorkspaceCurrent(): Promise<void> {
 }
 
 export async function commandWorkspacePath(name: string): Promise<void> {
-  // Bare path on stdout, for scripts: ONESHOT_GTM_HOME=$(oneshot-gtm workspace path gtm) …
+  // Bare path on stdout, for scripts: ONESHOT_GTM_HOME=$(oneshot-gtm workspace path <name>) …
   process.stdout.write(`${guarded(() => resolveWorkspaceHome(name))}\n`);
 }
 

--- a/docs/background-monitoring.md
+++ b/docs/background-monitoring.md
@@ -1,0 +1,73 @@
+# Background monitoring
+
+The dashboard server runs an in-process scheduler, so enabling a trigger is enough — no separate daemon. On a cron box or a headless machine, run `find watch` instead.
+
+## As a service
+
+`find watch --install-service` generates a service file that keeps the watch daemon running in the background — a launchd user agent on macOS, a systemd user unit on Linux. It prints to stdout (redirect-friendly); add `--write` to drop it at the platform-conventional path. Every path is embedded absolute at generation time — the bun binary, the CLI entry, and the active `ONESHOT_GTM_HOME` (so `--workspace acme find watch --install-service` pins the service to that workspace) — because service managers don't source your shell profile. Regenerate with `--write` after moving bun or the checkout.
+
+**macOS (launchd).** Logs go to `<home>/find-watch.log`; the agent restarts on crash and survives reboots.
+
+```bash
+oneshot-gtm find watch --install-service            # inspect the plist
+oneshot-gtm find watch --install-service --write    # → ~/Library/LaunchAgents/com.oneshot-gtm.find-watch.plist
+launchctl load ~/Library/LaunchAgents/com.oneshot-gtm.find-watch.plist
+
+# uninstall
+launchctl unload ~/Library/LaunchAgents/com.oneshot-gtm.find-watch.plist
+rm ~/Library/LaunchAgents/com.oneshot-gtm.find-watch.plist
+```
+
+**Linux (systemd user unit).** Logs go to the user journal: `journalctl --user -u oneshot-gtm-find-watch`.
+
+```bash
+oneshot-gtm find watch --install-service --write    # → ~/.config/systemd/user/oneshot-gtm-find-watch.service
+systemctl --user daemon-reload
+systemctl --user enable --now oneshot-gtm-find-watch
+
+# uninstall
+systemctl --user disable --now oneshot-gtm-find-watch
+rm ~/.config/systemd/user/oneshot-gtm-find-watch.service
+```
+
+On a headless box, also run `loginctl enable-linger $USER` once so the user unit starts at boot rather than at first login.
+
+**Windows (Task Scheduler).** There's no user-service template; schedule the cron-style `find watch --once` instead, which runs all due triggers and exits:
+
+```powershell
+$watchAction = New-ScheduledTaskAction -Execute 'C:\Users\you\.bun\bin\bun.exe' `
+  -Argument '"C:\path\to\oneshot-gtm\apps\cli\src\main.ts" find watch --once --quiet'
+$watchTrigger = New-ScheduledTaskTrigger -Once -At (Get-Date).AddMinutes(1) `
+  -RepetitionInterval (New-TimeSpan -Minutes 15)
+Register-ScheduledTask -TaskName 'oneshot-gtm find watch' -Action $watchAction -Trigger $watchTrigger
+
+# uninstall
+Unregister-ScheduledTask -TaskName 'oneshot-gtm find watch' -Confirm:$false
+```
+
+**Cron** works on POSIX hosts: `*/15 * * * * ONESHOT_GTM_HOME=$HOME/.oneshot-gtm /path/to/bun /path/to/apps/cli/src/main.ts find watch --once --quiet`.
+
+## Exit codes for scheduled runs
+
+`find watch --once` exits `1` when a due trigger errored. Add `--fail-on-empty` and a run that worked but produced nothing exits `2` instead of `0`, with one line on stderr naming the triggers and the zero count — enough for a cron wrapper to tell a dry run from a productive one without reading the ledger. `find drain <play>` takes the same flag. Both are opt-in: without it, exit codes are exactly what they were.
+
+|       | `find watch --once`                                | `find drain <play>`                                     |
+| ----- | -------------------------------------------------- | ------------------------------------------------------- |
+| **0** | candidates queued, or `--fail-on-empty` not passed | rows drained, or `--fail-on-empty` not passed           |
+| **1** | a due trigger errored (with or without the flag)   | with the flag: a row errored, or the drain itself threw |
+| **2** | with the flag: ran clean, queued nothing           | with the flag: no approved rows to drain                |
+
+Errors win over emptiness: a run that both errored and produced nothing exits `1`, not `2`. "Queued nothing" counts candidates that reached the queue, not raw hits scanned — a poll whose every hit was a duplicate or off-ICP left the ledger untouched and reads as empty. `--fail-on-empty` needs `--once`; on the daemon (which never ends on its own) it's rejected rather than ignored.
+
+```bash
+oneshot-gtm find watch --once --quiet --fail-on-empty
+case $? in
+  0) ;;                                  # candidates queued
+  2) echo "nothing found this tick" ;;   # idle, not broken
+  *) echo "watch failed" >&2 ;;
+esac
+```
+
+## Spend ceiling
+
+Per-run caps (`maxCostUsd` on a finder, `maxSpendPerRun` on x-reposters) bound one call; they don't stop fifteen independently-scheduled finders and automatic drains from collectively overspending across a day. `config spend-ceiling <amount>` (or the Wallet card on `/setup`) sets an install-wide daily USD ceiling, checked before every automated finder run and drain. A reservation held for the call's duration closes the race between two concurrent automated paths, so they can't both slip under the ceiling before either one's spend has posted. Once reached, scheduled and run-now finders and drains halt with a named reason (`daily spend ceiling reached ($X.XX/$Y.YY spent today)`) visible on the trigger cards and in `doctor`. Manual `/queue` sends (approve, reject, mark-sent, send-draft) are never gated by it — a founder reviewing and sending one email by hand is a deliberate decision the ceiling should never block. The counter resets at local midnight, the same boundary the per-identity send caps use. Unset (the default) is unlimited.

--- a/docs/demo-mode.md
+++ b/docs/demo-mode.md
@@ -1,0 +1,22 @@
+# Demo mode
+
+A fresh install is nine empty states, which makes it hard to show anyone what this looks like in use. `demo` builds a fictional, fully-populated install in its own home and opens the dashboard against it.
+
+```bash
+bun run cli -- demo seed      # → ~/.oneshot-gtm-demo
+bun run cli -- demo ui        # dashboard, pointed at the demo install
+bun run cli -- demo reset     # delete it
+```
+
+The cast is invented (it extends the one in `examples/`) and the numbers are internally consistent: ~24 prospects across eight plays and 30 days, 147 signed receipts totalling $2.94, cadences in all five states, replies matched to their prospects, two closed deals. Everything is anchored to a timestamp, so `--now` reproduces a ledger exactly and a re-shoot matches the first take.
+
+What demo mode changes, and nothing else:
+
+- Four **read-only** calls that fetch at request time rather than reading the ledger — the reply list, the platform RoCS rollup, the domain pool, the wallet balance — are served from JSON fixtures in the demo home. Without that, Replies is blank no matter what's in SQLite.
+- The in-process **scheduler idles**, so enabled triggers don't fire against the demo install and overwrite its state mid-screenshot.
+
+Nothing that sends, drafts or spends is faked. Under the flag, the demo home's `.env` is the **sole** source of secrets — real credentials inherited from your shell, your install, or a repo-root `.env` are overwritten or deleted — so a stray click on Run or Send fails at auth rather than doing something real. `demo seed` refuses to touch `~/.oneshot-gtm`, and `demo reset` only removes a directory it marked as its own.
+
+## Privacy toggle
+
+Independent of demo mode, the dashboard has a privacy toggle next to the strategist dock. Flip it on and names, emails, companies and phone numbers render partially masked everywhere — enough to screenshot a receipt or a cadence without exposing a real contact. Costs, receipt IDs and every other figure stay untouched. Off by default, remembered per browser. It's readable obfuscation for screenshots, not secure redaction.

--- a/docs/direct-mail.md
+++ b/docs/direct-mail.md
@@ -1,0 +1,32 @@
+# Direct mail
+
+Physical letters as an optional, individually approved step in a cadence. Bulk actions never send mailpieces; every letter needs its own proof review and approval.
+
+## Which prospects get a mail step
+
+**Plays → Direct mail** chooses suitable prospects automatically for selected motions. Choose **Automatic**, **Always include**, or **Off** per play, and edit the mail step's position and delay.
+
+| Motion                                         | Automatic selection                                                     | Default placement                            |
+| ---------------------------------------------- | ----------------------------------------------------------------------- | -------------------------------------------- |
+| New business, free pilot                       | Named prospect, company, and complete U.S. business address             | Step 2, three days after the first email     |
+| Design-partner LOI                             | Same address requirements; enterprise or hardware buyer                 | Step 2, three days after the first email     |
+| Post-funding, hiring-signal, competitor-switch | Same address requirements; confirmed ICP match and decision-maker title | Step 3, three days after the first follow-up |
+| Other motions                                  | Off by default; founder can choose Always include                       | Founder-selected                             |
+
+These are explainable starting rules, not predictions of conversion or account value. Sources labeled as registered-agent, registered-office or residential addresses are excluded from automatic selection. An address still needs review: complete postal fields do not establish that a person works there. Research can add mail to an eligible active cadence when its insertion point is still ahead; completed touches and existing mailpieces retain their plans. Explicit Off overrides survive future default changes.
+
+## Addresses
+
+Save your return address once under **Setup → Founder → Direct mail return address**. Business addresses are collected from prospect inputs, CSV/registry data, and company research for mail-enabled motions. Missing addresses hold the mail step until you correct them or explicitly skip mail.
+
+## Reviewing and sending
+
+On **Cadences**, click a prospect's **Review mail** button. Both saved addresses are filled automatically. Generate or edit a personalized letter, or upload a PDF/JPEG for that prospect, review the print proof and price, then **Approve and send**. Replacing content or changing an address requires a fresh proof. The dashboard sends U.S. letters; existing postcard orders and the artwork CLI remain supported. Mail history provides postal status, recovery, and cancellation.
+
+An accepted order advances the cadence once. Its next follow-up allows at least eight business days for printing and transit, plus two calendar days to read; longer configured delays remain in force. This is an estimate, not a delivery guarantee. Skipping mail keeps the normal next-touch delay. Postal delivery does not prove readership.
+
+## CLI
+
+```
+direct-mail list · upload · preview · refresh · approve · send · cancel
+```

--- a/docs/finders.md
+++ b/docs/finders.md
@@ -1,0 +1,38 @@
+# Finders and the ICP gates
+
+Finders discover prospects, ICP-filter them, and enqueue into `/queue` for one-click approve or reject. Each runs as a trigger with its own interval and spend cap. The finder table is in the [README](../README.md#where-targets-come-from); this page is what happens to a candidate after a finder sees it.
+
+## Readiness
+
+Only `show-hn` and `post-funding-auto` are on by default; enable the rest from `/queue`. A trigger missing required config reads as **not ready** — the toggle and Run button disable with the reason, and the API returns `409`, so scripted callers can't bypass the gate either.
+
+## Prescreen, before any spend
+
+Before any paid `findEmail`, a prescreen skips dud domains (`*.vercel.app`, social hosts, link aggregators, personal email providers) and inputs whose "name" is obviously a username. LinkedIn URLs are captured on every finder path and verified to belong to the person before they're stored.
+
+## Two ICP gates per candidate
+
+The **topic gate** judges the source — the repo, event, or announcement — and keeps whole categories of noise out before any spend.
+
+The **person gate** judges the human's role, staged by cost: free role text the finder already holds (an event bio, an extracted title), then the job title off the enrichment every verified email already pays for, then — only when still ambiguous and a LinkedIn URL exists — one extra ~$0.005 lookup. It judges capability to build and self-adopt, not job-title seniority: students shipping hackathon projects and consultants building agent systems for clients pass; a Marketing Manager at a brilliant AI company doesn't. Only a _positive_ reject drops a candidate — ambiguity escalates or proceeds, never silently discards. Rejections land in `/queue` as auditable `auto: role — <reason>` rows you can override, count as `role-drop` on trigger cards, and a prospect judged off-ICP after contact stops receiving cadence follow-ups (terminal status `off-icp`).
+
+## Product research
+
+Qualified first-touch rows receive a product dossier before the trigger completes: up to two known first-party pages plus quick external research covering the product, ecosystem, architecture, and business model. Set `productResearch: false` on a trigger to disable it. Research counts toward that trigger's `maxCostUsd`; a failure or exhausted cap leaves the row reviewable with an explicit warning. `find research-products` backfills the same context onto active/replied prospects and pending queue rows (`--dry-run`, `--limit`, and `--refresh` are supported). Use `--first-party-only` for a resilient bulk backfill when the external research provider is unavailable.
+
+## Review order
+
+The pending review list on `/queue` can be ordered `newest` or `ranked` (finder-interleaved priority score with exploration slots). It's a toggle on the page, defaulted by `queueReviewOrder` in config. `find calibrate` measures the score against logged outcomes (shadow only; scores drive nothing but this ordering until they clear the acceptance bar).
+
+## Draining
+
+Approved rows ship via the **Drain** button or `find drain <play>`. Both respect the daily [spend ceiling](./background-monitoring.md#spend-ceiling) and the per-identity send caps.
+
+## Finder-specific keys
+
+- `GITHUB_TOKEN` — without it the two GitHub finders share GitHub's unauthenticated ceiling of 60 requests/hour per IP and halt on a `403`. A classic token with **no scopes** is enough. `doctor` warns when it's missing and a GitHub finder is on.
+- `x-reposters` — four OAuth1 values for the first-party X API, or `TWITTERAPI_IO_KEY` for the ~55x cheaper third-party engine. Pick the provider on `/setup` or with `config x-engine`.
+- `SAM_GOV_API_KEY` — `gov-solicitation`.
+- `LUMA_SESSION_COOKIE` — optional; only buys authed Luma guest lists.
+
+All of these are env-only: `init` never asks, but `/setup` and `config keys` store them in the workspace's `.env`.

--- a/docs/sending.md
+++ b/docs/sending.md
@@ -1,0 +1,32 @@
+# Sending and deliverability
+
+Outbound ships through a **sender identity pool** — any mix of OneShot wallet-owned sending domains (several domains, several mailboxes per domain), your own Gmail / Workspace accounts, and Smartlead-hosted mailboxes. With no pool configured, behavior is the classic single OneShot identity.
+
+## Adding identities
+
+- **OneShot domain + mailbox** — `/setup` or `identities add`. Pick a provisioned domain or type a new one to auto-provision on first send. `domains list · pause · resume` manages the provisioned pool.
+- **Gmail / Workspace** — `gmail auth` (one-time OAuth; needs a Google Cloud _Desktop_ client with the Gmail API on).
+- **Smartlead** — `smartlead connect` (paste the workspace API key, pick from your connected accounts) or `/setup`. Smartlead does the warmup and hosts the inboxes; the default ramp ceiling clamps to each mailbox's own Smartlead limit. **Send-only for now**: replies to Smartlead-sent mail appear in Smartlead's inbox, not `/inbox`, and its bounces aren't harvested — like OneShot identities, `doctor` reports them as not bounce-covered.
+
+## Rules the pool enforces
+
+- **Sticky threads.** Every email to a prospect comes from the identity that sent their first touch, across plays and cadence steps. In-flight conversations never switch From address.
+- **Warm-up caps, per domain.** A new identity ramps 10/day, +10/week, to a 50 ceiling — editable per identity on `/setup`. OneShot reputation is per-domain, so every mailbox on a domain shares one ramp and budget. Gmail accounts ramp per account.
+- **Defer, never exceed.** When every identity is at cap, cadence steps stay due and queue rows stay approved until midnight. Nothing sends over cap.
+- **One founder, one inbox, however many products.** A [workspace](./workspaces.md) never first-touches someone another workspace emailed in the last 7 days: the draft is held with a `contacted-elsewhere` flag that you can override on a manual send, and auto paths (drain, cadence steps) wait the window out. Touches and the paid lookup caches live in one shared SQLite (`~/.oneshot-gtm-shared/`), so the same person is never researched twice.
+- **Idempotent sends.** Sends carry an idempotency key, so a retry after a timeout can't double-send.
+
+## Replies
+
+The inbox poll merges the OneShot inbox with every authorized Gmail account, so stop-on-reply works whichever identity sent. It walks everything since its last clean poll — a persisted watermark with an hour of overlap, paged newest-first, parking anything beyond one poll's page budget as a backlog the next ticks drain — so a reply is delayed by an outage, never lost to it. A reply you've already read and archived still counts.
+
+Every inbound is classified: out-of-office autoresponders, dead-mailbox notices and unsubscribes are recorded for the conversation history but never count as replies, and the latter two durably suppress the address at the send funnel.
+
+Answering from `/inbox` records the reply, sends from the receiving identity, and threads on both transports — Gmail via `In-Reply-To`/`References`, OneShot via `reply_to_email_id`. Drafting is research-grounded: known prospects reuse their stored dossier, unknown senders get enriched and their site read (~$0.06, cached 30 days, receipted under `inbox-reply`), and replies may cite links from your product brief — never invented ones.
+
+LinkedIn replies stop email too — by hand from `/cadences` or through the [LinkedIn reply webhook](./webhooks.md#linkedin-reply-webhook).
+
+## Deliverability
+
+- **Bounces.** Delivery status notifications are harvested from connected Gmail mailboxes on a 30-minute sweep, parsed per RFC 3464, and classified hard / block / soft. A hard bounce stops the cadence and suppresses the address at both draft and send time; a `5.7.x` policy block never suppresses, being a verdict on the message rather than the mailbox. `doctor` reports a per-identity rate — warn above 2%, fail above 5%, 20-send minimum. Gmail-only for now.
+- **Inbox placement.** `gmail placement` sends one real message between two authorized mailboxes and reads back where the receiving account filed it, plus the SPF/DKIM/DMARC verdicts that server recorded — a verdict on the real send path, needing no DNS tooling. It's never run automatically, since repeated canaries train the seed mailbox's filter.

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -1,0 +1,40 @@
+# Webhooks
+
+The dashboard server binds `127.0.0.1` only. Keep unsigned intake endpoints private or protect them at your reverse proxy.
+
+## Trigger webhooks
+
+Two JSON endpoints feed warm product signals through the normal ICP filter and review queue:
+
+- `POST /api/triggers/signup` requires `name`, `email`, and `phone`; optional fields are `signupContext`, `callWindow`, and `linkedinUrl`. Accepted ICP matches enqueue the `concierge` play.
+- `POST /api/triggers/cal-no-show` requires `name`, `email`, `company`, `missedAt`, and `rescheduleLink`; optional fields are `phone`, `whatTheyWanted`, and `linkedinUrl`. Accepted ICP matches enqueue `demo-no-show`.
+
+Valid matches return `202`; ICP rejections return `200` with `accepted: false`; malformed JSON or fields return `400`. Signup deliveries deduplicate by lowercase email, while no-shows deduplicate by lowercase `email + missedAt`.
+
+Set `WEBHOOK_SECRET` to authenticate both endpoints. Send `X-Webhook-Signature: t=<unix-seconds>,v1=<hex>` where the hex value is an HMAC-SHA256 of `<timestamp>.<raw JSON body>`. Signed deliveries are accepted for five minutes and may be used only once. When the secret is unset, intake remains unsigned for backwards-compatible local use.
+
+## LinkedIn reply webhook
+
+Public LinkedIn inbox APIs require partner approval, so the server exposes a provider-neutral intake that Expandi, Zapier, Make, n8n, or another automation can map into. Set a random bearer secret in `/setup` or the workspace `.env`:
+
+```bash
+LINKEDIN_REPLY_WEBHOOK_SECRET=<random-32+-character-secret>
+```
+
+Then send one stable event ID per actual reply. At least one of `linkedinUrl` or `email` is required; when both match different prospects the request is rejected.
+
+```bash
+curl -X POST http://127.0.0.1:3030/api/triggers/linkedin-reply \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer <secret>' \
+  -d '{
+    "source": "expandi",
+    "eventId": "provider-event-123",
+    "occurredAt": "2026-09-01T12:00:00Z",
+    "linkedinUrl": "https://www.linkedin.com/in/example-person"
+  }'
+```
+
+Successful responses include `duplicate`, `prospectId`, `cadencesStopped`, and `inFlightSends`. Retries of the same `source + eventId` succeed without applying the event twice. The endpoint stops OneShot email; the source tool remains responsible for stopping its own LinkedIn automation.
+
+The same thing by hand: on `/cadences`, **Mark LinkedIn reply** records the cross-channel reply and stops every active or paused cadence for that prospect. Connection acceptance alone does nothing, message text is not retained, and an email already handed to a sender cannot be recalled. A LinkedIn reply resets breakup-revive's cold clock just like an email reply; it does not receive fake email-play attribution.

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -1,0 +1,32 @@
+# Workspaces
+
+One install is one product: one founder voice, one ICP, one product brief, one ledger, one sender pool. Every install starts with a single workspace named `default` at `~/.oneshot-gtm`. Selling two things means two workspaces, each with its own profile, keys, identities and dashboard port:
+
+```bash
+bun run cli -- workspace create acme          # ~/.oneshot-gtm-workspaces/acme, next free port
+bun run cli -- --workspace acme init          # its own profile, keys, identities
+bun run cli -- --workspace acme ui            # runs side by side with the default dashboard
+bun run cli -- workspace use acme             # make it the default for runs without the flag
+bun run cli -- workspace list                 # every workspace, the current and the default
+```
+
+`--workspace` (or `ONESHOT_GTM_WORKSPACE`) is resolved by a bootstrap shim (`apps/cli/src/main.ts`) before anything else loads, so every command and the spawned dashboard see the right home. An explicit `ONESHOT_GTM_HOME` still wins — it's the escape hatch — and `workspace path <name>` prints a home for scripting: `ONESHOT_GTM_HOME=$(oneshot-gtm workspace path acme) …`.
+
+## What stays shared
+
+`~/.oneshot-gtm-shared/shared.sqlite` (relocate with `ONESHOT_GTM_SHARED`) holds the paid lookup caches (enrichment, LinkedIn — the same person is never bought twice) and contact touches. A workspace never first-touches someone another workspace emailed in the last 7 days: the draft holds with a `contacted-elsewhere` flag you can override on a manual send, while drain and cadence steps wait the window out.
+
+Each ledger's own cache tables are imported into the shared DB once on first use and then left unwritten, so rolling back is a code revert, not a data migration.
+
+## What `doctor` warns about
+
+- Two workspaces sharing a **sending domain** — warm-up caps are per-workspace, so the domain's real budget silently doubles.
+- Two workspaces sharing a **Gmail account** — both inbox pollers would see both products' replies.
+
+## In the dashboard
+
+A masthead chip names the workspace and its port; each name gets a stable colour. Clicking the chip — or `⌘K → Workspaces` — lists every registered workspace with a live status dot. Running ones open in a new tab; stopped ones start and then open. The server is spawned detached with no supervisor, so the status dots are the truth about what's up, and a launch that doesn't come up within 15s falls back to a copyable `--workspace <name> ui` command.
+
+## Background services
+
+`find watch --install-service` embeds the active home, so `--workspace acme find watch --install-service` pins the generated service to that workspace. See [background monitoring](./background-monitoring.md).


### PR DESCRIPTION
## Summary

- README rewritten answer-first (Minto pyramid): what it is, the pipeline in one sentence, then setup, surfaces, targets, sending, workspaces, architecture, development. 493 → 310 lines.
- Nothing deleted: operational detail moves into seven guides under `docs/` (workspaces, finders, sending, direct-mail, background-monitoring, webhooks, demo-mode), each linked from the section it left. Anchors that TELEMETRY.md and the guides link to (`#watching-whats-happening`, `#direct-mail`, `#background-monitoring-as-a-service`, `#where-targets-come-from`) are preserved.
- Public prose no longer presents a `gtm` workspace, its port, or a specific founder's motions as something that ships. Every install is unique; the workspaces section, STATUS.md and a CLI comment now use a neutral example.
- Hardcoded test and command totals removed from the README (they were stale: 1621 vs 3151 tests); it points at STATUS.md instead. STATUS.md's own numbers are untouched.

## Verification

- `bun run fmt:check`, `bun run lint`: clean
- Full test suite: 3151 passed / 243 files (only source change is a comment)
- Relative-link and anchor check across README, TELEMETRY.md and docs/: all ok
- Companion docs change on the oneshot repo: `13cb1520` on `staging`

https://claude.ai/code/session_011meFPo97LhmTcoNRwyPQeS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded guidance for founder profiles, setup, dashboards, CLI usage, event logs, testing, vendor integrations, and SDK usage.
  * Added documentation for background monitoring, scheduled services, spend limits, demo mode, privacy controls, direct mail, finders, outbound sending, webhooks, and workspaces.
  * Clarified webhook boundaries, event-log privacy and rotation, workspace commands, and verification notes.
  * Added operational details including approvals, retries, authentication, safety restrictions, scheduling, and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->