### PR TITLE
Fix follow-up prompt assembly and repeated pitches

### DIFF
--- a/packages/intel/__tests__/prompts.test.ts
+++ b/packages/intel/__tests__/prompts.test.ts
@@ -115,3 +115,18 @@ describe("loadPrompt — per-prompt memoization", () => {
     expect(second).toMatch(/Anti-AI-slop rules/);
   });
 });
+
+describe("follow-up prompt isolation", () => {
+  it("keeps first-touch guidance out of follow-ups regardless of cache order", () => {
+    _resetPromptCache();
+    const initial = loadPrompt("repo-interest-followup");
+    const followup = loadPrompt("repo-interest-followup", { humanizer: "followup" });
+    expect(initial).toContain("## The 4-step shape");
+    expect(followup).not.toContain("## The 4-step shape");
+    expect(followup).toContain("≤ 30 words");
+    expect(followup).toContain("Never transfer a prior claim");
+    expect(followup.match(/# Anti-AI-slop rules/g)).toHaveLength(1);
+    expect(loadPrompt("repo-interest-followup")).toBe(initial);
+    expect(loadPrompt("repo-interest-followup", { humanizer: "followup" })).toBe(followup);
+  });
+});

--- a/packages/intel/__tests__/truncation.test.ts
+++ b/packages/intel/__tests__/truncation.test.ts
@@ -242,3 +242,33 @@ describe("complete() truncation — anthropic", () => {
     expect(res.inputTokens).toBe(30);
   });
 });
