### PR TITLE
feat(web): /prospects — search and browse every queue row, any status

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,11 @@ Spend, CAC, RoCS and outcome logging live in the dashboard's Measure and Cadence
 bun run cli -- ui [--dev] [--port 4000] [--no-browser]
 ```
 
-Nine pages plus a run form:
+Ten pages plus a run form:
 
 - **Home** — spend, reply-rate trend, in-flight cadences, and a scheduler strip showing each trigger's state, last run and next due
 - **Queue** — triggers table (enable, edit config, fire) plus the target queue with bulk approve and per-play **Drain**
+- **Prospects** — search and browse every candidate a finder ever surfaced, any status, with who decided it and why, what happened after, and an override
 - **Add Prospect** — paste a LinkedIn / X / GitHub URL; deep research builds a dossier, the LLM picks an angle against your ICP and drafts an intro, and the row lands in the queue
 - **Replies** — every reply matched to its prospect, play and cadence status across all sender identities; answer in place, by hand or LLM-drafted and research-grounded
 - **Cadences** — stop, log outcome, preview the next step, batch send email, and [review/send direct mail](#direct-mail) per prospect

--- a/STATUS.md
+++ b/STATUS.md
@@ -1,8 +1,8 @@
 # Status
 
-**Assume green.** The 66 CLI commands, 23 plays, 15 finders, nine dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
+**Assume green.** The 66 CLI commands, 23 plays, 15 finders, ten dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-07** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3237 tests / 246 files** · typecheck + oxlint + oxfmt pass (36 lint warnings, 0 errors).
+Last verified **2026-09-08** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3292 tests / 253 files** · typecheck + oxlint + oxfmt pass (36 lint warnings, 0 errors).
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/apps/server/__tests__/prospect-timeline.test.ts
+++ b/apps/server/__tests__/prospect-timeline.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import { describeDecision } from "@oneshot-gtm/shared-types";
+import { buildProspectTimeline } from "../src/api/_prospect-timeline.ts";
+
+const row = {
+  play_name: "luma-events",
+  found_at: "2026-09-01 08:00:00",
+  decided_at: "2026-09-01T09:00:00.000Z",
+  decided_by: "machine" as const,
+  decision: "auto_reject" as const,
+  notes: "auto: not a builder",
+  sent_at: null,
+};
+
+describe("buildProspectTimeline", () => {
+  it("orders SQLite and ISO timestamps together, newest first", () => {
+    const out = buildProspectTimeline({
+      row: { ...row, sent_at: "2026-09-02T10:00:00.000Z" },
+      sequenceEvents: [
+        {
+          id: 1,
+          prospect_id: 1,
+          play_name: "luma-events",
+          step_index: 1,
+          channel: "email",
+          status: "bounced",
+          metadata_json: JSON.stringify({ subject: "following up" }),
+          created_at: "2026-09-05 07:30:00",
+        },
+      ],
+      replies: [
+        {
+          id: "r",
+          thread_key: "t",
+          prospect_id: 1,
+          play_name: "luma-events",
+          from_email: "a@b",
+          subject: "Re: hi",
+          body: "never surfaced",
+          received_at: "2026-09-03T00:00:00.000Z",
+          source_identity_id: null,
+          thread_id: null,
+          message_id: null,
+          kind: null,
+          intent: null,
+          intent_reason: null,
+          created_at: "2026-09-03T00:00:00.000Z",
+        },
+      ],
+      channelEvents: [
+        {
+          id: 1,
+          source: "expandi",
+          external_event_id: "x",
+          prospect_id: 1,
+          channel: "linkedin",
+          event_type: "reply",
+          occurred_at: "2026-09-04T00:00:00.000Z",
+          body: "hidden",
+          created_at: "2026-09-04T00:00:00.000Z",
+        },
+      ],
+      outcomes: [
+        {
+          id: 1,
+          prospect_id: 1,
+          play_name: null,
+          outcome: "deal_won",
+          amount_usd: 2500,
+          notes: null,
+          recorded_at: "2026-09-06 12:00:00",
+        },
+      ],
+    });
+    expect(out.map((e) => [e.kind, e.label])).toEqual([
+      ["outcome", "deal won · $2,500"],
+      ["sequence", "email step 2 · bounced"],
+      ["channel", "linkedin reply"],
+      ["reply", "reply"], // NULL kind reads as human; no intent yet
+      ["sent", "sent"],
+      ["decided", "auto-rejected"],
+      ["surfaced", "surfaced"],
+    ]);
+    expect(out.every((e) => /^\d{4}-\d{2}-\d{2}T/.test(e.at))).toBe(true);
+    expect(out.find((e) => e.kind === "decided")?.detail).toBe("auto: not a builder");
+    expect(out.find((e) => e.kind === "sequence")?.detail).toBe("following up");
+    expect(JSON.stringify(out)).not.toMatch(/never surfaced|hidden/);
+  });
+
+  it("uses the step label when the send recorded one, and labels non-human replies by kind", () => {
+    const out = buildProspectTimeline({
+      row: { ...row, decided_at: null, decision: null, decided_by: null, notes: null },
+      sequenceEvents: [
+        {
+          id: 1,
+          prospect_id: 1,
+          play_name: "show-hn",
+          step_index: 0,
+          channel: "email",
+          status: "delivered",
+          metadata_json: JSON.stringify({ label: "intro", subject: "s" }),
+          created_at: "2026-09-02 07:30:00",
+        },
+      ],
+      replies: [
+        {
+          id: "u",
+          thread_key: "t",
+          prospect_id: 1,
+          play_name: null,
+          from_email: "a@b",
+          subject: null,
+          body: "",
+          received_at: "2026-09-03T00:00:00.000Z",
+          source_identity_id: null,
+          thread_id: null,
+          message_id: null,
+          kind: "unsubscribe",
+          intent: null,
+          intent_reason: null,
+          created_at: "2026-09-03T00:00:00.000Z",
+        },
+      ],
+      channelEvents: [],
+      outcomes: [],
+    });
+    expect(out.map((e) => e.label)).toEqual(["unsubscribed", "email intro", "surfaced"]);
+  });
+});
+
+describe("buildProspectTimeline ordering", () => {
+  it("orders by instant, so a millisecond timestamp and a whole-second one interleave correctly", () => {
+    const out = buildProspectTimeline({
+      row: { ...row, decided_at: "2026-09-07T19:03:34.900Z", sent_at: null },
+      sequenceEvents: [
+        {
+          id: 1,
+          prospect_id: 1,
+          play_name: "luma-events",
+          step_index: 0,
+          channel: "email",
+          status: "sent",
+          metadata_json: null,
+          // SQLite whole-second form of the same second; lexically "34Z" > "34.900Z".
+          created_at: "2026-09-07 19:03:34",
+        },
+      ],
+      replies: [],
+      channelEvents: [],
+      outcomes: [],
+    });
+    expect(out.map((e) => e.kind)).toEqual(["decided", "sequence", "surfaced"]);
+  });
+});
+
+describe("describeDecision (shared vocabulary)", () => {
+  it("names who decided, the same way the table and the history do", () => {
+    expect(describeDecision({ decision: "auto_reject", decidedBy: "machine" })).toBe(
+      "auto-rejected",
+    );
+    expect(describeDecision({ decision: "reject", decidedBy: "human" })).toBe("rejected by you");
+    expect(describeDecision({ decision: "approve", decidedBy: "human" })).toBe("approved by you");
+    expect(describeDecision({ decision: "approve", decidedBy: "human_bulk" })).toBe(
+      "bulk-approved",
+    );
+    expect(describeDecision({ decision: null, decidedBy: null })).toBe("decided");
+  });
+});

--- a/apps/server/__tests__/queue-detail-route.test.ts
+++ b/apps/server/__tests__/queue-detail-route.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it, vi } from "vitest";
+
+// GET /api/queue/:id feeds the /prospects drawer. The contracts: a row with no
+// prospect_id still finds its prospect by payload email, the response never
+// carries a reply body, and approve refuses a sent row (drain would re-send).
+
+const queueRows = new Map<number, Record<string, unknown>>();
+const prospectsByEmail = new Map<string, { id: number }>();
+const prospectsById = new Map<number, Record<string, unknown>>();
+const statusCalls: Array<Record<string, unknown>> = [];
+
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    getLedger: () => ({
+      getQueueRow: (id: number) => queueRows.get(id) ?? null,
+      findProspectByEmail: (email: string) => prospectsByEmail.get(email.toLowerCase()) ?? null,
+      getProspectById: (id: number) => prospectsById.get(id) ?? null,
+      listCadencesForProspect: () => [],
+      // viewsForRows' bulk prior-step fetch, reached with an empty pair list.
+      listSequenceEventsForCadences: () => new Map(),
+      // The conversation view's filtered getter; the approve guard reads it.
+      listSequenceEventsForProspect: () => [],
+      // The history reads every status, including the bounced step.
+      listAllSequenceEventsForProspect: (id: number) =>
+        id === 44
+          ? [
+              {
+                id: 2,
+                prospect_id: 44,
+                play_name: "show-hn",
+                step_index: 1,
+                channel: "email",
+                status: "bounced",
+                metadata_json: JSON.stringify({ subject: "following up" }),
+                created_at: "2026-09-04 09:00:00",
+              },
+              {
+                id: 1,
+                prospect_id: 44,
+                play_name: "show-hn",
+                step_index: 0,
+                channel: "email",
+                status: "sent",
+                metadata_json: JSON.stringify({ subject: "quick one", label: "intro" }),
+                created_at: "2026-09-02 09:00:00",
+              },
+            ]
+          : [],
+      listInboxRepliesForProspect: (id: number) =>
+        id === 44
+          ? [
+              {
+                id: "m1",
+                thread_key: "t",
+                prospect_id: 44,
+                play_name: "show-hn",
+                from_email: "grace@x.example",
+                subject: "Re: quick one",
+                body: "SECRET BODY TEXT",
+                received_at: "2026-09-03T12:00:00.000Z",
+                source_identity_id: null,
+                thread_id: null,
+                message_id: null,
+                kind: "human",
+                intent: "interested",
+                intent_reason: null,
+                created_at: "2026-09-03T12:00:00.000Z",
+              },
+            ]
+          : [],
+      listChannelEventsForProspect: () => [],
+      listDealOutcomesForProspect: () => [],
+      suppressionFor: (email: string) => (email === "bounced@x.example" ? { kind: "hard" } : null),
+      contactSuppressionFor: (email: string) =>
+        email === "grace@x.example" ? { kind: "unsubscribe", received_at: "x" } : null,
+      breakupReviveHoldFor: () => null,
+      setQueueStatus: (input: Record<string, unknown>) => {
+        statusCalls.push(input);
+      },
+    }),
+  };
+});
+
+const { approveQueueRoute, queueRowDetailRoute } = await import("../src/api/queue.ts");
+
+const row = (overrides: Record<string, unknown>): Record<string, unknown> => ({
+  id: 9,
+  play_name: "show-hn",
+  payload_json: JSON.stringify({ founderName: "grace_h", founderEmail: "Grace@X.example" }),
+  dedupe_key: "k",
+  source: "find:show-hn",
+  status: "sent",
+  found_at: "2026-09-01 10:00:00",
+  reviewed_at: null,
+  sent_at: "2026-09-02T09:00:00.000Z",
+  notes: null,
+  prospect_id: null,
+  last_draft_json: null,
+  last_drafted_at: null,
+  drain_claimed_at: null,
+  send_started_at: null,
+  priority_json: null,
+  decision: "approve",
+  decided_at: "2026-09-01T11:00:00.000Z",
+  decided_by: "human",
+  ...overrides,
+});
+
+async function detail(id: string): Promise<{ status: number; body: Record<string, unknown> }> {
+  const res = queueRowDetailRoute(new Request(`http://x/api/queue/${id}`), { id });
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+describe("queueRowDetailRoute", () => {
+  it("rejects a bad id and reports a missing row", async () => {
+    expect((await detail("abc")).status).toBe(400);
+    expect((await detail("404")).status).toBe(404);
+  });
+
+  it("resolves the prospect by payload email when prospect_id is null", async () => {
+    queueRows.set(9, row({}));
+    prospectsByEmail.set("grace@x.example", { id: 44 });
+    prospectsById.set(44, {
+      id: 44,
+      name: "Grace H",
+      email: "grace@x.example",
+      company: "Navy",
+      title: "CTO",
+      linkedin_url: null,
+      dossier_json: '{"person":{}}',
+      icp_verdict: "reject",
+      icp_verdict_reason: "not a builder",
+      created_at: "2026-08-01 00:00:00",
+    });
+    const { status, body } = await detail("9");
+    expect(status).toBe(200);
+    expect(body["row"]).toMatchObject({
+      id: 9,
+      decision: "approve",
+      decidedBy: "human",
+      prospect: { id: 44, linkedBy: "email", hasDossier: true, icpVerdict: "reject" },
+    });
+    expect(body["prospect"]).toMatchObject({ id: 44, email: "grace@x.example", company: "Navy" });
+    expect(body["flags"]).toEqual({
+      replied: true,
+      bounced: false,
+      contactSuppressed: "unsubscribe",
+      breakupHold: false,
+      icpReject: true,
+    });
+    const timeline = body["timeline"] as Array<Record<string, unknown>>;
+    expect(timeline.map((e) => e["kind"])).toEqual([
+      "sequence", // 2026-09-04 — the bounced step, visible in history
+      "reply", // 2026-09-03
+      "sequence", // 2026-09-02 09:00 (SQLite format, normalised)
+      "sent", // 2026-09-02 09:00 ISO — same instant, later insertion first
+      "decided",
+      "surfaced",
+    ]);
+    expect(timeline[0]).toMatchObject({ label: "email step 2 · bounced" });
+    expect(timeline[1]).toMatchObject({ label: "reply · interested", detail: "Re: quick one" });
+    expect((body["flags"] as Record<string, unknown>)["replied"]).toBe(true);
+    expect(JSON.stringify(body)).not.toContain("SECRET BODY TEXT");
+  });
+
+  it("reads the ICP verdict off the payload when the row never became a prospect", async () => {
+    queueRows.set(
+      12,
+      row({
+        id: 12,
+        status: "rejected",
+        sent_at: null,
+        payload_json: JSON.stringify({ name: "N", icpVerdict: "reject", icpVerdictReason: "host" }),
+      }),
+    );
+    const { body } = await detail("12");
+    expect(body["prospect"]).toBeNull();
+    expect((body["flags"] as Record<string, unknown>)["icpReject"]).toBe(true);
+  });
+
+  it("returns a detached row (no prospect) with empty history and clean flags", async () => {
+    queueRows.set(10, row({ id: 10, payload_json: JSON.stringify({ postUrl: "https://a.b/c" }) }));
+    const { body } = await detail("10");
+    expect(body["prospect"]).toBeNull();
+    expect((body["row"] as Record<string, unknown>)["prospect"]).toBeNull();
+    expect((body["timeline"] as unknown[]).map((e) => (e as { kind: string }).kind)).toEqual([
+      "sent",
+      "decided",
+      "surfaced",
+    ]);
+    expect(body["flags"]).toEqual({
+      replied: false,
+      bounced: false,
+      contactSuppressed: null,
+      breakupHold: false,
+      icpReject: false,
+    });
+  });
+});
+
+describe("approveQueueRoute on a sent row", () => {
+  it("refuses with 409 so drain cannot re-send", async () => {
+    queueRows.set(9, row({ status: "sent" }));
+    const res = await approveQueueRoute(
+      new Request("http://x/api/queue/9/approve", { method: "POST" }),
+      {
+        id: "9",
+      },
+    );
+    expect(res.status).toBe(409);
+    expect(statusCalls).toEqual([]);
+  });
+
+  it("refuses to re-approve a rejected or expired row whose prospect has replied", async () => {
+    // Row 13 resolves to prospect 44 by email, and 44 has a human reply on file.
+    queueRows.set(13, row({ id: 13, status: "expired", sent_at: null }));
+    const res = await approveQueueRoute(
+      new Request("http://x/api/queue/13/approve", { method: "POST" }),
+      { id: "13" },
+    );
+    expect(res.status).toBe(409);
+    expect(((await res.json()) as { error: string }).error).toMatch(/replied/);
+    expect(statusCalls).toEqual([]);
+  });
+
+  it("still approves a rejected row (the override path)", async () => {
+    queueRows.set(
+      11,
+      row({
+        id: 11,
+        status: "rejected",
+        sent_at: null,
+        payload_json: JSON.stringify({ name: "Nobody Yet", email: "new@x.example" }),
+      }),
+    );
+    const res = await approveQueueRoute(
+      new Request("http://x/api/queue/11/approve", { method: "POST" }),
+      {
+        id: "11",
+      },
+    );
+    expect(res.status).toBe(200);
+    expect(statusCalls).toEqual([{ id: 11, status: "approved", decidedBy: "human" }]);
+  });
+});

--- a/apps/server/__tests__/queue-search-route.test.ts
+++ b/apps/server/__tests__/queue-search-route.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from "vitest";
+
+// GET /api/queue/search backs /prospects. What matters is the translation
+// from a bookmarkable URL into ledger args — junk falls back rather than 400s,
+// the page size is clamped, and the facet counts never see the status filter.
+
+const searchCalls: Array<Record<string, unknown>> = [];
+const countCalls: Array<Record<string, unknown>> = [];
+let nextRows: unknown[] = [];
+
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    getLedger: () => ({
+      searchQueue: (args: Record<string, unknown>) => {
+        searchCalls.push(args);
+        return { rows: nextRows, total: null };
+      },
+      searchQueueStatusCounts: (args: Record<string, unknown>) => {
+        countCalls.push(args);
+        return { pending: 12, approved: 473, rejected: 7764, sent: 728, expired: 205 };
+      },
+      listQueuePlayNames: () => ["luma-events", "show-hn"],
+    }),
+  };
+});
+
+const { searchQueueRoute } = await import("../src/api/queue.ts");
+
+async function body(url: string): Promise<Record<string, unknown>> {
+  searchCalls.length = 0;
+  countCalls.length = 0;
+  const res = searchQueueRoute(new Request(url));
+  expect(res.status).toBe(200);
+  return (await res.json()) as Record<string, unknown>;
+}
+
+const baseRow = {
+  id: 9,
+  play_name: "show-hn",
+  payload_json: JSON.stringify({ founderName: "grace_h", founderEmail: "g@x.example" }),
+  dedupe_key: "k",
+  source: "find:show-hn",
+  status: "rejected",
+  found_at: "2026-09-01 10:00:00",
+  reviewed_at: null,
+  sent_at: null,
+  notes: "auto: off-topic",
+  prospect_id: null,
+  last_draft_json: null,
+  last_drafted_at: null,
+  drain_claimed_at: null,
+  send_started_at: null,
+  priority_json: null,
+  decision: "auto_reject",
+  decided_at: "2026-09-01T10:00:01.000Z",
+  decided_by: "machine",
+};
+
+describe("searchQueueRoute", () => {
+  it("defaults to every status, newest first, 50 per page", async () => {
+    const out = await body("http://x/api/queue/search");
+    expect(searchCalls[0]).toEqual({
+      limit: 50,
+      offset: 0,
+      sort: "found_at",
+      dir: "desc",
+      withTotal: false,
+    });
+    // No COUNT(*) pass: the total is the sum of the facet counts (all statuses here).
+    expect(out).toMatchObject({
+      total: 12 + 473 + 7764 + 728 + 205,
+      limit: 50,
+      offset: 0,
+      plays: ["luma-events", "show-hn"],
+    });
+  });
+
+  it("maps every filter onto the ledger call", async () => {
+    await body(
+      "http://x/api/queue/search?q=%20github%20cto%20&status=rejected,approved&play=show-hn&decided=machine&sort=name&dir=asc&limit=25&offset=50",
+    );
+    expect(searchCalls[0]).toEqual({
+      q: "github cto",
+      statuses: ["rejected", "approved"],
+      playName: "show-hn",
+      decidedBy: "machine",
+      sort: "name",
+      dir: "asc",
+      limit: 25,
+      offset: 50,
+      withTotal: false,
+    });
+  });
+
+  it("keeps the facet counts free of the status filter but under the others", async () => {
+    const out = await body(
+      "http://x/api/queue/search?q=ada&status=rejected,approved&play=show-hn&decided=human",
+    );
+    // …and the total is the selected statuses' share of those counts.
+    expect(out["total"]).toBe(7764 + 473);
+    expect(countCalls[0]).toEqual({ q: "ada", playName: "show-hn", decidedBy: "human" });
+    expect(countCalls[0]).not.toHaveProperty("statuses");
+  });
+
+  it("drops junk statuses, sorts and decided values instead of failing", async () => {
+    await body(
+      "http://x/api/queue/search?status=bogus,sent,&decided=robot&sort=price&dir=sideways",
+    );
+    expect(searchCalls[0]).toMatchObject({ statuses: ["sent"], sort: "found_at", dir: "desc" });
+    // Prototype names are not sort keys.
+    await body("http://x/api/queue/search?sort=toString");
+    expect(searchCalls[0]).toMatchObject({ sort: "found_at" });
+    expect(searchCalls[0]).not.toHaveProperty("decidedBy");
+    // A status list made only of junk is the same as no status filter.
+    await body("http://x/api/queue/search?status=bogus");
+    expect(searchCalls[0]).not.toHaveProperty("statuses");
+  });
+
+  it("clamps the page size and floors the offset", async () => {
+    await body("http://x/api/queue/search?limit=5000&offset=-3");
+    expect(searchCalls[0]).toMatchObject({ limit: 200, offset: 0 });
+    await body("http://x/api/queue/search?limit=0&offset=abc");
+    expect(searchCalls[0]).toMatchObject({ limit: 50, offset: 0 });
+  });
+
+  it("truncates an over-long query rather than scanning on a paste", async () => {
+    await body(`http://x/api/queue/search?q=${"a".repeat(500)}`);
+    expect(searchCalls[0]).toMatchObject({ q: "a".repeat(200) });
+  });
+
+  it("carries the decision trail and the linked prospect onto each row", async () => {
+    nextRows = [
+      {
+        ...baseRow,
+        p_id: 44,
+        p_name: "Grace H",
+        p_email: "grace@x.example",
+        p_company: "Navy",
+        p_title: "CTO",
+        p_icp_verdict: "pass",
+        p_icp_verdict_reason: "builds",
+        p_has_dossier: 1,
+        p_linked_by_email: 1,
+      },
+      {
+        ...baseRow,
+        id: 10,
+        p_id: null,
+        p_name: null,
+        p_title: null,
+        p_icp_verdict: null,
+        p_icp_verdict_reason: null,
+        p_has_dossier: 0,
+        p_linked_by_email: 0,
+      },
+    ];
+    const out = await body("http://x/api/queue/search");
+    const rows = out["rows"] as Array<Record<string, unknown>>;
+    expect(rows[0]).toMatchObject({
+      id: 9,
+      status: "rejected",
+      decision: "auto_reject",
+      decidedBy: "machine",
+      decidedAt: "2026-09-01T10:00:01.000Z",
+      notes: "auto: off-topic",
+      prospect: {
+        id: 44,
+        name: "Grace H",
+        email: "grace@x.example",
+        company: "Navy",
+        title: "CTO",
+        icpVerdict: "pass",
+        hasDossier: true,
+        linkedBy: "email",
+      },
+    });
+    expect(rows[1]).toMatchObject({ id: 10, prospect: null });
+    nextRows = [];
+  });
+});

