### PR TITLE
fix: issue #569: Deferred review findings from ai/gtm/issue-355

### DIFF
--- a/packages/core/__tests__/angle.test.ts
+++ b/packages/core/__tests__/angle.test.ts
@@ -133,6 +133,28 @@ describe("parseProspectAngle", () => {
     expect(angle?.evidence).toEqual([{ claim: "has a dossier", source: "dossier" }]);
   });
 
+  it("keeps a 'dossier' citation when only 'dossier:live' was gathered — the prompt's own example cites the tier as 'dossier' either way (issue #569)", () => {
+    const liveOnly: ProspectAngleGroundingContext = {
+      evidenceText: "DOSSIER:\nfresh research payload",
+      sourceTags: ["dossier:live"],
+    };
+    const angle = parseProspectAngle(
+      { brief: "b", hook: "h", evidence: [{ claim: "has a dossier", source: "dossier" }] },
+      META,
+      liveOnly,
+    );
+    expect(angle?.evidence).toEqual([{ claim: "has a dossier", source: "dossier" }]);
+  });
+
+  it("still rejects 'dossier' when neither 'dossier' nor 'dossier:live' was gathered", () => {
+    const angle = parseProspectAngle(
+      { brief: "b", hook: "h", evidence: [{ claim: "has a dossier", source: "dossier" }] },
+      META,
+      UNGROUNDED,
+    );
+    expect(angle?.evidence).toEqual([]);
+  });
+
   it("returns null when both brief and hook are missing — nothing was actually synthesized", () => {
     expect(parseProspectAngle({ evidence: [] }, META, GROUNDED)).toBeNull();
     expect(parseProspectAngle({ brief: "", hook: "" }, META, GROUNDED)).toBeNull();
@@ -213,6 +235,15 @@ describe("parseProspectAngle", () => {
       GROUNDED,
     );
     expect(angle?.doNotSay).toEqual(["real"]);
+    expect(angle?.sources).toEqual(["dossier"]);
+  });
+
+  it("drops a top-level sources[] tier that was never actually gathered — a hallucinated tier name is not persisted as fact (issue #569)", () => {
+    const angle = parseProspectAngle(
+      { brief: "b", sources: ["dossier", "webread", "replies:3"] },
+      META,
+      GROUNDED, // sourceTags only has dossier/github:live — webread and replies:3 were never gathered
+    );
     expect(angle?.sources).toEqual(["dossier"]);
   });
 

--- a/packages/core/src/angle.ts
+++ b/packages/core/src/angle.ts
@@ -117,16 +117,33 @@ function strArray(v: unknown): string[] {
 const URL_SOURCE: RegExp = /^https?:\/\//i;
 
 /**
+ * Named-tier source aliases: a citation using the LEFT name is accepted when
+ * either it or its RIGHT alias is in `sourceTags`. Needed because the DOSSIER
+ * evidence block renders identically whether the dossier was already stored
+ * (`sources` tag `"dossier"`) or freshly bought this run (tag
+ * `"dossier:live"` — see `gatherAngleEvidence`), and the synthesis prompt's
+ * own literal example tells the model to cite it as `"dossier"` either way
+ * (packages/prompts/angle-synthesis.md:36). Without this, a legitimate
+ * `"dossier"` citation on a paid-research prospect was silently dropped by
+ * `isGroundedSource` even though the evidence really was gathered (issue
+ * #569 freshness audit).
+ */
+const NAMED_SOURCE_ALIASES: ReadonlyMap<string, string> = new Map([["dossier", "dossier:live"]]);
+
+/**
  * True when `source` is traceable to evidence the LLM was actually handed —
  * not merely a non-blank string. A URL-shaped source must appear literally in
  * the rendered evidence text (the GITHUB/DOSSIER/PROFILE PAGE blocks); a
  * named-tier source (`"dossier"`, `"replies:2"`, `"github:live"`) must match
- * one of the tiers `gatherAngleEvidence` actually recorded. Anything else —
- * a hallucinated URL, an invented tier name, "trust me" — is NOT grounded.
+ * one of the tiers `gatherAngleEvidence` actually recorded, or that tier's
+ * alias (see `NAMED_SOURCE_ALIASES`). Anything else — a hallucinated URL, an
+ * invented tier name, "trust me" — is NOT grounded.
  */
 function isGroundedSource(source: string, grounding: ProspectAngleGroundingContext): boolean {
   if (URL_SOURCE.test(source)) return grounding.evidenceText.includes(source);
-  return grounding.sourceTags.includes(source);
+  if (grounding.sourceTags.includes(source)) return true;
+  const alias = NAMED_SOURCE_ALIASES.get(source);
+  return alias !== undefined && grounding.sourceTags.includes(alias);
 }
 
 /**
@@ -198,7 +215,7 @@ export function parseProspectAngle(
     evidence,
     doNotSay: strArray(r["doNotSay"]),
     nextStep: str(r["nextStep"]) ?? "",
-    sources: strArray(r["sources"]),
+    sources: strArray(r["sources"]).filter((s) => isGroundedSource(s, grounding)),
     valueMode,
     buyerStage,
     qualification: str(r["qualification"]) ?? "",

--- a/packages/find/__tests__/angle.test.ts
+++ b/packages/find/__tests__/angle.test.ts
@@ -223,6 +223,7 @@ describe("gatherAngleEvidence", () => {
     const out = await gatherAngleEvidence(1);
     expect(webReadCalls).toEqual(["https://x.com/pat"]);
     expect(out?.webReadText).toContain("Pat's X profile bio");
+    expect(out?.webReadUrl).toBe("https://x.com/pat");
     expect(out?.webReadResearched).toBe(true);
     expect(out?.sources).toContain("webread");
   });
@@ -346,6 +347,7 @@ describe("synthesizePersonAngle", () => {
         queueSignal: null,
         github: null,
         webReadText: null,
+        webReadUrl: null,
         webReadResearched: false,
         replies: [],
         costUsd: 0,
@@ -382,6 +384,7 @@ describe("synthesizePersonAngle", () => {
         queueSignal: null,
         github: null,
         webReadText: null,
+        webReadUrl: null,
         webReadResearched: false,
         replies: [],
         costUsd: 0,
@@ -403,6 +406,7 @@ describe("synthesizePersonAngle", () => {
         queueSignal: null,
         github: null,
         webReadText: null,
+        webReadUrl: null,
         webReadResearched: false,
         replies: [],
         costUsd: 0,
@@ -421,6 +425,7 @@ describe("synthesizePersonAngle", () => {
         queueSignal: null,
         github: null,
         webReadText: null,
+        webReadUrl: null,
         webReadResearched: false,
         replies: [],
         costUsd: 0,
@@ -431,6 +436,59 @@ describe("synthesizePersonAngle", () => {
     expect(llmCalls[0]!.user).toContain("FOUNDER: Founder");
     expect(llmCalls[0]!.user).toContain("PRODUCT: TestProduct");
     expect(llmCalls[0]!.user).toContain("some dossier text");
+  });
+
+  it("renders the webRead URL alongside the PROFILE PAGE text so a citation of it can ground (issue #569)", async () => {
+    await synthesizePersonAngle({
+      prospect: { id: 1, name: "Pat", company: null, email: null },
+      evidence: {
+        dossierText: null,
+        dossierResearched: false,
+        queueSignal: null,
+        github: null,
+        webReadText: "Pat's bio, no URL repeated in the markdown itself",
+        webReadUrl: "https://x.com/pat",
+        webReadResearched: true,
+        replies: [],
+        costUsd: 0,
+        sources: ["webread"],
+      },
+    });
+    expect(llmCalls).toHaveLength(1);
+    expect(llmCalls[0]!.user).toContain("PROFILE PAGE (https://x.com/pat):");
+    expect(llmCalls[0]!.user).toContain("https://x.com/pat");
+  });
+
+  it("renders actual follow-network logins, not just counts, so a colleague citation is possible (issue #569)", async () => {
+    await synthesizePersonAngle({
+      prospect: { id: 1, name: "Pat", company: null, email: null },
+      evidence: {
+        dossierText: null,
+        dossierResearched: false,
+        queueSignal: null,
+        github: {
+          login: "ada",
+          profile: null,
+          topRepos: null,
+          orgs: null,
+          linkedOrg: null,
+          network: {
+            following: [{ login: "grace" }, { login: "linus" }],
+            followers: [{ login: "margaret" }],
+          },
+        },
+        webReadText: null,
+        webReadUrl: null,
+        webReadResearched: false,
+        replies: [],
+        costUsd: 0,
+        sources: ["github:live"],
+      },
+    });
+    expect(llmCalls).toHaveLength(1);
+    expect(llmCalls[0]!.user).toContain("grace");
+    expect(llmCalls[0]!.user).toContain("linus");
+    expect(llmCalls[0]!.user).toContain("margaret");
   });
 
   it("drops an evidence entry whose source is a hallucinated citation, end to end", async () => {
@@ -453,6 +511,7 @@ describe("synthesizePersonAngle", () => {
         queueSignal: null,
         github: null,
         webReadText: null,
+        webReadUrl: null,
         webReadResearched: false,
         replies: [],
         costUsd: 0,

--- a/packages/find/src/angle.ts
+++ b/packages/find/src/angle.ts
@@ -70,6 +70,11 @@ export interface AngleEvidenceBundle {
   github: AngleGitHubEvidence | null;
   /** First-party page text for a non-GitHub profile URL (LinkedIn/X/Luma etc). */
   webReadText: string | null;
+  /** The URL `webReadText` was read from — rendered alongside the text so a
+   *  citation of it can satisfy the URL-must-appear-literally grounding
+   *  check even when the fetched markdown doesn't happen to repeat its own
+   *  URL (issue #569 freshness audit). Null exactly when `webReadText` is. */
+  webReadUrl: string | null;
   /** True when a paid `webRead` call actually ran. */
   webReadResearched: boolean;
   replies: AngleReplyEvidence[];
@@ -171,6 +176,7 @@ export async function gatherAngleEvidence(
   // first-party read of whatever profile URL we do have.
   let github: AngleGitHubEvidence | null = null;
   let webReadText: string | null = null;
+  let webReadUrl: string | null = null;
   let webReadResearched = false;
   const profileUrl = researchUrl(prospect);
   const githubOwner = profileUrl ? ownerFromRepoUrl(profileUrl) : null;
@@ -197,6 +203,7 @@ export async function gatherAngleEvidence(
       const text = (read.result.markdown ?? "").trim().slice(0, WEBREAD_SLICE);
       if (text) {
         webReadText = text;
+        webReadUrl = profileUrl;
         webReadResearched = true;
         sources.push("webread");
       }
@@ -240,6 +247,7 @@ export async function gatherAngleEvidence(
     queueSignal,
     github,
     webReadText,
+    webReadUrl,
     webReadResearched,
     replies,
     costUsd,
@@ -295,8 +303,19 @@ function renderGitHubEvidence(gh: AngleGitHubEvidence): string {
     );
   }
   if (gh.network && (gh.network.following.length > 0 || gh.network.followers.length > 0)) {
+    const followingLogins = gh.network.following
+      .slice(0, 15)
+      .map((f) => f.login)
+      .join(", ");
+    const followerLogins = gh.network.followers
+      .slice(0, 15)
+      .map((f) => f.login)
+      .join(", ");
     lines.push(
-      `Network: follows ${gh.network.following.length}, followed by ${gh.network.followers.length}`,
+      `Network: follows ${gh.network.following.length}` +
+        `${followingLogins ? ` (${followingLogins})` : ""}` +
+        `, followed by ${gh.network.followers.length}` +
+        `${followerLogins ? ` (${followerLogins})` : ""}`,
     );
   }
   return lines.join("\n");
@@ -308,7 +327,10 @@ function renderEvidenceForPrompt(evidence: AngleEvidenceBundle): string {
   if (evidence.queueSignal)
     blocks.push(`FINDER SIGNAL (why they were queued):\n${evidence.queueSignal}`);
   if (evidence.github) blocks.push(renderGitHubEvidence(evidence.github));
-  if (evidence.webReadText) blocks.push(`PROFILE PAGE:\n${evidence.webReadText}`);
+  if (evidence.webReadText)
+    blocks.push(
+      `PROFILE PAGE${evidence.webReadUrl ? ` (${evidence.webReadUrl})` : ""}:\n${evidence.webReadText}`,
+    );
   if (evidence.replies.length > 0) {
     const replyLines = evidence.replies.map(
       (r, i) => `[${i + 1}] ${r.receivedAt}${r.subject ? ` — ${r.subject}` : ""}\n${r.body}`,


### PR DESCRIPTION
Closes #569.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 51f24a149369 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (2 errs) vs base ok (2 errs)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Profile-based evidence now includes the source URL, allowing citations to reference the page used.
  - Follow and follower evidence now shows individual account names alongside totals, making network references more informative.

- **Bug Fixes**
  - Improved citation validation for dossier evidence when live dossier data is available.
  - Ungrounded source entries are now excluded from generated prospect angles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->