### PR TITLE
fix: issue #357: feat(plays): refresh per-prospect angle on new reply or outcome

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -76,6 +76,16 @@ GITHUB_TOKEN-authed) and `GitHubUserInfo` now carries account-maturity fields (`
 of the same shape, the six-lookups-by-hand problem this issue exists to close. No drafting changes;
 reading the angle into drafts is #356.
 
+Per-prospect angle, Phase 3 (#357): the angle no longer sits frozen at backfill time. A new HUMAN
+reply (`pollInboxReplies`'s `recordInboxReply` call) and a tagged deal outcome (`tagOutcomeValue`)
+both fire-and-forget a re-synthesis through a new `triggerAngleRefresh` seam in
+`packages/core/src/angle.ts` — core can't import `@oneshot-gtm/find` back (a cycle), so find
+registers its `refreshProspectAngle` implementation onto the seam at module load instead. Debounced
+on `angle_synthesized_at`'s own freshness (6h) rather than extra state, so a reply burst or a
+reply-then-outcome pair only pays for one re-synthesis; auto-replies and unsubscribes never trigger
+it at all. Best-effort throughout: demo mode, an open circuit breaker, a missing prospect, or an
+empty LLM result all degrade to a silent no-op, never a thrown error on the hot path.
+
 Updated by hand after each dogfood run.
 
 ---

--- a/packages/core/__tests__/angle-refresh.test.ts
+++ b/packages/core/__tests__/angle-refresh.test.ts
@@ -57,7 +57,9 @@ describe("triggerAngleRefresh", () => {
 
   it("calls the registered trigger for a prospect with no angle yet", () => {
     const calls: number[] = [];
-    registerAngleRefreshTrigger((id) => calls.push(id));
+    registerAngleRefreshTrigger((id) => {
+      calls.push(id);
+    });
     const id = h.ledger.upsertProspect({ email: "b@x.dev" });
 
     triggerAngleRefresh(id);
@@ -67,7 +69,9 @@ describe("triggerAngleRefresh", () => {
 
   it("no-ops for a prospect id that does not exist", () => {
     const calls: number[] = [];
-    registerAngleRefreshTrigger((id) => calls.push(id));
+    registerAngleRefreshTrigger((id) => {
+      calls.push(id);
+    });
 
     triggerAngleRefresh(999999);
 
@@ -76,7 +80,9 @@ describe("triggerAngleRefresh", () => {
 
   it("debounces — does not re-trigger while the angle is fresher than the stale window", () => {
     const calls: number[] = [];
-    registerAngleRefreshTrigger((id) => calls.push(id));
+    registerAngleRefreshTrigger((id) => {
+      calls.push(id);
+    });
     const id = h.ledger.upsertProspect({ email: "c@x.dev" });
     h.ledger.setProspectAngle(id, JSON.stringify({ hook: "fresh" })); // stamps angle_synthesized_at = now
 
@@ -87,7 +93,9 @@ describe("triggerAngleRefresh", () => {
 
   it("fires again once the existing angle is older than the stale window", () => {
     const calls: number[] = [];
-    registerAngleRefreshTrigger((id) => calls.push(id));
+    registerAngleRefreshTrigger((id) => {
+      calls.push(id);
+    });
     const id = h.ledger.upsertProspect({ email: "d@x.dev" });
     h.ledger.setProspectAngle(id, JSON.stringify({ hook: "old" }));
     // Backdate the stamp past the debounce window directly in the DB — the
@@ -111,5 +119,81 @@ describe("triggerAngleRefresh", () => {
     const id = h.ledger.upsertProspect({ email: "e@x.dev" });
 
     expect(() => triggerAngleRefresh(id)).not.toThrow();
+  });
+
+  // Round-1 correction (issue #357): the timestamp debounce alone only
+  // protects once a PRIOR refresh has finished and stamped
+  // angle_synthesized_at. Two triggers landing before that write — e.g. two
+  // replies in one pollInboxReplies() page — must not both launch the paid
+  // pipeline concurrently.
+  it("drops a second trigger for the same prospect while the first is still in flight", async () => {
+    const calls: number[] = [];
+    let resolveFirst: (() => void) | null = null;
+    registerAngleRefreshTrigger(
+      (id) =>
+        new Promise<void>((resolve) => {
+          calls.push(id);
+          resolveFirst = resolve;
+        }),
+    );
+    const id = h.ledger.upsertProspect({ email: "f@x.dev" });
+
+    triggerAngleRefresh(id); // launches, never resolves yet
+    triggerAngleRefresh(id); // same prospect, still in flight — must be dropped
+    triggerAngleRefresh(id); // a third burst member — also dropped
+
+    expect(calls).toEqual([id]); // only one actual invocation
+
+    resolveFirst!();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Once the in-flight refresh has settled, a fresh trigger is allowed
+    // again (the in-flight guard doesn't leak past completion) — gated only
+    // by the timestamp debounce, which this test's ledger row never set, so
+    // it still fires.
+    triggerAngleRefresh(id);
+    expect(calls).toEqual([id, id]);
+  });
+
+  it("still allows a DIFFERENT prospect's refresh while one prospect is in flight", () => {
+    const calls: number[] = [];
+    registerAngleRefreshTrigger(
+      (id) =>
+        new Promise<void>(() => {
+          calls.push(id);
+        }),
+    );
+    const idA = h.ledger.upsertProspect({ email: "g@x.dev" });
+    const idB = h.ledger.upsertProspect({ email: "h@x.dev" });
+
+    triggerAngleRefresh(idA);
+    triggerAngleRefresh(idB);
+
+    expect(calls).toEqual([idA, idB]);
+  });
+
+  it("releases the in-flight slot even when the trigger's promise rejects", async () => {
+    const calls: number[] = [];
+    let rejectFirst: ((err: Error) => void) | null = null;
+    registerAngleRefreshTrigger(
+      (id) =>
+        new Promise<void>((_resolve, reject) => {
+          calls.push(id);
+          rejectFirst = reject;
+        }),
+    );
+    const id = h.ledger.upsertProspect({ email: "i@x.dev" });
+
+    triggerAngleRefresh(id);
+    triggerAngleRefresh(id); // dropped — still in flight
+
+    rejectFirst!(new Error("synthesis failed"));
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    triggerAngleRefresh(id); // in-flight slot released — allowed again
+    expect(calls).toEqual([id, id]);
   });
 });

--- a/packages/core/__tests__/angle-refresh.test.ts
+++ b/packages/core/__tests__/angle-refresh.test.ts
@@ -196,4 +196,88 @@ describe("triggerAngleRefresh", () => {
     triggerAngleRefresh(id); // in-flight slot released — allowed again
     expect(calls).toEqual([id, id]);
   });
+
+  // Round-2 correction, issue #357: an outcome dropped by the in-flight
+  // guard while a reply-triggered refresh is running must not be lost —
+  // the completed write can't reflect an outcome it never saw, and the
+  // freshness debounce would then block a retry for
+  // ANGLE_REFRESH_STALE_HOURS.
+  it("queues a dropped outcome trigger and fires it once the in-flight refresh settles", async () => {
+    const calls: Array<{ id: number; context?: { outcome?: { type: string } } }> = [];
+    let resolveFirst: (() => void) | null = null;
+    registerAngleRefreshTrigger(
+      (id, context) =>
+        new Promise<void>((resolve) => {
+          calls.push({ id, context });
+          resolveFirst = resolve;
+        }),
+    );
+    const id = h.ledger.upsertProspect({ email: "j@x.dev" });
+
+    triggerAngleRefresh(id); // reply-triggered, launches and never resolves yet
+    triggerAngleRefresh(id, { outcome: { type: "meeting" } }); // dropped but queued
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.context).toBeUndefined();
+
+    resolveFirst!();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // The queued outcome fires as a follow-up once the first settles, even
+    // though angle_synthesized_at is still unset (bypasses the freshness
+    // debounce for this deliberate catch-up).
+    expect(calls).toHaveLength(2);
+    expect(calls[1]?.id).toBe(id);
+    expect(calls[1]?.context).toEqual({ outcome: { type: "meeting" } });
+  });
+
+  it("does not queue a dropped REPLY trigger (no outcome) while one is in flight", async () => {
+    const calls: number[] = [];
+    let resolveFirst: (() => void) | null = null;
+    registerAngleRefreshTrigger(
+      (id) =>
+        new Promise<void>((resolve) => {
+          calls.push(id);
+          resolveFirst = resolve;
+        }),
+    );
+    const id = h.ledger.upsertProspect({ email: "k@x.dev" });
+
+    triggerAngleRefresh(id);
+    triggerAngleRefresh(id); // dropped, no outcome — not queued
+
+    resolveFirst!();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(calls).toEqual([id]); // no follow-up fired
+  });
+
+  it("keeps only the LAST queued outcome when several land while one is in flight", async () => {
+    const calls: Array<{ outcome?: { type: string } }> = [];
+    let resolveFirst: (() => void) | null = null;
+    registerAngleRefreshTrigger(
+      (id, context) =>
+        new Promise<void>((resolve) => {
+          calls.push({ outcome: context?.outcome });
+          resolveFirst = resolve;
+        }),
+    );
+    const id = h.ledger.upsertProspect({ email: "l@x.dev" });
+
+    triggerAngleRefresh(id);
+    triggerAngleRefresh(id, { outcome: { type: "meeting" } });
+    triggerAngleRefresh(id, { outcome: { type: "revenue", amount: 5000 } });
+
+    resolveFirst!();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(calls).toHaveLength(2);
+    expect(calls[1]?.outcome).toEqual({ type: "revenue", amount: 5000 });
+  });
 });

--- a/packages/core/__tests__/angle-refresh.test.ts
+++ b/packages/core/__tests__/angle-refresh.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { vi } from "vitest";
+
+// triggerAngleRefresh (issue #357): the fire-and-forget seam that lets a new
+// human reply / a tagged outcome ask `@oneshot-gtm/find` to re-synthesize a
+// prospect's angle, without core importing find back (a cycle). Tested here
+// against the REAL registration mechanism and a real Ledger, so the debounce
+// (angle_synthesized_at freshness) is exercised against real persisted state
+// rather than a mock.
+
+const h = vi.hoisted(() => ({ ledger: null as unknown as import("../src/ledger.ts").Ledger }));
+
+vi.mock("../src/ledger.ts", async () => {
+  const actual = await vi.importActual<typeof import("../src/ledger.ts")>("../src/ledger.ts");
+  return { ...actual, getLedger: () => h.ledger };
+});
+
+import { Ledger } from "../src/ledger.ts";
+import {
+  ANGLE_REFRESH_STALE_HOURS,
+  _resetAngleRefreshTrigger,
+  registerAngleRefreshTrigger,
+  triggerAngleRefresh,
+} from "../src/angle.ts";
+
+let dbPath: string;
+
+beforeEach(() => {
+  dbPath = join(
+    tmpdir(),
+    `oneshot-gtm-angle-refresh-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`,
+  );
+  h.ledger = new Ledger(dbPath);
+  _resetAngleRefreshTrigger();
+});
+
+afterEach(() => {
+  h.ledger.close();
+  _resetAngleRefreshTrigger();
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      rmSync(`${dbPath}${suffix}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+describe("triggerAngleRefresh", () => {
+  it("is a no-op until a trigger is registered", () => {
+    const id = h.ledger.upsertProspect({ email: "a@x.dev" });
+    expect(() => triggerAngleRefresh(id)).not.toThrow();
+  });
+
+  it("calls the registered trigger for a prospect with no angle yet", () => {
+    const calls: number[] = [];
+    registerAngleRefreshTrigger((id) => calls.push(id));
+    const id = h.ledger.upsertProspect({ email: "b@x.dev" });
+
+    triggerAngleRefresh(id);
+
+    expect(calls).toEqual([id]);
+  });
+
+  it("no-ops for a prospect id that does not exist", () => {
+    const calls: number[] = [];
+    registerAngleRefreshTrigger((id) => calls.push(id));
+
+    triggerAngleRefresh(999999);
+
+    expect(calls).toEqual([]);
+  });
+
+  it("debounces — does not re-trigger while the angle is fresher than the stale window", () => {
+    const calls: number[] = [];
+    registerAngleRefreshTrigger((id) => calls.push(id));
+    const id = h.ledger.upsertProspect({ email: "c@x.dev" });
+    h.ledger.setProspectAngle(id, JSON.stringify({ hook: "fresh" })); // stamps angle_synthesized_at = now
+
+    triggerAngleRefresh(id);
+
+    expect(calls).toEqual([]);
+  });
+
+  it("fires again once the existing angle is older than the stale window", () => {
+    const calls: number[] = [];
+    registerAngleRefreshTrigger((id) => calls.push(id));
+    const id = h.ledger.upsertProspect({ email: "d@x.dev" });
+    h.ledger.setProspectAngle(id, JSON.stringify({ hook: "old" }));
+    // Backdate the stamp past the debounce window directly in the DB — the
+    // public API only ever writes "now", so this simulates time passing.
+    const staleAt = new Date(
+      Date.now() - (ANGLE_REFRESH_STALE_HOURS * 3600_000 + 1000),
+    ).toISOString();
+    h.ledger["db"]
+      .prepare("UPDATE prospects SET angle_synthesized_at = ? WHERE id = ?")
+      .run(staleAt, id);
+
+    triggerAngleRefresh(id);
+
+    expect(calls).toEqual([id]);
+  });
+
+  it("never throws when the registered trigger itself throws", () => {
+    registerAngleRefreshTrigger(() => {
+      throw new Error("boom");
+    });
+    const id = h.ledger.upsertProspect({ email: "e@x.dev" });
+
+    expect(() => triggerAngleRefresh(id)).not.toThrow();
+  });
+});

--- a/packages/core/__tests__/oneshot-value-tag.test.ts
+++ b/packages/core/__tests__/oneshot-value-tag.test.ts
@@ -122,8 +122,10 @@ describe("tagOutcomeValue (goal-level)", () => {
   it("refreshes the prospect's angle when the tag actually applies", async () => {
     const { registerAngleRefreshTrigger, _resetAngleRefreshTrigger } =
       await import("../src/angle.ts");
-    const calls: number[] = [];
-    registerAngleRefreshTrigger((id) => calls.push(id));
+    const calls: Array<{ id: number; context?: { outcome?: unknown } }> = [];
+    registerAngleRefreshTrigger((id, context) => {
+      calls.push({ id, context });
+    });
     try {
       const { prospectId } = seedCadence("show-hn", "angle@x.dev");
 
@@ -133,7 +135,12 @@ describe("tagOutcomeValue (goal-level)", () => {
         valueTag: { type: "meeting", label: "meeting booked" },
       });
 
-      expect(calls).toEqual([prospectId]);
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.id).toBe(prospectId);
+      // Round-1 correction (issue #357): the value tag itself must reach the
+      // refresh pipeline as outcome context, not just a bare prospect id —
+      // otherwise the outcome-triggered synthesis can't reflect the outcome.
+      expect(calls[0]?.context?.outcome).toEqual({ type: "meeting", label: "meeting booked" });
     } finally {
       _resetAngleRefreshTrigger();
     }
@@ -143,7 +150,9 @@ describe("tagOutcomeValue (goal-level)", () => {
     const { registerAngleRefreshTrigger, _resetAngleRefreshTrigger } =
       await import("../src/angle.ts");
     const calls: number[] = [];
-    registerAngleRefreshTrigger((id) => calls.push(id));
+    registerAngleRefreshTrigger((id) => {
+      calls.push(id);
+    });
     try {
       const prospectId = h.ledger.upsertProspect({ email: "no-receipt@x.dev" });
 

--- a/packages/core/__tests__/oneshot-value-tag.test.ts
+++ b/packages/core/__tests__/oneshot-value-tag.test.ts
@@ -117,6 +117,48 @@ describe("tagOutcomeValue (goal-level)", () => {
     }
   });
 
+  // Issue #357: a tagged outcome is exactly the kind of signal that should
+  // refresh the prospect's stored angle.
+  it("refreshes the prospect's angle when the tag actually applies", async () => {
+    const { registerAngleRefreshTrigger, _resetAngleRefreshTrigger } =
+      await import("../src/angle.ts");
+    const calls: number[] = [];
+    registerAngleRefreshTrigger((id) => calls.push(id));
+    try {
+      const { prospectId } = seedCadence("show-hn", "angle@x.dev");
+
+      await tagOutcomeValue({
+        prospectId,
+        playName: "show-hn",
+        valueTag: { type: "meeting", label: "meeting booked" },
+      });
+
+      expect(calls).toEqual([prospectId]);
+    } finally {
+      _resetAngleRefreshTrigger();
+    }
+  });
+
+  it("does not refresh the angle when no receipt carries the goal (no-op tag)", async () => {
+    const { registerAngleRefreshTrigger, _resetAngleRefreshTrigger } =
+      await import("../src/angle.ts");
+    const calls: number[] = [];
+    registerAngleRefreshTrigger((id) => calls.push(id));
+    try {
+      const prospectId = h.ledger.upsertProspect({ email: "no-receipt@x.dev" });
+
+      await tagOutcomeValue({
+        prospectId,
+        playName: "show-hn",
+        valueTag: { type: "engagement" },
+      });
+
+      expect(calls).toEqual([]);
+    } finally {
+      _resetAngleRefreshTrigger();
+    }
+  });
+
   it("no-ops when no receipt carries the cadence goal", async () => {
     const prospectId = h.ledger.upsertProspect({ email: "nobody@x.dev" });
     const res = await tagOutcomeValue({

--- a/packages/core/src/angle.ts
+++ b/packages/core/src/angle.ts
@@ -222,8 +222,22 @@ export function parseProspectAngle(
  * never touches `@oneshot-gtm/find` — the trigger is a no-op, the same
  * degrade-gracefully rule every other best-effort call in this codebase
  * follows.
+ *
+ * `AngleRefreshContext` (round-1 correction, issue #357) lets a caller hand
+ * extra signal alongside the prospect id: an outcome tag carries data (deal
+ * value, meeting booked, ...) that reply-triggered refreshes never have, and
+ * without it the outcome-triggered path re-runs the identical
+ * gather+synthesize pipeline against unchanged evidence — an LLM call that
+ * can't reflect the outcome it was fired for.
  */
-export type AngleRefreshTrigger = (prospectId: number) => void;
+export interface AngleRefreshContext {
+  outcome?: { type: string; amount?: number; label?: string };
+}
+
+export type AngleRefreshTrigger = (
+  prospectId: number,
+  context?: AngleRefreshContext,
+) => void | Promise<void>;
 let angleRefreshTrigger: AngleRefreshTrigger | null = null;
 
 export function registerAngleRefreshTrigger(fn: AngleRefreshTrigger): void {
@@ -242,14 +256,32 @@ export function registerAngleRefreshTrigger(fn: AngleRefreshTrigger): void {
 export const ANGLE_REFRESH_STALE_HOURS = 6;
 
 /**
+ * In-flight guard (round-1 correction, issue #357): the timestamp-based
+ * debounce above only protects once a prior refresh has already finished and
+ * stamped `angle_synthesized_at` — two triggers for the same prospect that
+ * land before that write (two replies in one `pollInboxReplies()` page, or a
+ * reply immediately followed by an outcome tag) both read the same
+ * stale/missing timestamp and would both launch a full paid gather+synthesize
+ * concurrently, with the later completion silently overwriting the earlier
+ * one's `angle_json`. Tracking in-flight prospect ids in memory closes that
+ * window without touching the persisted debounce: a second trigger for a
+ * prospect already being refreshed is dropped outright (the in-flight
+ * refresh will itself read fresh evidence), and the id is released once the
+ * registered trigger's returned promise settles either way.
+ */
+const inFlightRefreshes = new Set<number>();
+
+/**
  * Best-effort, fire-and-forget: never throws. No-ops until a trigger is
- * registered (find's module hasn't loaded), and no-ops when the angle was
+ * registered (find's module hasn't loaded), no-ops when the angle was
  * synthesized more recently than `ANGLE_REFRESH_STALE_HOURS` ago — the
  * debounce that keeps a reply burst or a reply-then-outcome pair from paying
- * for synthesis twice.
+ * for synthesis twice — and no-ops when a refresh for this prospect is
+ * already in flight (see `inFlightRefreshes` above).
  */
-export function triggerAngleRefresh(prospectId: number): void {
+export function triggerAngleRefresh(prospectId: number, context?: AngleRefreshContext): void {
   if (!angleRefreshTrigger) return;
+  if (inFlightRefreshes.has(prospectId)) return;
   try {
     const prospect = getLedger().getProspectById(prospectId);
     if (!prospect) return;
@@ -257,14 +289,27 @@ export function triggerAngleRefresh(prospectId: number): void {
       const ageMs = Date.now() - Date.parse(prospect.angle_synthesized_at);
       if (Number.isFinite(ageMs) && ageMs < ANGLE_REFRESH_STALE_HOURS * 3600_000) return;
     }
-    angleRefreshTrigger(prospectId);
+    inFlightRefreshes.add(prospectId);
+    Promise.resolve(angleRefreshTrigger(prospectId, context))
+      .catch(() => {
+        // Best-effort — see the top-level try/catch below: a rejected
+        // refresh must never surface as an unhandled rejection in a
+        // caller's hot path (reply recording, outcome tagging).
+      })
+      .finally(() => {
+        inFlightRefreshes.delete(prospectId);
+      });
   } catch {
-    // Best-effort — a ledger read failure must never propagate into a
-    // caller's hot path (reply recording, outcome tagging).
+    // Best-effort — a ledger read failure (or a trigger that throws
+    // synchronously) must never propagate into a caller's hot path (reply
+    // recording, outcome tagging). Release the in-flight slot in case it was
+    // claimed before the throw.
+    inFlightRefreshes.delete(prospectId);
   }
 }
 
-/** Test-only: reset the registered hook between cases. */
+/** Test-only: reset the registered hook (and any in-flight tracking) between cases. */
 export function _resetAngleRefreshTrigger(): void {
   angleRefreshTrigger = null;
+  inFlightRefreshes.clear();
 }

--- a/packages/core/src/angle.ts
+++ b/packages/core/src/angle.ts
@@ -272,16 +272,68 @@ export const ANGLE_REFRESH_STALE_HOURS = 6;
 const inFlightRefreshes = new Set<number>();
 
 /**
+ * Outcome context dropped by the in-flight guard while a same-prospect
+ * refresh is already running (round-2 correction, issue #357): the guard
+ * above still drops the SECOND trigger outright (the in-flight refresh
+ * can't be redirected mid-flight), but an outcome carries data — deal
+ * value, meeting booked — a plain reply trigger never has, so silently
+ * losing it means the completed write can't reflect it and the freshness
+ * debounce then blocks a retry for `ANGLE_REFRESH_STALE_HOURS`. Queuing it
+ * here (last one wins) lets `launchAngleRefresh`'s completion hook fire a
+ * follow-up refresh carrying this context the moment the in-flight one
+ * settles, bypassing the freshness check since that check exists to guard
+ * against a plain re-trigger, not this deliberate catch-up. A dropped
+ * REPLY trigger (no `context.outcome`) is never queued — the in-flight
+ * refresh already reads replies fresh from the ledger, so nothing is lost.
+ */
+const pendingOutcomeRefreshes = new Map<number, AngleRefreshContext>();
+
+/**
+ * Add the in-flight marker and launch the registered trigger, draining any
+ * outcome queued for this prospect (see `pendingOutcomeRefreshes` above)
+ * once this run settles. Self-contained try/catch so a synchronous throw
+ * from `angleRefreshTrigger` — on the initial call or a queued follow-up —
+ * never escapes as an unhandled exception.
+ */
+function launchAngleRefresh(prospectId: number, context?: AngleRefreshContext): void {
+  try {
+    inFlightRefreshes.add(prospectId);
+    Promise.resolve(angleRefreshTrigger!(prospectId, context))
+      .catch(() => {
+        // Best-effort — a rejected refresh must never surface as an
+        // unhandled rejection in a caller's hot path (reply recording,
+        // outcome tagging).
+      })
+      .finally(() => {
+        inFlightRefreshes.delete(prospectId);
+        const pendingContext = pendingOutcomeRefreshes.get(prospectId);
+        if (pendingContext) {
+          pendingOutcomeRefreshes.delete(prospectId);
+          launchAngleRefresh(prospectId, pendingContext);
+        }
+      });
+  } catch {
+    // A trigger that throws synchronously must never propagate into a
+    // caller's hot path — release the in-flight slot it claimed above.
+    inFlightRefreshes.delete(prospectId);
+  }
+}
+
+/**
  * Best-effort, fire-and-forget: never throws. No-ops until a trigger is
  * registered (find's module hasn't loaded), no-ops when the angle was
  * synthesized more recently than `ANGLE_REFRESH_STALE_HOURS` ago — the
  * debounce that keeps a reply burst or a reply-then-outcome pair from paying
  * for synthesis twice — and no-ops when a refresh for this prospect is
- * already in flight (see `inFlightRefreshes` above).
+ * already in flight (see `inFlightRefreshes` above), queuing the outcome
+ * context instead when the dropped trigger carries one.
  */
 export function triggerAngleRefresh(prospectId: number, context?: AngleRefreshContext): void {
   if (!angleRefreshTrigger) return;
-  if (inFlightRefreshes.has(prospectId)) return;
+  if (inFlightRefreshes.has(prospectId)) {
+    if (context?.outcome) pendingOutcomeRefreshes.set(prospectId, context);
+    return;
+  }
   try {
     const prospect = getLedger().getProspectById(prospectId);
     if (!prospect) return;
@@ -289,21 +341,10 @@ export function triggerAngleRefresh(prospectId: number, context?: AngleRefreshCo
       const ageMs = Date.now() - Date.parse(prospect.angle_synthesized_at);
       if (Number.isFinite(ageMs) && ageMs < ANGLE_REFRESH_STALE_HOURS * 3600_000) return;
     }
-    inFlightRefreshes.add(prospectId);
-    Promise.resolve(angleRefreshTrigger(prospectId, context))
-      .catch(() => {
-        // Best-effort — see the top-level try/catch below: a rejected
-        // refresh must never surface as an unhandled rejection in a
-        // caller's hot path (reply recording, outcome tagging).
-      })
-      .finally(() => {
-        inFlightRefreshes.delete(prospectId);
-      });
+    launchAngleRefresh(prospectId, context);
   } catch {
-    // Best-effort — a ledger read failure (or a trigger that throws
-    // synchronously) must never propagate into a caller's hot path (reply
-    // recording, outcome tagging). Release the in-flight slot in case it was
-    // claimed before the throw.
+    // Best-effort — a ledger read failure must never propagate into a
+    // caller's hot path (reply recording, outcome tagging).
     inFlightRefreshes.delete(prospectId);
   }
 }
@@ -312,4 +353,5 @@ export function triggerAngleRefresh(prospectId: number, context?: AngleRefreshCo
 export function _resetAngleRefreshTrigger(): void {
   angleRefreshTrigger = null;
   inFlightRefreshes.clear();
+  pendingOutcomeRefreshes.clear();
 }

--- a/packages/core/src/angle.ts
+++ b/packages/core/src/angle.ts
@@ -10,6 +10,8 @@
  * signal just because the tone was friendly.
  */
 
+import { getLedger } from "./ledger.ts";
+
 export type AngleRelationship =
   | "builder"
   | "adjacent"
@@ -205,4 +207,64 @@ export function parseProspectAngle(
     model: meta.model,
     synthesizedAt: meta.synthesizedAt ?? new Date().toISOString(),
   };
+}
+
+/**
+ * Fire-and-forget re-synthesis hook (issue #357): a new human reply or a
+ * tagged outcome should refresh `angle_json` instead of leaving it frozen at
+ * backfill time. The actual work (gatherAngleEvidence + synthesizePersonAngle)
+ * lives in `@oneshot-gtm/find`, which depends on this package — core cannot
+ * import find back without a cycle, so find registers its implementation
+ * here at module load (`packages/find/src/angle.ts`) and core's hot paths
+ * (ledger's `recordInboxReply` caller in `pollInboxReplies`, and
+ * `tagOutcomeValue` below) call `triggerAngleRefresh` without ever knowing
+ * find exists. Until find's module has loaded — e.g. a CLI invocation that
+ * never touches `@oneshot-gtm/find` — the trigger is a no-op, the same
+ * degrade-gracefully rule every other best-effort call in this codebase
+ * follows.
+ */
+export type AngleRefreshTrigger = (prospectId: number) => void;
+let angleRefreshTrigger: AngleRefreshTrigger | null = null;
+
+export function registerAngleRefreshTrigger(fn: AngleRefreshTrigger): void {
+  angleRefreshTrigger = fn;
+}
+
+/**
+ * Debounce window (issue #357's "stale after N hours guard is enough"): a
+ * burst of replies on the same live thread, or a reply immediately followed
+ * by an outcome tag, must not each re-buy a synthesis. Re-synthesis only
+ * fires when the existing `angle_synthesized_at` is missing or older than
+ * this, so the guard is entirely a function of the persisted timestamp —
+ * no extra state, and correct across process restarts and across the two
+ * independent call sites (reply poll, outcome tagging).
+ */
+export const ANGLE_REFRESH_STALE_HOURS = 6;
+
+/**
+ * Best-effort, fire-and-forget: never throws. No-ops until a trigger is
+ * registered (find's module hasn't loaded), and no-ops when the angle was
+ * synthesized more recently than `ANGLE_REFRESH_STALE_HOURS` ago — the
+ * debounce that keeps a reply burst or a reply-then-outcome pair from paying
+ * for synthesis twice.
+ */
+export function triggerAngleRefresh(prospectId: number): void {
+  if (!angleRefreshTrigger) return;
+  try {
+    const prospect = getLedger().getProspectById(prospectId);
+    if (!prospect) return;
+    if (prospect.angle_synthesized_at) {
+      const ageMs = Date.now() - Date.parse(prospect.angle_synthesized_at);
+      if (Number.isFinite(ageMs) && ageMs < ANGLE_REFRESH_STALE_HOURS * 3600_000) return;
+    }
+    angleRefreshTrigger(prospectId);
+  } catch {
+    // Best-effort — a ledger read failure must never propagate into a
+    // caller's hot path (reply recording, outcome tagging).
+  }
+}
+
+/** Test-only: reset the registered hook between cases. */
+export function _resetAngleRefreshTrigger(): void {
+  angleRefreshTrigger = null;
 }

--- a/packages/core/src/oneshot.ts
+++ b/packages/core/src/oneshot.ts
@@ -1719,7 +1719,10 @@ export async function tagOutcomeValue(input: {
   // prospect. Keyed by prospect_id per the issue, fires once the value tag
   // is actually applied (not on a no-op/downgraded re-tag above), and is
   // itself debounced on `angle_synthesized_at` — never blocks this call.
-  triggerAngleRefresh(input.prospectId);
+  // The value tag itself is threaded through as refresh context (round-1
+  // correction) so the resynthesis prompt can actually reflect the outcome
+  // instead of re-running an unchanged evidence gather.
+  triggerAngleRefresh(input.prospectId, { outcome: input.valueTag });
 
   let agent: OneShot | null = null;
   try {

--- a/packages/core/src/oneshot.ts
+++ b/packages/core/src/oneshot.ts
@@ -27,6 +27,7 @@ import {
 } from "@oneshot-agent/sdk";
 import { createHash } from "node:crypto";
 import { getLedger } from "./ledger.ts";
+import { triggerAngleRefresh } from "./angle.ts";
 import { loadConfig, oneshotEnvReady } from "./config.ts";
 import { demoFixture, demoMode } from "./demo.ts";
 import { claimContactTouch, describeTouch, recordContactTouch } from "./shared-db.ts";
@@ -1712,6 +1713,13 @@ export async function tagOutcomeValue(input: {
   // can't run (no wallet creds) or fails. No-op when no receipt carries this goal.
   const mirrored = ledger.setReceiptValueTagByGoal(goalId, tagJson);
   if (mirrored === 0) return { tagged: false };
+
+  // Refresh the per-prospect angle (issue #357): an outcome is exactly the
+  // kind of signal that should change how the next touch reads this
+  // prospect. Keyed by prospect_id per the issue, fires once the value tag
+  // is actually applied (not on a no-op/downgraded re-tag above), and is
+  // itself debounced on `angle_synthesized_at` — never blocks this call.
+  triggerAngleRefresh(input.prospectId);
 
   let agent: OneShot | null = null;
   try {

--- a/packages/find/__tests__/angle-refresh.test.ts
+++ b/packages/find/__tests__/angle-refresh.test.ts
@@ -22,6 +22,13 @@ let prospect: ProspectStub | null = null;
 let setAngleCalls: Array<{ id: number; angle: string | null }> = [];
 let registeredTrigger: ((prospectId: number) => void) | null = null;
 let demoModeValue = false;
+// Round-2 correction, issue #357: refreshProspectAngle must gate its paid
+// gather behind the install-wide daily spend ceiling, same as every other
+// automated paid path. Default granted so the existing tests below (which
+// don't care about spend) keep passing unmodified.
+let reservationGranted = true;
+const reserveCalls: number[] = [];
+let releaseCalls = 0;
 
 vi.mock("@oneshot-gtm/core", async () => {
   const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
@@ -49,6 +56,13 @@ vi.mock("@oneshot-gtm/core", async () => {
     }),
     webRead: async () => ({ result: { markdown: "", cost: 0 } }),
     logEvent: () => {},
+    tryReserveDailySpend: (amountUsd: number) => {
+      reserveCalls.push(amountUsd);
+      if (!reservationGranted) {
+        return { granted: false, reason: "daily spend ceiling reached", status: {} };
+      }
+      return { granted: true, status: {}, release: () => releaseCalls++ };
+    },
     // Captured instead of delegated to the real module-scoped state, so the
     // test drives the registered callback directly.
     registerAngleRefreshTrigger: (
@@ -59,11 +73,15 @@ vi.mock("@oneshot-gtm/core", async () => {
   };
 });
 
+let deepResearchInputs: unknown[] = [];
 vi.mock("../src/_sdk-safe.ts", () => ({
-  safeDeepResearchPerson: async () => ({
-    result: { status: "completed", result: {}, cost: 0 },
-    receiptId: 0,
-  }),
+  safeDeepResearchPerson: async (input: unknown) => {
+    deepResearchInputs.push(input);
+    return {
+      result: { status: "completed", result: {}, cost: 0 },
+      receiptId: 0,
+    };
+  },
 }));
 
 vi.mock("../src/_github-user.ts", () => ({
@@ -108,6 +126,10 @@ beforeEach(() => {
   demoModeValue = false;
   isCircuitOpenValue = false;
   llmResponse = "{}";
+  reservationGranted = true;
+  reserveCalls.length = 0;
+  releaseCalls = 0;
+  deepResearchInputs = [];
 });
 
 afterEach(() => vi.clearAllMocks());
@@ -173,5 +195,38 @@ describe("registerAngleRefreshTrigger wiring (issue #357)", () => {
     await new Promise((r) => setTimeout(r, 0));
 
     expect(setAngleCalls).toHaveLength(0);
+  });
+
+  // Round-2 correction, issue #357: refreshProspectAngle must reserve
+  // against the install-wide daily spend ceiling before allowing
+  // gatherAngleEvidence to run its paid deepResearchPerson/webRead calls —
+  // the same gate every other automated paid path (trigger runs, drains,
+  // mail-research's address lookup) already enforces.
+  it("reserves against the daily spend ceiling before gathering paid evidence", async () => {
+    llmResponse = JSON.stringify({ brief: "x", hook: "y" });
+
+    registeredTrigger!(1);
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(reserveCalls.length).toBeGreaterThan(0);
+    // A prospect with no dossier and a real email is eligible for paid
+    // research when the reservation is granted.
+    expect(deepResearchInputs).toHaveLength(1);
+    expect(releaseCalls).toBe(1);
+  });
+
+  it("skips paid research (allowPaidResearch: false) when the spend ceiling refuses the reservation", async () => {
+    reservationGranted = false;
+    llmResponse = JSON.stringify({ brief: "x", hook: "y" });
+
+    registeredTrigger!(1);
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(reserveCalls.length).toBeGreaterThan(0);
+    expect(deepResearchInputs).toHaveLength(0);
+    // Refused reservations are never released (nothing was held).
+    expect(releaseCalls).toBe(0);
   });
 });

--- a/packages/find/__tests__/angle-refresh.test.ts
+++ b/packages/find/__tests__/angle-refresh.test.ts
@@ -1,0 +1,175 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The refresh side of issue #357: `packages/find/src/angle.ts` registers its
+// `refreshProspectAngle` implementation onto core's `registerAngleRefreshTrigger`
+// seam at module load, so `triggerAngleRefresh` (called from the reply poll /
+// tagOutcomeValue in core) reaches this package's synthesis pipeline without
+// core importing find back. Mocks mirror angle.test.ts's module boundaries;
+// this file additionally captures the registered callback and exercises it.
+
+interface ProspectStub {
+  id: number;
+  name: string | null;
+  company: string | null;
+  email: string | null;
+  dossier_json: string | null;
+  source_profile_url: string | null;
+  linkedin_url: string | null;
+  angle_json: string | null;
+}
+
+let prospect: ProspectStub | null = null;
+let setAngleCalls: Array<{ id: number; angle: string | null }> = [];
+let registeredTrigger: ((prospectId: number) => void) | null = null;
+let demoModeValue = false;
+
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    demoMode: () => demoModeValue,
+    loadConfig: () => ({
+      llmProvider: "anthropic",
+      llmModel: "test",
+      founderName: "Founder",
+      productOneLiner: "TestProduct",
+      icpOneLiner: "Engineers building agents",
+      founderCredentials: null,
+      productPortfolio: null,
+      founderAdmission: null,
+    }),
+    getLedger: () => ({
+      getProspectById: (id: number) => (prospect?.id === id ? prospect : null),
+      getQueueRowForProspect: () => null,
+      listInboxRepliesForProspect: () => [],
+      listChannelEventsForProspect: () => [],
+      setProspectAngle: (id: number, angle: string | null) => {
+        setAngleCalls.push({ id, angle });
+      },
+    }),
+    webRead: async () => ({ result: { markdown: "", cost: 0 } }),
+    logEvent: () => {},
+    // Captured instead of delegated to the real module-scoped state, so the
+    // test drives the registered callback directly.
+    registerAngleRefreshTrigger: (fn: (prospectId: number) => void) => {
+      registeredTrigger = fn;
+    },
+  };
+});
+
+vi.mock("../src/_sdk-safe.ts", () => ({
+  safeDeepResearchPerson: async () => ({
+    result: { status: "completed", result: {}, cost: 0 },
+    receiptId: 0,
+  }),
+}));
+
+vi.mock("../src/_github-user.ts", () => ({
+  fetchGitHubUser: async () => null,
+  fetchTopRepos: async () => null,
+  fetchGitHubOrgs: async () => null,
+  fetchGitHubOrgProfile: async () => null,
+  fetchFollowNetwork: async () => null,
+  ownerFromRepoUrl: () => null,
+}));
+
+let isCircuitOpenValue = false;
+vi.mock("../src/_breaker.ts", () => ({
+  isCircuitOpen: () => isCircuitOpenValue,
+}));
+
+let llmResponse = "{}";
+vi.mock("@oneshot-gtm/intel", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/intel")>("@oneshot-gtm/intel");
+  return {
+    ...actual,
+    complete: async () => ({ content: llmResponse, provider: "test", model: "test-model" }),
+  };
+});
+
+// Importing the module registers refreshProspectAngle onto the (mocked)
+// registerAngleRefreshTrigger as a side effect.
+await import("../src/angle.ts");
+
+beforeEach(() => {
+  prospect = {
+    id: 1,
+    name: "Pat",
+    company: "Acme",
+    email: "pat@acme.dev",
+    dossier_json: null,
+    source_profile_url: null,
+    linkedin_url: null,
+    angle_json: null,
+  };
+  setAngleCalls = [];
+  demoModeValue = false;
+  isCircuitOpenValue = false;
+  llmResponse = "{}";
+});
+
+afterEach(() => vi.clearAllMocks());
+
+describe("registerAngleRefreshTrigger wiring (issue #357)", () => {
+  it("registers a callback at module load", () => {
+    expect(registeredTrigger).not.toBeNull();
+  });
+
+  it("persists a re-synthesized angle when the LLM returns one", async () => {
+    llmResponse = JSON.stringify({
+      brief: "Builds agent infra.",
+      hook: "Just corrected the record on their role.",
+    });
+
+    registeredTrigger!(1);
+    // The trigger is fire-and-forget (`void refreshProspectAngle(...)`) —
+    // flush the microtask queue so the async pipeline completes.
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(setAngleCalls).toHaveLength(1);
+    expect(setAngleCalls[0]?.id).toBe(1);
+    expect(JSON.parse(setAngleCalls[0]?.angle ?? "{}").hook).toBe(
+      "Just corrected the record on their role.",
+    );
+  });
+
+  it("does not synthesize in demo mode", async () => {
+    demoModeValue = true;
+    llmResponse = JSON.stringify({ brief: "x", hook: "y" });
+
+    registeredTrigger!(1);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(setAngleCalls).toHaveLength(0);
+  });
+
+  it("does not synthesize while the circuit breaker is open", async () => {
+    isCircuitOpenValue = true;
+    llmResponse = JSON.stringify({ brief: "x", hook: "y" });
+
+    registeredTrigger!(1);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(setAngleCalls).toHaveLength(0);
+  });
+
+  it("does not persist when the LLM returns nothing usable (no brief/hook)", async () => {
+    llmResponse = JSON.stringify({ relationship: "builder" });
+
+    registeredTrigger!(1);
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(setAngleCalls).toHaveLength(0);
+  });
+
+  it("no-ops for a prospect id that no longer exists", async () => {
+    prospect = null;
+
+    registeredTrigger!(999);
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(setAngleCalls).toHaveLength(0);
+  });
+});

--- a/packages/find/__tests__/angle-refresh.test.ts
+++ b/packages/find/__tests__/angle-refresh.test.ts
@@ -51,7 +51,9 @@ vi.mock("@oneshot-gtm/core", async () => {
     logEvent: () => {},
     // Captured instead of delegated to the real module-scoped state, so the
     // test drives the registered callback directly.
-    registerAngleRefreshTrigger: (fn: (prospectId: number) => void) => {
+    registerAngleRefreshTrigger: (
+      fn: (prospectId: number, context?: { outcome?: { type: string } }) => void,
+    ) => {
       registeredTrigger = fn;
     },
   };

--- a/packages/find/__tests__/angle.test.ts
+++ b/packages/find/__tests__/angle.test.ts
@@ -227,6 +227,22 @@ describe("gatherAngleEvidence", () => {
     expect(out?.sources).toContain("webread");
   });
 
+  // Round-1 correction (issue #357): an outcome-triggered refresh threads
+  // the value tag through the evidence bundle so the synthesis prompt can
+  // actually reflect it, instead of re-running an unchanged gather.
+  it("threads an outcome through onto the evidence bundle when passed", async () => {
+    const out = await gatherAngleEvidence(1, {
+      allowPaidResearch: false,
+      outcome: { type: "meeting", label: "meeting booked" },
+    });
+    expect(out?.outcome).toEqual({ type: "meeting", label: "meeting booked" });
+  });
+
+  it("defaults the evidence bundle's outcome to null when none is given", async () => {
+    const out = await gatherAngleEvidence(1, { allowPaidResearch: false });
+    expect(out?.outcome).toBeNull();
+  });
+
   it("counts a billed webRead's cost even when the markdown comes back empty", async () => {
     prospect!.source_profile_url = "https://x.com/pat";
     // Isolate the webRead cost being asserted below: a cache-hit dossier
@@ -360,6 +376,31 @@ describe("synthesizePersonAngle", () => {
       { claim: "shipped agent-loop", source: "https://github.com/ada/agent-loop" },
     ]);
     expect(costUsd).toBe(0);
+  });
+
+  // Round-1 correction (issue #357): the outcome-triggered refresh's value
+  // tag must actually reach the LLM prompt, not just ride along on the
+  // bundle unused.
+  it("renders the outcome into the synthesis prompt when the evidence carries one", async () => {
+    llmResponse = JSON.stringify({ brief: "x", hook: "y" });
+    llmCalls.length = 0;
+    await synthesizePersonAngle({
+      prospect: { id: 1, name: "Pat", company: "Acme", email: "pat@acme.dev" },
+      evidence: {
+        dossierText: null,
+        dossierResearched: false,
+        queueSignal: null,
+        github: null,
+        webReadText: null,
+        webReadResearched: false,
+        replies: [],
+        costUsd: 0,
+        sources: [],
+        outcome: { type: "revenue", amount: 5000, label: "deal won" },
+      },
+    });
+    expect(llmCalls.at(-1)?.user).toContain("OUTCOME JUST RECORDED: revenue");
+    expect(llmCalls.at(-1)?.user).toContain("deal won");
   });
 
   it("returns a null angle (not a throw) on an LLM failure", async () => {

--- a/packages/find/src/angle.ts
+++ b/packages/find/src/angle.ts
@@ -1,9 +1,11 @@
 import {
+  demoMode,
   getLedger,
   hasDossierSignal,
   loadConfig,
   logEvent,
   parseProspectAngle,
+  registerAngleRefreshTrigger,
   type ProspectAngle,
   webRead,
 } from "@oneshot-gtm/core";
@@ -23,6 +25,7 @@ import {
 } from "./_github-user.ts";
 import { safeDeepResearchPerson } from "./_sdk-safe.ts";
 import { researchUrl } from "./_profile-url.ts";
+import { isCircuitOpen } from "./_breaker.ts";
 
 /**
  * Evidence gathering + LLM synthesis for the per-prospect angle (issue #355).
@@ -392,3 +395,55 @@ export async function synthesizePersonAngle(
   );
   return { angle, costUsd: 0 };
 }
+
+/**
+ * Re-synthesize and persist one prospect's angle (issue #357) — the same
+ * gather → synthesize → `setProspectAngle` pipeline `synthesize-angles`
+ * drives, invoked from `triggerAngleRefresh`'s fire-and-forget hook instead
+ * of a CLI backfill row. Never throws: every failure mode (demo mode, an
+ * open circuit, no evidence, an empty synthesis) degrades to a no-op, the
+ * same contract `runProspectResearch` (`packages/plays/src/add-prospect.ts`)
+ * follows for its own `void`-called background research.
+ */
+async function refreshProspectAngle(prospectId: number): Promise<void> {
+  // Demo mode is read-only by design (packages/core/src/demo.ts) — a stray
+  // reply/outcome on a seeded demo install must not synthesize for real.
+  if (demoMode()) return;
+  // The circuit breaker guards paid OneShot resolution calls; an open
+  // breaker means the backend is failing, so this is exactly the moment to
+  // skip a paid gather rather than add to the pile-up.
+  if (isCircuitOpen()) return;
+  try {
+    const evidence = await gatherAngleEvidence(prospectId);
+    if (!evidence) return;
+    const ledger = getLedger();
+    const prospect = ledger.getProspectById(prospectId);
+    if (!prospect) return;
+    const { angle } = await synthesizePersonAngle({
+      prospect: {
+        id: prospect.id,
+        name: prospect.name,
+        company: prospect.company,
+        email: prospect.email,
+      },
+      evidence,
+    });
+    if (!angle) return;
+    ledger.setProspectAngle(prospectId, JSON.stringify(angle));
+    logEvent("angle.refresh.done", { prospectId, hook: angle.hook.slice(0, 60) });
+  } catch (err) {
+    logEvent(
+      "angle.refresh.failed",
+      { prospectId, message_120: ((err as Error).message ?? "").slice(0, 120) },
+      "warn",
+    );
+  }
+}
+
+// Registered at module load so core's hot paths (recordInboxReply's caller
+// in pollInboxReplies, tagOutcomeValue) can trigger a refresh without
+// importing this package back — see registerAngleRefreshTrigger's doc in
+// packages/core/src/angle.ts for why the wiring runs this direction.
+registerAngleRefreshTrigger((prospectId: number) => {
+  void refreshProspectAngle(prospectId);
+});

--- a/packages/find/src/angle.ts
+++ b/packages/find/src/angle.ts
@@ -1,5 +1,6 @@
 import {
   type AngleRefreshContext,
+  DEFAULT_SPEND_RESERVATION_USD,
   demoMode,
   getLedger,
   hasDossierSignal,
@@ -8,6 +9,7 @@ import {
   parseProspectAngle,
   registerAngleRefreshTrigger,
   type ProspectAngle,
+  tryReserveDailySpend,
   webRead,
 } from "@oneshot-gtm/core";
 import { complete, loadPrompt, tryParseJsonObject } from "@oneshot-gtm/intel";
@@ -442,8 +444,29 @@ async function refreshProspectAngle(
   // breaker means the backend is failing, so this is exactly the moment to
   // skip a paid gather rather than add to the pile-up.
   if (isCircuitOpen()) return;
+  // Install-wide daily spend ceiling (issue #481, round-2 correction to
+  // #357): this fire-and-forget refresh has no cap of its own, and
+  // `gatherAngleEvidence` defaults `allowPaidResearch` to true — the same
+  // deepResearchPerson/webRead calls every OTHER automated paid path
+  // (trigger runs, drains, mail-research's address lookup) gates behind
+  // `tryReserveDailySpend` first. A reply or outcome tag can fire this on
+  // every prospect with no cached dossier signal, so it must be gated the
+  // same way rather than spending unbounded against the founder's
+  // configured `dailySpendCeilingUsd`. Reserved at the same worst-case
+  // bound `researchBusinessAddress` (packages/plays/src/_mail-research.ts)
+  // uses for its own uncapped automated research, and released the moment
+  // the gather returns regardless of whether it actually spent — the
+  // reservation only needs to close the race against other concurrently
+  // starting automated calls.
+  const reservation = tryReserveDailySpend(DEFAULT_SPEND_RESERVATION_USD);
+  if (!reservation.granted) {
+    logEvent("angle.refresh.spend_capped", { prospectId, reason: reservation.reason }, "warn");
+  }
   try {
-    const evidence = await gatherAngleEvidence(prospectId, { outcome: context?.outcome });
+    const evidence = await gatherAngleEvidence(prospectId, {
+      outcome: context?.outcome,
+      allowPaidResearch: reservation.granted,
+    });
     if (!evidence) return;
     const ledger = getLedger();
     const prospect = ledger.getProspectById(prospectId);
@@ -466,6 +489,8 @@ async function refreshProspectAngle(
       { prospectId, message_120: ((err as Error).message ?? "").slice(0, 120) },
       "warn",
     );
+  } finally {
+    if (reservation.granted) reservation.release();
   }
 }
 

--- a/packages/find/src/angle.ts
+++ b/packages/find/src/angle.ts
@@ -1,4 +1,5 @@
 import {
+  type AngleRefreshContext,
   demoMode,
   getLedger,
   hasDossierSignal,
@@ -80,6 +81,13 @@ export interface AngleEvidenceBundle {
   costUsd: number;
   /** Which tiers actually contributed evidence, e.g. ["dossier", "github:live", "replies:3"]. */
   sources: string[];
+  /**
+   * The value-tag outcome that triggered this refresh, if any (round-1
+   * correction, issue #357) — e.g. a meeting booked or a deal's amount.
+   * Optional/absent for reply-triggered and CLI-backfill gathers, which have
+   * no outcome to report.
+   */
+  outcome?: AngleRefreshContext["outcome"] | null;
 }
 
 /**
@@ -109,6 +117,14 @@ export interface GatherAngleEvidenceOpts {
    * backfill spends nothing.
    */
   allowPaidResearch?: boolean;
+  /**
+   * The value-tag outcome that triggered this gather, if any (round-1
+   * correction, issue #357) — threaded straight onto the returned bundle so
+   * `renderEvidenceForPrompt` can put it in front of the LLM instead of the
+   * outcome-triggered path paying for a synthesis call that can't reflect
+   * the outcome it was fired for.
+   */
+  outcome?: AngleRefreshContext["outcome"];
 }
 
 /**
@@ -247,6 +263,7 @@ export async function gatherAngleEvidence(
     replies,
     costUsd,
     sources,
+    outcome: opts.outcome ?? null,
   };
 }
 
@@ -307,6 +324,15 @@ function renderGitHubEvidence(gh: AngleGitHubEvidence): string {
 
 function renderEvidenceForPrompt(evidence: AngleEvidenceBundle): string {
   const blocks: string[] = [];
+  if (evidence.outcome) {
+    const o = evidence.outcome;
+    blocks.push(
+      `OUTCOME JUST RECORDED: ${o.type}` +
+        `${o.amount != null ? ` ($${o.amount})` : ""}` +
+        `${o.label ? ` — ${o.label}` : ""}` +
+        ` — this just happened; the angle should reflect it.`,
+    );
+  }
   if (evidence.dossierText) blocks.push(`DOSSIER:\n${evidence.dossierText}`);
   if (evidence.queueSignal)
     blocks.push(`FINDER SIGNAL (why they were queued):\n${evidence.queueSignal}`);
@@ -405,7 +431,10 @@ export async function synthesizePersonAngle(
  * same contract `runProspectResearch` (`packages/plays/src/add-prospect.ts`)
  * follows for its own `void`-called background research.
  */
-async function refreshProspectAngle(prospectId: number): Promise<void> {
+async function refreshProspectAngle(
+  prospectId: number,
+  context?: AngleRefreshContext,
+): Promise<void> {
   // Demo mode is read-only by design (packages/core/src/demo.ts) — a stray
   // reply/outcome on a seeded demo install must not synthesize for real.
   if (demoMode()) return;
@@ -414,7 +443,7 @@ async function refreshProspectAngle(prospectId: number): Promise<void> {
   // skip a paid gather rather than add to the pile-up.
   if (isCircuitOpen()) return;
   try {
-    const evidence = await gatherAngleEvidence(prospectId);
+    const evidence = await gatherAngleEvidence(prospectId, { outcome: context?.outcome });
     if (!evidence) return;
     const ledger = getLedger();
     const prospect = ledger.getProspectById(prospectId);
@@ -444,6 +473,6 @@ async function refreshProspectAngle(prospectId: number): Promise<void> {
 // in pollInboxReplies, tagOutcomeValue) can trigger a refresh without
 // importing this package back — see registerAngleRefreshTrigger's doc in
 // packages/core/src/angle.ts for why the wiring runs this direction.
-registerAngleRefreshTrigger((prospectId: number) => {
-  void refreshProspectAngle(prospectId);
+registerAngleRefreshTrigger((prospectId: number, context?: AngleRefreshContext) => {
+  return refreshProspectAngle(prospectId, context);
 });

--- a/packages/plays/__tests__/cadence-reply.test.ts
+++ b/packages/plays/__tests__/cadence-reply.test.ts
@@ -32,6 +32,8 @@ let intents: Map<string, { intent: string | null; intentReason: string | null }>
 // Persisted poll_state rows (watermark + backlog), as the real ledger holds them.
 let pollState: Record<string, string> = {};
 const watermarkOf = () => pollState["inbox_replies"] ?? null;
+// Prospect ids for which the angle-refresh hook (issue #357) fired.
+let angleRefreshCalls: number[] = [];
 
 type Row = {
   prospect_id: number;
@@ -55,6 +57,9 @@ vi.mock("@oneshot-gtm/core", async () => {
     sendEmail: async () => {
       calls.sendEmail++;
       return { receiptId: 1 };
+    },
+    triggerAngleRefresh: (prospectId: number) => {
+      angleRefreshCalls.push(prospectId);
     },
     // A faithful fake of listInbox's contract: filter `inboxEmails` by
     // since/until on received_at, newest first, clamp to `limit`, has_more
@@ -210,6 +215,7 @@ beforeEach(() => {
   seqEvents = [];
   intents = new Map();
   triageEmailsMock.mockClear();
+  angleRefreshCalls = [];
   // The fixture cadence is also the latest play that emailed the prospect.
   latestSentPlay = "stack-consolidation";
   pollState = {};
@@ -285,6 +291,27 @@ describe("pollInboxReplies — standalone background detection (no sends)", () =
     // The reply metric (home/CAC) is fed via markLatestStepReplied.
     expect(repliedSteps).toEqual([{ prospectId: 1, playName: "stack-consolidation" }]);
     expect(calls.sendEmail).toBe(0);
+  });
+
+  // Issue #357: a genuinely new human reply refreshes the per-prospect angle.
+  it("triggers an angle refresh for a new human reply", async () => {
+    inboxEmails = [{ id: "m1", from: "sophia@agenticarchitect.ai", subject: "re: stack" }];
+
+    await pollInboxReplies();
+
+    expect(angleRefreshCalls).toEqual([1]);
+  });
+
+  it("does not trigger an angle refresh for a re-swept already-recorded reply", async () => {
+    inboxEmails = [{ id: "m1", from: "sophia@agenticarchitect.ai", subject: "re: stack" }];
+
+    await pollInboxReplies();
+    angleRefreshCalls = [];
+    // Same email re-examined by the watermark overlap: recordInboxReply's
+    // INSERT OR IGNORE reports it as not-new.
+    await pollInboxReplies();
+
+    expect(angleRefreshCalls).toEqual([]);
   });
 
   it("persists every matched inbound (body included) into inbox_replies", async () => {
@@ -541,6 +568,8 @@ describe("pollInboxReplies — auto-reply classification (v23)", () => {
     expect(repliedSteps).toHaveLength(0); // no sequence_events flip → metric untouched
     expect(persistedReplies).toHaveLength(1); // conversation history stays complete
     expect(persistedReplies[0]?.kind).toBe("auto");
+    // Issue #357: an auto-reply is never signal worth paying to re-synthesize.
+    expect(angleRefreshCalls).toEqual([]);
   });
 
   it("a dead-mailbox autoresponder stops the cadence as bounced, not replied", async () => {
@@ -586,6 +615,8 @@ describe("pollInboxReplies — auto-reply classification (v23)", () => {
       { prospectId: 1, playName: "stack-consolidation", status: "unsubscribed" },
     ]);
     expect(persistedReplies[0]?.kind).toBe("unsubscribe");
+    // Issue #357: an unsubscribe is never signal worth paying to re-synthesize.
+    expect(angleRefreshCalls).toEqual([]);
   });
 
   it("a terminal cadence is not resurrected or re-stopped by a dead-mailbox notice", async () => {

--- a/packages/plays/src/_cadence.ts
+++ b/packages/plays/src/_cadence.ts
@@ -18,6 +18,7 @@ import {
   sendSms,
   tagOutcomeValue,
   trackSend,
+  triggerAngleRefresh,
   voiceCall,
   type BounceKind,
   type ProspectRecord,
@@ -490,7 +491,7 @@ async function walkInboxWindow(
       // inserted a new row no longer gates triage (round-1 correction,
       // #558): see claimInboxReplyForTriage below for why the atomic claim
       // on `intent` replaced it.
-      ledger.recordInboxReply({
+      const insertedReply = ledger.recordInboxReply({
         id: e.id,
         threadKey: e.thread_id ?? e.id,
         prospectId: prospect.id,
@@ -504,6 +505,13 @@ async function walkInboxWindow(
         messageId: e.message_id ?? null,
         kind,
       });
+      // Refresh the per-prospect angle (issue #357) on a genuinely new human
+      // reply only — never auto-replies/unsubscribes (no signal worth paying
+      // for), and never a re-swept row the watermark overlap re-examines
+      // (insertedReply false = recordInboxReply's INSERT OR IGNORE no-op).
+      // Fire-and-forget: triggerAngleRefresh itself debounces on
+      // angle_synthesized_at and never throws.
+      if (insertedReply && kind === "human") triggerAngleRefresh(prospect.id);
       if (kind !== "human") {
         out.autoRepliesSkipped++;
         // A dead mailbox ("retired", "no longer at company") is a human-layer


### PR DESCRIPTION
Closes #357.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 8179d2355e76 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (2 errs) vs base ok (2 errs)
```

**Review note:** review FAIL at the 2-round correction cap — findings filed: https://github.com/oneshot-agent/oneshot-gtm/issues/573