### PR TITLE
fix: issue #562: Export one sqliteToIso from core; six private copies drift

### DIFF
--- a/apps/cli/src/commands/score-prospects.ts
+++ b/apps/cli/src/commands/score-prospects.ts
@@ -5,6 +5,7 @@ import {
   isHumanApproval,
   isHumanDecision,
   parseProspectPriority,
+  sqliteToIso,
   type ProspectPriority,
   type QueueRow,
   safeParseJsonRecord,
@@ -102,8 +103,7 @@ export function shouldSkipRow(row: Pick<QueueRow, "priority_json">, refresh: boo
  */
 export function anchorFor(row: Pick<QueueRow, "found_at">): Date {
   const raw = (row.found_at ?? "").trim();
-  const iso = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(raw) ? `${raw.replace(" ", "T")}Z` : raw;
-  const t = Date.parse(iso);
+  const t = Date.parse(sqliteToIso(raw));
   return Number.isFinite(t) ? new Date(t) : new Date();
 }
 

--- a/apps/server/src/api/_prospect-timeline.ts
+++ b/apps/server/src/api/_prospect-timeline.ts
@@ -1,3 +1,4 @@
+import { sqliteToIso } from "@oneshot-gtm/core/time";
 import type {
   ChannelEventRecord,
   DealOutcomeRecord,
@@ -6,17 +7,6 @@ import type {
   SequenceEventRecord,
 } from "@oneshot-gtm/core";
 import { describeDecision, type ProspectTimelineEvent } from "@oneshot-gtm/shared-types";
-
-/**
- * sequence_events.created_at, deal_outcomes.recorded_at and target_queue's
- * found_at use SQLite datetime('now') format ("YYYY-MM-DD HH:MM:SS", UTC, no
- * 'T'/'Z'); reply and decision timestamps are ISO. Normalise so the merged
- * string sort is chronological. Same rule as inbox.ts, kept local so this
- * pure module does not drag the Gmail-backed inbox route into its tests.
- */
-function sqliteToIso(ts: string): string {
-  return ts.includes("T") ? ts : `${ts.replace(" ", "T")}Z`;
-}
 
 /**
  * The history behind one /prospects row, newest first: the queue row's own

--- a/apps/server/src/api/inbox.ts
+++ b/apps/server/src/api/inbox.ts
@@ -9,6 +9,7 @@ import {
   logEvent,
   replyEmail,
   resolveIdentities,
+  sqliteToIso,
   trackSend,
   type ReplyKind,
 } from "@oneshot-gtm/core";
@@ -396,15 +397,6 @@ function buildConversations(
   }
   // Most recent activity first — the row order of the matched tab.
   return out.toSorted((a, b) => (a.lastActivityAt < b.lastActivityAt ? 1 : -1));
-}
-
-/**
- * sequence_events.created_at and deal_outcomes.recorded_at use SQLite datetime('now') format ("YYYY-MM-DD
- * HH:MM:SS", UTC, no 'T'/'Z'); inbox timestamps are ISO. Normalize so the
- * merged timeline's string sort is chronological.
- */
-function sqliteToIso(ts: string): string {
-  return ts.includes("T") ? ts : `${ts.replace(" ", "T")}Z`;
 }
 
 /**

--- a/packages/core/__tests__/time.test.ts
+++ b/packages/core/__tests__/time.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { sqliteToIso } from "../src/time.ts";
+
+describe("sqliteToIso", () => {
+  it("converts SQLite datetime('now') form to ISO with a Z suffix", () => {
+    expect(sqliteToIso("2026-09-08 10:00:00")).toBe("2026-09-08T10:00:00Z");
+  });
+
+  it("returns an already-ISO string unchanged", () => {
+    expect(sqliteToIso("2026-09-08T10:00:00Z")).toBe("2026-09-08T10:00:00Z");
+  });
+
+  it("does not double-suffix an ISO string into the ZZ trap", () => {
+    const iso = "2026-09-08T10:00:00Z";
+    expect(sqliteToIso(iso)).not.toBe(`${iso}Z`);
+    expect(sqliteToIso(iso)).toBe(iso);
+  });
+
+  it("leaves an ISO string with an explicit offset unchanged", () => {
+    expect(sqliteToIso("2026-09-08T10:00:00+02:00")).toBe("2026-09-08T10:00:00+02:00");
+  });
+});

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -11,7 +11,8 @@
   "main": "./src/index.ts",
   "exports": {
     ".": "./src/index.ts",
-    "./workspaces": "./src/workspaces.ts"
+    "./workspaces": "./src/workspaces.ts",
+    "./time": "./src/time.ts"
   },
   "dependencies": {
     "@oneshot-agent/sdk": "file:../../vendor/oneshot-agent-sdk-0.32.0.tgz",

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -25,6 +25,7 @@ export * from "./types.ts";
 export { activeSendCount } from "./inflight.ts";
 export * from "./reply-classify.ts";
 export * from "./timezone.ts";
+export * from "./time.ts";
 export * from "./daily-spend.ts";
 
 export * from "./direct-mail.ts";

--- a/packages/core/src/send-routing.ts
+++ b/packages/core/src/send-routing.ts
@@ -2,6 +2,7 @@ import { loadConfig } from "./config.ts";
 import { logEvent } from "./events.ts";
 import { LEGACY_GMAIL_ID, LEGACY_ONESHOT_ID, resolveIdentities } from "./identities.ts";
 import { getLedger } from "./ledger.ts";
+import { sqliteToIso } from "./time.ts";
 import type { EmailIdentity } from "./types.ts";
 
 /**
@@ -125,7 +126,7 @@ export function warmupCap(
   const max = identity.maxPerDay ?? DEFAULT_WARMUP_MAX;
   if (!identity.warmup) return max;
   if (!firstSendAtSqliteUtc) return Math.min(identity.warmup.startPerDay, max);
-  const firstMs = new Date(`${firstSendAtSqliteUtc.replace(" ", "T")}Z`).getTime();
+  const firstMs = new Date(sqliteToIso(firstSendAtSqliteUtc)).getTime();
   const weeks = Number.isFinite(firstMs)
     ? Math.max(0, Math.floor((now.getTime() - firstMs) / MS_PER_WEEK))
     : 0;

--- a/packages/core/src/time.ts
+++ b/packages/core/src/time.ts
@@ -1,0 +1,19 @@
+/** `2026-08-27 02:30:00` — SQLite's `datetime('now')` form: UTC, no `T`/`Z`. */
+const SQLITE_DATETIME = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
+
+/**
+ * Several tables store `datetime('now')` timestamps
+ * (`"YYYY-MM-DD HH:MM:SS"`, UTC, no `T`/`Z`) while others already store ISO
+ * strings. This normalizes either into ISO 8601 with a `Z` suffix so a merged
+ * timeline's plain string sort stays chronological.
+ *
+ * ISO input is returned unchanged (idempotent) rather than blindly appended
+ * with `Z` — appending unconditionally turns an already-`Z`-suffixed ISO
+ * string into the `...ZZ` trap (`2026-09-08T10:00:00ZZ`), which is invalid
+ * and fails `Date.parse`. Matching the exact SQLite shape, rather than a
+ * looser `includes(" ")`/`includes("T")` check, is what makes this a safe
+ * superset of every inline version it replaces.
+ */
+export function sqliteToIso(ts: string): string {
+  return SQLITE_DATETIME.test(ts) ? `${ts.replace(" ", "T")}Z` : ts;
+}

--- a/packages/doctor/src/check.ts
+++ b/packages/doctor/src/check.ts
@@ -22,6 +22,7 @@ import {
   resolveIdentities,
   secretSource,
   secretsPath,
+  sqliteToIso,
   currentWorkspaceName,
   listWorkspaces,
   loadGmailTokens,
@@ -241,7 +242,7 @@ function placementCheck(): CheckResult {
       };
     }
     const ageDays = Math.floor(
-      (Date.now() - new Date(`${last.created_at.replace(" ", "T")}Z`).getTime()) / 86_400_000,
+      (Date.now() - new Date(sqliteToIso(last.created_at)).getTime()) / 86_400_000,
     );
     const age = Number.isFinite(ageDays) ? `${ageDays}d ago` : "unknown age";
     const auth = `spf=${last.spf} dkim=${last.dkim} dmarc=${last.dmarc}`;

--- a/packages/find/src/_outcomes.ts
+++ b/packages/find/src/_outcomes.ts
@@ -1,5 +1,5 @@
 import type { ProspectPriorityComponents, SentOutcomeRawRow } from "@oneshot-gtm/core";
-import { parseProspectPriority } from "@oneshot-gtm/core";
+import { parseProspectPriority, sqliteToIso } from "@oneshot-gtm/core";
 import { mannWhitneyAuc, meanOf, wilson95 } from "./_gauge.ts";
 import { SCORE_BUCKETS, bucketOf } from "./_buckets.ts";
 
@@ -99,9 +99,7 @@ export function labelSentRow(
   now: Date,
 ): SentOutcomeLabel {
   const priority = parseProspectPriority(raw.priority_json);
-  const sentAtIso = /^\d{4}-\d{2}-\d{2} /.test(raw.sent_at)
-    ? `${raw.sent_at.replace(" ", "T")}Z`
-    : raw.sent_at;
+  const sentAtIso = sqliteToIso(raw.sent_at);
   const sentMs = Date.parse(sentAtIso);
   const daysSinceSend = Number.isFinite(sentMs) ? (now.getTime() - sentMs) / DAY_MS : 0;
   const joinable = raw.joined_prospect_id !== null;


### PR DESCRIPTION
Closes #562.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 5cfe3f6e1419 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (2 errs) vs base ok (2 errs)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of SQLite timestamps across prospect scoring, inbox, timeline, routing, diagnostics, and outcome displays.
  * Preserved timestamps that are already in ISO format or include explicit timezone offsets, preventing incorrect date parsing.

* **Tests**
  * Added coverage for SQLite datetime conversion and existing ISO timestamp formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->