### PR TITLE
fix(inbox,intel,plays): shipped review findings from #556, redone on main (#558, #559)

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ bun run --cwd apps/web build       # → apps/web/dist/
 bun run --cwd apps/server build    # → apps/server/dist/bin.mjs + dist/web/
 ```
 
-The suite is 3237 cases across 246 files (STATUS.md carries the current totals). Tests set `ONESHOT_GTM_HOME` to a temp dir, so they never touch your real ledger. CI runs `bun --bun run test` — the flag matters, since `bun:sqlite` doesn't exist under Node. Core and server install the SDK from the archive in `vendor/`; its README has the coordinated release step.
+The suite is 3323 cases across 255 files (STATUS.md carries the current totals). Tests set `ONESHOT_GTM_HOME` to a temp dir, so they never touch your real ledger. CI runs `bun --bun run test` — the flag matters, since `bun:sqlite` doesn't exist under Node. Core and server install the SDK from the archive in `vendor/`; its README has the coordinated release step.
 
 ### Watching what's happening
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 66 CLI commands, 23 plays, 15 finders, ten dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-08** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3297 tests / 253 files** · typecheck + oxlint + oxfmt pass (36 lint warnings, 0 errors).
+Last verified **2026-09-08** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3323 tests / 255 files** · typecheck + oxlint + oxfmt pass (36 lint warnings, 0 errors).
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/apps/cli/__tests__/backfill-intent.test.ts
+++ b/apps/cli/__tests__/backfill-intent.test.ts
@@ -85,6 +85,34 @@ describe("commandIntelBackfillIntent (issue #480)", () => {
     expect(ledger.listUntriagedHumanReplies()).toHaveLength(0);
   });
 
+  it("skips a row the background poll has already claimed, and never bills it twice (#559)", async () => {
+    ledger.upsertProspect({ email: "p@prospect.example" });
+    record("r1", "human");
+    record("r2", "human");
+    // The scheduler's poll is mid-triage on r2: it holds the atomic claim.
+    expect(ledger.claimInboxReplyForTriage("r2")).toBe(true);
+
+    triageEmailsMock.mockImplementation(async (emails: Array<{ id: string }>) =>
+      emails.map((e) => ({
+        id: e.id,
+        from: "x",
+        subject: "x",
+        category: "not_now",
+        nextStep: "wait",
+        draftedReply: "",
+        reasoning: "later",
+      })),
+    );
+    await commandIntelBackfillIntent();
+
+    // r1 was triaged here; r2 was left to the poll that claimed it.
+    const sentIds = (triageEmailsMock.mock.calls[0]![0] as Array<{ id: string }>).map((e) => e.id);
+    expect(sentIds).toEqual(["r1"]);
+    expect(ledger.listInboxReplyIntents(["r1", "r2"]).get("r1")?.intent).toBe("not_now");
+    // Still the poll's claim — a second claimant loses.
+    expect(ledger.claimInboxReplyForTriage("r2")).toBe(false);
+  });
+
   it("is a no-op when nothing is untriaged", async () => {
     await commandIntelBackfillIntent();
     expect(triageEmailsMock).not.toHaveBeenCalled();

--- a/apps/cli/src/commands/intel.ts
+++ b/apps/cli/src/commands/intel.ts
@@ -138,8 +138,17 @@ export async function commandIntelBackfillIntent(opts: { limit?: number } = {}):
   const BATCH = 25;
   let done = 0;
   let failed = 0;
+  let skipped = 0;
   for (let i = 0; i < rows.length; i += BATCH) {
-    const batch = rows.slice(i, i + BATCH);
+    // Same atomic claim the background poll takes (#558/#559): this command
+    // runs while the server's scheduler is live, and a row both of them see
+    // untriaged must be paid for once. A lost claim means the poll has it.
+    const batch = rows.slice(i, i + BATCH).filter((r) => {
+      if (ledger.claimInboxReplyForTriage(r.id)) return true;
+      skipped++;
+      return false;
+    });
+    if (batch.length === 0) continue;
     try {
       const triaged = await triageEmails(
         batch.map((r) => ({
@@ -154,6 +163,8 @@ export async function commandIntelBackfillIntent(opts: { limit?: number } = {}):
       for (const r of batch) {
         const t = byId.get(r.id);
         if (!t) {
+          // Release the claim so a later poll (or re-run) can retry.
+          ledger.setInboxReplyIntent(r.id, null, null);
           failed++;
           continue;
         }
@@ -161,12 +172,13 @@ export async function commandIntelBackfillIntent(opts: { limit?: number } = {}):
         done++;
       }
     } catch (err) {
+      for (const r of batch) ledger.setInboxReplyIntent(r.id, null, null);
       failed += batch.length;
       warn(`batch starting at row ${i} failed: ${(err as Error)?.message ?? "unknown error"}`);
     }
   }
   ok(
-    `backfilled ${done} repl${done === 1 ? "y" : "ies"}${failed > 0 ? `, ${failed} failed` : ""}.`,
+    `backfilled ${done} repl${done === 1 ? "y" : "ies"}${failed > 0 ? `, ${failed} failed` : ""}${skipped > 0 ? `, ${skipped} already being triaged` : ""}.`,
   );
 }
 

--- a/apps/cli/src/commands/intel.ts
+++ b/apps/cli/src/commands/intel.ts
@@ -149,8 +149,12 @@ export async function commandIntelBackfillIntent(opts: { limit?: number } = {}):
       return false;
     });
     if (batch.length === 0) continue;
+    // Only the paid call is inside the try: a failure there releases every
+    // claim in the batch. The write-back below runs outside it, so a partial
+    // write-back can never be "undone" by releasing rows already classified.
+    let triaged: Awaited<ReturnType<typeof triageEmails>>;
     try {
-      const triaged = await triageEmails(
+      triaged = await triageEmails(
         batch.map((r) => ({
           id: r.id,
           from: r.from_email,
@@ -159,22 +163,23 @@ export async function commandIntelBackfillIntent(opts: { limit?: number } = {}):
           body: r.body,
         })),
       );
-      const byId = new Map(triaged.map((t) => [t.id, t]));
-      for (const r of batch) {
-        const t = byId.get(r.id);
-        if (!t) {
-          // Release the claim so a later poll (or re-run) can retry.
-          ledger.setInboxReplyIntent(r.id, null, null);
-          failed++;
-          continue;
-        }
-        ledger.setInboxReplyIntent(r.id, t.category, t.reasoning || null);
-        done++;
-      }
     } catch (err) {
       for (const r of batch) ledger.setInboxReplyIntent(r.id, null, null);
       failed += batch.length;
       warn(`batch starting at row ${i} failed: ${(err as Error)?.message ?? "unknown error"}`);
+      continue;
+    }
+    const byId = new Map(triaged.map((t) => [t.id, t]));
+    for (const r of batch) {
+      const t = byId.get(r.id);
+      if (!t) {
+        // Release the claim so a later poll (or re-run) can retry.
+        ledger.setInboxReplyIntent(r.id, null, null);
+        failed++;
+        continue;
+      }
+      ledger.setInboxReplyIntent(r.id, t.category, t.reasoning || null);
+      done++;
     }
   }
   ok(

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -912,8 +912,16 @@ intel
   .action(runOrFail(commandIntelTriage));
 intel
   .command("backfill-intent")
-  .option("-l, --limit <n>", "max untriaged human replies to process (default 200)", (v) =>
-    Number.parseInt(v, 10),
+  .option(
+    "-l, --limit <n>",
+    "max untriaged human replies to process (default 200)",
+    (v: string) => {
+      const limit = Number(v);
+      if (!Number.isSafeInteger(limit) || limit < 0) {
+        throw new Error("--limit must be a non-negative integer");
+      }
+      return limit;
+    },
   )
   .description("Classify sentiment intent onto persisted human replies that predate the classifier")
   .action(

--- a/apps/server/src/api/inbox.ts
+++ b/apps/server/src/api/inbox.ts
@@ -219,7 +219,10 @@ export async function listInboxRoute(req: Request): Promise<Response> {
   // Opportunistic capture: any matched live mail not yet persisted goes into
   // inbox_replies now (INSERT OR IGNORE — re-sees are no-ops). This is also
   // how pre-v21 history backfills itself: the targeted known-replier fetch
-  // above flows through here on first load. Best-effort.
+  // above flows through here on first load. Best-effort. Classification
+  // (issue #480/#558) is intentionally NOT done here — pollInboxReplies is
+  // the one choke point that also classifies rows this capture inserted but
+  // didn't triage (see _cadence.ts's isNewReply-or-untriaged check).
   try {
     for (const r of visible) {
       if (!r.matched) continue;
@@ -608,7 +611,9 @@ export async function steerRoute(req: Request): Promise<Response> {
   // row; if none exists yet, seed it with the inbound context and an empty
   // body so setInboxDraftSteer's UPDATE has something to land on.
   const existing = ledger.getInboxThreads().get(threadKey);
-  if (existing == null) {
+  // A thread with only sent history still yields an entry (draftBody null),
+  // so test the draft row itself — otherwise both UPDATEs below hit no rows.
+  if (existing?.draftBody == null && existing?.steer == null) {
     ledger.upsertInboxDraft({
       threadKey,
       inboundEmailId: typeof body.id === "string" ? body.id : threadKey,

--- a/apps/server/src/bin.ts
+++ b/apps/server/src/bin.ts
@@ -131,6 +131,28 @@ if (cache.__oneshotGtmServer) {
     process.stderr.write(`  warn: stale queue-send sweep failed: ${(err as Error).message}\n`);
   }
 
+  // Cold-boot recovery for `claimInboxReplyForTriage` (round-2 correction,
+  // #558): a process death mid-triage leaves `intent = '__triage_pending__'`
+  // permanently on a row — the claim UPDATE only matches `intent IS NULL`,
+  // so a stranded row could never be re-claimed or classified again without
+  // this. Unlike the other markers there's no `started_at` column to age
+  // against (the claim only lives for one in-process `await`), so this is
+  // an unconditional cold-boot reset, not a `maxAgeMs`-gated sweep.
+  try {
+    const swept = getLedger().sweepStaleInboxReplyTriage();
+    if (swept > 0) {
+      logEvent("inbox_reply.triage_claim.killed_by_restart", { count: swept }, "warn");
+      process.stdout.write(`  swept ${swept} stale inbox-reply triage claim(s)\n`);
+    }
+  } catch (err) {
+    logEvent(
+      "inbox_reply.triage_claim.sweep_failed",
+      { message_120: ((err as Error).message ?? "").slice(0, 120) },
+      "error",
+    );
+    process.stderr.write(`  warn: stale triage-claim sweep failed: ${(err as Error).message}\n`);
+  }
+
   // Cold-boot sweep for /run dispatches: flip zombie 'running' rows to
   // 'interrupted'; per-event counters on the row stay accurate.
   try {

--- a/apps/web/src/routes/inbox.tsx
+++ b/apps/web/src/routes/inbox.tsx
@@ -638,6 +638,7 @@ function ReplyComposer({
     },
     onSuccess: () => {
       setOutcomeOpen(false);
+      void queryClient.invalidateQueries({ queryKey: ["inbox"] });
       toast.success("outcome recorded");
     },
     onError: (err) => toast.error(`couldn't record outcome · ${err.message}`),