--- a/apps/server/__tests__/queue-search-route.test.ts
+++ b/apps/server/__tests__/queue-search-route.test.ts
@@ -109,10 +109,17 @@ describe("searchQueueRoute", () => {
       "http://x/api/queue/search?status=bogus,sent,&decided=robot&sort=price&dir=sideways",
     );
     expect(searchCalls[0]).toMatchObject({ statuses: ["sent"], sort: "found_at", dir: "desc" });
+    // The junk `decided` value is dropped, not forwarded — asserted on THIS
+    // request, before the next call clears `searchCalls`.
+    expect(searchCalls[0]).not.toHaveProperty("decidedBy");
     // Prototype names are not sort keys.
     await body("http://x/api/queue/search?sort=toString");
     expect(searchCalls[0]).toMatchObject({ sort: "found_at" });
-    expect(searchCalls[0]).not.toHaveProperty("decidedBy");
+    // Duplicates collapse: five copies of one status is one status, and the
+    // total is that status's count alone.
+    const dup = await body("http://x/api/queue/search?status=sent,sent,sent,sent,sent");
+    expect(searchCalls[0]).toMatchObject({ statuses: ["sent", "sent", "sent", "sent", "sent"] });
+    expect(dup["total"]).toBe(728);
     // A status list made only of junk is the same as no status filter.
     await body("http://x/api/queue/search?status=bogus");
     expect(searchCalls[0]).not.toHaveProperty("statuses");

--- a/apps/server/src/api/_prospect-timeline.ts
+++ b/apps/server/src/api/_prospect-timeline.ts
@@ -1,0 +1,151 @@
+import type {
+  ChannelEventRecord,
+  DealOutcomeRecord,
+  InboxReplyRecord,
+  QueueRow,
+  SequenceEventRecord,
+} from "@oneshot-gtm/core";
+import { describeDecision, type ProspectTimelineEvent } from "@oneshot-gtm/shared-types";
+
+/**
+ * sequence_events.created_at, deal_outcomes.recorded_at and target_queue's
+ * found_at use SQLite datetime('now') format ("YYYY-MM-DD HH:MM:SS", UTC, no
+ * 'T'/'Z'); reply and decision timestamps are ISO. Normalise so the merged
+ * string sort is chronological. Same rule as inbox.ts, kept local so this
+ * pure module does not drag the Gmail-backed inbox route into its tests.
+ */
+function sqliteToIso(ts: string): string {
+  return ts.includes("T") ? ts : `${ts.replace(" ", "T")}Z`;
+}
+
+/**
+ * The history behind one /prospects row, newest first: the queue row's own
+ * milestones (surfaced, decided, sent) merged with everything recorded
+ * against the prospect it resolved to. Pure — the route gathers the rows,
+ * this orders and labels them.
+ *
+ * No reply bodies on purpose. The drawer is a browse surface and the body is
+ * the one field a screenshot cannot mask; /inbox owns the conversation.
+ */
+export function buildProspectTimeline(input: {
+  row: Pick<
+    QueueRow,
+    "play_name" | "found_at" | "decided_at" | "decided_by" | "decision" | "notes" | "sent_at"
+  >;
+  sequenceEvents: ReadonlyArray<SequenceEventRecord>;
+  replies: ReadonlyArray<InboxReplyRecord>;
+  channelEvents: ReadonlyArray<ChannelEventRecord>;
+  outcomes: ReadonlyArray<DealOutcomeRecord>;
+}): ProspectTimelineEvent[] {
+  const { row } = input;
+  const events: ProspectTimelineEvent[] = [];
+
+  events.push({
+    at: sqliteToIso(row.found_at),
+    kind: "surfaced",
+    label: "surfaced",
+    detail: null,
+    playName: row.play_name,
+  });
+  if (row.decided_at) {
+    events.push({
+      at: sqliteToIso(row.decided_at),
+      kind: "decided",
+      label: describeDecision({ decision: row.decision, decidedBy: row.decided_by }),
+      detail: row.notes,
+      playName: row.play_name,
+    });
+  }
+  if (row.sent_at) {
+    events.push({
+      at: sqliteToIso(row.sent_at),
+      kind: "sent",
+      label: "sent",
+      detail: null,
+      playName: row.play_name,
+    });
+  }
+
+  for (const ev of input.sequenceEvents) {
+    const meta = parseMeta(ev.metadata_json);
+    const step = typeof meta["label"] === "string" ? meta["label"] : `step ${ev.step_index + 1}`;
+    const status = ev.status === "sent" || ev.status === "delivered" ? "" : ` · ${ev.status}`;
+    events.push({
+      at: sqliteToIso(ev.created_at),
+      kind: "sequence",
+      label: `${ev.channel} ${step}${status}`,
+      detail: typeof meta["subject"] === "string" ? meta["subject"] : null,
+      playName: ev.play_name,
+    });
+  }
+
+  for (const r of input.replies) {
+    // NULL kind predates the classifier and reads as human everywhere.
+    const kind = r.kind ?? "human";
+    const label =
+      kind === "human"
+        ? r.intent
+          ? `reply · ${r.intent}`
+          : "reply"
+        : kind === "unsubscribe"
+          ? "unsubscribed"
+          : kind === "auto_permanent"
+            ? "mailbox gone"
+            : "auto-reply";
+    events.push({
+      at: sqliteToIso(r.received_at),
+      kind: "reply",
+      label,
+      detail: r.subject,
+      playName: r.play_name,
+    });
+  }
+
+  for (const ce of input.channelEvents) {
+    events.push({
+      at: sqliteToIso(ce.occurred_at),
+      kind: "channel",
+      label: `${ce.channel} ${ce.event_type}`,
+      detail: null,
+      playName: null,
+    });
+  }
+
+  for (const o of input.outcomes) {
+    const amount =
+      typeof o.amount_usd === "number" && o.amount_usd > 0
+        ? ` · $${Math.round(o.amount_usd).toLocaleString("en-US")}`
+        : "";
+    events.push({
+      at: sqliteToIso(o.recorded_at),
+      kind: "outcome",
+      label: `${o.outcome.replace(/_/g, " ")}${amount}`,
+      detail: o.notes,
+      playName: o.play_name,
+    });
+  }
+
+  // Newest first. Compare as instants, not strings: "…:34Z" and "…:34.443Z"
+  // are the same second but sort the wrong way round lexically. Ties keep
+  // insertion order reversed so a same-instant milestone reads sensibly.
+  const instant = (e: ProspectTimelineEvent): number => {
+    const t = Date.parse(e.at);
+    return Number.isFinite(t) ? t : 0;
+  };
+  return events
+    .map((e, i) => ({ e, i, t: instant(e) }))
+    .toSorted((a, b) => b.t - a.t || b.i - a.i)
+    .map(({ e }) => e);
+}
+
+function parseMeta(raw: string | null): Record<string, unknown> {
+  if (!raw) return {};
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}

--- a/apps/server/src/api/cadences.ts
+++ b/apps/server/src/api/cadences.ts
@@ -109,7 +109,7 @@ function toView(
   };
 }
 
