### PR TITLE
fix(core,find): spend ceiling boundary; local-registry rows carry the plays' required fields (#488, #498)

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 66 CLI commands, 23 plays, 15 finders, ten dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-08** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3292 tests / 253 files** · typecheck + oxlint + oxfmt pass (36 lint warnings, 0 errors).
+Last verified **2026-09-08** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3297 tests / 253 files** · typecheck + oxlint + oxfmt pass (36 lint warnings, 0 errors).
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/packages/core/__tests__/daily-spend.test.ts
+++ b/packages/core/__tests__/daily-spend.test.ts
@@ -152,6 +152,24 @@ describe("tryReserveDailySpend — blocked-path reporting", () => {
     expect(dailySpendStatus().reservedUsd).toBe(0);
   });
 
+  it("grants a first-ever reservation that lands exactly on the ceiling (#488)", () => {
+    // A finder's worst-case estimate is its own maxCostUsd; with `>=` a
+    // ceiling equal to that estimate could never be reached, only refused.
+    mockCfg = { dailySpendCeilingUsd: 5 };
+    const exact = tryReserveDailySpend(5);
+    expect(exact.granted).toBe(true);
+    if (!exact.granted) throw new Error("expected granted");
+    expect(dailySpendStatus().effectiveUsd).toBe(5);
+    expect(dailySpendStatus().ceilingReached).toBe(true);
+    // Anything further is over, not at, the ceiling.
+    const over = tryReserveDailySpend(0.01);
+    expect(over.granted).toBe(false);
+    exact.release();
+    // Exceeding by a cent on a fresh day is still refused.
+    expect(tryReserveDailySpend(5.01).granted).toBe(false);
+    expect(dailySpendStatus().reservedUsd).toBe(0);
+  });
+
   it("release() is idempotent — a finally + an explicit release must not double-delete", () => {
     mockCfg = { dailySpendCeilingUsd: 10 };
     const outcome = tryReserveDailySpend(3);

--- a/packages/core/__tests__/daily-spend.test.ts
+++ b/packages/core/__tests__/daily-spend.test.ts
@@ -170,6 +170,18 @@ describe("tryReserveDailySpend — blocked-path reporting", () => {
     expect(dailySpendStatus().reservedUsd).toBe(0);
   });
 
+  it("compares in cents, so a decimal sum that lands exactly on the ceiling is granted", () => {
+    // 0.10 + 0.10 + 0.10 is 0.30000000000000004 as a double.
+    mockCfg = { dailySpendCeilingUsd: 0.3 };
+    recordSpend(0.1);
+    recordSpend(0.1);
+    const exact = tryReserveDailySpend(0.1);
+    expect(exact.granted).toBe(true);
+    if (!exact.granted) throw new Error("expected granted");
+    exact.release();
+    expect(tryReserveDailySpend(0.11).granted).toBe(false);
+  });
+
   it("release() is idempotent — a finally + an explicit release must not double-delete", () => {
     mockCfg = { dailySpendCeilingUsd: 10 };
     const outcome = tryReserveDailySpend(3);

--- a/packages/core/src/daily-spend.ts
+++ b/packages/core/src/daily-spend.ts
@@ -124,8 +124,11 @@ export type SpendReservationOutcome =
  * paid path (finder trigger runs, automatic drains). Sweeps orphaned
  * reservations first so a crashed process can't hold spend hostage for the
  * rest of the day, then checks the ceiling and reserves atomically — a call
- * that would push effective spend at/over the ceiling is refused outright
- * rather than reserved-then-immediately-over.
+ * that would push effective spend OVER the ceiling is refused outright
+ * rather than reserved-then-immediately-over. Landing exactly on it is
+ * allowed (the ceiling is a cap, not a fence — see
+ * `Ledger.reserveSpendIfUnderCeiling`); once effective spend has reached
+ * it, `ceilingReached` halts everything after.
  *
  * The check-then-reserve itself happens in ONE SQLite transaction on the
  * ledger connection (`Ledger.reserveSpendIfUnderCeiling`, `BEGIN IMMEDIATE`

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -111,6 +111,11 @@ const QUEUE_STATUSES: readonly QueueStatus[] = [
   "expired",
 ];
 
+/** USD as integer cents, so money comparisons are exact. */
+function cents(usd: number): number {
+  return Math.round(usd * 100);
+}
+
 /** Escape a user term for `LIKE ? ESCAPE '\'` so `%` and `_` match literally. */
 function escapeLike(term: string): string {
   return term.replace(/[\\%_]/g, (c) => `\\${c}`);
@@ -2720,7 +2725,9 @@ export class Ledger {
     const txn = this.db.transaction((): number | null => {
       const effectiveUsd =
         this.totalSpendUsd({ sinceIso: opts.sinceIso }) + this.reservedSpendUsd(opts.sinceIso);
-      if (effectiveUsd + opts.amountUsd > opts.ceilingUsd) return null;
+      // Compare in integer cents: receipts are REALs and three $0.10 calls
+      // sum to 0.30000000000000004, which would read as over a $0.30 ceiling.
+      if (cents(effectiveUsd) + cents(opts.amountUsd) > cents(opts.ceilingUsd)) return null;
       return this.reserveSpend(opts.amountUsd);
     });
     return txn.immediate();

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -2705,8 +2705,12 @@ export class Ledger {
    * total and both pass the check before either commits: the second
    * caller's transaction blocks until the first one's reservation is
    * already reflected in the sum it reads. Returns the new reservation id
-   * when granted, or null when posted+reserved+`amountUsd` would meet or
-   * exceed `ceilingUsd`.
+   * when granted, or null when posted+reserved+`amountUsd` would EXCEED
+   * `ceilingUsd`. Landing exactly on the ceiling is allowed: the ceiling is
+   * "spend up to this", and a finder whose worst-case estimate equals the
+   * ceiling (`config spend-ceiling 5` against a `maxCostUsd: 5` finder) must
+   * still be able to fire once — with `>=` it never could, reporting
+   * "$0.00/$5.00 spent today" while refusing forever (#488).
    */
   reserveSpendIfUnderCeiling(opts: {
     sinceIso: string;
@@ -2716,7 +2720,7 @@ export class Ledger {
     const txn = this.db.transaction((): number | null => {
       const effectiveUsd =
         this.totalSpendUsd({ sinceIso: opts.sinceIso }) + this.reservedSpendUsd(opts.sinceIso);
-      if (effectiveUsd + opts.amountUsd >= opts.ceilingUsd) return null;
+      if (effectiveUsd + opts.amountUsd > opts.ceilingUsd) return null;
       return this.reserveSpend(opts.amountUsd);
     });
     return txn.immediate();

--- a/packages/find/__tests__/local-registry.test.ts
+++ b/packages/find/__tests__/local-registry.test.ts
@@ -1,5 +1,11 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { dedupeKeyFor, routePlayFor } from "../src/local-registry.ts";
+import {
+  dedupeKeyFor,
+  routePlayFor,
+  businessTypeFor,
+  issuedAgoLabel,
+  licenseTypeFor,
+} from "../src/local-registry.ts";
 import type { RegistryRecord } from "../src/_registry-sources.ts";
 
 describe("dedupeKeyFor", () => {
@@ -414,6 +420,31 @@ describe("runLocalRegistryFinder — routing + isolation", () => {
     expect(fresh?.payload["source"]).toBe("socrata-license");
     expect(fresh?.payload["matchedDateIso"]).toBe(RECENT_ISO);
     expect(fresh?.payload["yourEdge"]).toBe("we set it up free");
+    // #498: both plays REQUIRE these, and runEmailPlay drops a row without
+    // them before the LLM — every local-registry row used to be dropped.
+    expect(fresh?.payload["businessType"]).toBe("newly licensed local business");
+    expect(fresh?.payload["licenseType"]).toBe("business licence");
+    expect(fresh?.payload["issuedAgo"]).toMatch(/\S/);
+    expect(old?.payload["businessType"]).toBe("newly licensed local business");
+  });
+
+  it("prefers the registry's own business type / licence description when the row carries one", async () => {
+    nextSocrataRecords = [
+      makeRecord({
+        name: "Rae's Taqueria",
+        matchedDateIso: RECENT_ISO,
+        businessType: "Retail Food Establishment",
+        licenseType: "Retail Food Establishment",
+      }),
+    ];
+    const out = await runLocalRegistryFinder({
+      dryRun: false,
+      yourEdge: "x",
+      portals: [{ host: "data.cityofnewyork.us", dataset: "w7w3-xahh", label: "NYC licenses" }],
+    });
+    expect(out.enqueued).toBe(1);
+    expect(enqueued[0]?.payload["businessType"]).toBe("Retail Food Establishment");
+    expect(enqueued[0]?.payload["licenseType"]).toBe("Retail Food Establishment");
   });
 
   it("keeps candidates from a healthy source when a sibling source throws (one dead source doesn't fail the run)", async () => {
@@ -836,5 +867,27 @@ describe("runLocalRegistryFinder — trade name from an address-confirmed match"
     expect(out.enqueued).toBe(1);
     expect(enqueued[0]?.payload["company"]).toBe("Smiles at Telfair Family and Cosmetic Dentistry");
     expect(enqueued[0]?.payload["registryName"]).toBe("A PROFESSIONAL DENTAL ORGANIZATION");
+  });
+});
+
+describe("issuedAgoLabel / per-source defaults (#498)", () => {
+  const now = Date.parse("2026-09-08T12:00:00Z");
+  const daysAgo = (n: number): string => new Date(now - n * 86_400_000).toISOString();
+  it("reads like a person would say it", () => {
+    expect(issuedAgoLabel(daysAgo(0), now)).toBe("today");
+    expect(issuedAgoLabel(daysAgo(1), now)).toBe("yesterday");
+    expect(issuedAgoLabel(daysAgo(6), now)).toBe("6 days ago");
+    expect(issuedAgoLabel(daysAgo(20), now)).toBe("2 weeks ago");
+    expect(issuedAgoLabel(daysAgo(45), now)).toBe("6 weeks ago");
+    expect(issuedAgoLabel(daysAgo(60), now)).toBe("2 months ago");
+    expect(issuedAgoLabel(daysAgo(100), now)).toBe("3 months ago");
+    expect(issuedAgoLabel("not a date", now)).toBe("recently");
+  });
+  it("falls back per source and never returns an empty string", () => {
+    const base = makeRecord({ businessType: "  ", licenseType: null });
+    expect(businessTypeFor({ ...base, source: "nppes" })).toBe("healthcare practice");
+    expect(licenseTypeFor({ ...base, source: "nppes" })).toBe("NPI enumeration");
+    expect(businessTypeFor({ ...base, source: "fmcsa" })).toBe("motor carrier");
+    expect(businessTypeFor({ ...base, businessType: "Dentist" })).toBe("Dentist");
   });
 });

--- a/packages/find/__tests__/registry-sources.test.ts
+++ b/packages/find/__tests__/registry-sources.test.ts
@@ -78,6 +78,25 @@ describe("mapSocrataRows — canned payload", () => {
     });
   });
 
+  it("carries the licence description as the business type when the row has one (#498)", () => {
+    const out = mapSocrataRows(
+      [
+        {
+          business_name: "Rae's Taqueria",
+          license_creation_date: RECENT_ISO,
+          license_description: "Retail Food Establishment",
+        },
+        { business_name: "No Type Co", license_creation_date: RECENT_ISO },
+      ],
+      "NYC business licenses",
+      60,
+    );
+    expect(out.map((r) => [r.name, r.businessType, r.licenseType])).toEqual([
+      ["Rae's Taqueria", "Retail Food Establishment", "Retail Food Establishment"],
+      ["No Type Co", null, null],
+    ]);
+  });
+
   it("falls back across alternate name/date field spellings (dba_name, issue_date)", () => {
     const out = mapSocrataRows(rows, "NYC business licenses", 500);
     const names = out.map((r) => r.name).toSorted();

--- a/packages/find/src/_registry-sources.ts
+++ b/packages/find/src/_registry-sources.ts
@@ -34,6 +34,19 @@ export interface RegistryRecord {
    */
   subjectType?: "individual" | "organization";
   /**
+   * What kind of business this is, in the registry's own words — a Socrata
+   * licence description ("Retail Food Establishment"), the NPPES taxonomy
+   * that matched ("Dentist"), or "motor carrier" for FMCSA. Null when the
+   * portal's row has no such column. The plays' `businessType` field.
+   */
+  businessType?: string | null;
+  /**
+   * What was issued: the licence description again for Socrata, the NPI
+   * enumeration for NPPES, USDOT registration for FMCSA. Null when unknown.
+   * The `new-business` play's `licenseType` field.
+   */
+  licenseType?: string | null;
+  /**
    * The record's own on-file email (fmcsa only) — carries a published email,
    * so the caller skips `findEmail`/`verifyEmail` entirely for this
    * candidate rather than paying to re-derive what the record already
@@ -112,6 +125,20 @@ const SOCRATA_ADDRESS_FIELDS = [
 const SOCRATA_CITY_FIELDS = ["city", "business_city", "city_name", "address_city"];
 const SOCRATA_STATE_FIELDS = ["state", "business_state", "state_code", "address_state"];
 const SOCRATA_PHONE_FIELDS = ["phone", "contact_phone", "business_phone", "telephone_number"];
+/** What the licence is for — the closest thing a business-licence row has to a business type. */
+const SOCRATA_LICENSE_FIELDS = [
+  "license_description",
+  "licence_description",
+  "license_type",
+  "licence_type",
+  "license_category",
+  "business_activity",
+  "industry",
+  "naics_description",
+  "category",
+  "description",
+];
+
 const SOCRATA_DATE_FIELDS = [
   "license_creation_date",
   "issue_date",
@@ -269,6 +296,8 @@ export function mapSocrataRows(
       matchedDateIso,
       source: "socrata-license",
       sourceLabel: portalLabel,
+      businessType: pickField(rec, SOCRATA_LICENSE_FIELDS),
+      licenseType: pickField(rec, SOCRATA_LICENSE_FIELDS),
     });
   }
   return out;
@@ -504,6 +533,8 @@ export function mapNppesResults(
   label: string,
   fallbackState: string,
   sinceDays: number,
+  /** The taxonomy description the query matched on ("Dentist") — the record's business type. */
+  taxonomy?: string,
 ): RegistryRecord[] {
   const sinceMs = Date.now() - sinceDays * 86_400_000;
   const out: RegistryRecord[] = [];
@@ -527,6 +558,8 @@ export function mapNppesResults(
       source: "nppes",
       sourceLabel: label,
       subjectType: nppesSubjectType(r.basic),
+      businessType: taxonomy ?? null,
+      licenseType: taxonomy ? `NPI enumeration as ${taxonomy}` : "NPI enumeration",
     });
   }
   return out;
@@ -599,7 +632,7 @@ async function fetchNppesPair(
     return { records: [], diagnostic: `nppes has no ${taxonomy} providers in ${state}` };
   }
 
-  const records = mapNppesResults(results, label, state, cfg.sinceDays);
+  const records = mapNppesResults(results, label, state, cfg.sinceDays, taxonomy);
   if (records.length === 0) {
     return {
       records: [],
@@ -749,6 +782,8 @@ export function mapFmcsaRows(rows: unknown[], sinceDays: number): RegistryRecord
       source: "fmcsa",
       sourceLabel: "FMCSA Company Census",
       knownEmail: email.toLowerCase(),
+      businessType: "motor carrier",
+      licenseType: "USDOT motor carrier registration",
     });
   }
   return out;

--- a/packages/find/src/local-registry.ts
+++ b/packages/find/src/local-registry.ts
@@ -76,6 +76,17 @@ export interface LocalRegistryTarget {
   matchedDateIso: string;
   yourEdge: string;
   /**
+   * The three fields `free-pilot` / `new-business` REQUIRE (`requiredFields`
+   * in packages/plays): without them `runEmailPlay` drops the row before the
+   * LLM with "missing required field(s)", which is what every local-registry
+   * row did until #498. Filled from the registry record when it says, else
+   * from a per-source default that is at least true.
+   */
+  businessType: string;
+  licenseType: string;
+  /** "3 days ago", "2 weeks ago" — computed at enqueue time from `matchedDateIso`. */
+  issuedAgo: string;
+  /**
    * nppes only. Carried through from `RegistryRecord.subjectType` so a
    * `/queue` reviewer sees the same NPI-1 (individual) vs NPI-2
    * (organization) signal that explains why a "company" row shows a
@@ -186,6 +197,46 @@ function leadingStreetNumber(address: string | null | undefined): string | null 
 function postalCode5(postalCode: string | null | undefined): string | null {
   const digits = (postalCode ?? "").replace(/\D/g, "");
   return digits.length >= 5 ? digits.slice(0, 5) : null;
+}
+
+/** What kind of business, when the registry row did not say. */
+const DEFAULT_BUSINESS_TYPE: Record<RegistryRecord["source"], string> = {
+  "socrata-license": "newly licensed local business",
+  nppes: "healthcare practice",
+  fmcsa: "motor carrier",
+};
+
+/** What was issued, when the registry row did not say. */
+const DEFAULT_LICENSE_TYPE: Record<RegistryRecord["source"], string> = {
+  "socrata-license": "business licence",
+  nppes: "NPI enumeration",
+  fmcsa: "USDOT motor carrier registration",
+};
+
+export function businessTypeFor(record: RegistryRecord): string {
+  return record.businessType?.trim() || DEFAULT_BUSINESS_TYPE[record.source];
+}
+
+export function licenseTypeFor(record: RegistryRecord): string {
+  return record.licenseType?.trim() || DEFAULT_LICENSE_TYPE[record.source];
+}
+
+/**
+ * "today", "3 days ago", "2 weeks ago", "3 months ago" — the `issuedAgo` the
+ * new-business prompt reads. Computed when the row is enqueued, so a row
+ * that sits in /queue for a while reads slightly fresher than it is; the
+ * matched date itself is on the payload for anyone who needs the exact day.
+ */
+export function issuedAgoLabel(matchedDateIso: string, now = Date.now()): string {
+  const t = Date.parse(matchedDateIso);
+  if (!Number.isFinite(t)) return "recently";
+  const days = Math.max(0, Math.floor((now - t) / 86_400_000));
+  if (days === 0) return "today";
+  if (days === 1) return "yesterday";
+  if (days < 14) return `${days} days ago`;
+  if (days < 60) return `${Math.floor(days / 7)} weeks ago`;
+  const months = Math.floor(days / 30);
+  return months === 1 ? "a month ago" : `${months} months ago`;
 }
 
 /** Recent-issue routing: fresh (within `freshnessDays`) → new-business, else → free-pilot. */
@@ -490,6 +541,9 @@ export async function runLocalRegistryFinder(opts: LocalRegistryFinderOpts): Pro
       sourceLabel: record.sourceLabel,
       matchedDateIso: record.matchedDateIso,
       yourEdge: opts.yourEdge,
+      businessType: businessTypeFor(record),
+      licenseType: licenseTypeFor(record),
+      issuedAgo: issuedAgoLabel(record.matchedDateIso),
       ...(record.subjectType ? { subjectType: record.subjectType } : {}),
       ...(record.postalCode ? { postalCode: record.postalCode } : {}),
       ...(record.address ? { address: record.address } : {}),


### PR DESCRIPTION
## What

Triage of the seven open "Deferred review findings" issues. Each finding was reproduced against `main` @ 5cfe3f6 first. Four issues were entirely obsolete (fixed since filing) and are closed with file:line evidence (#487, #471, #472, #366); one describes a branch that has not merged and is forwarded to that PR (#559 → PR #560). This PR fixes the two that are real.

Closes #488. Closes #498.

## Fixes

**#488 — daily spend ceiling refuses a reservation that lands exactly on the ceiling.** `Ledger.reserveSpendIfUnderCeiling` used `>=`, so a finder whose worst-case estimate equals the ceiling (`config spend-ceiling 5` against a `maxCostUsd: 5` finder) could never fire, reporting "$0.00/$5.00 spent today" while refusing forever. Now `>`: landing on the ceiling is allowed, exceeding it is not, and `ceilingReached` (`>=`) still halts everything after. Doc comments in `ledger.ts` and `daily-spend.ts` say so; `daily-spend.test.ts` covers the exact-ceiling grant, the one-cent-over refusal, and the post-reach halt.

**#498 — every local-registry row was undraftable.** The finding said `free-pilot` rendered `BUSINESS TYPE: undefined`; on `main` it is worse: both `free-pilot` and `new-business` now list `businessType` (and `new-business` also `licenseType`, `issuedAgo`) in `requiredFields`, and `runEmailPlay`'s guard #0 drops a row missing any of them before the LLM. `LocalRegistryTarget` never carried the three, so every row the five local-registry packs enqueue died at drain with "missing required field(s)". The first bullet of #498 (`new-business` unregistered) is already fixed on `main` (`registry.ts:267`).

- `RegistryRecord` gains optional `businessType` / `licenseType`; the Socrata mapper reads the licence description column (`license_description`, `license_type`, `business_activity`, …), NPPES carries the taxonomy that matched ("Dentist"), FMCSA is "motor carrier" / "USDOT motor carrier registration".
- `LocalRegistryTarget` gains the three required fields, filled from the record when it says, else a per-source default that is at least true ("newly licensed local business" / "business licence", "healthcare practice" / "NPI enumeration"). `issuedAgo` is "today" / "6 days ago" / "2 weeks ago" / "3 months ago" from `matchedDateIso` at enqueue time.
- Tests: mapper picks the licence description; finder payload carries all three with the right fallbacks; label unit test.

## Verify

`bun run test` green, typecheck / lint (36 warnings, baseline) / fmt clean. STATUS.md count updated in this PR.

https://claude.ai/code/session_01RaGFRjZeREgB7Fg5hboxsx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Daily spend reservations now allow usage exactly at the configured ceiling while refusing reservations that exceed it.
  * Registry results now include business type, license type, and human-readable business age information.
  * Local registry entries apply source-specific defaults when metadata is unavailable.
* **Bug Fixes**
  * Local registry records now retain the metadata required for downstream processing.
* **Tests**
  * Expanded coverage for daily spend limits, registry metadata mapping, defaults, and date formatting.
* **Documentation**
  * Clarified daily spend ceiling behavior in user-facing documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->