--- a/packages/core/__tests__/inbox-replies.test.ts
+++ b/packages/core/__tests__/inbox-replies.test.ts
@@ -203,6 +203,79 @@ describe("inbox_replies.intent (issue #480)", () => {
     expect(ledger.listInboxRepliesForProspect(1)[0]!.intent).toBeNull();
   });
 
+  // Round-1 correction (#558): claimInboxReplyForTriage replaces a bare
+  // re-check of `intent` with an atomic UPDATE ... WHERE intent IS NULL, so
+  // two overlapping pollInboxReplies() calls (background scheduler tick +
+  // manual `cadence advance`) racing the same freshly-inserted row can't both
+  // trigger a paid triageEmails() call.
+  it("claimInboxReplyForTriage: only one of two concurrent callers wins the claim", () => {
+    record({ kind: "human" });
+    expect(ledger.claimInboxReplyForTriage("msg-1")).toBe(true);
+    // A second caller observing the same still-in-flight row must lose.
+    expect(ledger.claimInboxReplyForTriage("msg-1")).toBe(false);
+    // The pending marker is bookkeeping, not a category: readers see NULL
+    // (#559), while the row stays unclaimable and out of the backfill set.
+    expect(ledger.listInboxRepliesForProspect(1)[0]!.intent).toBeNull();
+    expect(ledger.listInboxReplyIntents(["msg-1"]).get("msg-1")?.intent).toBeNull();
+    expect(ledger.listUntriagedHumanReplies()).toEqual([]);
+  });
+
+  it("claimInboxReplyForTriage: a failed triage releases the claim so a later poll can retry", () => {
+    record({ kind: "human" });
+    expect(ledger.claimInboxReplyForTriage("msg-1")).toBe(true);
+    // Winner's triage call fails — it releases the claim back to NULL.
+    ledger.setInboxReplyIntent("msg-1", null, null);
+    expect(ledger.listInboxRepliesForProspect(1)[0]!.intent).toBeNull();
+    // A later poll can now claim and succeed.
+    expect(ledger.claimInboxReplyForTriage("msg-1")).toBe(true);
+    ledger.setInboxReplyIntent("msg-1", "interested", "r");
+    expect(ledger.listInboxRepliesForProspect(1)[0]!.intent).toBe("interested");
+  });
+
+  it("claimInboxReplyForTriage: never re-claims a row that already has a real classification", () => {
+    record({ kind: "human" });
+    ledger.setInboxReplyIntent("msg-1", "not_now", "declined");
+    expect(ledger.claimInboxReplyForTriage("msg-1")).toBe(false);
+    expect(ledger.listInboxRepliesForProspect(1)[0]!.intent).toBe("not_now");
+  });
+
+  // Round-2 correction (#558, this round): every other claim-marker in
+  // ledger.ts pairs its atomic claim with a sweepStale* recovery so a crash
+  // between the claim and the release doesn't strand the marker forever.
+  // claimInboxReplyForTriage had none — a process death mid-triage left
+  // '__triage_pending__' on the row permanently (unclaimable, unclassified,
+  // and visible to every intent reader). sweepStaleInboxReplyTriage is the
+  // cold-boot recovery, called once from apps/server/src/bin.ts like the
+  // other sweeps.
+  describe("sweepStaleInboxReplyTriage", () => {
+    it("resets a stranded __triage_pending__ claim back to NULL", () => {
+      record({ kind: "human" });
+      expect(ledger.claimInboxReplyForTriage("msg-1")).toBe(true);
+      // Still claimed (a second claim loses) even though readers report NULL.
+      expect(ledger.claimInboxReplyForTriage("msg-1")).toBe(false);
+      // Simulate a crash: nobody calls setInboxReplyIntent to release it.
+      expect(ledger.sweepStaleInboxReplyTriage()).toBe(1);
+      expect(ledger.listInboxRepliesForProspect(1)[0]!.intent).toBeNull();
+      // The row is claimable again after the sweep.
+      expect(ledger.claimInboxReplyForTriage("msg-1")).toBe(true);
+    });
+
+    it("never touches rows with a real classification or no claim at all", () => {
+      record({ kind: "human" });
+      record({ id: "msg-2", kind: "human" });
+      ledger.setInboxReplyIntent("msg-1", "interested", "r");
+      // msg-2 is left with intent NULL (no claim in flight).
+      expect(ledger.sweepStaleInboxReplyTriage()).toBe(0);
+      const rows = ledger.listInboxRepliesForProspect(1);
+      expect(rows.find((r) => r.id === "msg-1")!.intent).toBe("interested");
+      expect(rows.find((r) => r.id === "msg-2")!.intent).toBeNull();
+    });
+
+    it("is a no-op on an empty table", () => {
+      expect(ledger.sweepStaleInboxReplyTriage()).toBe(0);
+    });
+  });
+
   it("listUntriagedHumanReplies finds human replies with no intent yet, oldest first", () => {
     record({ id: "msg-1", kind: "human", receivedAt: "2026-08-20T00:00:00.000Z" });
     record({ id: "msg-2", kind: "human", receivedAt: "2026-08-25T00:00:00.000Z" });

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -1317,6 +1317,13 @@ export class Ledger {
    * from apps/server/src/bin.ts) is the only moment a stranded claim can be
    * told apart from one a live process still holds. Returns the number of
    * rows reset so the caller can log it.
+   *
+   * Known trade-off: a claim held by a live `intel backfill-intent` CLI
+   * process at the instant the server boots is cleared too, and the next
+   * poll may re-claim that row. The cost is one duplicated triage call
+   * (cents) whose result is the same category — last writer wins, no data
+   * is lost. Telling the two apart would need a claim timestamp column and
+   * an age-gated sweep; not worth a schema change for that window.
    */
   sweepStaleInboxReplyTriage(): number {
     const res = this.db

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -257,6 +257,28 @@ function normalizeSubject(subject: string | null | undefined): string | null {
   return s.length > 0 ? s : null;
 }
 
+/**
+ * Sentinel written into `inbox_replies.intent` by `claimInboxReplyForTriage`
+ * to atomically mark "a caller is triaging this row right now" without
+ * committing to a real category yet. Never a valid `TriageCategory` /
+ * `ReplyIntent` value, and never read back as a classification: every reader
+ * of `intent` (`listInboxReplyIntents`, the /inbox route, `POSITIVE_REPLY_INTENTS`
+ * checks) only sees it during the brief window between the claim and the
+ * winner's `setInboxReplyIntent` call overwriting it with the real result (or
+ * NULL on failure) — same transaction-scoped visibility any other in-flight
+ * write has.
+ */
+const INBOX_REPLY_TRIAGE_PENDING = "__triage_pending__";
+
+/**
+ * The claim sentinel is bookkeeping, not a classification: every reader of
+ * `intent` gets NULL back for it (#559), so the column's `ReplyIntent | null`
+ * contract holds even during the window a triage call is in flight.
+ */
+function publicIntent(intent: string | null): string | null {
+  return intent === INBOX_REPLY_TRIAGE_PENDING ? null : intent;
+}
+
 export class Ledger {
   private db: Database;
   private path: string;
@@ -1253,6 +1275,57 @@ export class Ledger {
   }
 
   /**
+   * Atomically claim a persisted reply for triage (issue #558 round-1
+   * correction). Two overlapping `pollInboxReplies()` calls (realistically:
+   * the server's background scheduler tick and a manually-run `cadence
+   * advance` CLI invocation) can both observe the same freshly-inserted row
+   * with `intent` still NULL while the first call's `triageEmails()` await is
+   * in flight — a bare re-check of the nullable `intent` column can't tell
+   * "nobody has started triaging this yet" from "I already looked a moment
+   * ago", so both callers would re-trigger the paid triage call and race on
+   * the write-back. This flips `intent` from NULL to `INBOX_REPLY_TRIAGE_PENDING`
+   * in the SAME statement that checks it's still NULL — SQLite serializes
+   * writers, so only one caller's UPDATE can match a given row, and its
+   * `changes` count is the claim. The winner must call `setInboxReplyIntent`
+   * (real result) or release the claim (`setInboxReplyIntent(id, null, null)`
+   * on failure) so a later poll can retry; the loser must skip triage
+   * entirely for this row this poll.
+   */
+  claimInboxReplyForTriage(id: string): boolean {
+    const res = this.db
+      .prepare(`UPDATE inbox_replies SET intent = ? WHERE id = ? AND intent IS NULL`)
+      .run(INBOX_REPLY_TRIAGE_PENDING, id);
+    return res.changes > 0;
+  }
+
+  /**
+   * Cold-boot recovery for `claimInboxReplyForTriage` (round-2 correction,
+   * #558): every other claim-marker in this file
+   * (claimCadenceSendingMarker/sweepStaleCadenceSends,
+   * claimQueueSendingMarker/sweepStaleQueueSends,
+   * claimRunningTrigger/sweepStaleRunningTriggers) has a paired sweep so a
+   * crash between the claim UPDATE and the try/catch's release doesn't
+   * strand the marker forever. This one didn't: a process death mid-triage
+   * left `intent = '__triage_pending__'` permanently on the row — it could
+   * never be re-claimed (the claim UPDATE only matches `intent IS NULL`) or
+   * classified again, and the non-`ReplyIntent` sentinel was exposed to
+   * every reader of `intent` (`listInboxReplyIntents`, the /inbox route).
+   * Unlike the other markers, the claim here has no `started_at` column to
+   * age against — it's held only for the duration of one in-process `await
+   * triageEmails(...)`, which cannot survive past that process's death — so
+   * there's no `maxAgeMs`: cold boot (called once, like the other sweeps,
+   * from apps/server/src/bin.ts) is the only moment a stranded claim can be
+   * told apart from one a live process still holds. Returns the number of
+   * rows reset so the caller can log it.
+   */
+  sweepStaleInboxReplyTriage(): number {
+    const res = this.db
+      .prepare(`UPDATE inbox_replies SET intent = NULL WHERE intent = ?`)
+      .run(INBOX_REPLY_TRIAGE_PENDING);
+    return res.changes;
+  }
+
+  /**
    * Bulk intent lookup for a set of provider email ids — the /inbox route's
    * badge needs the persisted (LLM-classified) intent per visible reply
    * without an N+1 query. Empty input short-circuits (SQLite's `IN ()` is
@@ -1269,14 +1342,18 @@ export class Ledger {
          WHERE id IN (${placeholders})`,
       )
       .all(...ids) as Array<{ id: string; intent: string | null; intentReason: string | null }>;
-    return new Map(rows.map((r) => [r.id, { intent: r.intent, intentReason: r.intentReason }]));
+    return new Map(
+      rows.map((r) => [r.id, { intent: publicIntent(r.intent), intentReason: r.intentReason }]),
+    );
   }
 
   /** All persisted inbound replies for one prospect, oldest first. */
   listInboxRepliesForProspect(prospectId: number): InboxReplyRecord[] {
-    return this.db
+    const rows = this.db
       .query(`SELECT * FROM inbox_replies WHERE prospect_id = ? ORDER BY received_at ASC, id ASC`)
       .all(prospectId) as InboxReplyRecord[];
+    for (const r of rows) if (r.intent === INBOX_REPLY_TRIAGE_PENDING) r.intent = null;
+    return rows;
   }
 
   /** Provider ids of every persisted reply — dedupe set for capture passes. */

--- a/packages/intel/__tests__/triage.test.ts
+++ b/packages/intel/__tests__/triage.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// complete() is the seam: triageEmails' own parsing/validation is what this
+// suite exercises, so the LLM call itself is mocked to return controlled JSON.
+const completeMock = vi.fn();
+vi.mock("../src/client.ts", () => ({ complete: completeMock }));
+vi.mock("../src/prompts.ts", () => ({ loadPrompt: () => "system prompt" }));
+
+const { triageEmails } = await import("../src/triage.ts");
+
+function inbound(id: string) {
+  return {
+    id,
+    from: "prospect@example.com",
+    subject: "Re: hi",
+    received_at: "2026-08-25T10:00:00.000Z",
+    body: "hello",
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("triageEmails category validation (issue #558)", () => {
+  it("passes through a valid category unchanged", async () => {
+    completeMock.mockResolvedValue({
+      content: JSON.stringify([
+        { id: "e1", category: "interested", next_step: "reply", reasoning: "" },
+      ]),
+    });
+    const [triaged] = await triageEmails([inbound("e1")]);
+    expect(triaged?.category).toBe("interested");
+  });
+
+  it("falls back to 'other' when the model returns a malformed/hallucinated category", async () => {
+    completeMock.mockResolvedValue({
+      content: JSON.stringify([
+        { id: "e1", category: "definitely_positive_vibes", next_step: "reply", reasoning: "" },
+      ]),
+    });
+    const [triaged] = await triageEmails([inbound("e1")]);
+    // Never the raw hallucinated string — a `false-not-in-set` value must not
+    // leak through and read as positive intent (replyIntentIsPositive treats
+    // any unrecognized string as positive, same as null).
+    expect(triaged?.category).toBe("other");
+  });
+
+  it("falls back to 'other' when the model omits category entirely", async () => {
+    completeMock.mockResolvedValue({
+      content: JSON.stringify([{ id: "e1", next_step: "reply", reasoning: "" }]),
+    });
+    const [triaged] = await triageEmails([inbound("e1")]);
+    expect(triaged?.category).toBe("other");
+  });
+});

--- a/packages/intel/src/triage.ts
+++ b/packages/intel/src/triage.ts
@@ -12,6 +12,21 @@ export type TriageCategory =
   | "auto_reply"
   | "other";
 
+/** The exact `TriageCategory` values — the runtime source of truth `triageEmails`
+ *  validates the model's output against, so a hallucinated/malformed category can
+ *  never reach the ledger and silently read as positive intent (issue #558:
+ *  `replyIntentIsPositive` treats any unrecognized string as positive). */
+const TRIAGE_CATEGORIES: ReadonlySet<string> = new Set<TriageCategory>([
+  "interested",
+  "not_now",
+  "wrong_person",
+  "objection",
+  "question",
+  "unsubscribe",
+  "auto_reply",
+  "other",
+]);
+
 export interface TriagedReply {
   id: string;
   from: string;
@@ -76,13 +91,16 @@ export async function triageEmails(emails: InboxEmail[]): Promise<TriagedReply[]
     const id = String(r["id"] ?? "");
     const src = byId.get(id);
     if (!src) return [];
-    const category = String(r["category"] ?? "other") as TriageCategory;
+    const category = String(r["category"] ?? "other");
+    const validCategory: TriageCategory = TRIAGE_CATEGORIES.has(category)
+      ? (category as TriageCategory)
+      : "other";
     return [
       {
         id,
         from: src.from,
         subject: src.subject,
-        category,
+        category: validCategory,
         nextStep: String(r["next_step"] ?? "manual_review"),
         draftedReply: String(r["drafted_reply"] ?? "").trim(),
         reasoning: String(r["reasoning"] ?? "").trim(),

--- a/packages/plays/__tests__/cadence-reply.test.ts
+++ b/packages/plays/__tests__/cadence-reply.test.ts
@@ -154,7 +154,8 @@ vi.mock("@oneshot-gtm/core", async () => {
         const out = new Map<string, { intent: string | null; intentReason: string | null }>();
         for (const id of ids) {
           const v = intents.get(id);
-          if (v) out.set(id, v);
+          // Same contract as the real reader: the pending claim reads as NULL.
+          if (v) out.set(id, v.intent === "__triage_pending__" ? { ...v, intent: null } : v);
         }
         return out;
       },

--- a/packages/plays/__tests__/cadence-reply.test.ts
+++ b/packages/plays/__tests__/cadence-reply.test.ts
@@ -25,6 +25,10 @@ let latestSentPlay: string | null = null;
 let persistedReplies: Array<{ id: string; kind?: string | null }> = [];
 // Audit-trail sequence events recorded outside recordProspectReply (bounced/unsubscribed).
 let seqEvents: Array<{ prospectId: number; playName: string; status: string }> = [];
+// Persisted intent classifications (issue #558): keyed by reply id, mirrors
+// the real ledger's inbox_replies.intent column that setInboxReplyIntent
+// writes and listInboxReplyIntents reads back.
+let intents: Map<string, { intent: string | null; intentReason: string | null }> = new Map();
 // Persisted poll_state rows (watermark + backlog), as the real ledger holds them.
 let pollState: Record<string, string> = {};
 const watermarkOf = () => pollState["inbox_replies"] ?? null;
@@ -146,13 +150,38 @@ vi.mock("@oneshot-gtm/core", async () => {
       setPollWatermark: (key: string, value: string) => {
         pollState[key] = value;
       },
+      listInboxReplyIntents: (ids: string[]) => {
+        const out = new Map<string, { intent: string | null; intentReason: string | null }>();
+        for (const id of ids) {
+          const v = intents.get(id);
+          if (v) out.set(id, v);
+        }
+        return out;
+      },
+      setInboxReplyIntent: (id: string, intent: string | null, intentReason: string | null) => {
+        intents.set(id, { intent, intentReason });
+      },
+      // issue #558 round-1 correction: mirrors the real ledger's
+      // `UPDATE ... WHERE intent IS NULL` atomic claim — check-and-mark in
+      // one step so an overlapping poll racing the same row can't also
+      // claim it. Returns true (claim won) only when intent isn't already
+      // set (NULL or unset); the mock doesn't need real concurrency since a
+      // single test only ever calls this synchronously in sequence, but the
+      // semantics (claim fails once intent is non-null) must match.
+      claimInboxReplyForTriage: (id: string) => {
+        const cur = intents.get(id);
+        if (cur && cur.intent != null) return false;
+        intents.set(id, { intent: "__triage_pending__", intentReason: cur?.intentReason ?? null });
+        return true;
+      },
     }),
   };
 });
 
-// Round-1 correction (#480): recordInboxReply's return value (new-row vs.
-// already-seen) gates the paid triageEmails call — mocked here so the dedupe
-// test below can assert call counts/args without hitting a real LLM.
+// Round-1 correction (#558): claimInboxReplyForTriage's atomic
+// check-and-mark on `intent` gates the paid triageEmails call — mocked here
+// so the dedupe test below can assert call counts/args without hitting a
+// real LLM.
 const triageEmailsMock = vi.fn(async (emails: Array<{ id: string }>) =>
   emails.map((e) => ({
     id: e.id,
@@ -178,6 +207,7 @@ beforeEach(() => {
   repliedSteps = [];
   persistedReplies = [];
   seqEvents = [];
+  intents = new Map();
   triageEmailsMock.mockClear();
   // The fixture cadence is also the latest play that emailed the prospect.
   latestSentPlay = "stack-consolidation";
@@ -345,6 +375,47 @@ describe("pollInboxReplies — standalone background detection (no sends)", () =
     // recordInboxReply reports it as not-new (INSERT OR IGNORE no-op), so the
     // triage call must be skipped this time.
     await pollInboxReplies();
+    expect(triageEmailsMock).toHaveBeenCalledTimes(1);
+  });
+
+  // Round-1 correction (#558): two overlapping pollInboxReplies() calls
+  // (realistically: the server's background scheduler tick and a manually-run
+  // `cadence advance` CLI invocation) both observe the same freshly-inserted
+  // row with intent still NULL while the first call's triageEmails() await is
+  // in flight. The atomic claim (claimInboxReplyForTriage) must let only one
+  // of them actually call the paid triageEmails — a bare re-check of `intent`
+  // would let both through since neither has written back yet.
+  it("does not double-triage the same reply across two overlapping polls", async () => {
+    inboxEmails = [{ id: "m1", from: "sophia@agenticarchitect.ai", subject: "re: stack" }];
+    // Simulate the first poll's triage call being slow (still in flight)
+    // when the second, overlapping poll starts.
+    let resolveFirst: (() => void) | null = null;
+    triageEmailsMock.mockImplementationOnce(
+      (emails: Array<{ id: string }>) =>
+        new Promise((resolve) => {
+          resolveFirst = (): void =>
+            resolve(
+              emails.map((e) => ({
+                id: e.id,
+                from: "x",
+                subject: "x",
+                category: "interested" as const,
+                reasoning: "r",
+              })),
+            );
+        }),
+    );
+
+    const firstPoll = pollInboxReplies();
+    // Give the first poll's synchronous prelude (recordInboxReply, the claim)
+    // a turn to run before starting the second, overlapping poll.
+    await Promise.resolve();
+    await Promise.resolve();
+    const secondPoll = pollInboxReplies();
+
+    (resolveFirst as (() => void) | null)?.();
+    await Promise.all([firstPoll, secondPoll]);
+
     expect(triageEmailsMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/plays/__tests__/reply-commits-terms.test.ts
+++ b/packages/plays/__tests__/reply-commits-terms.test.ts
@@ -98,6 +98,38 @@ describe("bodyCommitsTerms (issue #480)", () => {
   it("does not fire on small talk about hiring", () => {
     expect(bodyCommitsTerms("How is your hiring going this quarter?")).toBe(false);
   });
+
+  // Round-3 correction (#480/#558): NEGATION_CUE matched anywhere in the
+  // sentence, so a trailing hedge unrelated to the commitment cleared the
+  // gate — reviewer-reproduced false negative from PR #556.
+  it("still fires when an unrelated negation trails the commitment in the same sentence", () => {
+    expect(bodyCommitsTerms("Sure, I can do a 20% discount, no problem.")).toBe(true);
+  });
+
+  it("does not fire when the negation applies to the same clause as the commitment", () => {
+    expect(bodyCommitsTerms("We don't offer discounts right now, sorry.")).toBe(false);
+  });
+
+  // Round-4 correction (#558): the round-3 fix anchored the clause's start at
+  // the nearest PRECEDING comma, so a negation separated from the matched
+  // keyword by a parenthetical aside (its own comma-delimited fragment)
+  // landed outside the checked span and this returned true — a real
+  // regression on a legitimate, explicit refusal main correctly clears.
+  it("does not fire when a negation is separated from the commitment by a parenthetical aside", () => {
+    expect(bodyCommitsTerms("We will not, under any circumstances, offer a discount.")).toBe(false);
+  });
+
+  // Round-2 correction (#558, this round): the round-1 fix scoped
+  // NEGATION_CUE to the leading clause (start of sentence through the next
+  // comma after the matched keyword), which incidentally fixed the
+  // parenthetical-aside case above but broke this one — a genuine refusal
+  // that legitimately follows the comma landed outside the checked clause
+  // and this returned true against main's correct false. Fixed by stripping
+  // only the specific "no problem"/"no worries" hedge idiom and checking
+  // NEGATION_CUE against the whole sentence again, like main.
+  it("still catches a refusal that follows a comma in the same sentence", () => {
+    expect(bodyCommitsTerms("We can review pricing, but cannot offer a discount.")).toBe(false);
+  });
 });
 
 describe("intentDirectiveBlock (issue #480)", () => {

--- a/packages/plays/src/_cadence.ts
+++ b/packages/plays/src/_cadence.ts
@@ -485,12 +485,12 @@ async function walkInboxWindow(
       // is the reply store. Every matched email, not just the first reply per
       // (prospect, play): later replies on a live thread must be kept too.
       // Same thread key convention as inboxThreadKey (thread_id, else id).
-      // recordInboxReply is INSERT OR IGNORE and reports whether THIS call
-      // inserted a new row — false means the overlap/backlog re-examination
-      // is looking at a row a prior poll already recorded (and, for `human`
-      // mail, already triaged), so the paid triageEmails call below must be
-      // skipped for it rather than re-billed and re-classified every poll.
-      const isNewReply = ledger.recordInboxReply({
+      // recordInboxReply is INSERT OR IGNORE — an idempotent re-sweep is a
+      // no-op on a row a prior poll already recorded. Whether THIS call
+      // inserted a new row no longer gates triage (round-1 correction,
+      // #558): see claimInboxReplyForTriage below for why the atomic claim
+      // on `intent` replaced it.
+      ledger.recordInboxReply({
         id: e.id,
         threadKey: e.thread_id ?? e.id,
         prospectId: prospect.id,
@@ -533,18 +533,35 @@ async function walkInboxWindow(
       // sentiment). Best-effort and non-blocking, like the neighbouring
       // tagOutcomeValue call below: a triage failure logs and leaves
       // `intent` NULL, it never loses the reply itself (already persisted
-      // above). Skipped when this row was already recorded by a prior poll
-      // (`isNewReply` false) — the 1h overlap window and the backlog drain
-      // both deliberately re-walk mail the ledger has already seen, and
-      // re-triaging it would re-bill the paid LLM call and clobber an
-      // already-set intent for no reason.
-      if (isNewReply) {
+      // above). `isNewReply` alone used to gate this and skipped rows the
+      // /inbox route's opportunistic capture had already inserted (issue
+      // #558) — those are real new replies from this poll's perspective but
+      // arrive here with isNewReply === false, so they were silently never
+      // triaged.
+      //
+      // Round-1 correction (#558): a bare re-check of the persisted `intent`
+      // column ("skip only when this row already carries a classification")
+      // is not atomic — two overlapping pollInboxReplies() calls (the
+      // server's background scheduler tick and a manually-run `cadence
+      // advance` CLI invocation both call it) can both observe the same
+      // freshly-inserted row with intent still NULL while the first call's
+      // triageEmails() await is in flight, so the second call re-triggers
+      // the paid triage call and races the write-back. claimInboxReplyForTriage
+      // does the check-and-mark in one UPDATE ... WHERE intent IS NULL
+      // statement, so only one caller's claim can succeed for a given row;
+      // the loser skips triage entirely this poll. The winner releases the
+      // claim (resets intent back to NULL) on any failure so a later poll
+      // can retry — the pending marker itself is never a real category.
+      if (ledger.claimInboxReplyForTriage(e.id)) {
         try {
           const [triaged] = await triageEmails([e]);
           if (triaged) {
             ledger.setInboxReplyIntent(e.id, triaged.category, triaged.reasoning || null);
+          } else {
+            ledger.setInboxReplyIntent(e.id, null, null);
           }
         } catch (err) {
+          ledger.setInboxReplyIntent(e.id, null, null);
           logEvent(
             "inbox.reply.triage_failed",
             { message_120: ((err as Error)?.message ?? "").slice(0, 120) },

--- a/packages/plays/src/reply.ts
+++ b/packages/plays/src/reply.ts
@@ -140,6 +140,16 @@ const COMMITS_TERMS_PATTERNS: CommitPattern[] = [
 const NEGATION_CUE = /\b(?:not|no|never|nobody|nothing|unable|cannot)\b|n['’]t\b/i;
 
 /**
+ * Trailing hedge idioms that use the word "no" without negating anything —
+ * "no problem" / "no worries" acknowledge a commitment just made, they don't
+ * retract it. Stripped before the negation check so `bodyCommitsTerms` can
+ * check the whole sentence for real negations (round-2 correction, #558)
+ * instead of a hand-rolled clause boundary that both let this idiom through
+ * AND cut off genuine refusals elsewhere in the same sentence (see below).
+ */
+const TRAILING_HEDGE = /,?\s*no (?:problem|worries|issue|big deal)\b[.!?]?/gi;
+
+/**
  * A sentence that affirmatively offers or agrees to something. Includes
  * "plan(ning) to" / "aim to" (round-2 correction, #480) so a founder stating a
  * roadmap intent ("we're planning to ship SSO by Q1") still counts as a
@@ -168,13 +178,35 @@ function splitSentences(text: string): string[] {
     .filter(Boolean);
 }
 
-/** True when the body makes (or looks like it's making) a commitment the founder never authorised. */
+/**
+ * True when the body makes (or looks like it's making) a commitment the
+ * founder never authorised. `NEGATION_CUE` is checked against the WHOLE
+ * sentence — matching main's original behaviour — after stripping
+ * `TRAILING_HEDGE` idioms ("no problem"/"no worries"/etc), which use "no"
+ * without negating anything.
+ *
+ * Round-3 correction (#480/#558) tried to fix "Sure, I can do a 20%
+ * discount, no problem." (should stay `true`) by scoping the negation check
+ * to the leading clause up to the next comma. Round-4 correction (#558) then
+ * had to special-case the clause boundary again for a parenthetical aside
+ * ("We will not, under any circumstances, offer a discount." — the
+ * comma-delimited clause split "not" from "discount" and flipped this to
+ * `true`). Round-2 correction (#558, THIS round): the clause-scoping
+ * approach itself is unsound — ANY clause boundary drawn on commas cuts off
+ * a genuine refusal that legitimately follows a comma in the same sentence
+ * ("We can review pricing, but cannot offer a discount." regressed to
+ * `true` against main's `false`). Stripping the specific hedge idiom instead
+ * of truncating the sentence fixes the "no problem" false-negative without
+ * narrowing the negation check's scope at all, so it can go back to
+ * matching main: the whole sentence, no clause games.
+ */
 export function bodyCommitsTerms(body: string): boolean {
   const sentences = splitSentences(body);
   return COMMITS_TERMS_PATTERNS.some(({ regex, requireAffirmative }) =>
     sentences.some((sentence) => {
       if (!regex.test(sentence)) return false;
-      if (NEGATION_CUE.test(sentence)) return false;
+      const negationCheckText = sentence.replace(TRAILING_HEDGE, "");
+      if (NEGATION_CUE.test(negationCheckText)) return false;
       if (requireAffirmative && (QUESTION_CUE.test(sentence) || !AFFIRMATIVE_CUE.test(sentence))) {
         return false;
       }


### PR DESCRIPTION
## What

The six shipped review findings from PR #556 (#558), plus the two deferred findings filed against the agent's attempt (#559). The loop's PR #560 for #558 had reached its correction cap and then went `CONFLICTING` after #563; its branch is the loop's, so this redoes the work on a fresh branch from current `main` — the diff is #560's, applied cleanly, with the #559 gaps closed on top.

Closes #558. Closes #559. Supersedes #560.

## Findings, verified against `main` first

1. **`intel backfill-intent --limit=-1` reaches SQLite as an unlimited `LIMIT -1`** — real; the option now rejects anything but a non-negative integer.
2. **`steerRoute` skips seeding when only sent history exists** — real; seeds on `draftBody == null && steer == null`, not on a missing thread entry.
3. **`logOutcome` leaves the shared `["inbox"]` query stale** — real; invalidated on success so the header count and nav dot move at once.
4. **Replies captured by `/inbox` before the poll were never classified** — real; triage is gated by an atomic `claimInboxReplyForTriage` (`UPDATE … WHERE intent IS NULL`) instead of `isNewReply`, so a row inserted by the opportunistic capture is still triaged by the next poll, and two overlapping polls cannot both pay for the same row.
5. **`triageEmails` persisted whatever category the model returned** — real; validated against the `TriageCategory` set, unknown values fall back to `other` (previously an unknown string read as *positive* intent).
6. **`bodyCommitsTerms` cleared on any negation in the sentence** — real; the "no problem / no worries" hedge idiom is stripped before the whole-sentence negation check, which keeps the four regression phrasings (`… 20% discount, no problem.` → true; `We will not, under any circumstances, offer a discount.` → false; `We can review pricing, but cannot offer a discount.` → false) all correct.

From #559:
- **`intel backfill-intent` bypassed the claim** — it now takes the same claim per row, skips rows the live poll holds ("N already being triaged"), and releases the claim on a failed batch. Test: a row claimed by the poll is not sent to triage and stays claimed.
- **The `__triage_pending__` sentinel leaked into the `intent` column's `ReplyIntent | null` contract** — every reader (`listInboxReplyIntents`, `listInboxRepliesForProspect`) now reports `null` for it; the row stays unclaimable and out of `listUntriagedHumanReplies`. A cold-boot sweep (`sweepStaleInboxReplyTriage`, wired in `bin.ts` like the other sweeps) resets a claim stranded by a crash.

## Verify

| Check | Result |
|---|---|
| `bun run test` | 255 files, 3,323 tests pass |
| typecheck / lint / fmt | clean, 36 warnings (baseline) |

STATUS.md and README counts updated in this PR.

https://claude.ai/code/session_01RaGFRjZeREgB7Fg5hboxsx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate inbox-reply triage during overlapping polls or command runs.
  - Added recovery for interrupted triage after server restarts, enabling replies to be retried.
  - Improved detection of commitment refusals in varied wording and sentence structures.
  - Invalid or missing triage categories now safely fall back to “other.”
  - Inbox updates now appear immediately after recording an outcome.
  - Improved validation for the backfill command’s limit option.

- **Documentation**
  - Updated reported test-suite totals and verification metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->