-function viewsForRows(
+export function viewsForRows(
   rows: ReadonlyArray<ReturnType<ReturnType<typeof getLedger>["listAllCadences"]>[number]>,
 ): CadenceView[] {
   // Single SQL fetch for ALL (prospect_id, play_name) pairs — avoids N+1.

--- a/apps/server/src/api/queue.ts
+++ b/apps/server/src/api/queue.ts
@@ -7,6 +7,8 @@ import {
   isSendDeferred,
   parseProspectPriority,
   type QueueRow,
+  type QueueSearchOpts,
+  type QueueSearchRow,
   type QueueStatus,
   type TelemetryOutcome,
 } from "@oneshot-gtm/core";
@@ -25,15 +27,22 @@ import {
   type DrainResult,
   type LastDraft,
   parseQueueIds,
+  type DecidedByFilter,
+  type ProspectBrowseRow,
   type ProspectPriorityView,
+  type ProspectSearchResponse,
+  type ProspectSortKey,
   type QueueCounts,
   type QueueListResponse,
+  type QueueRowDetail,
   type QueueRowView,
   type RunPlayRequest,
 } from "@oneshot-gtm/shared-types";
 import { jsonResponse } from "../server.ts";
 import { sendsToday } from "./_capacity.ts";
 import { dispatchPlay } from "./_play-dispatch.ts";
+import { buildProspectTimeline } from "./_prospect-timeline.ts";
+import { viewsForRows } from "./cadences.ts";
 
 /**
  * Shape-check a stored priority artifact via the shared core validator —
@@ -46,7 +55,7 @@ function parsePriority(raw: string | null): ProspectPriorityView | null {
   return parseProspectPriority(raw);
 }
 
-function toView(row: QueueRow): QueueRowView {
+export function toView(row: QueueRow): QueueRowView {
   let payload: unknown = null;
   try {
     payload = JSON.parse(row.payload_json);
@@ -90,7 +99,211 @@ function toView(row: QueueRow): QueueRowView {
     lastDraftedAt: row.last_drafted_at,
     isSending: row.send_started_at != null,
     priority: parsePriority(row.priority_json),
+    // `?? null`: pre-v26 rows and test fakes may not carry the columns.
+    decision: row.decision ?? null,
+    decidedBy: row.decided_by ?? null,
+    decidedAt: row.decided_at ?? null,
   };
+}
+
+function toBrowseRow(row: QueueSearchRow): ProspectBrowseRow {
+  return {
+    ...toView(row),
+    prospect:
+      row.p_id == null
+        ? null
+        : {
+            id: row.p_id,
+            name: row.p_name,
+            email: row.p_email,
+            company: row.p_company,
+            title: row.p_title,
+            icpVerdict: row.p_icp_verdict,
+            icpVerdictReason: row.p_icp_verdict_reason,
+            hasDossier: row.p_has_dossier === 1,
+            linkedBy: row.p_linked_by_email === 1 ? "email" : "prospect_id",
+          },
+  };
+}
+
+const QUEUE_STATUS_VALUES = new Set<QueueStatus>([
+  "pending",
+  "approved",
+  "rejected",
+  "sent",
+  "expired",
+]);
+const SORT_KEYS: Record<ProspectSortKey, QueueSearchOpts["sort"]> = {
+  found: "found_at",
+  decided: "decided_at",
+  name: "name",
+};
+const DECIDED_FILTERS = new Set<DecidedByFilter>(["human", "machine", "none"]);
+/** Longest search string accepted — anything longer is a paste, not a search. */
+const MAX_QUERY_CHARS = 200;
+
+/**
+ * GET /api/queue/search — the /prospects browse view. Every queue row, any
+ * status, with free-text search, sort and offset paging. `status` is a comma
+ * list; absent means all. Junk values fall back rather than 400: a stale
+ * bookmark should still open the page.
+ */
+export function searchQueueRoute(req: Request): Response {
+  const url = new URL(req.url);
+  const q = (url.searchParams.get("q") ?? "").trim().slice(0, MAX_QUERY_CHARS);
+  const statuses = (url.searchParams.get("status") ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s): s is QueueStatus => QUEUE_STATUS_VALUES.has(s as QueueStatus));
+  const playName = url.searchParams.get("play") ?? undefined;
+  const decidedRaw = url.searchParams.get("decided");
+  const decidedBy = DECIDED_FILTERS.has(decidedRaw as DecidedByFilter)
+    ? (decidedRaw as DecidedByFilter)
+    : undefined;
+  const sortRaw = url.searchParams.get("sort");
+  // Own-property check: `"toString" in SORT_KEYS` is true via the prototype.
+  const sort =
+    sortRaw && Object.hasOwn(SORT_KEYS, sortRaw)
+      ? SORT_KEYS[sortRaw as ProspectSortKey]
+      : "found_at";
+  const dir = url.searchParams.get("dir") === "asc" ? "asc" : "desc";
+  const limit = Math.min(
+    200,
+    Math.max(1, Number.parseInt(url.searchParams.get("limit") ?? "50", 10) || 50),
+  );
+  const offset = Math.max(0, Number.parseInt(url.searchParams.get("offset") ?? "0", 10) || 0);
+
+  const ledger = getLedger();
+  const opts: QueueSearchOpts = { limit, offset, sort, dir, withTotal: false };
+  if (q) opts.q = q;
+  if (statuses.length > 0) opts.statuses = statuses;
+  if (playName) opts.playName = playName;
+  if (decidedBy) opts.decidedBy = decidedBy;
+  const { rows } = ledger.searchQueue(opts);
+  const countOpts: Pick<QueueSearchOpts, "q" | "playName" | "decidedBy"> = {};
+  if (q) countOpts.q = q;
+  if (playName) countOpts.playName = playName;
+  if (decidedBy) countOpts.decidedBy = decidedBy;
+  // The facets are computed under every filter but status, so the total of
+  // the selected statuses IS the page total — no separate COUNT(*) scan.
+  const counts = ledger.searchQueueStatusCounts(countOpts);
+  const selected = statuses.length > 0 ? statuses : ([...QUEUE_STATUS_VALUES] as QueueStatus[]);
+  const total = [...new Set(selected)].reduce((n, st) => n + counts[st], 0);
+  const body: ProspectSearchResponse = {
+    rows: rows.map(toBrowseRow),
+    total,
+    limit,
+    offset,
+    counts,
+    plays: ledger.listQueuePlayNames(),
+  };
+  return jsonResponse(body, 200, req);
+}
+
+function payloadString(row: QueueRow, ...keys: string[]): string | null {
+  try {
+    const p = JSON.parse(row.payload_json) as Record<string, unknown> | null;
+    if (!p || typeof p !== "object") return null;
+    for (const key of keys) {
+      const v = p[key];
+      if (typeof v === "string" && v.trim()) return v.trim();
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+function payloadEmail(row: QueueRow): string | null {
+  return payloadString(row, "email", "founderEmail");
+}
+
+/** The prospect a queue row resolves to: its FK, else the payload's email. */
+function resolveProspectId(ledger: ReturnType<typeof getLedger>, row: QueueRow): number | null {
+  if (row.prospect_id != null) return row.prospect_id;
+  const email = payloadEmail(row);
+  return email ? (ledger.findProspectByEmail(email)?.id ?? null) : null;
+}
+
+/**
+ * Has this person answered, on any channel? Human email replies, LinkedIn
+ * replies, or a step whose status flipped to `replied` (legacy rows that
+ * predate `inbox_replies`). Overrides must not email past this.
+ */
+function prospectHasReplied(ledger: ReturnType<typeof getLedger>, prospectId: number): boolean {
+  return (
+    ledger.listInboxRepliesForProspect(prospectId).some((r) => (r.kind ?? "human") === "human") ||
+    ledger.listChannelEventsForProspect(prospectId).some((e) => e.event_type === "reply") ||
+    ledger.listSequenceEventsForProspect(prospectId).some((e) => e.status === "replied")
+  );
+}
+
+/**
+ * GET /api/queue/:id — the /prospects detail drawer. The queue row, the
+ * prospect it resolved to, and everything recorded against that prospect.
+ * Reads only; nothing here spends (no `gatherReplyContext`).
+ */
+export function queueRowDetailRoute(req: Request, params: Record<string, string>): Response {
+  const id = Number.parseInt(params["id"] ?? "", 10);
+  if (!Number.isFinite(id)) return jsonResponse({ error: "bad id" }, 400, req);
+  const ledger = getLedger();
+  const row = ledger.getQueueRow(id);
+  if (!row) return jsonResponse({ error: `row #${id} not found` }, 404, req);
+
+  const email = payloadEmail(row);
+  const prospectId = resolveProspectId(ledger, row);
+  const prospect = prospectId != null ? ledger.getProspectById(prospectId) : null;
+  const linkedBy = row.prospect_id != null ? "prospect_id" : "email";
+
+  const browseRow = toBrowseRow({
+    ...row,
+    p_id: prospect?.id ?? null,
+    p_name: prospect?.name ?? null,
+    p_email: prospect?.email ?? null,
+    p_company: prospect?.company ?? null,
+    p_title: prospect?.title ?? null,
+    p_icp_verdict: prospect?.icp_verdict ?? null,
+    p_icp_verdict_reason: prospect?.icp_verdict_reason ?? null,
+    p_has_dossier: prospect?.dossier_json && prospect.dossier_json.trim() ? 1 : 0,
+    p_linked_by_email: prospect && linkedBy === "email" ? 1 : 0,
+  });
+
+  const cadences = prospect ? viewsForRows(ledger.listCadencesForProspect(prospect.id)) : [];
+  const timeline = buildProspectTimeline({
+    row,
+    sequenceEvents: prospect ? ledger.listAllSequenceEventsForProspect(prospect.id) : [],
+    replies: prospect ? ledger.listInboxRepliesForProspect(prospect.id) : [],
+    channelEvents: prospect ? ledger.listChannelEventsForProspect(prospect.id) : [],
+    outcomes: prospect ? ledger.listDealOutcomesForProspect(prospect.id) : [],
+  });
+  const flagEmail = prospect?.email ?? email;
+  const contactSuppressed = flagEmail ? ledger.contactSuppressionFor(flagEmail) : null;
+  const body: QueueRowDetail = {
+    row: browseRow,
+    prospect:
+      prospect && browseRow.prospect
+        ? {
+            ...browseRow.prospect,
+            linkedinUrl: prospect.linkedin_url,
+            createdAt: prospect.created_at,
+          }
+        : null,
+    cadences,
+    timeline,
+    flags: {
+      replied: prospect ? prospectHasReplied(ledger, prospect.id) : false,
+      bounced: flagEmail ? ledger.suppressionFor(flagEmail) != null : false,
+      contactSuppressed: contactSuppressed?.kind ?? null,
+      breakupHold: flagEmail ? ledger.breakupReviveHoldFor(flagEmail) != null : false,
+      // The prospect record wins; a row that was never emailed only carries
+      // the gate's verdict on its payload.
+      icpReject:
+        prospect != null
+          ? prospect.icp_verdict === "reject"
+          : payloadString(row, "icpVerdict") === "reject",
+    },
+  };
+  return jsonResponse(body, 200, req);
 }
 
 /**
@@ -154,6 +367,25 @@ export async function approveQueueRoute(
   const ledger = getLedger();
   const row = ledger.getQueueRow(id);
   if (!row) return jsonResponse({ error: `row #${id} not found` }, 404, req);
+  // Drain picks up every `approved` row, so re-approving a sent one would
+  // email the same person again. /prospects can reach sent rows; /queue
+  // never offered the button on them.
+  if (row.status === "sent") {
+    return jsonResponse({ error: "row already sent; re-approving would re-send" }, 409, req);
+  }
+  // An override (a row that already left `pending`) must not re-open a
+  // conversation the prospect has answered: a breakup-revive row expires with
+  // "prospect replied", and nothing downstream of `approved` checks that.
+  if (row.status !== "pending") {
+    const prospectId = resolveProspectId(ledger, row);
+    if (prospectId != null && prospectHasReplied(ledger, prospectId)) {
+      return jsonResponse(
+        { error: "prospect has replied; approving would email them mid-conversation" },
+        409,
+        req,
+      );
+    }
+  }
   ledger.setQueueStatus({ id, status: "approved", decidedBy: "human" });
   return jsonResponse({ ok: true }, 200, req);
 }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -47,8 +47,10 @@ import {
   drainQueueRoute,
   listQueueRoute,
   markSentRoute,
+  queueRowDetailRoute,
   regenerateDraftRoute,
   rejectQueueRoute,
+  searchQueueRoute,
   sendDraftRoute,
 } from "./api/queue.ts";
 import {
@@ -134,6 +136,9 @@ const routes: RouteEntry[] = [
   route("GET", "/api/runs/:id", getRunRoute),
   route("POST", "/api/prospects/add", addProspectRoute),
   route("GET", "/api/queue", listQueueRoute),
+  // Literal before param: `:id` matches [^/]+ and would otherwise swallow "search".
+  route("GET", "/api/queue/search", searchQueueRoute),
+  route("GET", "/api/queue/:id", queueRowDetailRoute),
   route("POST", "/api/queue/approve-all", approveAllRoute),
   route("POST", "/api/queue/drain", drainQueueRoute),
   route("POST", "/api/queue/:id/approve", approveQueueRoute),

--- a/apps/web/__tests__/payloadIdentity.test.ts
+++ b/apps/web/__tests__/payloadIdentity.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import {
+  companyFor,
+  emailFor,
+  linkedinUrlFor,
+  nameFor,
+  phoneFor,
+  sourceDetail,
+  titleFor,
+} from "../src/lib/payloadIdentity.ts";
+
+describe("payload identity readers", () => {
+  it("prefers the plain keys and falls back to the show-hn founder keys", () => {
+    expect(nameFor({ name: "Ada", founderName: "ada_l" })).toBe("Ada");
+    expect(nameFor({ founderName: "ada_l" })).toBe("ada_l");
+    expect(emailFor({ email: "a@b.example" })).toBe("a@b.example");
+    expect(emailFor({ founderEmail: "f@b.example" })).toBe("f@b.example");
+  });
+
+  it("derives a handle for URL-only rejects", () => {
+    expect(nameFor({ repoUrl: "https://github.com/octo/engine?tab=readme" })).toBe("octo/engine");
+    expect(nameFor({ postUrl: "https://www.example.org/post/1" })).toBe("example.org");
+    expect(nameFor({ postUrl: "not a url" })).toBeNull();
+  });
+
+  it("returns null on anything that is not an object payload", () => {
+    for (const bad of [null, undefined, "str", 42, ["a"]]) {
+      expect(nameFor(bad)).toBeNull();
+      expect(emailFor(bad)).toBeNull();
+      expect(companyFor(bad)).toBeNull();
+      expect(titleFor(bad)).toBeNull();
+      expect(linkedinUrlFor(bad)).toBeNull();
+      expect(phoneFor(bad)).toBeNull();
+    }
+  });
+
+  it("only renders a real LinkedIn profile link", () => {
+    expect(linkedinUrlFor({ linkedinUrl: "https://www.linkedin.com/in/ada" })).toBe(
+      "https://www.linkedin.com/in/ada",
+    );
+    expect(linkedinUrlFor({ linkedinUrl: "javascript:alert(1)" })).toBeNull();
+    expect(linkedinUrlFor({ linkedinUrl: "https://x.com/ada" })).toBeNull();
+  });
+
+  it("trims titles, keeps phones verbatim, and strips the finder prefix from source", () => {
+    expect(titleFor({ title: "  CTO " })).toBe("CTO");
+    expect(titleFor({ title: "   " })).toBeNull();
+    expect(phoneFor({ phone: "+1 555" })).toBe("+1 555");
+    expect(sourceDetail("find:github-stars:vercel/eve")).toBe("vercel/eve");
+    expect(sourceDetail("find:show-hn")).toBe("");
+    expect(sourceDetail(null)).toBe("");
+  });
+});

--- a/apps/web/__tests__/payloadIdentity.test.ts
+++ b/apps/web/__tests__/payloadIdentity.test.ts
@@ -39,6 +39,9 @@ describe("payload identity readers", () => {
       "https://www.linkedin.com/in/ada",
     );
     expect(linkedinUrlFor({ linkedinUrl: "javascript:alert(1)" })).toBeNull();
+    // A scheme smuggled in front of a real-looking host, as a stored column value might carry.
+    expect(linkedinUrlFor({ linkedinUrl: "javascript:x//linkedin.com/in/a" })).toBeNull();
+    expect(linkedinUrlFor({ linkedinUrl: null })).toBeNull();
     expect(linkedinUrlFor({ linkedinUrl: "https://x.com/ada" })).toBeNull();
   });
 

--- a/apps/web/__tests__/signalDays.test.ts
+++ b/apps/web/__tests__/signalDays.test.ts
@@ -19,6 +19,9 @@ function row(foundAt: string): QueueRowView {
     lastDraftedAt: null,
     isSending: false,
     priority: null,
+    decision: null,
+    decidedBy: null,
+    decidedAt: null,
   };
 }
 

--- a/apps/web/scripts/capture-fixtures.ts
+++ b/apps/web/scripts/capture-fixtures.ts
@@ -77,6 +77,10 @@ const SEEDS = [
 
   // Queue: the table (limit 200), the Today strip (16), and the nav's alert dot.
   "/queue?limit=16",
+
+  // Prospects: one document — the whole seeded ledger — and the page
+  // searches, sorts and pages it client-side (client.ts `prospectSearch`).
+  "/queue/search?limit=500",
   "/queue?status=pending&limit=1",
 
   // Measure: all-time, 30d, 7d — the three range buttons.
@@ -117,6 +121,21 @@ function expand(url: string, body: unknown): string[] {
     // Clicking a row opens its detail. Every row is clickable, so every row's
     // detail is part of the demo.
     return (receipts ?? []).map((r) => `/receipts/${r.id}`);
+  }
+
+  if (url.startsWith("/queue/search?")) {
+    const { rows, total } = body as { rows?: Array<{ id: number }>; total?: number };
+    // The demo searches this one document client-side, so it has to hold the
+    // whole seeded queue. The server clamps `limit` (to 200 today), so compare
+    // against the total it reports rather than the limit we asked for.
+    if (typeof total === "number" && total > (rows ?? []).length) {
+      console.error(
+        `  /queue/search fixture holds ${(rows ?? []).length} of ${total} rows — the seed outgrew the server's page cap`,
+      );
+      process.exit(1);
+    }
+    // Every row opens a detail drawer.
+    return (rows ?? []).map((r) => `/queue/${r.id}`);
   }
 
   if (url.startsWith("/queue?") && !url.includes("play=")) {

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -26,6 +26,8 @@ import type {
   PackApplyResult,
   PackView,
   PlayDescriptor,
+  ProspectSearchResponse,
+  QueueRowDetail,
   WorkspaceInfo,
   DomainActionResult,
   DomainPoolView,
@@ -46,6 +48,11 @@ import type {
   TriggerView,
 } from "@oneshot-gtm/shared-types";
 import { demoGet, demoWrite, IS_DEMO } from "./demo.ts";
+import {
+  applyProspectFilters,
+  toApiQuery,
+  type ProspectsSearch,
+} from "../lib/prospects-helpers.ts";
 
 const BASE = "/api";
 
@@ -274,6 +281,19 @@ export const api = {
     const qs = q.toString();
     return getJson<QueueListResponse>(`/queue${qs ? `?${qs}` : ""}`);
   },
+  /**
+   * /prospects browse. In the demo the search runs client-side over ONE
+   * captured document (the whole seeded ledger, `limit=500`): a free-text
+   * `q` has no bounded fixture space, and refusing to search would leave the
+   * page a mockup of itself. Live installs hand the filters to SQL.
+   */
+  prospectSearch: (search: ProspectsSearch) =>
+    IS_DEMO
+      ? demoGet<ProspectSearchResponse>("/queue/search?limit=500").then((r) =>
+          applyProspectFilters(r.rows, search),
+        )
+      : getJson<ProspectSearchResponse>(`/queue/search?${toApiQuery(search)}`),
+  queueRowDetail: (id: number) => getJson<QueueRowDetail>(`/queue/${id}`),
   approveQueue: (id: number) => postJson<{ ok: boolean }>(`/queue/${id}/approve`, {}),
   rejectQueue: (id: number, reason?: string) =>
     postJson<{ ok: boolean }>(`/queue/${id}/reject`, reason ? { reason } : {}),

--- a/apps/web/src/components/shell/CommandPalette.tsx
+++ b/apps/web/src/components/shell/CommandPalette.tsx
@@ -16,6 +16,7 @@ import {
   Receipt,
   Settings,
   UserPlus,
+  Users,
 } from "lucide-react";
 import { useEffect } from "react";
 import { toast } from "sonner";
@@ -27,6 +28,7 @@ import { READ_ONLY } from "../../lib/readOnly.ts";
 type NavTarget =
   | "/"
   | "/queue"
+  | "/prospects"
   | "/cadences"
   | "/receipts"
   | "/measure"
@@ -124,6 +126,9 @@ export function CommandPalette({
           </Command.Item>
           <Command.Item value="queue review" onSelect={go("/queue")}>
             <Inbox size={14} /> Queue <kbd className="ml-auto">g q</kbd>
+          </Command.Item>
+          <Command.Item value="prospects browse search rejected" onSelect={go("/prospects")}>
+            <Users size={14} /> Prospects
           </Command.Item>
           <Command.Item value="cadences sequences" onSelect={go("/cadences")}>
             <Layers size={14} /> Cadences <kbd className="ml-auto">g c</kbd>

--- a/apps/web/src/lib/payloadIdentity.ts
+++ b/apps/web/src/lib/payloadIdentity.ts
@@ -1,0 +1,89 @@
+/**
+ * Who a queue row is about, read from the finder's payload. Every finder
+ * writes a slightly different shape (`name` vs `founderName`, `email` vs
+ * `founderEmail`), and a pre-enrichment reject may carry only a source URL,
+ * so these readers are the one place that knows the fallbacks. Shared by
+ * /queue and /prospects so the same row reads the same on both pages.
+ *
+ * Pure and total: a missing key or a payload of the wrong shape returns null.
+ */
+
+function record(payload: unknown): Record<string, unknown> | null {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
+  return payload as Record<string, unknown>;
+}
+
+export function emailFor(payload: unknown): string | null {
+  const p = record(payload);
+  if (!p) return null;
+  if (typeof p["email"] === "string") return p["email"] as string;
+  if (typeof p["founderEmail"] === "string") return p["founderEmail"] as string;
+  return null;
+}
+
+export function nameFor(payload: unknown): string | null {
+  const p = record(payload);
+  if (!p) return null;
+  if (typeof p["name"] === "string") return p["name"] as string;
+  if (typeof p["founderName"] === "string") return p["founderName"] as string;
+  // Pre-enrichment rejected rows only carry a source URL — derive a handle.
+  const repoUrl = typeof p["repoUrl"] === "string" ? (p["repoUrl"] as string) : null;
+  if (repoUrl) {
+    const m = repoUrl.match(/github\.com\/([^/]+)\/([^/?#]+)/);
+    if (m) return `${m[1]}/${m[2]}`;
+  }
+  const postUrl = typeof p["postUrl"] === "string" ? (p["postUrl"] as string) : null;
+  if (postUrl) {
+    try {
+      const host = new URL(postUrl).hostname.replace(/^www\./, "");
+      if (host) return host;
+    } catch {
+      // fall through
+    }
+  }
+  return null;
+}
+
+/**
+ * The finder-specific tail of `source` ("find:github-stars:vercel/eve" ->
+ * "vercel/eve") — which repo / cohort matched. Empty when source is just the
+ * finder name (fully redundant with the play column).
+ */
+export function sourceDetail(source: string | null | undefined): string {
+  if (!source) return "";
+  return source.split(":").slice(2).join(":");
+}
+
+export function companyFor(payload: unknown): string | null {
+  const p = record(payload);
+  if (!p) return null;
+  if (typeof p["company"] === "string") return p["company"] as string;
+  return null;
+}
+
+// Stamped on the payload by the person-level ICP gate; absent on rows queued
+// before the gate existed.
+export function titleFor(payload: unknown): string | null {
+  const p = record(payload);
+  if (!p) return null;
+  const v = p["title"];
+  return typeof v === "string" && v.trim().length > 0 ? v.trim() : null;
+}
+
+export function linkedinUrlFor(payload: unknown): string | null {
+  const p = record(payload);
+  if (!p) return null;
+  const v = p["linkedinUrl"];
+  if (typeof v !== "string" || v.length === 0) return null;
+  // Defense in depth — payload comes from sqlite but a stale/garbage row should
+  // never render as a clickable javascript:// or data:// link.
+  return /^https?:\/\/(?:[a-z0-9-]+\.)*linkedin\.com\/in\//i.test(v) ? v : null;
+}
+
+export function phoneFor(payload: unknown): string | null {
+  const p = record(payload);
+  if (!p) return null;
+  const v = p["phone"];
+  if (typeof v === "string" && v.length > 0) return v;
+  return null;
+}

--- a/apps/web/src/lib/prospects-helpers.test.ts
+++ b/apps/web/src/lib/prospects-helpers.test.ts
@@ -1,0 +1,207 @@
+import type { ProspectBrowseRow } from "@oneshot-gtm/shared-types";
+import { describe, expect, it } from "vitest";
+import { describeDecision } from "@oneshot-gtm/shared-types";
+import {
+  applyProspectFilters,
+  pageSummary,
+  parseProspectsSearch,
+  pastEnd,
+  toApiQuery,
+} from "./prospects-helpers.ts";
+
+function row(overrides: Partial<ProspectBrowseRow> & { id: number }): ProspectBrowseRow {
+  return {
+    playName: "show-hn",
+    payload: null,
+    dedupeKey: `k${overrides.id}`,
+    source: "find:show-hn",
+    status: "pending",
+    foundAt: `2026-09-0${overrides.id} 10:00:00`,
+    reviewedAt: null,
+    sentAt: null,
+    notes: null,
+    prospectId: null,
+    lastDraft: null,
+    lastDraftedAt: null,
+    isSending: false,
+    priority: null,
+    decision: null,
+    decidedBy: null,
+    decidedAt: null,
+    prospect: null,
+    ...overrides,
+  };
+}
+
+describe("parseProspectsSearch", () => {
+  it("keeps well-formed values and drops defaults and junk", () => {
+    expect(
+      parseProspectsSearch({
+        q: "  ada ",
+        status: "rejected",
+        play: "show-hn",
+        decided: "machine",
+        sort: "name",
+        dir: "asc",
+        page: "3",
+      }),
+    ).toEqual({
+      q: "ada",
+      status: "rejected",
+      play: "show-hn",
+      decided: "machine",
+      sort: "name",
+      dir: "asc",
+      page: 3,
+    });
+    expect(
+      parseProspectsSearch({
+        q: " ",
+        status: "bogus",
+        decided: "robot",
+        sort: "x",
+        dir: "desc",
+        page: "1",
+      }),
+    ).toEqual({});
+    expect(parseProspectsSearch({ page: 2.7 })).toEqual({ page: 2 });
+    expect(parseProspectsSearch({ page: "-4" })).toEqual({});
+  });
+});
+
+describe("toApiQuery", () => {
+  it("omits defaults, sorts keys and turns page into offset", () => {
+    expect(toApiQuery({})).toBe("limit=50");
+    expect(toApiQuery({ page: 1, dir: "desc" })).toBe("limit=50");
+    expect(
+      toApiQuery({ q: "ada cto", status: "rejected", page: 3, sort: "name", dir: "asc" }),
+    ).toBe("dir=asc&limit=50&offset=100&q=ada+cto&sort=name&status=rejected");
+  });
+});
+
+describe("pageSummary", () => {
+  it("describes the visible window", () => {
+    expect(pageSummary(7764, 0, 50)).toEqual({ from: 1, to: 50, page: 1, pages: 156 });
+    expect(pageSummary(7764, 7750, 50)).toEqual({ from: 7751, to: 7764, page: 156, pages: 156 });
+    expect(pageSummary(0, 0, 50)).toEqual({ from: 0, to: 0, page: 1, pages: 1 });
+    // An offset past the end reads as the last page — never "showing 101–95".
+    expect(pageSummary(10, 500, 50)).toEqual({ from: 1, to: 10, page: 1, pages: 1 });
+    expect(pageSummary(95, 100, 50)).toEqual({ from: 51, to: 95, page: 2, pages: 2 });
+    expect(pastEnd(95, 100)).toBe(true);
+    expect(pastEnd(95, 50)).toBe(false);
+    expect(pastEnd(0, 0)).toBe(false);
+  });
+});
+
+describe("describeDecision", () => {
+  it("names the decision and who made it", () => {
+    expect(
+      describeDecision({ status: "rejected", decision: "auto_reject", decidedBy: "machine" }),
+    ).toBe("auto-rejected");
+    expect(describeDecision({ status: "rejected", decision: "reject", decidedBy: "human" })).toBe(
+      "rejected by you",
+    );
+    expect(
+      describeDecision({ status: "approved", decision: "approve", decidedBy: "human_bulk" }),
+    ).toBe("bulk-approved");
+    expect(describeDecision({ status: "sent", decision: "approve", decidedBy: "human" })).toBe(
+      "approved by you",
+    );
+    expect(describeDecision({ status: "expired", decision: null, decidedBy: null })).toBe(
+      "expired",
+    );
+    expect(describeDecision({ status: "pending", decision: null, decidedBy: null })).toBe(
+      "undecided",
+    );
+  });
+});
+
+describe("applyProspectFilters (demo mode)", () => {
+  const rows = [
+    row({
+      id: 1,
+      payload: {
+        name: "Ada Lovelace",
+        email: "ada@x.example",
+        company: "Analytical",
+        title: "CTO",
+      },
+      status: "rejected",
+      decision: "auto_reject",
+      decidedBy: "machine",
+      decidedAt: "2026-09-01T12:00:00Z",
+      notes: "auto: off-topic",
+    }),
+    row({
+      id: 2,
+      playName: "luma-events",
+      payload: { founderName: "grace_h" },
+      status: "approved",
+      decision: "approve",
+      decidedBy: "human_bulk",
+      decidedAt: "2026-09-02T12:00:00Z",
+      prospect: {
+        id: 9,
+        name: "Grace Hopper",
+        email: "grace@navy.example",
+        company: "US Navy",
+        title: "Rear Admiral",
+        icpVerdict: null,
+        icpVerdictReason: null,
+        hasDossier: false,
+        linkedBy: "email",
+      },
+    }),
+    row({
+      id: 3,
+      payload: { repoUrl: "https://github.com/octo/engine", postTitle: "Show HN: COBOL" },
+      status: "sent",
+    }),
+  ];
+
+  it("searches, counts before the status filter, and pages", () => {
+    const out = applyProspectFilters(rows, { q: "ada cto" });
+    expect(out.rows.map((r) => r.id)).toEqual([1]);
+    expect(out.total).toBe(1);
+    // The linked prospect is searchable, like the server.
+    expect(applyProspectFilters(rows, { q: "hopper admiral" }).rows.map((r) => r.id)).toEqual([2]);
+    expect(applyProspectFilters(rows, { q: "off-topic" }).total).toBe(1);
+    // Parity with the server haystack: post title, repo URL, prospect email/company.
+    expect(applyProspectFilters(rows, { q: "cobol" }).rows.map((r) => r.id)).toEqual([3]);
+    expect(applyProspectFilters(rows, { q: "octo/engine" }).rows.map((r) => r.id)).toEqual([3]);
+    expect(applyProspectFilters(rows, { q: "navy.example" }).rows.map((r) => r.id)).toEqual([2]);
+    expect(applyProspectFilters(rows, { q: "us navy" }).rows.map((r) => r.id)).toEqual([2]);
+    const byStatus = applyProspectFilters(rows, { status: "sent", play: "show-hn" });
+    expect(byStatus.rows.map((r) => r.id)).toEqual([3]);
+    expect(byStatus.counts).toEqual({ pending: 0, approved: 0, rejected: 1, sent: 1, expired: 0 });
+    expect(byStatus.plays).toEqual(["luma-events", "show-hn"]);
+    expect(applyProspectFilters(rows, { page: 2 })).toMatchObject({
+      rows: [],
+      total: 3,
+      offset: 50,
+    });
+  });
+
+  it("filters by who decided", () => {
+    expect(applyProspectFilters(rows, { decided: "human" }).rows.map((r) => r.id)).toEqual([2]);
+    expect(applyProspectFilters(rows, { decided: "machine" }).rows.map((r) => r.id)).toEqual([1]);
+    expect(applyProspectFilters(rows, { decided: "none" }).rows.map((r) => r.id)).toEqual([3]);
+  });
+
+  it("sorts the same three ways as the server", () => {
+    expect(applyProspectFilters(rows, {}).rows.map((r) => r.id)).toEqual([3, 2, 1]);
+    expect(applyProspectFilters(rows, { dir: "asc" }).rows.map((r) => r.id)).toEqual([1, 2, 3]);
+    // Named rows first (Ada, Grace), the URL-only row last in both directions.
+    expect(applyProspectFilters(rows, { sort: "name", dir: "asc" }).rows.map((r) => r.id)).toEqual([
+      1, 2, 3,
+    ]);
+    expect(applyProspectFilters(rows, { sort: "name" }).rows.map((r) => r.id)).toEqual([2, 1, 3]);
+    // Undecided last in both directions.
+    expect(applyProspectFilters(rows, { sort: "decided" }).rows.map((r) => r.id)).toEqual([
+      2, 1, 3,
+    ]);
+    expect(
+      applyProspectFilters(rows, { sort: "decided", dir: "asc" }).rows.map((r) => r.id),
+    ).toEqual([1, 2, 3]);
+  });
+});

--- a/apps/web/src/lib/prospects-helpers.ts
+++ b/apps/web/src/lib/prospects-helpers.ts
@@ -1,0 +1,203 @@
+import type {
+  DecidedByFilter,
+  ProspectBrowseRow,
+  ProspectSearchResponse,
+  ProspectSortKey,
+  QueueCounts,
+  QueueStatusView,
+} from "@oneshot-gtm/shared-types";
+import { companyFor, emailFor, nameFor, titleFor } from "./payloadIdentity.ts";
+
+/**
+ * /prospects keeps its filters in the URL so a search is a link. Defaults are
+ * left OUT of the URL (`parseProspectsSearch` drops them, `toApiQuery` omits
+ * them) — `/prospects` stays clean and the demo's fixture path stays stable.
+ */
+export interface ProspectsSearch {
+  q?: string;
+  status?: QueueStatusView;
+  play?: string;
+  decided?: DecidedByFilter;
+  sort?: ProspectSortKey;
+  dir?: "asc" | "desc";
+  /** 1-based. Absent = first page. */
+  page?: number;
+}
+
+export const PAGE_SIZE = 50;
+
+/**
+ * Mirrors the server's name expression: a real name (prospect record, then
+ * `name`/`founderName`) counts; a handle derived from a URL does not, so
+ * URL-only rejects sort after every named row in both directions.
+ */
+function displayName(r: ProspectBrowseRow): string | null {
+  const p =
+    r.payload && typeof r.payload === "object" ? (r.payload as Record<string, unknown>) : null;
+  // `||`, not `??`: SQL's NULLIF(…, '') treats an empty name as missing too.
+  const raw = r.prospect?.name || p?.["name"] || p?.["founderName"];
+  return typeof raw === "string" && raw.length > 0 ? raw : null;
+}
+
+function payloadText(payload: unknown, key: string): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const v = (payload as Record<string, unknown>)[key];
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+const STATUSES = new Set<QueueStatusView>(["pending", "approved", "rejected", "sent", "expired"]);
+const DECIDED = new Set<DecidedByFilter>(["human", "machine", "none"]);
+const SORTS = new Set<ProspectSortKey>(["found", "decided", "name"]);
+
+/** For `validateSearch`: keep only well-formed, non-default values. */
+export function parseProspectsSearch(raw: Record<string, unknown>): ProspectsSearch {
+  const out: ProspectsSearch = {};
+  const q = typeof raw["q"] === "string" ? raw["q"].trim() : "";
+  if (q) out.q = q;
+  if (typeof raw["status"] === "string" && STATUSES.has(raw["status"] as QueueStatusView)) {
+    out.status = raw["status"] as QueueStatusView;
+  }
+  if (typeof raw["play"] === "string" && raw["play"].trim()) out.play = raw["play"].trim();
+  if (typeof raw["decided"] === "string" && DECIDED.has(raw["decided"] as DecidedByFilter)) {
+    out.decided = raw["decided"] as DecidedByFilter;
+  }
+  if (typeof raw["sort"] === "string" && SORTS.has(raw["sort"] as ProspectSortKey)) {
+    out.sort = raw["sort"] as ProspectSortKey;
+  }
+  if (raw["dir"] === "asc") out.dir = "asc";
+  const page =
+    typeof raw["page"] === "number"
+      ? raw["page"]
+      : typeof raw["page"] === "string" && /^\d+$/.test(raw["page"])
+        ? Number.parseInt(raw["page"], 10)
+        : 1;
+  if (Number.isFinite(page) && page > 1) out.page = Math.floor(page);
+  return out;
+}
+
+/** The `/queue/search?…` query string for a search — sorted keys, defaults omitted. */
+export function toApiQuery(s: ProspectsSearch): string {
+  const q = new URLSearchParams();
+  if (s.decided) q.set("decided", s.decided);
+  if (s.dir === "asc") q.set("dir", "asc");
+  q.set("limit", String(PAGE_SIZE));
+  const offset = ((s.page ?? 1) - 1) * PAGE_SIZE;
+  if (offset > 0) q.set("offset", String(offset));
+  if (s.play) q.set("play", s.play);
+  if (s.q) q.set("q", s.q);
+  if (s.sort) q.set("sort", s.sort);
+  if (s.status) q.set("status", s.status);
+  return q.toString();
+}
+
+export interface PageSummary {
+  /** 1-based index of the first row shown; 0 when the page is empty. */
+  from: number;
+  to: number;
+  page: number;
+  pages: number;
+}
+
+export function pageSummary(total: number, offset: number, limit: number): PageSummary {
+  const size = Math.max(1, limit);
+  const pages = Math.max(1, Math.ceil(total / size));
+  if (total === 0) return { from: 0, to: 0, page: 1, pages: 1 };
+  // An offset past the end (rows approved out from under a deep page) reads
+  // as the last page, never as "showing 101–95".
+  const page = Math.min(pages, Math.floor(offset / size) + 1);
+  const start = (page - 1) * size;
+  return { from: start + 1, to: Math.min(total, start + size), page, pages };
+}
+
+/** True when the requested page starts past the last row (and there are rows). */
+export function pastEnd(total: number, offset: number): boolean {
+  return total > 0 && offset >= total;
+}
+
+/**
+ * Demo mode serves one captured `/queue/search?limit=500` document (the whole
+ * seeded ledger) and runs the search here, so the box works without an
+ * unbounded fixture space. Same semantics as `Ledger.searchQueue`: terms
+ * AND-ed as case-insensitive substrings over the identity keys, notes, play
+ * and the linked prospect; the same three sorts; the same paging.
+ */
+export function applyProspectFilters(
+  rows: ReadonlyArray<ProspectBrowseRow>,
+  s: ProspectsSearch,
+): ProspectSearchResponse {
+  const terms = (s.q ?? "")
+    .toLowerCase()
+    .split(/\s+/)
+    .filter((t) => t.length > 0);
+  // The same fields `Ledger.searchQueue` concatenates, in JS.
+  const haystack = (r: ProspectBrowseRow): string =>
+    [
+      nameFor(r.payload),
+      emailFor(r.payload),
+      companyFor(r.payload),
+      titleFor(r.payload),
+      payloadText(r.payload, "postTitle"),
+      payloadText(r.payload, "repoUrl"),
+      payloadText(r.payload, "postUrl"),
+      payloadText(r.payload, "linkedinUrl"),
+      r.notes,
+      r.playName,
+      r.prospect?.name,
+      r.prospect?.email,
+      r.prospect?.company,
+      r.prospect?.title,
+    ]
+      .filter((v): v is string => typeof v === "string" && v.length > 0)
+      .join(" ")
+      .toLowerCase();
+  const unpaged = rows.filter((r) => {
+    if (s.play && r.playName !== s.play) return false;
+    if (s.decided === "human" && !(r.decidedBy === "human" || r.decidedBy === "human_bulk"))
+      return false;
+    if (s.decided === "machine" && r.decidedBy !== "machine") return false;
+    if (s.decided === "none" && r.decidedBy != null) return false;
+    if (terms.length > 0) {
+      const h = haystack(r);
+      if (!terms.every((t) => h.includes(t))) return false;
+    }
+    return true;
+  });
+  const counts: QueueCounts = { pending: 0, approved: 0, rejected: 0, sent: 0, expired: 0 };
+  for (const r of unpaged) counts[r.status] += 1;
+  const matched = s.status ? unpaged.filter((r) => r.status === s.status) : unpaged;
+
+  const dir = s.dir === "asc" ? 1 : -1;
+  const cmp = (a: ProspectBrowseRow, b: ProspectBrowseRow): number => {
+    if (s.sort === "decided") {
+      if (a.decidedAt == null || b.decidedAt == null) {
+        return a.decidedAt == null && b.decidedAt == null ? 0 : a.decidedAt == null ? 1 : -1;
+      }
+      return a.decidedAt === b.decidedAt ? 0 : (a.decidedAt < b.decidedAt ? -1 : 1) * dir;
+    }
+    if (s.sort === "name") {
+      const an = displayName(a);
+      const bn = displayName(b);
+      if (an == null || bn == null) {
+        if (an != null || bn != null) return an == null ? 1 : -1;
+        // Both URL-only: order by the derived handle, as the server does.
+        return (
+          (nameFor(a.payload) ?? a.dedupeKey)
+            .toLowerCase()
+            .localeCompare((nameFor(b.payload) ?? b.dedupeKey).toLowerCase()) * dir
+        );
+      }
+      return an.toLowerCase().localeCompare(bn.toLowerCase()) * dir;
+    }
+    return a.foundAt === b.foundAt ? 0 : (a.foundAt < b.foundAt ? -1 : 1) * dir;
+  };
+  const sorted = matched.toSorted((a, b) => cmp(a, b) || (a.id - b.id) * dir);
+  const offset = ((s.page ?? 1) - 1) * PAGE_SIZE;
+  return {
+    rows: sorted.slice(offset, offset + PAGE_SIZE),
+    total: sorted.length,
+    limit: PAGE_SIZE,
+    offset,
+    counts,
+    plays: [...new Set(rows.map((r) => r.playName))].toSorted(),
+  };
+}

--- a/apps/web/src/lib/queue-helpers.test.ts
+++ b/apps/web/src/lib/queue-helpers.test.ts
@@ -170,6 +170,9 @@ describe("queue.tsx fixed-props render fixture", () => {
       lastDraftedAt: null,
       isSending: false,
       priority: null,
+      decision: null,
+      decidedBy: null,
+      decidedAt: null,
     };
 
     const html = renderToStaticMarkup(

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -12,6 +12,7 @@ import { Route as rootRouteImport } from './routes/__root'
 import { Route as SetupRouteImport } from './routes/setup'
 import { Route as ReceiptsRouteImport } from './routes/receipts'
 import { Route as QueueRouteImport } from './routes/queue'
+import { Route as ProspectsRouteImport } from './routes/prospects'
 import { Route as PlaysRouteImport } from './routes/plays'
 import { Route as MeasureRouteImport } from './routes/measure'
 import { Route as InboxRouteImport } from './routes/inbox'
@@ -33,6 +34,11 @@ const ReceiptsRoute = ReceiptsRouteImport.update({
 const QueueRoute = QueueRouteImport.update({
   id: '/queue',
   path: '/queue',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ProspectsRoute = ProspectsRouteImport.update({
+  id: '/prospects',
+  path: '/prospects',
   getParentRoute: () => rootRouteImport,
 } as any)
 const PlaysRoute = PlaysRouteImport.update({
@@ -78,6 +84,7 @@ export interface FileRoutesByFullPath {
   '/inbox': typeof InboxRoute
   '/measure': typeof MeasureRoute
   '/plays': typeof PlaysRoute
+  '/prospects': typeof ProspectsRoute
   '/queue': typeof QueueRoute
   '/receipts': typeof ReceiptsRoute
   '/setup': typeof SetupRoute
@@ -90,6 +97,7 @@ export interface FileRoutesByTo {
   '/inbox': typeof InboxRoute
   '/measure': typeof MeasureRoute
   '/plays': typeof PlaysRoute
+  '/prospects': typeof ProspectsRoute
   '/queue': typeof QueueRoute
   '/receipts': typeof ReceiptsRoute
   '/setup': typeof SetupRoute
@@ -103,6 +111,7 @@ export interface FileRoutesById {
   '/inbox': typeof InboxRoute
   '/measure': typeof MeasureRoute
   '/plays': typeof PlaysRoute
+  '/prospects': typeof ProspectsRoute
   '/queue': typeof QueueRoute
   '/receipts': typeof ReceiptsRoute
   '/setup': typeof SetupRoute
@@ -117,6 +126,7 @@ export interface FileRouteTypes {
     | '/inbox'
     | '/measure'
     | '/plays'
+    | '/prospects'
     | '/queue'
     | '/receipts'
     | '/setup'
@@ -129,6 +139,7 @@ export interface FileRouteTypes {
     | '/inbox'
     | '/measure'
     | '/plays'
+    | '/prospects'
     | '/queue'
     | '/receipts'
     | '/setup'
@@ -141,6 +152,7 @@ export interface FileRouteTypes {
     | '/inbox'
     | '/measure'
     | '/plays'
+    | '/prospects'
     | '/queue'
     | '/receipts'
     | '/setup'
@@ -154,6 +166,7 @@ export interface RootRouteChildren {
   InboxRoute: typeof InboxRoute
   MeasureRoute: typeof MeasureRoute
   PlaysRoute: typeof PlaysRoute
+  ProspectsRoute: typeof ProspectsRoute
   QueueRoute: typeof QueueRoute
   ReceiptsRoute: typeof ReceiptsRoute
   SetupRoute: typeof SetupRoute
@@ -181,6 +194,13 @@ declare module '@tanstack/react-router' {
       path: '/queue'
       fullPath: '/queue'
       preLoaderRoute: typeof QueueRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/prospects': {
+      id: '/prospects'
+      path: '/prospects'
+      fullPath: '/prospects'
+      preLoaderRoute: typeof ProspectsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/plays': {
@@ -242,6 +262,7 @@ const rootRouteChildren: RootRouteChildren = {
   InboxRoute: InboxRoute,
   MeasureRoute: MeasureRoute,
   PlaysRoute: PlaysRoute,
+  ProspectsRoute: ProspectsRoute,
   QueueRoute: QueueRoute,
   ReceiptsRoute: ReceiptsRoute,
   SetupRoute: SetupRoute,

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -1,7 +1,17 @@
 import { useQuery } from "@tanstack/react-query";
 import { Outlet, createRootRouteWithContext, Link, useRouterState } from "@tanstack/react-router";
 import type { QueryClient } from "@tanstack/react-query";
-import { Activity, BarChart3, Feather, Inbox, Layers, Mail, Receipt, Settings } from "lucide-react";
+import {
+  Activity,
+  BarChart3,
+  Feather,
+  Inbox,
+  Layers,
+  Mail,
+  Receipt,
+  Settings,
+  Users,
+} from "lucide-react";
 import { useEffect, useRef, useState, type ComponentType, type ReactNode } from "react";
 import { Toaster } from "sonner";
 import { api } from "../api/client.ts";
@@ -27,7 +37,16 @@ export const Route = createRootRouteWithContext<RootContext>()({
 });
 
 interface NavItem {
-  to: "/" | "/queue" | "/inbox" | "/cadences" | "/receipts" | "/measure" | "/plays" | "/setup";
+  to:
+    | "/"
+    | "/queue"
+    | "/prospects"
+    | "/inbox"
+    | "/cadences"
+    | "/receipts"
+    | "/measure"
+    | "/plays"
+    | "/setup";
   label: string;
   icon: ComponentType<{ size?: number; className?: string }>;
   /** Which alert-data key, if any, lights a dot next to this nav item. */
@@ -37,6 +56,7 @@ interface NavItem {
 const NAV: NavItem[] = [
   { to: "/", label: "Today", icon: Activity },
   { to: "/queue", label: "Queue", icon: Inbox, alert: "queue-pending" },
+  { to: "/prospects", label: "Prospects", icon: Users },
   { to: "/inbox", label: "Replies", icon: Mail, alert: "inbox-positive" },
   { to: "/cadences", label: "Cadences", icon: Layers },
   { to: "/receipts", label: "Receipts", icon: Receipt },

--- a/apps/web/src/routes/prospects.tsx
+++ b/apps/web/src/routes/prospects.tsx
@@ -740,7 +740,11 @@ function IdentityBlock({ row, detail }: { row: ProspectBrowseRow; detail: QueueR
   const { masked } = usePrivacy();
   const title = detail.prospect?.title ?? titleFor(row.payload);
   const company = detail.prospect?.company ?? companyFor(row.payload);
-  const linkedinUrl = detail.prospect?.linkedinUrl ?? linkedinUrlFor(row.payload);
+  // The prospect column is polymorphic (LinkedIn, X or GitHub) and written
+  // unvalidated; run it through the same guard as the payload so a stored
+  // `javascript:` value can never become an href.
+  const linkedinUrl =
+    linkedinUrlFor({ linkedinUrl: detail.prospect?.linkedinUrl }) ?? linkedinUrlFor(row.payload);
   const evidence = queueEvidence(row.playName, row.payload);
   const source = sourceDetail(row.source);
   return (
@@ -750,7 +754,7 @@ function IdentityBlock({ row, detail }: { row: ProspectBrowseRow; detail: QueueR
         {[title, company ? maskDeep(company, masked, "company") : null]
           .filter(Boolean)
           .join(" · ") || <span className="text-ink-faint">no title or company on record</span>}
-        {linkedinUrl && /linkedin\.com\/in\//i.test(linkedinUrl) && (
+        {linkedinUrl && (
           <a
             href={linkedinUrl}
             target="_blank"

--- a/apps/web/src/routes/prospects.tsx
+++ b/apps/web/src/routes/prospects.tsx
@@ -1,7 +1,7 @@
 import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
-import { Check, ChevronLeft, ChevronRight, Search, X } from "lucide-react";
-import { useEffect, useState } from "react";
+import { Check, ChevronDown, ChevronLeft, ChevronRight, Search, X } from "lucide-react";
+import { Fragment, useEffect, useState } from "react";
 import { toast } from "sonner";
 import {
   describeDecision,
@@ -17,7 +17,6 @@ import { Badge } from "../components/primitives/Badge.tsx";
 import { Button } from "../components/primitives/Button.tsx";
 import { EmptyNote } from "../components/primitives/EmptyNote.tsx";
 import { Field, Input, Select, Textarea } from "../components/primitives/Field.tsx";
-import { Modal } from "../components/primitives/Modal.tsx";
 import { Pii } from "../components/primitives/Pii.tsx";
 import { Skeleton, SkeletonRow } from "../components/primitives/Skeleton.tsx";
 import { cn, formatCount, timeAgo } from "../lib/cn.ts";
@@ -95,11 +94,13 @@ function statusTone(
 function ProspectsPage() {
   const search = Route.useSearch();
   const navigate = Route.useNavigate();
-  const [activeId, setActiveId] = useState<number | null>(null);
+  // One row open at a time, expanded in place — the same shape as /queue.
+  const [expanded, setExpanded] = useState<number | null>(null);
 
   const update = (patch: Partial<ProspectsSearch>, opts: { replace?: boolean } = {}): void => {
     // Every filter change restarts at page one — page N of a different
     // search is not a place.
+    setExpanded(null);
     void navigate({
       search: (prev) => ({ ...prev, ...patch, page: undefined }),
       ...(opts.replace ? { replace: true } : {}),
@@ -314,7 +315,8 @@ function ProspectsPage() {
           <table className={cn("w-full text-[13px]", results.isFetching && "opacity-70")}>
             <thead className="sticky top-0 z-10 bg-ink-bg">
               <tr className="border-b border-ink-rule text-[10px] uppercase tracking-[0.14em] text-ink-faint">
-                <th className="px-6 py-2 text-left font-medium">prospect</th>
+                <th className="w-6 py-2 pl-4 pr-0" aria-label="expand" />
+                <th className="py-2 text-left font-medium">prospect</th>
                 <th className="py-2 text-left font-medium">play</th>
                 <th className="py-2 pr-4 text-left font-medium">status</th>
                 <th className="py-2 text-left font-medium">decision</th>
@@ -328,7 +330,8 @@ function ProspectsPage() {
                   key={row.id}
                   row={row}
                   zebra={i % 2 === 1}
-                  onOpen={() => setActiveId(row.id)}
+                  expanded={expanded === row.id}
+                  onToggle={() => setExpanded((prev) => (prev === row.id ? null : row.id))}
                 />
               ))}
             </tbody>
@@ -377,8 +380,6 @@ function ProspectsPage() {
           </div>
         </div>
       )}
-
-      <DetailModal id={activeId} onClose={() => setActiveId(null)} />
     </div>
   );
 }
@@ -386,11 +387,13 @@ function ProspectsPage() {
 function BrowseRow({
   row,
   zebra,
-  onOpen,
+  expanded,
+  onToggle,
 }: {
   row: ProspectBrowseRow;
   zebra: boolean;
-  onOpen: () => void;
+  expanded: boolean;
+  onToggle: () => void;
 }) {
   const { masked } = usePrivacy();
   const name = row.prospect?.name ?? nameFor(row.payload);
@@ -401,99 +404,115 @@ function BrowseRow({
   const evidence = queueEvidence(row.playName, row.payload);
   const detail = sourceDetail(row.source);
   return (
-    <tr
-      onClick={onOpen}
-      // Rows are the only way into the drawer, so they take focus and open on
-      // Enter like a button would.
-      tabIndex={0}
-      onKeyDown={(e) => {
-        if (e.key === "Enter" && e.target === e.currentTarget) onOpen();
-      }}
-      className={cn(
-        "cursor-pointer border-b border-ink-rule/60 focus:outline-none focus-visible:bg-ink-surface/60",
-        "transition-colors duration-[var(--dur-stamp)]",
-        "hover:bg-ink-surface/60",
-        zebra && "bg-ink-surface/20",
-      )}
-    >
-      <td className="px-6 py-2">
-        <div className="text-ink-cream">{name ? <Pii kind="name">{name}</Pii> : "(unknown)"}</div>
-        <div className="font-mono text-[11px] text-ink-faint">
-          {email ? <Pii kind="email">{email}</Pii> : "—"}
-          {title ? (
-            <>
-              {" · "}
-              <span className="inline-block max-w-[38ch] truncate align-bottom text-ink-cream-2">
-                {title}
-              </span>
-            </>
-          ) : null}
-          {company ? (
-            <>
-              {" · "}
-              <Pii kind="company">{company}</Pii>
-            </>
-          ) : null}
-          {linkedinUrl ? (
-            <a
-              href={linkedinUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="ml-1 text-ink-cream-2 underline decoration-ink-rule underline-offset-2 hover:text-ink-cream hover:decoration-ink-cream-2"
-              onClick={(e) => e.stopPropagation()}
-            >
-              [in]
-            </a>
-          ) : null}
-        </div>
-        {/* Freeform finder evidence can name people the structured masking
-            cannot reach, so it hides under privacy mode as it does on /queue. */}
-        {evidence && !masked ? (
-          <div className="mt-0.5 max-w-[46ch] truncate text-[11px] text-ink-muted">{evidence}</div>
-        ) : null}
-      </td>
-      <td className="py-2 text-ink-cream-2">
-        {row.playName}
-        {detail && <div className="truncate font-mono text-[10.5px] text-ink-faint">{detail}</div>}
-      </td>
-      <td className="py-2 pr-4">
-        <Badge tone={statusTone(row.status)}>{row.status}</Badge>
-      </td>
-      <td className="py-2 text-[12px] text-ink-cream-2">
-        {describeDecision(row)}
-        {(row.prospect?.icpVerdict ?? payloadString(row.payload, "icpVerdict")) === "reject" && (
-          <span className="ml-1.5 font-mono text-[10px] uppercase tracking-[0.08em] text-[color:var(--ink-blocked-2)]">
-            off-icp
-          </span>
+    <Fragment>
+      <tr
+        onClick={onToggle}
+        // Rows are the only way into the detail, so they take focus and toggle
+        // on Enter like a button would.
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && e.target === e.currentTarget) onToggle();
+        }}
+        aria-expanded={expanded}
+        className={cn(
+          "cursor-pointer border-b border-ink-rule/60 focus:outline-none focus-visible:bg-ink-surface/60",
+          "transition-colors duration-[var(--dur-stamp)]",
+          "hover:bg-ink-surface/60",
+          zebra && "bg-ink-surface/20",
+          expanded && "bg-ink-surface/40",
         )}
-      </td>
-      <td className="py-2 text-right font-mono text-[12px] text-ink-muted">
-        {timeAgo(row.foundAt)}
-      </td>
-      <td className="px-6 py-2 text-right font-mono text-[12px] text-ink-muted">
-        {row.decidedAt ? timeAgo(row.decidedAt) : "—"}
-      </td>
-    </tr>
+      >
+        <td className="w-6 py-2 pl-4 pr-0 text-ink-faint">
+          {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+        </td>
+        <td className="py-2">
+          <div className="text-ink-cream">{name ? <Pii kind="name">{name}</Pii> : "(unknown)"}</div>
+          <div className="font-mono text-[11px] text-ink-faint">
+            {email ? <Pii kind="email">{email}</Pii> : "—"}
+            {title ? (
+              <>
+                {" · "}
+                <span className="inline-block max-w-[38ch] truncate align-bottom text-ink-cream-2">
+                  {title}
+                </span>
+              </>
+            ) : null}
+            {company ? (
+              <>
+                {" · "}
+                <Pii kind="company">{company}</Pii>
+              </>
+            ) : null}
+            {linkedinUrl ? (
+              <a
+                href={linkedinUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="ml-1 text-ink-cream-2 underline decoration-ink-rule underline-offset-2 hover:text-ink-cream hover:decoration-ink-cream-2"
+                onClick={(e) => e.stopPropagation()}
+              >
+                [in]
+              </a>
+            ) : null}
+          </div>
+          {/* Freeform finder evidence can name people the structured masking
+            cannot reach, so it hides under privacy mode as it does on /queue. */}
+          {evidence && !masked ? (
+            <div className="mt-0.5 max-w-[46ch] truncate text-[11px] text-ink-muted">
+              {evidence}
+            </div>
+          ) : null}
+        </td>
+        <td className="py-2 text-ink-cream-2">
+          {row.playName}
+          {detail && (
+            <div className="truncate font-mono text-[10.5px] text-ink-faint">{detail}</div>
+          )}
+        </td>
+        <td className="py-2 pr-4">
+          <Badge tone={statusTone(row.status)}>{row.status}</Badge>
+        </td>
+        <td className="py-2 text-[12px] text-ink-cream-2">
+          {describeDecision(row)}
+          {(row.prospect?.icpVerdict ?? payloadString(row.payload, "icpVerdict")) === "reject" && (
+            <span className="ml-1.5 font-mono text-[10px] uppercase tracking-[0.08em] text-[color:var(--ink-blocked-2)]">
+              off-icp
+            </span>
+          )}
+        </td>
+        <td className="py-2 text-right font-mono text-[12px] text-ink-muted">
+          {timeAgo(row.foundAt)}
+        </td>
+        <td className="px-6 py-2 text-right font-mono text-[12px] text-ink-muted">
+          {row.decidedAt ? timeAgo(row.decidedAt) : "—"}
+        </td>
+      </tr>
+      {expanded && (
+        <tr className="border-b border-ink-rule/60 bg-ink-surface/20">
+          <td colSpan={7} className="px-6 py-4">
+            <DetailPanel id={row.id} />
+          </td>
+        </tr>
+      )}
+    </Fragment>
   );
 }
 
-function DetailModal({ id, onClose }: { id: number | null; onClose: () => void }) {
+/**
+ * The expanded row: everything /api/queue/:id knows about this candidate, plus
+ * the override actions. Mounted per row (keyed by the table), so its
+ * rejection draft dies with the row it belonged to.
+ */
+function DetailPanel({ id }: { id: number }) {
   const qc = useQueryClient();
   const { masked } = usePrivacy();
   const [rejecting, setRejecting] = useState(false);
   const [reason, setReason] = useState("");
   const detail = useQuery({
     queryKey: ["prospects", "detail", id],
-    queryFn: () => (id == null ? Promise.resolve(null) : api.queueRowDetail(id)),
-    enabled: id != null,
+    queryFn: () => api.queueRowDetail(id),
   });
   const d = detail.data ?? null;
-
-  // A fresh row closes any half-typed rejection from the previous one.
-  useEffect(() => {
-    setRejecting(false);
-    setReason("");
-  }, [id]);
 
   const invalidate = (): void => {
     void qc.invalidateQueries({ queryKey: ["prospects"] });
@@ -520,8 +539,6 @@ function DetailModal({ id, onClose }: { id: number | null; onClose: () => void }
   });
 
   const row = d?.row ?? null;
-  const name = row ? (row.prospect?.name ?? nameFor(row.payload)) : null;
-  const email = row ? (d?.prospect?.email ?? emailFor(row.payload)) : null;
   // Never past a reply: the server refuses too (409), but the button should
   // not be there to press.
   const canApprove =
@@ -534,62 +551,7 @@ function DetailModal({ id, onClose }: { id: number | null; onClose: () => void }
     row?.prospect?.icpVerdictReason ?? payloadString(row?.payload, "icpVerdictReason");
 
   return (
-    <Modal
-      open={id != null}
-      title={name ? maskDeep(name, masked, "name") : row ? "(unknown)" : "prospect"}
-      subtitle={
-        row
-          ? `#${row.id} · ${row.playName}${email ? ` · ${maskDeep(email, masked, "email")}` : ""}`
-          : `#${id}`
-      }
-      onClose={onClose}
-      width={720}
-      footer={
-        row ? (
-          <>
-            {!rejecting && canReject && (
-              <Button
-                variant="ghost"
-                onClick={() => {
-                  setReason(row.notes ?? "");
-                  setRejecting(true);
-                }}
-                {...readOnly}
-              >
-                <X size={12} /> Reject…
-              </Button>
-            )}
-            {rejecting && (
-              <>
-                <Button variant="ghost" onClick={() => setRejecting(false)}>
-                  Cancel
-                </Button>
-                <Button
-                  variant="danger"
-                  disabled={reject.isPending}
-                  onClick={() =>
-                    reject.mutate({ rowId: row.id, reason: reason.trim() || undefined })
-                  }
-                  {...readOnly}
-                >
-                  {reject.isPending ? "Rejecting…" : "Reject"}
-                </Button>
-              </>
-            )}
-            {!rejecting && canApprove && (
-              <Button
-                variant="secondary"
-                disabled={approve.isPending}
-                onClick={() => approve.mutate(row.id)}
-                {...readOnly}
-              >
-                <Check size={12} /> {row.status === "rejected" ? "Approve anyway" : "Approve"}
-              </Button>
-            )}
-          </>
-        ) : undefined
-      }
-    >
+    <div className="flex flex-col gap-4">
       {detail.isLoading || !d || !row ? (
         detail.isError ? (
           <div className="text-[13px] text-[color:var(--ink-blocked-2)]">
@@ -729,7 +691,48 @@ function DetailModal({ id, onClose }: { id: number | null; onClose: () => void }
           </details>
         </div>
       )}
-    </Modal>
+      {row && (canApprove || canReject || rejecting) && (
+        <div className="flex items-center justify-end gap-2 border-t border-ink-rule/60 pt-3">
+          {!rejecting && canReject && (
+            <Button
+              variant="ghost"
+              onClick={() => {
+                setReason(row.notes ?? "");
+                setRejecting(true);
+              }}
+              {...readOnly}
+            >
+              <X size={12} /> Reject…
+            </Button>
+          )}
+          {rejecting && (
+            <>
+              <Button variant="ghost" onClick={() => setRejecting(false)}>
+                Cancel
+              </Button>
+              <Button
+                variant="danger"
+                disabled={reject.isPending}
+                onClick={() => reject.mutate({ rowId: row.id, reason: reason.trim() || undefined })}
+                {...readOnly}
+              >
+                {reject.isPending ? "Rejecting…" : "Reject"}
+              </Button>
+            </>
+          )}
+          {!rejecting && canApprove && (
+            <Button
+              variant="secondary"
+              disabled={approve.isPending}
+              onClick={() => approve.mutate(row.id)}
+              {...readOnly}
+            >
+              <Check size={12} /> {row.status === "rejected" ? "Approve anyway" : "Approve"}
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
   );
 }
 

--- a/apps/web/src/routes/prospects.tsx
+++ b/apps/web/src/routes/prospects.tsx
@@ -1,0 +1,795 @@
+import { keepPreviousData, useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { Check, ChevronLeft, ChevronRight, Search, X } from "lucide-react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import {
+  describeDecision,
+  type CadenceView,
+  type DecidedByFilter,
+  type ProspectBrowseRow,
+  type ProspectSortKey,
+  type QueueRowDetail,
+  type QueueStatusView,
+} from "@oneshot-gtm/shared-types";
+import { api } from "../api/client.ts";
+import { Badge } from "../components/primitives/Badge.tsx";
+import { Button } from "../components/primitives/Button.tsx";
+import { EmptyNote } from "../components/primitives/EmptyNote.tsx";
+import { Field, Input, Select, Textarea } from "../components/primitives/Field.tsx";
+import { Modal } from "../components/primitives/Modal.tsx";
+import { Pii } from "../components/primitives/Pii.tsx";
+import { Skeleton, SkeletonRow } from "../components/primitives/Skeleton.tsx";
+import { cn, formatCount, timeAgo } from "../lib/cn.ts";
+import { maskDeep } from "../lib/mask.ts";
+import {
+  companyFor,
+  emailFor,
+  linkedinUrlFor,
+  nameFor,
+  sourceDetail,
+  titleFor,
+} from "../lib/payloadIdentity.ts";
+import { usePrivacy } from "../lib/privacy.tsx";
+import {
+  pageSummary,
+  parseProspectsSearch,
+  pastEnd,
+  type ProspectsSearch,
+} from "../lib/prospects-helpers.ts";
+import { queueEvidence } from "../lib/queueEvidence.ts";
+import { readOnly } from "../lib/readOnly.ts";
+
+export const Route = createFileRoute("/prospects")({
+  staticData: { title: "Prospects" },
+  // Filters live in the URL so a search is a link; defaults are dropped so
+  // /prospects stays clean and the demo's fixture path stays stable.
+  validateSearch: parseProspectsSearch,
+  component: ProspectsPage,
+});
+
+const STATUSES: Array<QueueStatusView | "all"> = [
+  "all",
+  "pending",
+  "approved",
+  "rejected",
+  "sent",
+  "expired",
+];
+
+const DECIDED: Array<{ key: DecidedByFilter | "any"; label: string }> = [
+  { key: "any", label: "anyone" },
+  { key: "human", label: "you" },
+  { key: "machine", label: "machine" },
+  { key: "none", label: "undecided" },
+];
+
+/** Every sort × direction the URL accepts, so a shared link always shows its own order. */
+const SORTS: Array<{ key: ProspectSortKey; dir: "asc" | "desc"; label: string }> = [
+  { key: "found", dir: "desc", label: "newest" },
+  { key: "found", dir: "asc", label: "oldest" },
+  { key: "decided", dir: "desc", label: "last decided" },
+  { key: "decided", dir: "asc", label: "first decided" },
+  { key: "name", dir: "asc", label: "name a–z" },
+  { key: "name", dir: "desc", label: "name z–a" },
+];
+
+/** Same tone map as /queue, so a status reads the same colour on both pages. */
+function statusTone(
+  status: QueueStatusView,
+): "receipt" | "spend" | "blocked" | "signal" | "neutral" {
+  switch (status) {
+    case "pending":
+      return "spend";
+    case "approved":
+      return "receipt";
+    case "rejected":
+      return "blocked";
+    case "sent":
+      return "signal";
+    case "expired":
+      return "neutral";
+  }
+}
+
+function ProspectsPage() {
+  const search = Route.useSearch();
+  const navigate = Route.useNavigate();
+  const [activeId, setActiveId] = useState<number | null>(null);
+
+  const update = (patch: Partial<ProspectsSearch>, opts: { replace?: boolean } = {}): void => {
+    // Every filter change restarts at page one — page N of a different
+    // search is not a place.
+    void navigate({
+      search: (prev) => ({ ...prev, ...patch, page: undefined }),
+      ...(opts.replace ? { replace: true } : {}),
+    });
+  };
+
+  // The search box is local state, pushed to the URL 250 ms after typing
+  // stops (replacing the entry, so Back does not walk through keystrokes);
+  // a browser back/forward that changes `q` pulls it back down — but only
+  // when the box does not already say that, or the URL's trimmed value
+  // would eat a trailing space or a character typed while the push landed.
+  const [qDraft, setQDraft] = useState(search.q ?? "");
+  useEffect(() => {
+    setQDraft((prev) => (prev.trim() === (search.q ?? "") ? prev : (search.q ?? "")));
+  }, [search.q]);
+  useEffect(() => {
+    const trimmed = qDraft.trim();
+    if (trimmed === (search.q ?? "")) return;
+    const id = setTimeout(() => update({ q: trimmed || undefined }, { replace: true }), 250);
+    return () => clearTimeout(id);
+    // `update` is stable per render but not memoised; the URL value is the
+    // only dependency that should re-arm the timer.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [qDraft, search.q]);
+
+  const results = useQuery({
+    queryKey: ["prospects", search],
+    queryFn: () => api.prospectSearch(search),
+    placeholderData: keepPreviousData,
+    refetchInterval: 30_000,
+  });
+  const data = results.data;
+  const rows = data?.rows ?? [];
+  const counts = data?.counts;
+  const allCount = counts
+    ? counts.pending + counts.approved + counts.rejected + counts.sent + counts.expired
+    : null;
+  const summary = data ? pageSummary(data.total, data.offset, data.limit) : null;
+  const isPastEnd = data ? pastEnd(data.total, data.offset) : false;
+  const sortKey = `${search.sort ?? "found"}:${search.dir ?? "desc"}`;
+  const filterActive =
+    !!search.q || !!search.status || !!search.play || !!search.decided || !!search.sort;
+
+  return (
+    <div className="-mx-6 -my-6 flex flex-col">
+      <section className="flex items-end justify-between gap-4 border-b border-ink-rule px-6 pb-5 pt-6">
+        <div>
+          <div className="ln-eyebrow">The Ledger · Prospects</div>
+          <h1
+            className="mt-1 text-ink-cream"
+            style={{
+              fontFamily: "var(--font-display)",
+              fontSize: 44,
+              fontWeight: 600,
+              letterSpacing: "-0.025em",
+              lineHeight: 0.98,
+            }}
+          >
+            Everyone the finders found.
+          </h1>
+        </div>
+        <div className="text-right font-mono text-[11px] text-ink-faint">
+          {data ? (
+            <>
+              <div>
+                <span className="text-ink-cream-2">{formatCount(data.total)}</span>{" "}
+                <span className="text-ink-muted">{filterActive ? "matching" : "rows"}</span>
+              </div>
+              {allCount != null && filterActive && (
+                <div className="mt-0.5">
+                  <span className="text-ink-cream-2">{formatCount(allCount)}</span>{" "}
+                  <span className="text-ink-muted">in this view</span>
+                </div>
+              )}
+            </>
+          ) : (
+            <Skeleton lines={2} widths={["96px", "64px"]} />
+          )}
+        </div>
+      </section>
+
+      {/* One filter block, one rule under it: search, then status with the
+          counts each chip would reveal, then who decided, sort and play. */}
+      <div className="flex flex-col gap-2.5 border-b border-ink-rule/60 px-6 py-3">
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="relative w-[min(420px,100%)]">
+            <Search
+              size={13}
+              aria-hidden
+              className="pointer-events-none absolute left-2.5 top-1/2 -translate-y-1/2 text-ink-muted"
+            />
+            <Input
+              type="search"
+              value={qDraft}
+              onChange={(e) => setQDraft(e.target.value)}
+              placeholder="name, email, company, title, play, note…"
+              aria-label="search prospects"
+              className="pl-8"
+            />
+          </div>
+          <span className="mx-1 h-4 w-px bg-ink-rule" />
+          <span className="ln-eyebrow">sort</span>
+          <Select
+            aria-label="sort"
+            value={sortKey}
+            onChange={(e) => {
+              const [key, dir] = e.target.value.split(":") as [ProspectSortKey, "asc" | "desc"];
+              update({
+                sort: key === "found" && dir === "desc" ? undefined : key,
+                dir: dir === "asc" ? "asc" : undefined,
+              });
+            }}
+            className="w-[150px]"
+          >
+            {SORTS.map((s) => (
+              <option key={`${s.key}:${s.dir}`} value={`${s.key}:${s.dir}`}>
+                {s.label}
+              </option>
+            ))}
+          </Select>
+          <span className="ln-eyebrow">play</span>
+          <Select
+            aria-label="play"
+            value={search.play ?? ""}
+            onChange={(e) => update({ play: e.target.value || undefined })}
+            className="w-[190px]"
+          >
+            <option value="">every play</option>
+            {(data?.plays ?? (search.play ? [search.play] : [])).map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </Select>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="ln-eyebrow">status</span>
+          {STATUSES.map((s) => {
+            const active = (search.status ?? "all") === s;
+            const n = s === "all" ? allCount : (counts?.[s] ?? null);
+            return (
+              <Button
+                key={s}
+                variant={active ? "secondary" : "ghost"}
+                size="sm"
+                onClick={() => update({ status: s === "all" ? undefined : s })}
+              >
+                {s}
+                {n != null && <span className="ml-1 font-mono opacity-60">{formatCount(n)}</span>}
+              </Button>
+            );
+          })}
+          <span className="mx-2 h-4 w-px bg-ink-rule" />
+          <span className="ln-eyebrow">decided by</span>
+          {DECIDED.map((d) => (
+            <Button
+              key={d.key}
+              variant={(search.decided ?? "any") === d.key ? "secondary" : "ghost"}
+              size="sm"
+              onClick={() => update({ decided: d.key === "any" ? undefined : d.key })}
+            >
+              {d.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      <section>
+        {results.isLoading ? (
+          <div>
+            {Array.from({ length: 8 }, (_, i) => (
+              <SkeletonRow key={i} />
+            ))}
+          </div>
+        ) : results.isError ? (
+          <div className="px-6 py-8">
+            <EmptyNote note={`Couldn't load prospects · ${results.error.message}`} />
+          </div>
+        ) : rows.length === 0 ? (
+          <div className="px-6 py-8">
+            {isPastEnd && summary ? (
+              <EmptyNote note="This page is past the end — rows were decided out from under it.">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() =>
+                    void navigate({
+                      search: (prev) => ({
+                        ...prev,
+                        page: summary.pages > 1 ? summary.pages : undefined,
+                      }),
+                    })
+                  }
+                >
+                  go to the last page
+                </Button>
+              </EmptyNote>
+            ) : filterActive ? (
+              <EmptyNote note="Nothing matches. Loosen a filter or clear the search.">
+                <Button variant="ghost" size="sm" onClick={() => void navigate({ search: {} })}>
+                  clear filters
+                </Button>
+              </EmptyNote>
+            ) : (
+              <EmptyNote
+                note="No candidates yet. Run a finder from /queue's Triggers panel; everything it surfaces — kept or rejected — lands here."
+                cli="oneshot-gtm find watch"
+              />
+            )}
+          </div>
+        ) : (
+          <table className={cn("w-full text-[13px]", results.isFetching && "opacity-70")}>
+            <thead className="sticky top-0 z-10 bg-ink-bg">
+              <tr className="border-b border-ink-rule text-[10px] uppercase tracking-[0.14em] text-ink-faint">
+                <th className="px-6 py-2 text-left font-medium">prospect</th>
+                <th className="py-2 text-left font-medium">play</th>
+                <th className="py-2 pr-4 text-left font-medium">status</th>
+                <th className="py-2 text-left font-medium">decision</th>
+                <th className="py-2 text-right font-medium">found</th>
+                <th className="px-6 py-2 text-right font-medium">decided</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, i) => (
+                <BrowseRow
+                  key={row.id}
+                  row={row}
+                  zebra={i % 2 === 1}
+                  onOpen={() => setActiveId(row.id)}
+                />
+              ))}
+            </tbody>
+          </table>
+        )}
+      </section>
+
+      {summary && data && data.total > 0 && (
+        <div className="flex items-center justify-between gap-4 border-t border-ink-rule/60 px-6 py-3 font-mono text-[11px] text-ink-faint">
+          <div>
+            showing <span className="text-ink-cream-2">{formatCount(summary.from)}</span>–
+            <span className="text-ink-cream-2">{formatCount(summary.to)}</span> of{" "}
+            <span className="text-ink-cream-2">{formatCount(data.total)}</span>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={summary.page <= 1}
+              onClick={() =>
+                void navigate({
+                  search: (prev) => ({
+                    ...prev,
+                    page: summary.page > 2 ? summary.page - 1 : undefined,
+                  }),
+                })
+              }
+              aria-label="previous page"
+            >
+              <ChevronLeft size={12} /> prev
+            </Button>
+            <span>
+              page {summary.page} / {summary.pages}
+            </span>
+            <Button
+              variant="ghost"
+              size="sm"
+              disabled={summary.page >= summary.pages}
+              onClick={() =>
+                void navigate({ search: (prev) => ({ ...prev, page: summary.page + 1 }) })
+              }
+              aria-label="next page"
+            >
+              next <ChevronRight size={12} />
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <DetailModal id={activeId} onClose={() => setActiveId(null)} />
+    </div>
+  );
+}
+
+function BrowseRow({
+  row,
+  zebra,
+  onOpen,
+}: {
+  row: ProspectBrowseRow;
+  zebra: boolean;
+  onOpen: () => void;
+}) {
+  const { masked } = usePrivacy();
+  const name = row.prospect?.name ?? nameFor(row.payload);
+  const email = emailFor(row.payload);
+  const title = row.prospect?.title ?? titleFor(row.payload);
+  const company = companyFor(row.payload);
+  const linkedinUrl = linkedinUrlFor(row.payload);
+  const evidence = queueEvidence(row.playName, row.payload);
+  const detail = sourceDetail(row.source);
+  return (
+    <tr
+      onClick={onOpen}
+      // Rows are the only way into the drawer, so they take focus and open on
+      // Enter like a button would.
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" && e.target === e.currentTarget) onOpen();
+      }}
+      className={cn(
+        "cursor-pointer border-b border-ink-rule/60 focus:outline-none focus-visible:bg-ink-surface/60",
+        "transition-colors duration-[var(--dur-stamp)]",
+        "hover:bg-ink-surface/60",
+        zebra && "bg-ink-surface/20",
+      )}
+    >
+      <td className="px-6 py-2">
+        <div className="text-ink-cream">{name ? <Pii kind="name">{name}</Pii> : "(unknown)"}</div>
+        <div className="font-mono text-[11px] text-ink-faint">
+          {email ? <Pii kind="email">{email}</Pii> : "—"}
+          {title ? (
+            <>
+              {" · "}
+              <span className="inline-block max-w-[38ch] truncate align-bottom text-ink-cream-2">
+                {title}
+              </span>
+            </>
+          ) : null}
+          {company ? (
+            <>
+              {" · "}
+              <Pii kind="company">{company}</Pii>
+            </>
+          ) : null}
+          {linkedinUrl ? (
+            <a
+              href={linkedinUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="ml-1 text-ink-cream-2 underline decoration-ink-rule underline-offset-2 hover:text-ink-cream hover:decoration-ink-cream-2"
+              onClick={(e) => e.stopPropagation()}
+            >
+              [in]
+            </a>
+          ) : null}
+        </div>
+        {/* Freeform finder evidence can name people the structured masking
+            cannot reach, so it hides under privacy mode as it does on /queue. */}
+        {evidence && !masked ? (
+          <div className="mt-0.5 max-w-[46ch] truncate text-[11px] text-ink-muted">{evidence}</div>
+        ) : null}
+      </td>
+      <td className="py-2 text-ink-cream-2">
+        {row.playName}
+        {detail && <div className="truncate font-mono text-[10.5px] text-ink-faint">{detail}</div>}
+      </td>
+      <td className="py-2 pr-4">
+        <Badge tone={statusTone(row.status)}>{row.status}</Badge>
+      </td>
+      <td className="py-2 text-[12px] text-ink-cream-2">
+        {describeDecision(row)}
+        {(row.prospect?.icpVerdict ?? payloadString(row.payload, "icpVerdict")) === "reject" && (
+          <span className="ml-1.5 font-mono text-[10px] uppercase tracking-[0.08em] text-[color:var(--ink-blocked-2)]">
+            off-icp
+          </span>
+        )}
+      </td>
+      <td className="py-2 text-right font-mono text-[12px] text-ink-muted">
+        {timeAgo(row.foundAt)}
+      </td>
+      <td className="px-6 py-2 text-right font-mono text-[12px] text-ink-muted">
+        {row.decidedAt ? timeAgo(row.decidedAt) : "—"}
+      </td>
+    </tr>
+  );
+}
+
+function DetailModal({ id, onClose }: { id: number | null; onClose: () => void }) {
+  const qc = useQueryClient();
+  const { masked } = usePrivacy();
+  const [rejecting, setRejecting] = useState(false);
+  const [reason, setReason] = useState("");
+  const detail = useQuery({
+    queryKey: ["prospects", "detail", id],
+    queryFn: () => (id == null ? Promise.resolve(null) : api.queueRowDetail(id)),
+    enabled: id != null,
+  });
+  const d = detail.data ?? null;
+
+  // A fresh row closes any half-typed rejection from the previous one.
+  useEffect(() => {
+    setRejecting(false);
+    setReason("");
+  }, [id]);
+
+  const invalidate = (): void => {
+    void qc.invalidateQueries({ queryKey: ["prospects"] });
+    void qc.invalidateQueries({ queryKey: ["queue"] });
+    void qc.invalidateQueries({ queryKey: ["home"] });
+  };
+  const approve = useMutation({
+    mutationFn: (rowId: number) => api.approveQueue(rowId),
+    onSuccess: () => {
+      toast.success("approved — it will go out on the next drain");
+      invalidate();
+    },
+    onError: (err) => toast.error(`couldn't approve · ${err.message}`),
+  });
+  const reject = useMutation({
+    mutationFn: (vars: { rowId: number; reason?: string }) =>
+      api.rejectQueue(vars.rowId, vars.reason),
+    onSuccess: () => {
+      toast.success("rejected");
+      setRejecting(false);
+      invalidate();
+    },
+    onError: (err) => toast.error(`couldn't reject · ${err.message}`),
+  });
+
+  const row = d?.row ?? null;
+  const name = row ? (row.prospect?.name ?? nameFor(row.payload)) : null;
+  const email = row ? (d?.prospect?.email ?? emailFor(row.payload)) : null;
+  // Never past a reply: the server refuses too (409), but the button should
+  // not be there to press.
+  const canApprove =
+    row != null &&
+    !d?.flags.replied &&
+    (row.status === "pending" || row.status === "rejected" || row.status === "expired");
+  const canReject = row != null && (row.status === "pending" || row.status === "approved");
+  const icpVerdict = row?.prospect?.icpVerdict ?? payloadString(row?.payload, "icpVerdict");
+  const icpReason =
+    row?.prospect?.icpVerdictReason ?? payloadString(row?.payload, "icpVerdictReason");
+
+  return (
+    <Modal
+      open={id != null}
+      title={name ? maskDeep(name, masked, "name") : row ? "(unknown)" : "prospect"}
+      subtitle={
+        row
+          ? `#${row.id} · ${row.playName}${email ? ` · ${maskDeep(email, masked, "email")}` : ""}`
+          : `#${id}`
+      }
+      onClose={onClose}
+      width={720}
+      footer={
+        row ? (
+          <>
+            {!rejecting && canReject && (
+              <Button
+                variant="ghost"
+                onClick={() => {
+                  setReason(row.notes ?? "");
+                  setRejecting(true);
+                }}
+                {...readOnly}
+              >
+                <X size={12} /> Reject…
+              </Button>
+            )}
+            {rejecting && (
+              <>
+                <Button variant="ghost" onClick={() => setRejecting(false)}>
+                  Cancel
+                </Button>
+                <Button
+                  variant="danger"
+                  disabled={reject.isPending}
+                  onClick={() =>
+                    reject.mutate({ rowId: row.id, reason: reason.trim() || undefined })
+                  }
+                  {...readOnly}
+                >
+                  {reject.isPending ? "Rejecting…" : "Reject"}
+                </Button>
+              </>
+            )}
+            {!rejecting && canApprove && (
+              <Button
+                variant="secondary"
+                disabled={approve.isPending}
+                onClick={() => approve.mutate(row.id)}
+                {...readOnly}
+              >
+                <Check size={12} /> {row.status === "rejected" ? "Approve anyway" : "Approve"}
+              </Button>
+            )}
+          </>
+        ) : undefined
+      }
+    >
+      {detail.isLoading || !d || !row ? (
+        detail.isError ? (
+          <div className="text-[13px] text-[color:var(--ink-blocked-2)]">
+            {detail.error.message}
+          </div>
+        ) : (
+          <Skeleton lines={8} />
+        )
+      ) : (
+        <div className="flex flex-col gap-4">
+          {/* Decision block: what happened to this row and why. */}
+          <div className="flex flex-wrap items-center gap-2">
+            <Badge tone={statusTone(row.status)}>{row.status}</Badge>
+            <span className="text-[13px] text-ink-cream-2">{describeDecision(row)}</span>
+            {row.decidedAt && (
+              <span className="font-mono text-[11px] text-ink-faint">{timeAgo(row.decidedAt)}</span>
+            )}
+            {d.flags.icpReject && <Badge tone="blocked">off-icp</Badge>}
+            {d.flags.bounced && <Badge tone="blocked">hard bounce</Badge>}
+            {d.flags.contactSuppressed && (
+              <Badge tone="blocked">
+                {d.flags.contactSuppressed === "unsubscribe" ? "unsubscribed" : "mailbox gone"}
+              </Badge>
+            )}
+            {d.flags.breakupHold && <Badge tone="blocked">do not contact</Badge>}
+          </div>
+          {row.notes && (
+            <div>
+              <div className="ln-eyebrow mb-1">notes · reason</div>
+              {/* Freeform: an auto-reject reason routinely names the person and
+                  their company, which structured masking cannot reach, so under
+                  privacy mode it is withheld rather than half-masked. */}
+              {masked ? (
+                <div className="text-[12px] text-ink-faint">hidden under privacy mode</div>
+              ) : (
+                <div className="text-[13px] text-ink-cream-2">{row.notes}</div>
+              )}
+            </div>
+          )}
+          {d.flags.replied && (
+            <div className="text-[12px] text-ink-muted">
+              This person has replied — the conversation lives on /inbox and this row will not be
+              re-approved here.
+            </div>
+          )}
+          {row.status === "expired" && !d.flags.replied && (
+            <div className="text-[12px] text-ink-muted">
+              Expired rows can be approved again, but any draft below is stale — it will be
+              re-drafted on the next run.
+            </div>
+          )}
+          {rejecting && (
+            <Field label="Reason (optional, logged for ICP-filter learning)">
+              <Textarea
+                rows={3}
+                value={reason}
+                onChange={(e) => setReason(e.target.value)}
+                placeholder="e.g. wrong stage, wrong industry, already a customer"
+              />
+            </Field>
+          )}
+
+          <IdentityBlock row={row} detail={d} />
+
+          {(icpVerdict || icpReason) && (
+            <div>
+              <div className="ln-eyebrow mb-1">icp verdict</div>
+              <div className="text-[13px] text-ink-cream-2">
+                <span
+                  className={cn(icpVerdict === "reject" && "text-[color:var(--ink-blocked-2)]")}
+                >
+                  {icpVerdict ?? "—"}
+                </span>
+                {icpReason && (
+                  <span className="text-ink-muted"> · {maskDeep(icpReason, masked)}</span>
+                )}
+              </div>
+            </div>
+          )}
+
+          {d.cadences.length > 0 && (
+            <div>
+              <div className="ln-eyebrow mb-1">cadences</div>
+              <ul className="flex flex-col gap-1 text-[13px] text-ink-cream-2">
+                {d.cadences.map((c) => (
+                  <CadenceLine key={`${c.prospectId}-${c.playName}`} c={c} />
+                ))}
+              </ul>
+            </div>
+          )}
+
+          <div>
+            <div className="ln-eyebrow mb-1">history</div>
+            <ol className="flex flex-col gap-1">
+              {d.timeline.map((ev) => (
+                <li
+                  key={`${ev.at}|${ev.kind}|${ev.label}`}
+                  className="flex items-baseline gap-3 text-[13px]"
+                >
+                  <span className="w-[64px] shrink-0 text-right font-mono text-[11px] text-ink-faint">
+                    {timeAgo(ev.at)}
+                  </span>
+                  <span className="shrink-0 whitespace-nowrap text-ink-cream-2">{ev.label}</span>
+                  {ev.playName && ev.playName !== row.playName && (
+                    <span className="font-mono text-[11px] text-ink-faint">{ev.playName}</span>
+                  )}
+                  {ev.detail && !masked && (
+                    <span className="min-w-0 truncate text-[12px] text-ink-muted">{ev.detail}</span>
+                  )}
+                </li>
+              ))}
+            </ol>
+          </div>
+
+          {row.lastDraft && (
+            <div>
+              <div className="ln-eyebrow mb-1">
+                last draft{row.lastDraft.sent ? " · sent" : ""}
+                {row.lastDraftedAt ? ` · ${timeAgo(row.lastDraftedAt)}` : ""}
+              </div>
+              <div className="text-[13px] text-ink-cream">
+                {maskDeep(row.lastDraft.subject, masked)}
+              </div>
+              <pre className="mt-1 max-h-[28vh] overflow-auto whitespace-pre-wrap rounded-[var(--radius-md)] border border-ink-rule bg-ink-bg-deep p-3 font-prose text-[12.5px] leading-[1.55] text-ink-cream-2">
+                {maskDeep(row.lastDraft.body, masked)}
+              </pre>
+            </div>
+          )}
+
+          <details className="text-ink-faint">
+            <summary className="cursor-pointer font-mono text-[10px] uppercase tracking-[0.14em] hover:text-ink-cream-2">
+              payload json
+            </summary>
+            <pre className="mt-2 max-h-[300px] overflow-auto rounded-[var(--radius-sm)] border border-ink-rule bg-ink-bg-deep p-3 font-mono text-[11.5px] leading-[1.55] text-ink-cream-2">
+              {JSON.stringify(maskDeep(row.payload, masked), null, 2)}
+            </pre>
+          </details>
+        </div>
+      )}
+    </Modal>
+  );
+}
+
+function IdentityBlock({ row, detail }: { row: ProspectBrowseRow; detail: QueueRowDetail }) {
+  const { masked } = usePrivacy();
+  const title = detail.prospect?.title ?? titleFor(row.payload);
+  const company = detail.prospect?.company ?? companyFor(row.payload);
+  const linkedinUrl = detail.prospect?.linkedinUrl ?? linkedinUrlFor(row.payload);
+  const evidence = queueEvidence(row.playName, row.payload);
+  const source = sourceDetail(row.source);
+  return (
+    <div>
+      <div className="ln-eyebrow mb-1">who · why</div>
+      <div className="text-[13px] text-ink-cream-2">
+        {[title, company ? maskDeep(company, masked, "company") : null]
+          .filter(Boolean)
+          .join(" · ") || <span className="text-ink-faint">no title or company on record</span>}
+        {linkedinUrl && /linkedin\.com\/in\//i.test(linkedinUrl) && (
+          <a
+            href={linkedinUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="ml-2 text-ink-cream-2 underline decoration-ink-rule underline-offset-2 hover:text-ink-cream"
+          >
+            [in]
+          </a>
+        )}
+      </div>
+      {evidence && !masked && <div className="mt-0.5 text-[12px] text-ink-muted">{evidence}</div>}
+      <div className="mt-1 font-mono text-[11px] text-ink-faint">
+        surfaced {timeAgo(row.foundAt)} by {row.playName}
+        {source ? ` · ${source}` : ""}
+        {detail.prospect
+          ? ` · prospect #${detail.prospect.id}${detail.prospect.linkedBy === "email" ? " (matched by email)" : ""}${detail.prospect.hasDossier ? " · researched" : ""}`
+          : " · never emailed"}
+      </div>
+    </div>
+  );
+}
+
+function CadenceLine({ c }: { c: CadenceView }) {
+  return (
+    <li className="flex items-center gap-2">
+      <span>{c.playName}</span>
+      <Badge
+        tone={c.status === "replied" ? "receipt" : c.status === "active" ? "signal" : "neutral"}
+      >
+        {c.status}
+      </Badge>
+      <span className="font-mono text-[11px] text-ink-faint">
+        step {Math.min(c.currentStep + 1, c.followupCount + 1)}/{c.followupCount + 1}
+        {c.nextDueAt && c.status === "active" ? ` · next ${timeAgo(c.nextDueAt)}` : ""}
+        {c.stopReason ? ` · ${c.stopReason.replace(/_/g, " ")}` : ""}
+      </span>
+    </li>
+  );
+}
+
+function payloadString(payload: unknown, key: string): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const v = (payload as Record<string, unknown>)[key];
+  return typeof v === "string" && v.trim() ? v.trim() : null;
+}

--- a/apps/web/src/routes/queue.tsx
+++ b/apps/web/src/routes/queue.tsx
@@ -63,6 +63,15 @@ import {
 import { humanInterval } from "../lib/humanInterval.ts";
 import { priorityBreakdown, priorityChip } from "../lib/priorityChip.ts";
 import { queueEvidence } from "../lib/queueEvidence.ts";
+import {
+  companyFor,
+  emailFor,
+  linkedinUrlFor,
+  nameFor,
+  phoneFor,
+  sourceDetail,
+  titleFor,
+} from "../lib/payloadIdentity.ts";
 import { INTERVAL_PRESETS_MS, withIntervalOverride } from "../lib/triggerInterval.ts";
 import { summarizeTriggers } from "../lib/triggerSummary.ts";
 import { useLocalStorage } from "../lib/useLocalStorage.ts";
@@ -2307,81 +2316,6 @@ function EmptyQueueHelp({ filterActive }: { filterActive: boolean }) {
       />
     </div>
   );
-}
-
-function emailFor(payload: unknown): string | null {
-  if (!payload || typeof payload !== "object") return null;
-  const p = payload as Record<string, unknown>;
-  if (typeof p["email"] === "string") return p["email"] as string;
-  if (typeof p["founderEmail"] === "string") return p["founderEmail"] as string;
-  return null;
-}
-
-function nameFor(payload: unknown): string | null {
-  if (!payload || typeof payload !== "object") return null;
-  const p = payload as Record<string, unknown>;
-  if (typeof p["name"] === "string") return p["name"] as string;
-  if (typeof p["founderName"] === "string") return p["founderName"] as string;
-  // Pre-enrichment rejected rows only carry a source URL — derive a handle.
-  const repoUrl = typeof p["repoUrl"] === "string" ? (p["repoUrl"] as string) : null;
-  if (repoUrl) {
-    const m = repoUrl.match(/github\.com\/([^/]+)\/([^/?#]+)/);
-    if (m) return `${m[1]}/${m[2]}`;
-  }
-  const postUrl = typeof p["postUrl"] === "string" ? (p["postUrl"] as string) : null;
-  if (postUrl) {
-    try {
-      const host = new URL(postUrl).hostname.replace(/^www\./, "");
-      if (host) return host;
-    } catch {
-      // fall through
-    }
-  }
-  return null;
-}
-
-/**
- * The finder-specific tail of `source` ("find:github-stars:vercel/eve" ->
- * "vercel/eve") — which repo / cohort matched. Empty when source is just the
- * finder name (fully redundant with the play column).
- */
-function sourceDetail(source: string | null | undefined): string {
-  if (!source) return "";
-  return source.split(":").slice(2).join(":");
-}
-
-function companyFor(payload: unknown): string | null {
-  if (!payload || typeof payload !== "object") return null;
-  const p = payload as Record<string, unknown>;
-  if (typeof p["company"] === "string") return p["company"] as string;
-  return null;
-}
-
-// Stamped on the payload by the person-level ICP gate; absent on rows queued
-// before the gate existed.
-function titleFor(payload: unknown): string | null {
-  if (!payload || typeof payload !== "object") return null;
-  const p = payload as Record<string, unknown>;
-  const v = p["title"];
-  return typeof v === "string" && v.trim().length > 0 ? v.trim() : null;
-}
-
-function linkedinUrlFor(payload: unknown): string | null {
-  if (!payload || typeof payload !== "object") return null;
-  const p = payload as Record<string, unknown>;
-  const v = p["linkedinUrl"];
-  if (typeof v !== "string" || v.length === 0) return null;
-  // Defense in depth — payload comes from sqlite but a stale/garbage row should
-  // never render as a clickable javascript:// or data:// link.
-  return /^https?:\/\/(?:[a-z0-9-]+\.)*linkedin\.com\/in\//i.test(v) ? v : null;
-}
-
-function phoneFor(payload: unknown): string | null {
-  if (!payload || typeof payload !== "object") return null;
-  const p = payload as Record<string, unknown>;
-  const v = p["phone"];
-  if (typeof v === "string" && v.length > 0) return v;
-  return null;
 }
 
 // Event metadata — present only on luma-events payloads (the persisted

--- a/packages/core/__tests__/ledger-search-queue.test.ts
+++ b/packages/core/__tests__/ledger-search-queue.test.ts
@@ -1,0 +1,354 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { Ledger } from "../src/ledger.ts";
+
+/*
+ * `searchQueue` backs the /prospects browse view: every queue row, any status,
+ * searched, sorted and paged. The contracts that matter are the ones a
+ * browse page silently breaks on — a stable `total` under OFFSET, no row
+ * fan-out from the prospect join, and search that reads the same payload
+ * keys the /queue row renders.
+ */
+
+let dbPath: string;
+let ledger: Ledger;
+
+beforeEach(() => {
+  dbPath = join(
+    tmpdir(),
+    `oneshot-gtm-search-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`,
+  );
+  ledger = new Ledger(dbPath);
+});
+
+afterEach(() => {
+  ledger.close();
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      rmSync(`${dbPath}${suffix}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+function enqueue(
+  playName: string,
+  dedupeKey: string,
+  payload: unknown,
+  extra: { initialStatus?: "pending" | "rejected"; notes?: string } = {},
+): number {
+  const id = ledger.enqueueTarget({
+    playName,
+    payload,
+    dedupeKey,
+    source: `find:${playName}`,
+    ...extra,
+  });
+  if (id == null) throw new Error(`enqueue failed for ${dedupeKey}`);
+  return id;
+}
+
+/** Seed the shapes the real ledger holds: named, URL-only, auto-rejected, decided by hand. */
+function seed(): Record<string, number> {
+  const ids: Record<string, number> = {};
+  ids["ada"] = enqueue("post-funding", "ada", {
+    name: "Ada Lovelace",
+    email: "Ada@Analytical.example",
+    company: "Analytical Engines",
+    title: "CTO",
+  });
+  ids["grace"] = enqueue("show-hn", "grace", {
+    founderName: "grace_h",
+    founderEmail: "grace@navy.example",
+    postTitle: "Show HN: COBOL in the browser",
+  });
+  ids["repo"] = enqueue(
+    "repo-interest",
+    "repo",
+    { repoUrl: "https://github.com/octo/engine_100%" },
+    { initialStatus: "rejected" },
+  );
+  ids["linus"] = enqueue("hiring-signal", "linus", {
+    name: "Linus T",
+    email: "linus@kernel.example",
+    company: "Kernel Co",
+  });
+  ledger.setQueueStatus({
+    id: ids["linus"],
+    status: "rejected",
+    notes: "wrong industry",
+    decidedBy: "human",
+  });
+  ids["bulk"] = enqueue("show-hn", "bulk", { name: "Bulk Approved", email: "bulk@x.example" });
+  ledger.approveAllPending({ playName: "show-hn" });
+  return ids;
+}
+
+describe("searchQueue", () => {
+  it("returns every status by default with a total that ignores the page", () => {
+    const ids = seed();
+    const page = ledger.searchQueue({ limit: 2, offset: 0 });
+    expect(page.total).toBe(5);
+    expect(page.rows).toHaveLength(2);
+    const rest = ledger.searchQueue({ limit: 2, offset: 4 });
+    expect(rest.total).toBe(5);
+    expect(rest.rows).toHaveLength(1);
+    // Default order is newest-found first, id as the tie-break.
+    expect(page.rows.map((r) => r.id)).toEqual([ids["bulk"], ids["linus"]]);
+  });
+
+  it("filters by status list, play and who decided", () => {
+    const ids = seed();
+    expect(ledger.searchQueue({ statuses: ["rejected"], limit: 50, offset: 0 }).total).toBe(2);
+    expect(
+      ledger.searchQueue({ statuses: ["rejected", "approved"], limit: 50, offset: 0 }).total,
+    ).toBe(4);
+    // Every status listed is the same as no status filter.
+    expect(
+      ledger.searchQueue({
+        statuses: ["pending", "approved", "rejected", "sent", "expired"],
+        limit: 50,
+        offset: 0,
+      }).total,
+    ).toBe(5);
+    expect(ledger.searchQueue({ playName: "show-hn", limit: 50, offset: 0 }).total).toBe(2);
+    // `human` groups per-row and bulk decisions; `machine` is the auto-reject; `none` undecided.
+    const human = ledger.searchQueue({ decidedBy: "human", limit: 50, offset: 0 });
+    expect(human.rows.map((r) => r.id).toSorted()).toEqual(
+      [ids["linus"], ids["bulk"], ids["grace"]].toSorted(),
+    );
+    expect(ledger.searchQueue({ decidedBy: "machine", limit: 50, offset: 0 }).rows).toEqual([
+      expect.objectContaining({ id: ids["repo"] }),
+    ]);
+    expect(ledger.searchQueue({ decidedBy: "none", limit: 50, offset: 0 }).rows).toEqual([
+      expect.objectContaining({ id: ids["ada"] }),
+    ]);
+  });
+
+  it("matches the payload identity keys, notes and play, case-insensitively", () => {
+    const ids = seed();
+    const hits = (q: string): number[] =>
+      ledger
+        .searchQueue({ q, limit: 50, offset: 0 })
+        .rows.map((r) => r.id)
+        .toSorted();
+    expect(hits("lovelace")).toEqual([ids["ada"]]); // name
+    expect(hits("GRACE_H")).toEqual([ids["grace"]]); // founderName
+    expect(hits("navy.example")).toEqual([ids["grace"]]); // founderEmail
+    expect(hits("kernel co")).toEqual([ids["linus"]]); // company, two terms AND-ed
+    expect(hits("cobol")).toEqual([ids["grace"]]); // postTitle
+    expect(hits("octo/engine")).toEqual([ids["repo"]]); // repoUrl on a URL-only reject
+    expect(hits("wrong industry")).toEqual([ids["linus"]]); // reviewer notes
+    expect(hits("hiring-signal")).toEqual([ids["linus"]]); // play name
+    expect(hits("nobody-here")).toEqual([]);
+  });
+
+  it("treats LIKE wildcards in a term literally", () => {
+    const ids = seed();
+    expect(ledger.searchQueue({ q: "100%", limit: 50, offset: 0 }).rows.map((r) => r.id)).toEqual([
+      ids["repo"],
+    ]);
+    // `_` is a single-char wildcard in LIKE; escaped, it must not match "a".
+    expect(ledger.searchQueue({ q: "engine_", limit: 50, offset: 0 }).total).toBe(1);
+    expect(ledger.searchQueue({ q: "engine_z", limit: 50, offset: 0 }).total).toBe(0);
+  });
+
+  it("AND-s terms, so every term has to hit the same row", () => {
+    seed();
+    expect(ledger.searchQueue({ q: "ada kernel", limit: 50, offset: 0 }).total).toBe(0);
+    expect(ledger.searchQueue({ q: "ada cto", limit: 50, offset: 0 }).total).toBe(1);
+  });
+
+  it("sorts by name with URL-only rows after named ones, and by decision time with undecided last", () => {
+    const ids = seed();
+    const byName = ledger.searchQueue({ sort: "name", dir: "asc", limit: 50, offset: 0 });
+    expect(byName.rows.map((r) => r.id)).toEqual([
+      ids["ada"], // Ada Lovelace
+      ids["bulk"], // Bulk Approved
+      ids["grace"], // grace_h (founderName fallback)
+      ids["linus"], // Linus T
+      ids["repo"], // URL-only, sorts last
+    ]);
+    const byNameDesc = ledger.searchQueue({ sort: "name", dir: "desc", limit: 50, offset: 0 });
+    expect(byNameDesc.rows.at(-1)?.id).toBe(ids["repo"]);
+
+    for (const dir of ["asc", "desc"] as const) {
+      const decided = ledger.searchQueue({ sort: "decided_at", dir, limit: 50, offset: 0 });
+      expect(decided.rows.at(-1)?.id).toBe(ids["ada"]); // the only undecided row
+    }
+  });
+
+  it("links a prospect by prospect_id, else by payload email, without duplicating rows", () => {
+    const ids = seed();
+    // Two prospects can never share an email (unique index), but the fallback
+    // must still be a scalar lookup: one queue row in, one row out.
+    const adaId = ledger.upsertProspect({
+      name: "Ada L.",
+      email: "ada@analytical.example",
+      title: "Chief Engineer",
+      icp_verdict: "pass",
+      icp_verdict_reason: "builds the thing",
+      dossier_json: JSON.stringify({ person: { summary: "x" } }),
+      source: "post-funding",
+    });
+    ledger.setProspectIcpVerdict(adaId, "pass", "builds the thing");
+    const linusId = ledger.upsertProspect({
+      name: "Linus",
+      email: "linus@kernel.example",
+      source: "hiring-signal",
+    });
+    ledger.setQueueProspectId(ids["linus"]!, linusId);
+
+    const rows = ledger.searchQueue({ limit: 50, offset: 0 });
+    expect(rows.total).toBe(5);
+    const ada = rows.rows.find((r) => r.id === ids["ada"]);
+    expect(ada).toMatchObject({
+      p_id: adaId,
+      p_name: "Ada L.",
+      p_title: "Chief Engineer",
+      p_icp_verdict: "pass",
+      p_has_dossier: 1,
+      p_linked_by_email: 1,
+    });
+    const linus = rows.rows.find((r) => r.id === ids["linus"]);
+    expect(linus).toMatchObject({ p_id: linusId, p_linked_by_email: 0, p_has_dossier: 0 });
+    // The joined prospect is searchable too.
+    expect(ledger.searchQueue({ q: "chief engineer", limit: 50, offset: 0 }).total).toBe(1);
+    // A row with no prospect carries nulls, not a phantom join.
+    const grace = rows.rows.find((r) => r.id === ids["grace"]);
+    expect(grace).toMatchObject({ p_id: null, p_linked_by_email: 0 });
+  });
+
+  it("finds non-ASCII names in any case, without ICU", () => {
+    // bun's SQLite folds ASCII only: LOWER('É') is 'É' and 'É' LIKE 'é' is false,
+    // so a lowercased term alone would never find an accented capital.
+    enqueue("post-funding", "emile", { name: "Émile Durand", email: "e@d.example" });
+    for (const q of ["émile", "ÉMILE", "Émile", "durand émile"]) {
+      expect(ledger.searchQueue({ q, limit: 50, offset: 0 }).total, q).toBe(1);
+    }
+    expect(ledger.searchQueue({ q: "émilie", limit: 50, offset: 0 }).total).toBe(0);
+  });
+
+  it("carries the linked prospect's email and company, and can skip the count", () => {
+    const ids = seed();
+    ledger.upsertProspect({
+      name: "Ada L.",
+      email: "ada@analytical.example",
+      company: "Analytical Engines Ltd",
+      source: "post-funding",
+    });
+    const { rows, total } = ledger.searchQueue({
+      q: "ada",
+      limit: 50,
+      offset: 0,
+      withTotal: false,
+    });
+    expect(total).toBeNull();
+    expect(rows.find((r) => r.id === ids["ada"])).toMatchObject({
+      p_email: "ada@analytical.example",
+      p_company: "Analytical Engines Ltd",
+    });
+    // The prospect's company is part of the haystack.
+    expect(ledger.searchQueue({ q: "engines ltd", limit: 50, offset: 0 }).total).toBe(1);
+  });
+
+  it("clamps limit and offset defensively", () => {
+    seed();
+    expect(ledger.searchQueue({ limit: 0, offset: -5 }).rows).toHaveLength(1);
+    expect(ledger.searchQueue({ limit: 10_000, offset: 0 }).rows).toHaveLength(5);
+  });
+});
+
+describe("searchQueueStatusCounts", () => {
+  it("counts every status under the search/play/decided filters, ignoring the status filter", () => {
+    seed();
+    expect(ledger.searchQueueStatusCounts({})).toEqual({
+      pending: 1,
+      approved: 2,
+      rejected: 2,
+      sent: 0,
+      expired: 0,
+    });
+    expect(ledger.searchQueueStatusCounts({ playName: "show-hn" })).toMatchObject({
+      approved: 2,
+      rejected: 0,
+    });
+    expect(ledger.searchQueueStatusCounts({ q: "kernel" })).toMatchObject({
+      rejected: 1,
+      approved: 0,
+      pending: 0,
+    });
+    expect(ledger.searchQueueStatusCounts({ decidedBy: "machine" })).toMatchObject({
+      rejected: 1,
+      approved: 0,
+    });
+  });
+});
+
+describe("per-prospect detail getters", () => {
+  it("lists play names, channel events and deal outcomes in stable order", () => {
+    seed();
+    expect(ledger.listQueuePlayNames()).toEqual([
+      "hiring-signal",
+      "post-funding",
+      "repo-interest",
+      "show-hn",
+    ]);
+    const pid = ledger.upsertProspect({ name: "P", email: "p@x.example", source: "t" });
+    ledger.recordLinkedInReply({
+      prospectId: pid,
+      source: "expandi",
+      externalEventId: "b",
+      occurredAt: "2026-02-02T00:00:00Z",
+      body: "later",
+    });
+    ledger.recordLinkedInReply({
+      prospectId: pid,
+      source: "expandi",
+      externalEventId: "a",
+      occurredAt: "2026-01-01T00:00:00Z",
+      body: "earlier",
+    });
+    expect(ledger.listChannelEventsForProspect(pid).map((e) => e.body)).toEqual([
+      "earlier",
+      "later",
+    ]);
+    expect(ledger.listChannelEventsForProspect(pid + 1)).toEqual([]);
+    // The history getter keeps bounced/failed steps the conversation getter drops.
+    ledger.recordSequenceEvent({
+      prospectId: pid,
+      playName: "show-hn",
+      stepIndex: 0,
+      channel: "email",
+      status: "sent",
+    });
+    ledger.recordSequenceEvent({
+      prospectId: pid,
+      playName: "show-hn",
+      stepIndex: 1,
+      channel: "email",
+      status: "bounced",
+    });
+    ledger.recordSequenceEvent({
+      prospectId: pid,
+      playName: "show-hn",
+      stepIndex: 2,
+      channel: "email",
+      status: "queued",
+    });
+    expect(ledger.listSequenceEventsForProspect(pid).map((e) => e.status)).toEqual(["sent"]);
+    expect(ledger.listAllSequenceEventsForProspect(pid).map((e) => e.status)).toEqual([
+      "sent",
+      "bounced",
+    ]);
+    ledger.recordOutcome({ prospectId: pid, outcome: "meeting_booked", playName: "show-hn" });
+    ledger.recordOutcome({ prospectId: pid, outcome: "deal_won", amountUsd: 1200 });
+    expect(ledger.listDealOutcomesForProspect(pid).map((o) => [o.outcome, o.amount_usd])).toEqual([
+      ["meeting_booked", null],
+      ["deal_won", 1200],
+    ]);
+  });
+});

--- a/packages/core/__tests__/ledger-search-queue.test.ts
+++ b/packages/core/__tests__/ledger-search-queue.test.ts
@@ -106,6 +106,14 @@ describe("searchQueue", () => {
     expect(
       ledger.searchQueue({ statuses: ["rejected", "approved"], limit: 50, offset: 0 }).total,
     ).toBe(4);
+    // A repeated status is one status, not "as many as there are statuses".
+    expect(
+      ledger.searchQueue({
+        statuses: ["sent", "sent", "sent", "sent", "sent"],
+        limit: 50,
+        offset: 0,
+      }).total,
+    ).toBe(0);
     // Every status listed is the same as no status filter.
     expect(
       ledger.searchQueue({

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -20,6 +20,7 @@ import type {
   BounceRecord,
   CanaryResultRecord,
   ChannelEventRecord,
+  DealOutcomeRecord,
   GmailPlacement,
   InboxReplyRecord,
   IcpDecisionExample,
@@ -28,6 +29,8 @@ import type {
   ProspectRecord,
   SentOutcomeRawRow,
   QueueRow,
+  QueueSearchOpts,
+  QueueSearchRow,
   QueueStatus,
   ReceiptRecord,
   SequenceEventRecord,
@@ -99,6 +102,72 @@ export const LINKEDIN_CACHE_TTL_MS = 30 * 24 * 3600 * 1000;
  * spend of repeatedly running finders over the same candidate pool.
  */
 export const LINKEDIN_MISS_TTL_MS = 14 * 24 * 3600 * 1000;
+
+const QUEUE_STATUSES: readonly QueueStatus[] = [
+  "pending",
+  "approved",
+  "rejected",
+  "sent",
+  "expired",
+];
+
+/** Escape a user term for `LIKE ? ESCAPE '\'` so `%` and `_` match literally. */
+function escapeLike(term: string): string {
+  return term.replace(/[\\%_]/g, (c) => `\\${c}`);
+}
+
+/**
+ * The searchable text of a queue row for `searchQueue`: every identity key a
+ * finder writes into `payload_json` (the same keys the /queue row reads —
+ * `name`/`founderName`, `email`/`founderEmail`, company, title, the show-hn
+ * post, the repo/post URLs a pre-enrichment reject only carries, LinkedIn),
+ * plus the reviewer's notes, the play, and the joined prospect record. Built
+ * once as a string so each term binds against the same expression.
+ *
+ * No LOWER(): bun's SQLite has no ICU, so LOWER() and LIKE fold ASCII only.
+ * Case-insensitivity for non-ASCII letters comes from binding each term
+ * twice (see `likePatternsFor`) rather than from a wrapper that would leave
+ * "Émile" unfindable by "émile".
+ */
+const QUEUE_SEARCH_HAYSTACK = `(${[
+  "name",
+  "founderName",
+  "email",
+  "founderEmail",
+  "company",
+  "title",
+  "postTitle",
+  "repoUrl",
+  "postUrl",
+  "linkedinUrl",
+]
+  .map((key) => `COALESCE(json_extract(b.payload_json, '$.${key}'), '')`)
+  .concat([
+    "COALESCE(b.notes, '')",
+    "b.play_name",
+    "COALESCE(p.name, '')",
+    "COALESCE(p.email, '')",
+    "COALESCE(p.company, '')",
+    "COALESCE(p.title, '')",
+  ])
+  .join(" || ' ' || ")})`;
+
+/**
+ * Bind patterns for one search term. LIKE already folds ASCII case, so an
+ * ASCII term needs one pattern; a term with non-ASCII letters is bound in
+ * lower and upper case, which together also catch title case ("Émile"
+ * matches the upper pattern because every ASCII letter after É folds).
+ */
+function likePatternsFor(term: string): string[] {
+  const lower = term.toLowerCase();
+  const upper = term.toUpperCase();
+  // eslint-disable-next-line no-control-regex
+  if (lower === upper || !/[^\x00-\x7f]/.test(term)) return [`%${escapeLike(lower)}%`];
+  return [`%${escapeLike(lower)}%`, `%${escapeLike(upper)}%`];
+}
+
+/** Best display name for a queue row: the prospect record, then the payload. */
+const QUEUE_SEARCH_NAME_EXPR = `COALESCE(NULLIF(p.name, ''), NULLIF(json_extract(b.payload_json, '$.name'), ''), NULLIF(json_extract(b.payload_json, '$.founderName'), ''))`;
 
 /**
  * Canonical form for matching prospect emails — trim + lowercase. Inbound reply
@@ -2974,6 +3043,181 @@ export class Ledger {
 
   getQueueRow(id: number): QueueRow | null {
     return (this.db.query("SELECT * FROM target_queue WHERE id = ?").get(id) as QueueRow) ?? null;
+  }
+
+  /**
+   * FROM + WHERE shared by `searchQueue` (rows and total) and
+   * `searchQueueStatusCounts`. The prospect is resolved with a scalar
+   * subquery (`LIMIT 1`) rather than an OR-join so one queue row can never
+   * fan out into two — two prospects sharing an email would otherwise
+   * inflate `total` and shift every OFFSET. Filters that only need the queue
+   * row (status, play, decided_by) go inside the derived table so the
+   * existing status/play indexes still prune before the prospect lookup;
+   * the free-text terms need the joined prospect and stay outside.
+   */
+  private queueSearchParts(
+    opts: Pick<QueueSearchOpts, "q" | "statuses" | "playName" | "decidedBy">,
+    withStatus: boolean,
+  ): { sql: string; args: unknown[] } {
+    const inner: string[] = [];
+    const outer: string[] = [];
+    const args: unknown[] = [];
+    const statuses = (opts.statuses ?? []).filter((s) => QUEUE_STATUSES.includes(s));
+    if (withStatus && statuses.length > 0 && statuses.length < QUEUE_STATUSES.length) {
+      inner.push(`q.status IN (${statuses.map(() => "?").join(",")})`);
+      args.push(...statuses);
+    }
+    if (opts.playName) {
+      inner.push("q.play_name = ?");
+      args.push(opts.playName);
+    }
+    switch (opts.decidedBy) {
+      case "human":
+        inner.push("q.decided_by IN ('human', 'human_bulk')");
+        break;
+      case "machine":
+        inner.push("q.decided_by = 'machine'");
+        break;
+      case "none":
+        inner.push("q.decided_by IS NULL");
+        break;
+      default:
+        break;
+    }
+    const terms = (opts.q ?? "")
+      .split(/\s+/)
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0);
+    for (const term of terms) {
+      const patterns = likePatternsFor(term);
+      outer.push(
+        `(${patterns.map(() => `${QUEUE_SEARCH_HAYSTACK} LIKE ? ESCAPE '\\'`).join(" OR ")})`,
+      );
+      args.push(...patterns);
+    }
+    const sql = `
+      FROM (
+        SELECT q.*, COALESCE(q.prospect_id, (
+            SELECT p2.id FROM prospects p2
+             WHERE p2.email = LOWER(TRIM(COALESCE(json_extract(q.payload_json, '$.email'),
+                                                  json_extract(q.payload_json, '$.founderEmail'))))
+             ORDER BY p2.id LIMIT 1)) AS joined_prospect_id
+          FROM target_queue q
+          ${inner.length ? `WHERE ${inner.join(" AND ")}` : ""}) b
+      LEFT JOIN prospects p ON p.id = b.joined_prospect_id
+      ${outer.length ? `WHERE ${outer.join(" AND ")}` : ""}`;
+    return { sql, args };
+  }
+
+  /**
+   * The /prospects browse view: every queue row, any status, searched, sorted
+   * and paged. `q` is a deliberate full scan (LIKE over json_extract can use
+   * no index) — measured at ~50 ms on 9k rows. Past ~100k rows an FTS5
+   * external-content table is the upgrade path; nothing here would change
+   * shape. Without `q` the derived table is pruned by the status/play
+   * indexes like `listQueue`.
+   */
+  searchQueue(opts: QueueSearchOpts): { rows: QueueSearchRow[]; total: number | null } {
+    const limit = Math.max(1, Math.min(200, Math.floor(opts.limit)));
+    const offset = Math.max(0, Math.floor(opts.offset));
+    const dir = opts.dir === "asc" ? "ASC" : "DESC";
+    let orderSql: string;
+    switch (opts.sort) {
+      case "decided_at":
+        // Undecided rows sink to the bottom in both directions.
+        orderSql = `(b.decided_at IS NULL) ASC, b.decided_at ${dir}, b.id ${dir}`;
+        break;
+      case "name":
+        // Named rows first; rows that only carry a source URL (pre-enrichment
+        // rejects) sort after them by that URL, then by dedupe key.
+        orderSql = `(${QUEUE_SEARCH_NAME_EXPR} IS NULL) ASC, LOWER(COALESCE(${QUEUE_SEARCH_NAME_EXPR}, json_extract(b.payload_json, '$.repoUrl'), json_extract(b.payload_json, '$.postUrl'), b.dedupe_key)) ${dir}, b.id ${dir}`;
+        break;
+      default:
+        orderSql = `b.found_at ${dir}, b.id ${dir}`;
+        break;
+    }
+    const { sql, args } = this.queueSearchParts(opts, true);
+    const rows = this.db
+      .query(
+        `SELECT b.*, p.id AS p_id, p.name AS p_name, p.email AS p_email, p.company AS p_company,
+                p.title AS p_title,
+                p.icp_verdict AS p_icp_verdict, p.icp_verdict_reason AS p_icp_verdict_reason,
+                (p.dossier_json IS NOT NULL AND TRIM(p.dossier_json) != '') AS p_has_dossier,
+                (b.prospect_id IS NULL AND p.id IS NOT NULL) AS p_linked_by_email
+         ${sql}
+         ORDER BY ${orderSql}
+         LIMIT ? OFFSET ?`,
+      )
+      .all(...(args as never[]), limit, offset) as QueueSearchRow[];
+    if (opts.withTotal === false) return { rows, total: null };
+    const total = (
+      this.db.query(`SELECT COUNT(*) AS n ${sql}`).get(...(args as never[])) as {
+        n: number;
+      }
+    ).n;
+    return { rows, total };
+  }
+
+  /**
+   * Per-status counts for the /prospects filter chips under the current
+   * search/play/decided filters — the status filter itself is left out so a
+   * chip can show how many rows it would reveal.
+   */
+  searchQueueStatusCounts(
+    opts: Pick<QueueSearchOpts, "q" | "playName" | "decidedBy">,
+  ): Record<QueueStatus, number> {
+    const { sql, args } = this.queueSearchParts(opts, false);
+    const rows = this.db
+      .query(`SELECT b.status AS status, COUNT(*) AS n ${sql} GROUP BY b.status`)
+      .all(...(args as never[])) as Array<{ status: QueueStatus; n: number }>;
+    const out: Record<QueueStatus, number> = {
+      pending: 0,
+      approved: 0,
+      rejected: 0,
+      sent: 0,
+      expired: 0,
+    };
+    for (const r of rows) if (r.status in out) out[r.status] = r.n;
+    return out;
+  }
+
+  /** Every play that has ever enqueued a row, for the /prospects play filter. */
+  listQueuePlayNames(): string[] {
+    return (
+      this.db
+        .query("SELECT DISTINCT play_name FROM target_queue ORDER BY play_name ASC")
+        .all() as Array<{ play_name: string }>
+    ).map((r) => r.play_name);
+  }
+
+  /**
+   * Every recorded step for a prospect across all plays — including bounced,
+   * failed and unsubscribed ones, which `listSequenceEventsForProspect`
+   * (the conversation view) filters out. `queued` rows are reservations,
+   * not history. Oldest first.
+   */
+  listAllSequenceEventsForProspect(prospectId: number): SequenceEventRecord[] {
+    return this.db
+      .query(
+        `SELECT * FROM sequence_events
+         WHERE prospect_id = ? AND status != 'queued'
+         ORDER BY created_at ASC, id ASC`,
+      )
+      .all(prospectId) as SequenceEventRecord[];
+  }
+
+  /** Inbound engagement on non-email channels (LinkedIn replies) for one prospect, oldest first. */
+  listChannelEventsForProspect(prospectId: number): ChannelEventRecord[] {
+    return this.db
+      .query(`SELECT * FROM channel_events WHERE prospect_id = ? ORDER BY occurred_at ASC, id ASC`)
+      .all(prospectId) as ChannelEventRecord[];
+  }
+
+  /** Recorded deal outcomes for one prospect, oldest first. */
+  listDealOutcomesForProspect(prospectId: number): DealOutcomeRecord[] {
+    return this.db
+      .query(`SELECT * FROM deal_outcomes WHERE prospect_id = ? ORDER BY recorded_at ASC, id ASC`)
+      .all(prospectId) as DealOutcomeRecord[];
   }
 
   /** Remove an unreviewed queue reservation, leaving reviewed rows untouched. */

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -3062,7 +3062,9 @@ export class Ledger {
     const inner: string[] = [];
     const outer: string[] = [];
     const args: unknown[] = [];
-    const statuses = (opts.statuses ?? []).filter((s) => QUEUE_STATUSES.includes(s));
+    // De-duplicated: `?status=sent,sent,sent,sent,sent` is one status, not
+    // "all five" — the length guard below must see distinct values.
+    const statuses = [...new Set((opts.statuses ?? []).filter((s) => QUEUE_STATUSES.includes(s)))];
     if (withStatus && statuses.length > 0 && statuses.length < QUEUE_STATUSES.length) {
       inner.push(`q.status IN (${statuses.map(() => "?").join(",")})`);
       args.push(...statuses);

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -86,6 +86,19 @@ export interface ChannelEventRecord {
   created_at: string;
 }
 
+/** One `deal_outcomes` row — column-shaped. Positives-only by construction
+ *  (the cadences modal offers only the three positive states), so a missing
+ *  row is never evidence of failure. */
+export interface DealOutcomeRecord {
+  id: number;
+  prospect_id: number;
+  play_name: string | null;
+  outcome: string;
+  amount_usd: number | null;
+  notes: string | null;
+  recorded_at: string;
+}
+
 export interface CadencePlanStep {
   id: string;
   dayOffset: number;
@@ -433,6 +446,49 @@ export interface QueueRow {
   decided_at: string | null;
   /** 'human' (per-row click) | 'human_bulk' (approve-all batch) | 'machine'. */
   decided_by: "human" | "human_bulk" | "machine" | null;
+}
+
+/** Who decided a queue row: `human` groups per-row and bulk clicks; `none` = undecided. */
+export type QueueSearchDecidedBy = "human" | "machine" | "none";
+export type QueueSearchSort = "found_at" | "decided_at" | "name";
+
+/** Filters for `Ledger.searchQueue` — the /prospects browse view. */
+export interface QueueSearchOpts {
+  /** Free text; whitespace-split terms are AND-ed, each a case-insensitive substring. */
+  q?: string;
+  /** Empty or absent = every status. */
+  statuses?: QueueStatus[];
+  playName?: string;
+  decidedBy?: QueueSearchDecidedBy;
+  sort?: QueueSearchSort;
+  dir?: "asc" | "desc";
+  limit: number;
+  offset: number;
+  /**
+   * Skip the COUNT(*) pass and return `total: null`. The /prospects route
+   * already runs the per-status facet query under the same filters, and the
+   * total is the sum of the selected statuses' counts — a third scan of the
+   * haystack buys nothing.
+   */
+  withTotal?: boolean;
+}
+
+/**
+ * A queue row joined to the prospect it resolved to — by `prospect_id`, else
+ * by the payload's email. `p_*` columns are null when no prospect exists (the
+ * common case: `prospects` only holds people who were actually emailed).
+ */
+export interface QueueSearchRow extends QueueRow {
+  p_id: number | null;
+  p_name: string | null;
+  p_email: string | null;
+  p_company: string | null;
+  p_title: string | null;
+  p_icp_verdict: string | null;
+  p_icp_verdict_reason: string | null;
+  p_has_dossier: 0 | 1;
+  /** 1 when the link came from the email fallback rather than `prospect_id`. */
+  p_linked_by_email: 0 | 1;
 }
 
 /**

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -575,6 +575,101 @@ export interface QueueRowView {
    * rows and rows whose stored artifact fails shape validation.
    */
   priority: ProspectPriorityView | null;
+  /**
+   * Decision provenance (ledger v26). `status` alone is lossy — an expiry
+   * overwrites an approval — so the browse view reads these to say who
+   * decided what. Null on undecided and pre-v26 rows.
+   */
+  decision: "approve" | "reject" | "auto_reject" | null;
+  decidedBy: "human" | "human_bulk" | "machine" | null;
+  decidedAt: string | null;
+}
+
+/** Who decided a queue row, as a /prospects filter. `human` groups per-row and bulk clicks. */
+export type DecidedByFilter = "human" | "machine" | "none";
+export type ProspectSortKey = "found" | "decided" | "name";
+
+/** The prospect record a queue row resolved to — by `prospect_id`, else by its payload email. */
+export interface ProspectLinkView {
+  id: number;
+  name: string | null;
+  email: string | null;
+  company: string | null;
+  title: string | null;
+  /** 'pass' | 'reject' | 'unclear' | null (never judged). Only 'reject' suppresses sending. */
+  icpVerdict: string | null;
+  icpVerdictReason: string | null;
+  hasDossier: boolean;
+  linkedBy: "prospect_id" | "email";
+}
+
+/** One row of the /prospects browse table: a queue row plus its linked prospect, if any. */
+export interface ProspectBrowseRow extends QueueRowView {
+  prospect: ProspectLinkView | null;
+}
+
+/**
+ * The decision trail in three words — one vocabulary for the /prospects
+ * table, its drawer and the history list, so a bulk approval never reads
+ * "bulk-approved" on one line and "approved (bulk)" on the next.
+ */
+export function describeDecision(row: {
+  decision: QueueRowView["decision"];
+  decidedBy: QueueRowView["decidedBy"];
+  status?: QueueStatusView;
+}): string {
+  if (row.decision === "auto_reject" || (row.decision === "reject" && row.decidedBy === "machine"))
+    return "auto-rejected";
+  if (row.decision === "reject") return "rejected by you";
+  if (row.decision === "approve") {
+    if (row.decidedBy === "human_bulk") return "bulk-approved";
+    if (row.decidedBy === "machine") return "approved by machine";
+    return "approved by you";
+  }
+  if (row.status === "expired") return "expired";
+  return row.status ? "undecided" : "decided";
+}
+
+/** GET /api/queue/search */
+export interface ProspectSearchResponse {
+  rows: ProspectBrowseRow[];
+  /** Rows matching every filter, before paging. */
+  total: number;
+  limit: number;
+  offset: number;
+  /** Per-status counts under the q/play/decided filters — NOT narrowed by the status filter. */
+  counts: QueueCounts;
+  /** Every play that has ever enqueued a row, for the play filter. */
+  plays: string[];
+}
+
+/** One entry of a prospect's history, newest first. Carries no reply bodies — /inbox owns those. */
+export interface ProspectTimelineEvent {
+  /** ISO timestamp. */
+  at: string;
+  kind: "surfaced" | "decided" | "sent" | "sequence" | "reply" | "channel" | "outcome";
+  label: string;
+  detail: string | null;
+  playName: string | null;
+}
+
+/** GET /api/queue/:id — everything the /prospects detail drawer shows. */
+export interface QueueRowDetail {
+  row: ProspectBrowseRow;
+  prospect: (ProspectLinkView & { linkedinUrl: string | null; createdAt: string }) | null;
+  cadences: CadenceView[];
+  timeline: ProspectTimelineEvent[];
+  flags: {
+    /** The prospect has answered (email or LinkedIn) — an override must not re-email them. */
+    replied: boolean;
+    /** A hard bounce suppresses the address. */
+    bounced: boolean;
+    /** 'unsubscribe' | 'auto_permanent' from the reply stream, else null. */
+    contactSuppressed: string | null;
+    /** A not-a-fit / do-not-contact manual stop. */
+    breakupHold: boolean;
+    icpReject: boolean;
+  };
 }
 
 /**


### PR DESCRIPTION
## What

A new `/prospects` dashboard page: search and browse **every** candidate a finder ever surfaced — pending, approved, rejected, sent, expired — with the decision trail (who decided it and why), the linked prospect's ICP verdict, cadences and a merged history, and an override (approve / reject) from the drawer.

`/queue` stays the review surface and is unchanged apart from moving its payload identity readers into a shared lib.

## How

- **Ledger** — `searchQueue` (free-text terms AND-ed as `LIKE` over the payload identity keys, notes, play and the joined prospect; offset paging; three sorts), `searchQueueStatusCounts` for the facet chips, `listAllSequenceEventsForProspect` for the history. The prospect join is a scalar subquery so a row can never fan out. **No schema change**; the no-search path is served by `idx_queue_status_play` (query plan checked). Non-ASCII terms are bound in lower and upper case because bun's SQLite has no ICU.
- **Server** — `GET /api/queue/search`, `GET /api/queue/:id` (registered before `:id` — the literal must precede the param). `toView` now carries `decision` / `decidedBy` / `decidedAt`. `approveQueueRoute` refuses a `sent` row (409) and any override whose prospect has already replied — drain would otherwise re-email them.
- **Web** — `routes/prospects.tsx` with URL-backed filters, a debounced search box (replace-navigation), status chips with counts, pager, detail `Modal`. One `describeDecision` in shared-types feeds the table, drawer and history. Demo mode searches one captured `/queue/search?limit=500` document client-side (`applyProspectFilters`), so search works without an unbounded fixture space.
- **Docs** — README page list ("Ten pages"), STATUS counts.

## Verify

| Check | Result |
|---|---|
| `bun run test` | 253 files, 3,292 tests pass |
| typecheck / oxlint / oxfmt | clean, 36 warnings (baseline) |
| Search on the real 8,723-row sdk ledger | ~100 ms end to end incl. deep offset |
| Live on both workspace servers after kickstart | list, filters, sort, drawer, override, privacy masking, accent search |

The override was exercised end to end on a scratch copy: a machine-rejected row flipped to "approved by you", history updated, the original auto-reject note preserved.

Reviewed once already with `/code-review high`; its findings (re-email after reply, non-ASCII search, bounced steps missing from history, search box eating keystrokes, demo/live search parity, page past the end, sort menu, one label vocabulary, redundant `COUNT(*)`) are all fixed in this PR. Two pre-existing patterns it surfaced are filed separately as #561 and #562.

Demo fixtures are not in git; the capture script seeds the new document for the next publish.

https://claude.ai/code/session_01RaGFRjZeREgB7Fg5hboxsx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Prospects page for browsing, searching, filtering, sorting, and paginating prospect records.
  - Added expandable prospect details with identity information, ICP results, decision history, timelines, cadences, drafts, and payload details.
  - Added approval and rejection actions with optional rejection reasons.
  - Added Prospects navigation through the sidebar and command palette.
  - Added queue search and row-detail API support, including decision and prospect information.

- **Bug Fixes**
  - Prevented approval of already-sent prospects or prospects who have replied.
  - Improved handling and validation of prospect identity data.

- **Documentation**
  - Updated dashboard documentation and verification status to reflect the new Prospects page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->