### PR TITLE
fix: issue #356: feat(plays): wire per-prospect angle into reply, cadence, and outbound drafts

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -76,6 +76,17 @@ GITHUB_TOKEN-authed) and `GitHubUserInfo` now carries account-maturity fields (`
 of the same shape, the six-lookups-by-hand problem this issue exists to close. No drafting changes;
 reading the angle into drafts is #356.
 
+Per-prospect angle, Phase 2 (#356): the three draft paths now read `prospects.angle_json`.
+`angleBlockFromJson` (`packages/core/src/angle.ts`) renders a stored angle into an ANGLE block —
+`hook` to lead with, `doNotSay` (binding — a prompt rule now forbids restating any of it) plus
+`evidence`/`nextStep` when present; null/blank/unparsable JSON returns null, so a prospect with no
+synthesis yet sees byte-identical output. Wired into `buildFollowUpEmail` (`_cadence.ts`, the
+biggest win — cadence follow-ups previously read only config + name/email/company + prior bodies),
+`draftInboxReply` (`reply.ts`, threaded through `gatherReplyContext`/`_reply-research.ts` and
+`inbox.ts`'s two draft routes — free, since it rides the same prospect row the dossier tier already
+reads), and `runEmailPlay`'s `buildInputBlock` assembly (`_run-play.ts`, lowest priority — most
+outbound is first-touch with no angle yet, but a re-contact can have one).
+
 Updated by hand after each dogfood run.
 
 ---

--- a/apps/server/__tests__/inbox-route.test.ts
+++ b/apps/server/__tests__/inbox-route.test.ts
@@ -17,6 +17,10 @@ const recordInboxReplyMock = vi.fn(() => true);
 const getProspectByIdMock = vi.fn((): unknown => null);
 const listInboxReplyIntentsMock = vi.fn(() => new Map());
 const listLatestOutcomeRecordedAtByProspectMock = vi.fn((): Map<number, string> => new Map());
+// null by default (unmatched sender); tests override with mockReturnValueOnce
+// to exercise the matched-prospect path (angle preservation, cadence rank).
+const getProspectByEmailMock = vi.fn((): unknown => null);
+const listCadencesForProspectMock = vi.fn((): unknown[] => []);
 let knownProspect: { id: number } | null = null;
 
 const ledger = {
@@ -33,7 +37,8 @@ const ledger = {
   listSequenceEventsForProspect: listSequenceEventsForProspectMock,
   recordInboxReply: recordInboxReplyMock,
   getProspectById: getProspectByIdMock,
-  getProspectByEmail: () => null,
+  getProspectByEmail: getProspectByEmailMock,
+  listCadencesForProspect: listCadencesForProspectMock,
   findProspectByEmail: () => knownProspect,
   recordProspectReply: recordProspectReplyMock,
   // issue #480: sentiment/intent, bulk-read for the list route's badge.
@@ -447,6 +452,25 @@ describe("inbox route — research-grounded drafting", () => {
       expect.objectContaining({ dossier: null, threadSent: [] }),
     );
   });
+
+  it("preserves the matched prospect's angle_json when research throws (finding PRRT_kwDOSKzrBs6gZ7Qs)", async () => {
+    getProspectByEmailMock.mockReturnValueOnce({
+      id: 9,
+      name: "Ada",
+      company: "Acme",
+      source: "cold",
+      angle_json: '{"hook":"already synthesized"}',
+    });
+    listCadencesForProspectMock.mockReturnValueOnce([]);
+    gatherReplyContextMock.mockRejectedValue(new Error("research exploded"));
+    const res = await draftReplyRoute(
+      post("/api/inbox/draft-reply", { fromEmail: "ada@acme.com", subject: "s", body: "hi" }),
+    );
+    expect(res.status).toBe(200);
+    expect(draftInboxReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ dossier: null, angleJson: '{"hook":"already synthesized"}' }),
+    );
+  });
 });
 
 describe("steerRoute — persists the generated redraft (round-1 correction, #480)", () => {
@@ -500,6 +524,33 @@ describe("steerRoute — persists the generated redraft (round-1 correction, #48
       "t1",
       "20% discount, deal",
       "needs_decision",
+    );
+  });
+
+  it("preserves the matched prospect's angle_json when research throws (finding PRRT_kwDOSKzrBs6gZ7Qs)", async () => {
+    getProspectByEmailMock.mockReturnValueOnce({
+      id: 10,
+      name: "Ada",
+      company: "Acme",
+      source: "cold",
+      angle_json: '{"hook":"steer path angle"}',
+    });
+    listCadencesForProspectMock.mockReturnValueOnce([]);
+    gatherReplyContextMock.mockRejectedValue(new Error("research exploded"));
+    draftInboxReplyMock.mockResolvedValue({ body: "the redraft", flags: [] });
+    const res = await steerRoute(
+      post("/api/inbox/steer", {
+        fromEmail: "ada@acme.com",
+        subject: "Re: hi",
+        body: "their message",
+        id: "e1",
+        threadKey: "t1",
+        steer: "mention pricing is public",
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(draftInboxReplyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ dossier: null, angleJson: '{"hook":"steer path angle"}' }),
     );
   });
 });

--- a/apps/server/__tests__/reply-research.test.ts
+++ b/apps/server/__tests__/reply-research.test.ts
@@ -65,6 +65,37 @@ describe("gatherReplyContext", () => {
     expect(webReadMock).not.toHaveBeenCalled();
   });
 
+  it("surfaces the prospect's angle_json verbatim, for free, alongside the dossier (issue #356)", async () => {
+    ledger.getProspectById.mockReturnValue({
+      dossier_json: '{"title":"CTO"}',
+      angle_json: '{"hook":"shipped x402 support"}',
+    });
+    const ctx = await gatherReplyContext({
+      fromEmail: "aladdin@aliyev.site",
+      prospectId: 7,
+      threadKey: null,
+    });
+    expect(ctx.angleJson).toBe('{"hook":"shipped x402 support"}');
+    expect(ctx.costUsd).toBe(0);
+  });
+
+  it("angleJson is null when the prospect has none, or there is no prospect", async () => {
+    ledger.getProspectById.mockReturnValue({ dossier_json: '{"title":"CTO"}', angle_json: null });
+    const withProspect = await gatherReplyContext({
+      fromEmail: "aladdin@aliyev.site",
+      prospectId: 7,
+      threadKey: null,
+    });
+    expect(withProspect.angleJson).toBeNull();
+
+    const withoutProspect = await gatherReplyContext({
+      fromEmail: "someone@gmail.com",
+      prospectId: null,
+      threadKey: null,
+    });
+    expect(withoutProspect.angleJson).toBeNull();
+  });
+
   it("researches an unknown sender on a real domain: enrich + site read, cost summed", async () => {
     const ctx = await gatherReplyContext({
       fromEmail: "aladdin@aliyev.site",

--- a/apps/server/src/api/_reply-research.ts
+++ b/apps/server/src/api/_reply-research.ts
@@ -20,6 +20,11 @@ const WEBREAD_SLICE = 3500;
 export interface ReplyContext {
   /** Combined research text for the SENDER DOSSIER block; null = nothing known. */
   dossier: string | null;
+  /**
+   * The prospect's `angle_json` verbatim, when one exists (issue #355/#356).
+   * Free — read alongside the stored dossier, no extra research call.
+   */
+  angleJson: string | null;
   /** Replies the founder already sent in this thread (oldest first). */
   threadSent: Array<{ body: string; sentAt: string }>;
   /** The prospect's earlier inbound messages (persisted replies, oldest first) — the other half of the exchange. */
@@ -142,6 +147,7 @@ export async function gatherReplyContext(input: {
 
   return {
     dossier: parts.length > 0 ? parts.join("\n\n---\n\n") : null,
+    angleJson: prospect?.angle_json ?? null,
     threadSent,
     priorInbound,
     costUsd,

--- a/apps/server/src/api/inbox.ts
+++ b/apps/server/src/api/inbox.ts
@@ -445,9 +445,13 @@ export async function draftReplyRoute(req: Request): Promise<Response> {
 
   // Research before drafting: free tiers always, paid tier only for unknown
   // senders. Research failing must degrade the draft, never block it.
+  // angleJson still seeds from the matched prospect on this fallback path —
+  // it's a free ledger field, not part of what research produces, so a
+  // research failure must not also throw away a stored angle (finding
+  // PRRT_kwDOSKzrBs6gZ7Qs).
   let context: Awaited<ReturnType<typeof gatherReplyContext>> = {
     dossier: null,
-    angleJson: null,
+    angleJson: prospect?.angle_json ?? null,
     threadSent: [],
     priorInbound: [],
     costUsd: 0,
@@ -629,7 +633,7 @@ export async function steerRoute(req: Request): Promise<Response> {
 
   let context: Awaited<ReturnType<typeof gatherReplyContext>> = {
     dossier: null,
-    angleJson: null,
+    angleJson: prospect?.angle_json ?? null,
     threadSent: [],
     priorInbound: [],
     costUsd: 0,

--- a/apps/server/src/api/inbox.ts
+++ b/apps/server/src/api/inbox.ts
@@ -447,6 +447,7 @@ export async function draftReplyRoute(req: Request): Promise<Response> {
   // senders. Research failing must degrade the draft, never block it.
   let context: Awaited<ReturnType<typeof gatherReplyContext>> = {
     dossier: null,
+    angleJson: null,
     threadSent: [],
     priorInbound: [],
     costUsd: 0,
@@ -499,6 +500,7 @@ export async function draftReplyRoute(req: Request): Promise<Response> {
       body: inboundBody,
       matched,
       dossier: context.dossier,
+      angleJson: context.angleJson,
       threadSent: context.threadSent,
       priorInbound: context.priorInbound,
       intent,
@@ -627,6 +629,7 @@ export async function steerRoute(req: Request): Promise<Response> {
 
   let context: Awaited<ReturnType<typeof gatherReplyContext>> = {
     dossier: null,
+    angleJson: null,
     threadSent: [],
     priorInbound: [],
     costUsd: 0,
@@ -662,6 +665,7 @@ export async function steerRoute(req: Request): Promise<Response> {
       body: inboundBody,
       matched,
       dossier: context.dossier,
+      angleJson: context.angleJson,
       threadSent: context.threadSent,
       priorInbound: context.priorInbound,
       intent,

--- a/packages/core/__tests__/angle.test.ts
+++ b/packages/core/__tests__/angle.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { parseProspectAngle, type ProspectAngleGroundingContext } from "../src/angle.ts";
+import {
+  angleBlockFromJson,
+  parseProspectAngle,
+  type ProspectAngleGroundingContext,
+} from "../src/angle.ts";
 
 // Schema validation + the anti-fabrication gate for issue #355's per-prospect
 // angle. Every evidence claim without a real, TRACEABLE source must be
@@ -262,5 +266,100 @@ describe("parseProspectAngle", () => {
     expect(angle?.doNotSay).toEqual([]);
     expect(angle?.sources).toEqual([]);
     expect(angle?.evidence).toEqual([]);
+  });
+});
+
+// angleBlockFromJson — issue #356's guarded, read-only ANGLE block. Every
+// caller (cadence follow-up, reply, outbound) shares this renderer, so its
+// contract is tested once here rather than duplicated per call site.
+describe("angleBlockFromJson", () => {
+  it("returns null for null/undefined/blank input — the missing-angle case that must change nothing", () => {
+    expect(angleBlockFromJson(null)).toBeNull();
+    expect(angleBlockFromJson(undefined)).toBeNull();
+    expect(angleBlockFromJson("")).toBeNull();
+    expect(angleBlockFromJson("   ")).toBeNull();
+  });
+
+  it("returns null for unparsable JSON", () => {
+    expect(angleBlockFromJson("not json")).toBeNull();
+    expect(angleBlockFromJson("{broken")).toBeNull();
+  });
+
+  it("returns null for a non-object JSON value", () => {
+    expect(angleBlockFromJson("42")).toBeNull();
+    expect(angleBlockFromJson("null")).toBeNull();
+    expect(angleBlockFromJson("[]")).toBeNull();
+    expect(angleBlockFromJson('"a string"')).toBeNull();
+  });
+
+  it("returns null when every field is empty — an all-null shell must not render a block", () => {
+    expect(angleBlockFromJson(JSON.stringify({ hook: "", doNotSay: [], nextStep: "" }))).toBeNull();
+    expect(angleBlockFromJson(JSON.stringify({}))).toBeNull();
+  });
+
+  it("renders the Hook line when present", () => {
+    const block = angleBlockFromJson(JSON.stringify({ hook: "Shipped agent-loop v2 yesterday." }));
+    expect(block).toContain("ANGLE");
+    expect(block).toContain("Hook: Shipped agent-loop v2 yesterday.");
+  });
+
+  it("renders every doNotSay entry under a binding label", () => {
+    const block = angleBlockFromJson(
+      JSON.stringify({ doNotSay: ["not building this, just researching", "not the buyer"] }),
+    );
+    expect(block).toContain("Do NOT say");
+    expect(block).toContain("- not building this, just researching");
+    expect(block).toContain("- not the buyer");
+  });
+
+  it("renders nextStep and up to maxEvidence evidence entries", () => {
+    const block = angleBlockFromJson(
+      JSON.stringify({
+        hook: "h",
+        nextStep: "Ask about their eval pipeline.",
+        evidence: [
+          { claim: "Shipped agent-loop v2", source: "https://github.com/x/agent-loop" },
+          { claim: "Replied twice", source: "replies:2" },
+          { claim: "third", source: "dossier" },
+          { claim: "fourth, should be dropped by default cap", source: "github:live" },
+        ],
+      }),
+    );
+    expect(block).toContain("Next step: Ask about their eval pipeline.");
+    expect(block).toContain("Shipped agent-loop v2 (https://github.com/x/agent-loop)");
+    expect(block).toContain("Replied twice (replies:2)");
+    expect(block).toContain("third (dossier)");
+    expect(block).not.toContain("fourth, should be dropped");
+  });
+
+  it("drops an evidence entry missing a claim or source", () => {
+    const block = angleBlockFromJson(
+      JSON.stringify({
+        hook: "h",
+        evidence: [
+          { claim: "no source" },
+          { source: "no-claim" },
+          { claim: "ok", source: "dossier" },
+        ],
+      }),
+    );
+    expect(block).toContain("ok (dossier)");
+    expect(block).not.toContain("no source");
+    expect(block).not.toContain("no-claim");
+  });
+
+  it("respects a caller-supplied maxEvidence", () => {
+    const block = angleBlockFromJson(
+      JSON.stringify({
+        hook: "h",
+        evidence: [
+          { claim: "one", source: "dossier" },
+          { claim: "two", source: "dossier" },
+        ],
+      }),
+      { maxEvidence: 1 },
+    );
+    expect(block).toContain("one (dossier)");
+    expect(block).not.toContain("two (dossier)");
   });
 });

--- a/packages/core/src/angle.ts
+++ b/packages/core/src/angle.ts
@@ -223,3 +223,64 @@ export function parseProspectAngle(
     synthesizedAt: meta.synthesizedAt ?? new Date().toISOString(),
   };
 }
+
+/**
+ * Render a persisted `prospects.angle_json` value into an ANGLE input block
+ * for a draft prompt — issue #356, the payoff for #355's synthesis. `hook`
+ * is what the next message should lead with; `doNotSay` is what stops a
+ * draft re-asserting a premise the prospect already corrected — the
+ * strongest signal of the two, since repeating it reads as not having read
+ * their reply. `evidence`/`nextStep` are included when present because they
+ * cost nothing extra and a concrete citation beats a vague hook.
+ *
+ * Guarded and additive by design: missing, blank, unparsable, or
+ * all-empty-fields JSON returns null so callers can skip the block
+ * entirely — a prospect with no synthesis yet must see byte-identical
+ * output to before this issue.
+ */
+export function angleBlockFromJson(
+  raw: string | null | undefined,
+  opts: { maxEvidence?: number } = {},
+): string | null {
+  const trimmed = raw?.trim();
+  if (!trimmed) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    return null;
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) return null;
+  const a = parsed as Record<string, unknown>;
+
+  const hook = str(a["hook"]);
+  const doNotSay = strArray(a["doNotSay"]);
+  const nextStep = str(a["nextStep"]);
+  const rawEvidence = Array.isArray(a["evidence"]) ? (a["evidence"] as unknown[]) : [];
+  const evidence = rawEvidence
+    .map((e) => {
+      if (e === null || typeof e !== "object") return null;
+      const claim = str((e as Record<string, unknown>)["claim"]);
+      const source = str((e as Record<string, unknown>)["source"]);
+      return claim && source ? { claim, source } : null;
+    })
+    .filter((e): e is ProspectAngleEvidence => e !== null);
+
+  if (!hook && doNotSay.length === 0 && !nextStep && evidence.length === 0) return null;
+
+  const maxEvidence = opts.maxEvidence ?? 3;
+  const lines: string[] = [
+    "ANGLE (synthesized read on this prospect — a hook to lead with, and premises never to repeat):",
+  ];
+  if (hook) lines.push(`Hook: ${hook}`);
+  if (doNotSay.length > 0) {
+    lines.push("Do NOT say (they already corrected these in a reply — never repeat):");
+    for (const d of doNotSay) lines.push(`- ${d}`);
+  }
+  if (evidence.length > 0) {
+    lines.push("Evidence:");
+    for (const e of evidence.slice(0, maxEvidence)) lines.push(`- ${e.claim} (${e.source})`);
+  }
+  if (nextStep) lines.push(`Next step: ${nextStep}`);
+  return lines.join("\n");
+}

--- a/packages/plays/__tests__/cadence-prior-emails.test.ts
+++ b/packages/plays/__tests__/cadence-prior-emails.test.ts
@@ -73,7 +73,7 @@ let storedRows: Array<{
 
 const { buildFollowUpEmail, getPriorStepsForProspect } = await import("../src/_cadence.ts");
 
-function ctx(prospectId = 42) {
+function ctx(prospectId = 42, angleJson: string | null = null) {
   const prospect: ProspectRecord = {
     id: prospectId,
     name: "Sam",
@@ -81,6 +81,7 @@ function ctx(prospectId = 42) {
     company: "Acme",
     linkedin_url: null,
     dossier_json: null,
+    angle_json: angleJson,
     source: "test",
     created_at: new Date().toISOString(),
   } as ProspectRecord;
@@ -228,6 +229,52 @@ describe("buildFollowUpEmail — PRIOR EMAILS injection", () => {
     });
     await builder(ctx());
     expect(llmCalls[0]!.user).not.toContain("PRIOR EMAILS");
+  });
+});
+
+describe("buildFollowUpEmail — ANGLE injection (issue #356)", () => {
+  it("omits the ANGLE block when the prospect has no angle_json", async () => {
+    storedRows = [];
+    const builder = buildFollowUpEmail({
+      playName: "stack-consolidation",
+      promptName: "stack-consolidation-followup",
+      contextLines: [],
+    });
+    await builder(ctx(42, null));
+    expect(llmCalls[0]!.user).not.toContain("ANGLE");
+  });
+
+  it("omits the ANGLE block for blank/unparsable angle_json — must not throw", async () => {
+    storedRows = [];
+    const builder = buildFollowUpEmail({
+      playName: "stack-consolidation",
+      promptName: "stack-consolidation-followup",
+      contextLines: [],
+    });
+    await builder(ctx(42, "  "));
+    expect(llmCalls[0]!.user).not.toContain("ANGLE");
+    llmCalls.length = 0;
+    await builder(ctx(42, "not json"));
+    expect(llmCalls[0]!.user).not.toContain("ANGLE");
+  });
+
+  it("injects hook and doNotSay from angle_json into the user block", async () => {
+    storedRows = [];
+    const builder = buildFollowUpEmail({
+      playName: "stack-consolidation",
+      promptName: "stack-consolidation-followup",
+      contextLines: [],
+    });
+    const angle = JSON.stringify({
+      hook: "Shipped the v2 migration last week.",
+      doNotSay: ["not evaluating vendors right now"],
+    });
+    await builder(ctx(42, angle));
+    const userMsg = llmCalls[0]!.user;
+    expect(userMsg).toContain("ANGLE");
+    expect(userMsg).toContain("Hook: Shipped the v2 migration last week.");
+    expect(userMsg).toContain("Do NOT say");
+    expect(userMsg).toContain("not evaluating vendors right now");
   });
 });
 

--- a/packages/plays/__tests__/reply-draft-context.test.ts
+++ b/packages/plays/__tests__/reply-draft-context.test.ts
@@ -151,4 +151,39 @@ describe("draftInboxReply context assembly", () => {
     });
     expect(lastUserBlock()).not.toContain("ASKS ALREADY MADE");
   });
+
+  // ANGLE injection (issue #356) — the reply-path payoff for #355's synthesis.
+  // `doNotSay` matters most here: it's what stops a reply re-asserting a
+  // premise the prospect already corrected ("not sure what you mean" /
+  // "starred for research").
+  it("omits the ANGLE block when angleJson is absent", async () => {
+    await draftInboxReply(BASE);
+    expect(lastUserBlock()).not.toContain("ANGLE");
+  });
+
+  it("omits the ANGLE block for null angle_json — unchanged output (issue #356)", async () => {
+    await draftInboxReply({ ...BASE, angleJson: null });
+    expect(lastUserBlock()).not.toContain("ANGLE");
+  });
+
+  it("omits the ANGLE block for blank/unparsable angle_json — must not throw", async () => {
+    await draftInboxReply({ ...BASE, angleJson: "  " });
+    expect(lastUserBlock()).not.toContain("ANGLE");
+    await draftInboxReply({ ...BASE, angleJson: "not json" });
+    expect(lastUserBlock()).not.toContain("ANGLE");
+  });
+
+  it("injects hook and doNotSay from angle_json — doNotSay is what stops re-asserting a corrected premise", async () => {
+    const angle = JSON.stringify({
+      hook: "Just shipped x402 support.",
+      doNotSay: ["not sure what you mean by that", "this was starred for research only"],
+    });
+    await draftInboxReply({ ...BASE, angleJson: angle });
+    const block = lastUserBlock();
+    expect(block).toContain("ANGLE");
+    expect(block).toContain("Hook: Just shipped x402 support.");
+    expect(block).toContain("Do NOT say");
+    expect(block).toContain("not sure what you mean by that");
+    expect(block).toContain("this was starred for research only");
+  });
 });

--- a/packages/plays/src/_cadence.ts
+++ b/packages/plays/src/_cadence.ts
@@ -19,6 +19,7 @@ import {
   tagOutcomeValue,
   trackSend,
   voiceCall,
+  angleBlockFromJson,
   type BounceKind,
   type ProspectRecord,
   type CadencePlanStep,
@@ -1758,6 +1759,11 @@ export function buildFollowUpEmail(opts: {
     // than only rejecting them afterwards: a rejected draft costs another paid
     // completion, and the model cannot see the last 40 sends on its own.
     const avoidBlock = overusedOpenersBlock(ctx.prospect.id, opts.playName);
+    // Per-prospect angle (issue #356, payoff for #355's synthesis): the only
+    // signal a follow-up got before this was config + name/email/company +
+    // prior step bodies. Missing/empty angle_json → null → no block, byte-
+    // identical output to before this issue.
+    const angleBlock = angleBlockFromJson(ctx.prospect.angle_json);
     const user = [
       `FOUNDER: ${ctx.cfg.founderName}`,
       `PRODUCT: ${ctx.cfg.productOneLiner}`,
@@ -1766,6 +1772,7 @@ export function buildFollowUpEmail(opts: {
       `COMPANY: ${ctx.prospect.company ?? "(unknown)"}`,
       ...opts.contextLines,
       ...(priorBlock ? ["", priorBlock] : []),
+      ...(angleBlock ? ["", angleBlock] : []),
       ...(firstName ? ["", `PROSPECT_FIRST_NAME: ${firstName}`] : []),
       ...(avoidBlock ? ["", avoidBlock] : []),
     ].join("\n");

--- a/packages/plays/src/_run-play.ts
+++ b/packages/plays/src/_run-play.ts
@@ -11,6 +11,7 @@ import {
   throwIfCancelled,
   CONTACTED_ELSEWHERE_FLAG,
   recentTouchElsewhere,
+  angleBlockFromJson,
 } from "@oneshot-gtm/core";
 import {
   draftEmailFromPrompt,
@@ -246,6 +247,14 @@ export async function runEmailPlay<T, X = Record<string, never>>(
         // keep, which it can't).
         const admission = admissionBlock(def.toEmail(target));
         if (admission) inputBlock = `${inputBlock}\n\n${admission}`;
+        // ANGLE (issue #356, lowest priority of the three draft paths — most
+        // outbound is first-touch, so a stored angle_json is the exception,
+        // not the rule): only present when a prior finder/synthesis run
+        // already persisted one for this email, e.g. a re-contact. Missing →
+        // no lookup cost beyond the read, no block, unchanged output.
+        const existingAngle = getLedger().getProspectByEmail(def.toEmail(target))?.angle_json;
+        const angleBlock = angleBlockFromJson(existingAngle ?? null);
+        if (angleBlock) inputBlock = `${inputBlock}\n\n${angleBlock}`;
         // Surface a real first name when extractable so the prompt can
         // occasionally open with "Hey {firstName},". Absent → prompt rule
         // says never invent a greeting; LLM dives into the Hook.

--- a/packages/plays/src/_run-play.ts
+++ b/packages/plays/src/_run-play.ts
@@ -252,7 +252,15 @@ export async function runEmailPlay<T, X = Record<string, never>>(
         // not the rule): only present when a prior finder/synthesis run
         // already persisted one for this email, e.g. a re-contact. Missing →
         // no lookup cost beyond the read, no block, unchanged output.
-        const existingAngle = getLedger().getProspectByEmail(def.toEmail(target))?.angle_json;
+        // Uses findProspectByEmail + getProspectById (not getProspectByEmail)
+        // deliberately: both are already the lookup pair every play's
+        // sendDraftedEmail call relies on, so every existing ledger test
+        // double already implements them — no test churn to add this read.
+        const existingProspectId = getLedger().findProspectByEmail(def.toEmail(target))?.id;
+        const existingAngle =
+          existingProspectId != null
+            ? getLedger().getProspectById(existingProspectId)?.angle_json
+            : null;
         const angleBlock = angleBlockFromJson(existingAngle ?? null);
         if (angleBlock) inputBlock = `${inputBlock}\n\n${angleBlock}`;
         // Surface a real first name when extractable so the prompt can

--- a/packages/plays/src/reply.ts
+++ b/packages/plays/src/reply.ts
@@ -1,4 +1,4 @@
-import { loadConfig, stripQuotedChain } from "@oneshot-gtm/core";
+import { loadConfig, stripQuotedChain, angleBlockFromJson } from "@oneshot-gtm/core";
 import { complete, type LlmMessage, loadPrompt, tryParseJsonObject } from "@oneshot-gtm/intel";
 import { getPriorStepsForProspect, type PriorStepRow } from "./_cadence.ts";
 import {
@@ -301,6 +301,14 @@ export interface DraftInboxReplyInput {
    * technical message with substance instead of curiosity questions.
    */
   dossier?: string | null;
+  /**
+   * Synthesized per-prospect angle JSON (issue #355), verbatim from
+   * `prospects.angle_json`. Threaded through so the ANGLE block's
+   * `doNotSay` can stop a reply re-asserting a premise the prospect already
+   * corrected — the "not sure what you mean" / "starred for research"
+   * cases. Missing/empty → no block, unchanged output (issue #356).
+   */
+  angleJson?: string | null;
   /** Replies the founder already sent in this thread (oldest first) — round 2+ must not repeat round 1. */
   threadSent?: Array<{ body: string; sentAt: string }>;
   /** The prospect's earlier inbound messages (oldest first) — the other half of the exchange. */
@@ -400,6 +408,7 @@ export async function draftInboxReply(input: DraftInboxReplyInput): Promise<Draf
   // and portfolio lines only render as a self-introduction, which the prospect
   // already read in the intro email. Social proof belongs in outbound drafts.
   const firstName = firstNameFrom(input.matched?.name ?? null);
+  const angleBlock = angleBlockFromJson(input.angleJson);
   const user = [
     `FOUNDER: ${cfg.founderName ?? "(unknown)"}`,
     `PRODUCT: ${cfg.productOneLiner ?? "(unknown)"}`,
@@ -414,6 +423,7 @@ export async function draftInboxReply(input: DraftInboxReplyInput): Promise<Draf
     ...(input.dossier?.trim()
       ? ["", `SENDER DOSSIER (research about who wrote this):\n${input.dossier.trim()}`]
       : []),
+    ...(angleBlock ? ["", angleBlock] : []),
     ...(priorBlock ? ["", priorBlock] : []),
     ...(priorInboundBlock ? ["", priorInboundBlock] : []),
     ...(threadBlock ? ["", threadBlock] : []),

--- a/packages/prompts/_humanizer-followup.md
+++ b/packages/prompts/_humanizer-followup.md
@@ -3,6 +3,7 @@
 You are continuing an existing conversation, not writing a first-touch email. The motion prompt controls the length, purpose and CTA.
 
 - Use the prior sent emails as factual context, never as a draft to rewrite. Do not repeat their hook, pitch, introduction or founder credentials.
+- When an ANGLE block is present: its Hook is good material for a specific, current opener; its "Do NOT say" list is binding — never restate one of those premises, in any phrasing, even if it would otherwise fit the shape below.
 - Preserve which facts belong to which person, company or project. Never transfer a prior claim to another repo or invent a new observation.
 - For a short ping, ask one brief question anchored to the original topic. Do not recap the email. For other follow-up steps, follow their specific instructions.
 - Write plainly, like a person. Avoid hype, jargon, capability lists, em dashes, fake quotations and unnecessary formatting.

--- a/packages/prompts/reply-email.md
+++ b/packages/prompts/reply-email.md
@@ -8,6 +8,7 @@ You are the founder, personally answering an email a prospect wrote back to you.
 - PROSPECT name / EMAIL / COMPANY (when known) and PLAY (which outreach sequence they came from)
 - PRODUCT BRIEF (optional): real facts about the product — architecture, pricing model — and the ONLY links you are allowed to cite
 - SENDER DOSSIER (optional): research about who wrote this — their company, what they've built, what their site says
+- ANGLE (optional): a synthesized read on this prospect — a Hook to lead with, and a "Do NOT say" list of premises they've already corrected in a prior reply. The Do NOT say list is binding: never restate one of those premises, even rephrased.
 - PRIOR EMAILS: what you already sent them (subject + body) — so you know what they're reacting to
 - THEIR EARLIER MESSAGES (optional): what the prospect already told you in this exchange — never re-ask any of it
 - THREAD — REPLIES YOU ALREADY SENT (optional): your earlier answers in this same conversation
@@ -22,6 +23,7 @@ You are the founder, personally answering an email a prospect wrote back to you.
 - If they asked a question: answer it directly in the first sentence or two, then stop. Don't append a pitch.
 - If they're interested: propose ONE concrete next step (a short call, a link, an answer) — not a menu.
 - Match the sender's depth. If they made a technical claim, described their architecture, or asked how something works, engage with its SUBSTANCE using PRODUCT BRIEF and SENDER DOSSIER — one concrete, specific point (name the mechanism, the protocol, the tradeoff) beats three generic ones. Never answer a technical message with only curiosity questions.
+- When ANGLE is present: never say anything in its "Do NOT say" list, in any phrasing — those are premises this prospect has already corrected. Its Hook, when it fits what they actually wrote, is good material for a specific, current opener or point.
 - Links: you may include at most ONE link, and only a URL that appears VERBATIM in PRODUCT BRIEF. Never construct, guess, or adapt a URL. No PRODUCT BRIEF = no links.
 - Length: MIRROR THEIRS. A one-line answer gets one or two sentences back (under 40 words) — acknowledging their answer and asking or offering ONE thing. 40-90 words only when they wrote substance; up to 130 only for a substantive technical message. 1-3 short paragraphs. It's a reply, not a letter.
 - A short answer to a question you asked is not an invitation to pitch. Take the answer, go one level deeper on THEIR pain, and stop. No "I built X to handle that" origin story mid-thread — mention the product only when they ask about it, in one sentence.


### PR DESCRIPTION
Closes #356.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 8179d2355e76 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (2 errs) vs base ok (2 errs)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Email drafts now use stored prospect insights across follow-up emails, inbox replies, and email plays.
  - Drafts may include a tailored hook, relevant evidence, next steps, and binding “Do NOT say” guidance.
  - Personalized context helps create more specific openers while avoiding previously corrected assumptions.

- **Bug Fixes**
  - Missing, blank, or invalid prospect insights are safely ignored, preserving previous drafting behavior without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->