### PR TITLE
Fix blank email drafts from invalid model responses

### DIFF
--- a/packages/plays/__tests__/email-draft-response.test.ts
+++ b/packages/plays/__tests__/email-draft-response.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+const completeMock = vi.hoisted(() => vi.fn());
+vi.mock("@oneshot-gtm/intel", async () => ({
+  ...(await vi.importActual<typeof import("@oneshot-gtm/intel")>("@oneshot-gtm/intel")),
+  complete: completeMock,
+}));
+const { draftEmailFromPrompt } = await import("../src/_lib.ts");
+const opts = { promptName: "luma-events-email", inputBlock: "A developer hosting a meetup" };
+afterEach(() => completeMock.mockReset());
+
+describe("email draft response validation", () => {
+  it("accepts a fenced draft without retrying", async () => {
+    completeMock.mockResolvedValue({
+      content: '```json\n{"subject":"meetup","body":"A useful question?"}\n```',
+    });
+    expect(await draftEmailFromPrompt(opts)).toEqual({
+      subject: "meetup",
+      body: "A useful question?",
+    });
+    expect(completeMock).toHaveBeenCalledTimes(1);
+  });
+  it.each([
+    "not JSON",
+    "null",
+    "[]",
+    "{}",
+    '{"subject":123,"body":"text"}',
+    '{"subject":"hello","body":"  "}',
+  ])("retries invalid response %s once", async (content) => {
+    completeMock
+      .mockResolvedValueOnce({ content })
+      .mockResolvedValueOnce({ content: '{"subject":"meetup","body":"A useful question?"}' });
+    expect((await draftEmailFromPrompt(opts)).subject).toBe("meetup");
+    expect(completeMock).toHaveBeenCalledTimes(2);
+    expect(completeMock.mock.calls[1]![0].messages.at(-1).content).toContain("valid JSON object");
+  });
+  it("throws a generation error after two invalid responses instead of returning a blank draft", async () => {
+    completeMock.mockResolvedValue({ content: '{"email":"unusable format"}' });
+    await expect(draftEmailFromPrompt(opts)).rejects.toThrow("Draft generation failed");
+    expect(completeMock).toHaveBeenCalledTimes(2);
+  });
+  it("does not add a retry for transport errors", async () => {
+    completeMock.mockRejectedValue(new Error("Provider unavailable"));
+    await expect(draftEmailFromPrompt(opts)).rejects.toThrow("Provider unavailable");
+    expect(completeMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/plays/__tests__/email-draft-response.test.ts
+++ b/packages/plays/__tests__/email-draft-response.test.ts
@@ -25,6 +25,8 @@ describe("email draft response validation", () => {
     "[]",
     "{}",
     '{"subject":123,"body":"text"}',
+    '{"subject":"😀","body":"text"}',
+    '{"subject":"hello","body":"😀"}',
     '{"subject":"hello","body":"  "}',
   ])("retries invalid response %s once", async (content) => {
     completeMock

--- a/packages/plays/src/_lib.ts
+++ b/packages/plays/src/_lib.ts
@@ -610,7 +610,10 @@ export async function draftEmailFromPrompt(opts: {
       maxTokens: opts.maxTokens ?? 500,
     });
     const draft = parseSubjectBody(res.content);
-    if (draft) return humanizeDraft(draft);
+    if (draft) {
+      const humanized = humanizeDraft(draft);
+      if (humanized.subject.trim() && humanized.body.trim()) return humanized;
+    }
     logEvent("email.draft.invalid_response", { promptName: opts.promptName, attempt: attempt + 1 });
     if (attempt === 0) {
       messages.push(

--- a/packages/plays/src/_lib.ts
+++ b/packages/plays/src/_lib.ts
@@ -599,23 +599,42 @@ export async function draftEmailFromPrompt(opts: {
   maxTokens?: number;
 }): Promise<DraftedEmail> {
   const system = loadPrompt(opts.promptName) + signatureDirective();
-  const res = await complete({
-    messages: [
-      { role: "system", content: system },
-      { role: "user", content: opts.inputBlock },
-    ],
-    temperature: opts.temperature ?? 0.65,
-    maxTokens: opts.maxTokens ?? 500,
-  });
-  return humanizeDraft(parseSubjectBody(res.content));
+  const messages: Array<{ role: "system" | "user" | "assistant"; content: string }> = [
+    { role: "system", content: system },
+    { role: "user", content: opts.inputBlock },
+  ];
+  for (let attempt = 0; attempt < 2; attempt++) {
+    const res = await complete({
+      messages,
+      temperature: opts.temperature ?? 0.65,
+      maxTokens: opts.maxTokens ?? 500,
+    });
+    const draft = parseSubjectBody(res.content);
+    if (draft) return humanizeDraft(draft);
+    logEvent("email.draft.invalid_response", { promptName: opts.promptName, attempt: attempt + 1 });
+    if (attempt === 0) {
+      messages.push(
+        { role: "assistant", content: res.content },
+        {
+          role: "user",
+          content:
+            'The response could not be read as an email draft. Return only one valid JSON object with non-empty string fields "subject" and "body". Escape newlines inside strings. Do not include commentary or other fields. Keep the original email instructions and facts.',
+        },
+      );
+    }
+  }
+  throw new Error(
+    "Draft generation failed: the model returned invalid or empty subject/body twice. Try regenerating.",
+  );
 }
 
-function parseSubjectBody(raw: string): DraftedEmail {
-  const parsed = tryParseJsonObject<{ subject?: string; body?: string }>(raw, {});
-  return {
-    subject: (parsed.subject ?? "").trim(),
-    body: (parsed.body ?? "").trim(),
-  };
+function parseSubjectBody(raw: string): DraftedEmail | null {
+  const parsed = tryParseJsonObject<unknown>(raw, null);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const { subject, body } = parsed as Record<string, unknown>;
+  if (typeof subject !== "string" || typeof body !== "string") return null;
+  if (!subject.trim() || !body.trim()) return null;
+  return { subject: subject.trim(), body: body.trim() };
 }
 
 export interface SendDraftedOpts {


### PR DESCRIPTION
Email generation could silently convert malformed responses or missing subject/body fields into a blank draft with empty-subject and empty-body flags. Validate both fields as non-empty strings, retry an invalid response once with explicit JSON instructions, and surface a generation error if both responses are unusable. Transport failures retain their existing retry behavior.

Validation: all 3,197 tests passed, including malformed JSON, null/array responses, invalid field types, empty fields, bounded retries, and transport errors. Typecheck and server build passed; lint had no errors. Ian's affected preview regenerated successfully with no flags and nothing sent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved email draft generation when responses contain invalid or improperly formatted content, including fenced JSON.
  - Added validation to ensure generated drafts contain meaningful, non-empty subject and body text.
  - Emoji-only subject or body fields are now treated as empty and handled appropriately.
  - The system retries once with corrective guidance before reporting repeated draft-generation failures.
  - Transport errors continue to be reported immediately without unnecessary retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->