+
+describe("outbound prompt assembly", () => {
+  it.each(["openrouter", "anthropic"] as const)(
+    "does not duplicate the selected humanizer for %s",
+    async (provider) => {
+      cfg.provider = provider;
+      const { loadPrompt } = await import("../src/prompts.ts");
+      const system = loadPrompt("repo-interest-followup", { humanizer: "followup" });
+      const fetchMock = respondWith(
+        provider === "anthropic"
+          ? { content: [{ type: "text", text: "ok" }], stop_reason: "end_turn" }
+          : { choices: [{ message: { content: "ok" }, finish_reason: "stop" }] },
+      );
+      await complete({
+        messages: [
+          { role: "system", content: system },
+          { role: "user", content: "Prior email context" },
+        ],
+      });
+      const body = requestOf(fetchMock).body;
+      const sent =
+        provider === "anthropic"
+          ? body.system
+          : (body.messages as Array<{ role: string; content: string }>)[0]!.content;
+      expect(sent).toBe(system);
+      expect(String(sent).match(/# Anti-AI-slop rules/g)).toHaveLength(1);
+      expect(sent).not.toContain("## The 4-step shape");
+    },
+  );
+});

--- a/packages/intel/src/client.ts
+++ b/packages/intel/src/client.ts
@@ -187,7 +187,9 @@ function injectHumanizer(messages: LlmMessage[]): LlmMessage[] {
   }
   const sys = messages[sysIdx];
   if (!sys) return messages;
-  if (sys.content.includes("_humanizer.md") || sys.content.includes("Anti-AI-slop rules")) {
+  // loadPrompt already expands the selected humanizer; never prepend it again.
+  if (sys.content.includes("Anti-AI-slop rules")) return messages;
+  if (sys.content.includes("_humanizer.md")) {
     const out: LlmMessage[] = messages.slice();
     out[sysIdx] = { role: "system", content: `${prologue}\n\n---\n\n${sys.content}` };
     return out;

--- a/packages/intel/src/prompts.ts
+++ b/packages/intel/src/prompts.ts
@@ -41,11 +41,12 @@ function loadHumanizer(): string {
   return humanizerCache;
 }
 
-export function loadPrompt(name: string): string {
+export function loadPrompt(name: string, options: { humanizer?: "followup" } = {}): string {
   if (!/^[A-Za-z0-9_-]+$/.test(name)) {
     throw new Error(`invalid prompt name: ${JSON.stringify(name)}`);
   }
-  const cached = promptCache.get(name);
+  const cacheKey = `${name}:${options.humanizer ?? "default"}`;
+  const cached = promptCache.get(cacheKey);
   if (cached != null) return cached;
   const raw = readPromptFile(name);
   if (raw == null) {
@@ -55,8 +56,9 @@ export function loadPrompt(name: string): string {
   // false promise: the LLM read "see X" but the content was never attached.
   // Inline it here so every prompt that opts in (by including the reference)
   // actually receives the humanizer rules.
-  const final = HUMANIZER_REF_RE.test(raw) ? raw.replace(HUMANIZER_REF_RE, loadHumanizer()) : raw;
-  promptCache.set(name, final);
+  const humanizer = options.humanizer === "followup" ? loadPrompt("_humanizer-followup") : null;
+  const final = raw.replace(HUMANIZER_REF_RE, () => humanizer ?? loadHumanizer());
+  promptCache.set(cacheKey, final);
   return final;
 }
 

--- a/packages/plays/__tests__/cadence-prior-emails.test.ts
+++ b/packages/plays/__tests__/cadence-prior-emails.test.ts
@@ -21,7 +21,7 @@ vi.mock("@oneshot-gtm/core", async () => {
       emailIdentities: null,
       icpOneLiner: null,
       cadenceOverrides: null,
-      founderCredentials: null,
+      founderCredentials: "Previously built a million-user app",
       productPortfolio: null,
       partners: null,
       founderAdmission: null,
@@ -157,6 +157,8 @@ describe("buildFollowUpEmail — PRIOR EMAILS injection", () => {
     expect(llmCalls).toHaveLength(1);
     const userMsg = llmCalls[0]!.user;
     expect(userMsg).toContain("PRIOR EMAILS");
+    expect(userMsg).not.toContain("SOCIAL PROOF");
+    expect(userMsg).not.toContain("Previously built a million-user app");
     const firstIdx = userMsg.indexOf("step 1");
     const zeroIdx = userMsg.indexOf("step 0");
     expect(firstIdx).toBeGreaterThan(-1);

--- a/packages/plays/src/_cadence.ts
+++ b/packages/plays/src/_cadence.ts
@@ -33,7 +33,6 @@ import {
   lintOpenerFrequency,
   overusedOpeners,
   signatureDirective,
-  socialProofBlock,
 } from "./_lib.ts";
 
 export interface CadenceContext {
@@ -1704,9 +1703,8 @@ export function buildFollowUpEmail(opts: {
   contextLines: string[];
 }): SequenceStep["builder"] {
   return async (ctx: CadenceContext) => {
-    const system = loadPrompt(opts.promptName) + signatureDirective();
+    const system = loadPrompt(opts.promptName, { humanizer: "followup" }) + signatureDirective();
     const priorBlock = buildPriorEmailsBlock(ctx.prospect.id, opts.playName);
-    const proofBlock = socialProofBlock();
     // Optional first-name field: prompt rule lets the LLM occasionally open
     // with "Hey {firstName},". Absent when name is null / (unknown) / handle.
     const firstName = firstNameFrom(ctx.prospect.name);
@@ -1722,7 +1720,6 @@ export function buildFollowUpEmail(opts: {
       `COMPANY: ${ctx.prospect.company ?? "(unknown)"}`,
       ...opts.contextLines,
       ...(priorBlock ? ["", priorBlock] : []),
-      ...(proofBlock ? ["", proofBlock] : []),
       ...(firstName ? ["", `PROSPECT_FIRST_NAME: ${firstName}`] : []),
       ...(avoidBlock ? ["", avoidBlock] : []),
     ].join("\n");

--- a/packages/plays/src/repo-interest.ts
+++ b/packages/plays/src/repo-interest.ts
@@ -140,6 +140,7 @@ registerSequence({
       channel: "email",
       breakOnReply: true,
       label: "value follow-up",
+      maxBodyWords: 30,
       builder: buildFollowUpEmail({
         playName: PLAY_NAME,
         promptName: "repo-interest-followup",

--- a/packages/prompts/_humanizer-followup.md
+++ b/packages/prompts/_humanizer-followup.md
@@ -1,0 +1,12 @@
+# Anti-AI-slop rules — follow-ups
+
+You are continuing an existing conversation, not writing a first-touch email. The motion prompt controls the length, purpose and CTA.
+
+- Use the prior sent emails as factual context, never as a draft to rewrite. Do not repeat their hook, pitch, introduction or founder credentials.
+- Preserve which facts belong to which person, company or project. Never transfer a prior claim to another repo or invent a new observation.
+- For a short ping, ask one brief question anchored to the original topic. Do not recap the email. For other follow-up steps, follow their specific instructions.
+- Write plainly, like a person. Avoid hype, jargon, capability lists, em dashes, fake quotations and unnecessary formatting.
+- Do not use stock openers such as “following up”, “circling back”, “just checking in”, “bumping this” or “hope you are well”. Vary the opener using the concrete topic.
+- Never invent an offer to send a document, teardown, benchmark or other artifact. Never add a meeting ask or a discount.
+- Do not add a greeting or sign-off beyond what the motion prompt and signature directive require.
+- Return only the requested output format.


### PR DESCRIPTION
Follow-up drafts could repeat the original pitch because prompt assembly injected the full humanizer twice, including first-touch instructions and founder credentials. Use a dedicated follow-up style guide, preserve the prior sent emails as context, and avoid injecting an already-expanded humanizer again. Repo-interest previews now use the intended 30-word limit.

Validation: all 3,188 tests pass; typecheck, formatting, and server build pass; lint reports no errors. A captured request shrank from 42,475 to 3,681 system characters. Regenerated the affected live preview successfully as one short question with no flags; nothing was sent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Follow-up messages now use dedicated guidance for better conversational continuity, plain language, varied openings, and concise questions.
  - Follow-up prompts avoid repeating guidance or humanizer content.
  - Follow-up emails no longer include social-proof sections or founder credentials.
  - Repo-interest day-three follow-ups are limited to 30 words.
- **Bug Fixes**
  - Prevented duplicate anti-AI-slop guidance and repeated humanizer content in generated messages.
  - Improved consistency when loading first-touch and follow-up prompt variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->