### PR TITLE
fix: issue #577: Read the founder's calendar and collect past meetings that need an outcome

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 67 CLI commands, 23 plays, 15 finders, ten dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-08** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3503 tests / 261 files** · typecheck + oxlint + oxfmt pass (38 lint warnings, 0 errors).
+Last verified **2026-09-09** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3612 tests / 270 files** · typecheck + oxlint + oxfmt pass (38 lint warnings, 0 errors).
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/apps/cli/__tests__/init-config.test.ts
+++ b/apps/cli/__tests__/init-config.test.ts
@@ -27,6 +27,8 @@ const current = {
   clientId: "client-1",
   slackWebhookUrl: null,
   dailySpendCeilingUsd: null,
+  calendarIdentityId: null,
+  calendarId: "primary",
 } satisfies OneShotConfig;
 
 describe("init config writer", () => {

--- a/apps/cli/src/commands/gmail.ts
+++ b/apps/cli/src/commands/gmail.ts
@@ -9,6 +9,7 @@ import {
   resolveCanaryPair,
   runPlacementCanary,
   SAME_DOMAIN_WARNING,
+  saveGmailToken,
   saveSecrets,
   secretsPath,
   SINGLE_SEED_CAVEAT,
@@ -116,13 +117,16 @@ export async function commandGmailAuth(): Promise<void> {
     }
 
     let refreshToken: string;
+    let scope: string | null;
     try {
-      refreshToken = await exchangeGmailAuthCode({
+      const exchanged = await exchangeGmailAuthCode({
         code: outcome.code,
         clientId,
         clientSecret,
         redirectUri,
       });
+      refreshToken = exchanged.refreshToken;
+      scope = exchanged.scope;
     } catch (err) {
       warn((err as Error).message);
       return;
@@ -136,6 +140,10 @@ export async function commandGmailAuth(): Promise<void> {
     const { emailAddress } = await getGmailProfile({ id: "pending", refreshToken });
     _resetGmailCache();
     const { identityId, created } = registerGmailIdentity({ address: emailAddress, refreshToken });
+    // registerGmailIdentity's saveGmailToken call doesn't carry the scope;
+    // overwrite it here so `doctor`/`setup` can tell whether this consent
+    // actually granted calendar access (issue #577).
+    saveGmailToken(identityId, { refreshToken, address: emailAddress, scope });
     ok(`Saved refresh token for ${c.cyan(emailAddress)} (${c.dim(secretsPath())} dir)`);
 
     if (created) {

--- a/apps/server/__tests__/calendar-setup-route.test.ts
+++ b/apps/server/__tests__/calendar-setup-route.test.ts
@@ -1,0 +1,130 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// GET /api/setup/calendars — the /setup calendar picker's source list
+// (issue #577). Refusal of sub-writer access is enforced by
+// listWritableCalendars itself (core, tested there); this route's own job is
+// identity resolution, the 7-day count fan-out, and error mapping.
+
+let cfgOverride: Record<string, unknown> = {};
+const listWritableCalendarsMock = vi.fn();
+const recentEventCountMock = vi.fn(async () => 3);
+const gmailAccountForMock = vi.fn(
+  () =>
+    ({ refreshToken: "rt", clientId: "id", clientSecret: "secret" }) as unknown as ReturnType<
+      typeof import("@oneshot-gtm/core").gmailAccountFor
+    >,
+);
+
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    loadConfig: () => ({ ...actual.loadConfig(), ...cfgOverride }),
+    listWritableCalendars: listWritableCalendarsMock,
+    recentEventCount: recentEventCountMock,
+    gmailAccountFor: gmailAccountForMock,
+  };
+});
+
+const { listCalendarsRoute } = await import("../src/api/calendar-setup.ts");
+
+function req(url: string): Request {
+  return new Request(url, { headers: { host: "127.0.0.1:3030" } });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  gmailAccountForMock.mockReturnValue({
+    refreshToken: "rt",
+    clientId: "id",
+    clientSecret: "secret",
+  } as unknown as ReturnType<typeof import("@oneshot-gtm/core").gmailAccountFor>);
+  cfgOverride = {
+    emailIdentities: [
+      {
+        id: "gmail:jn@x.dev",
+        provider: "gmail",
+        address: "jn@x.dev",
+        maxPerDay: null,
+        warmup: null,
+      },
+      {
+        id: "oneshot:jn@mail.x.dev",
+        provider: "oneshot",
+        sendingDomain: "mail.x.dev",
+        mailbox: "jn",
+        maxPerDay: 40,
+        warmup: null,
+      },
+    ],
+  };
+});
+
+describe("GET /api/setup/calendars", () => {
+  it("400s without an identityId", async () => {
+    const res = await listCalendarsRoute(req("http://localhost/api/setup/calendars"));
+    expect(res.status).toBe(400);
+  });
+
+  it("404s for an identityId not in the pool or not gmail", async () => {
+    const res = await listCalendarsRoute(
+      req("http://localhost/api/setup/calendars?identityId=oneshot:jn@mail.x.dev"),
+    );
+    expect(res.status).toBe(404);
+    expect(listWritableCalendarsMock).not.toHaveBeenCalled();
+  });
+
+  it("404s for an unknown identityId", async () => {
+    const res = await listCalendarsRoute(
+      req("http://localhost/api/setup/calendars?identityId=gmail:never@x.dev"),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("404s when the identity has no refresh token stored", async () => {
+    gmailAccountForMock.mockReturnValue(
+      null as unknown as ReturnType<typeof import("@oneshot-gtm/core").gmailAccountFor>,
+    );
+    const res = await listCalendarsRoute(
+      req("http://localhost/api/setup/calendars?identityId=gmail:jn@x.dev"),
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it("returns calendars with a 7-day event count fanned out per entry", async () => {
+    listWritableCalendarsMock.mockResolvedValue([
+      { id: "primary", summary: "Jane", accessRole: "owner" },
+      { id: "work@group.calendar.google.com", summary: "Team", accessRole: "writer" },
+    ]);
+    recentEventCountMock.mockResolvedValueOnce(5).mockResolvedValueOnce(2);
+    const res = await listCalendarsRoute(
+      req("http://localhost/api/setup/calendars?identityId=gmail:jn@x.dev"),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      calendars: Array<{ id: string; recentEventCount: number }>;
+    };
+    expect(body.calendars).toEqual([
+      { id: "primary", summary: "Jane", accessRole: "owner", recentEventCount: 5 },
+      {
+        id: "work@group.calendar.google.com",
+        summary: "Team",
+        accessRole: "writer",
+        recentEventCount: 2,
+      },
+    ]);
+  });
+
+  it("maps a listWritableCalendars failure to a 502, not a 500", async () => {
+    listWritableCalendarsMock.mockRejectedValue(
+      new Error("Gmail API failed (401): re-auth required"),
+    );
+    const res = await listCalendarsRoute(
+      req("http://localhost/api/setup/calendars?identityId=gmail:jn@x.dev"),
+    );
+    expect(res.status).toBe(502);
+    expect((await res.json()) as { error: string }).toEqual({
+      error: "Gmail API failed (401): re-auth required",
+    });
+  });
+});

--- a/apps/server/__tests__/meetings-route.test.ts
+++ b/apps/server/__tests__/meetings-route.test.ts
@@ -1,0 +1,234 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// /api/meetings + outcome/confirm/dismiss routes (issue #577 queue UI).
+
+const getMeetingMock = vi.fn();
+const listPendingOutcomeMeetingsMock = vi.fn(() => [] as unknown[]);
+const listMeetingsForReviewMock = vi.fn(() => [] as unknown[]);
+const getProspectByIdMock = vi.fn((): unknown => null);
+const setMeetingOutcomeMock = vi.fn();
+const confirmMeetingMatchMock = vi.fn();
+const dismissMeetingMatchMock = vi.fn();
+
+const ledger = {
+  getMeeting: getMeetingMock,
+  listPendingOutcomeMeetings: listPendingOutcomeMeetingsMock,
+  listMeetingsForReview: listMeetingsForReviewMock,
+  getProspectById: getProspectByIdMock,
+  setMeetingOutcome: setMeetingOutcomeMock,
+  confirmMeetingMatch: confirmMeetingMatchMock,
+  dismissMeetingMatch: dismissMeetingMatchMock,
+};
+
+let cfgOverride: Record<string, unknown> = { calendarIdentityId: "gmail:jn@x.dev" };
+let demoModeOverride = false;
+
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    getLedger: () => ledger,
+    loadConfig: () => ({ ...actual.loadConfig(), ...cfgOverride }),
+    demoMode: () => demoModeOverride,
+  };
+});
+
+const {
+  listMeetingsRoute,
+  logMeetingOutcomeRoute,
+  confirmMeetingMatchRoute,
+  dismissMeetingMatchRoute,
+} = await import("../src/api/meetings.ts");
+
+function getReq(url: string): Request {
+  return new Request(url, { headers: { host: "127.0.0.1:3030" } });
+}
+
+function postReq(url: string, body: unknown): Request {
+  return new Request(url, {
+    method: "POST",
+    headers: { "content-type": "application/json", host: "127.0.0.1:3030" },
+    body: JSON.stringify(body),
+  });
+}
+
+const BASE_ROW = {
+  calendar_id: "primary",
+  event_id: "e1",
+  ical_uid: "ical-1",
+  recurring_event_id: null,
+  status: "confirmed",
+  summary: "Intro call",
+  all_day: 0,
+  starts_at: "2024-01-01T10:00:00Z",
+  ends_at: "2024-01-01T10:30:00Z",
+  event_timezone: null,
+  organizer_email: "jn@x.dev",
+  self_response: null,
+  external_attendee_count: 1,
+  external_attendees_json: JSON.stringify(["pat@acme.com"]),
+  attendees_omitted: 0,
+  prospect_id: 1,
+  suggested_prospect_id: null,
+  match_status: "exact",
+  match_method: null,
+  match_confidence: 1,
+  outcome: null,
+  outcome_note: null,
+  outcome_recorded_at: null,
+  outcome_prompted_at: null,
+  event_updated_at: "2024-01-01T09:00:00Z",
+  first_seen_at: "2024-01-01T09:00:00Z",
+  last_seen_at: "2024-01-01T09:00:00Z",
+  attendees_fingerprint: "pat@acme.com",
+};
+
+beforeEach(() => {
+  cfgOverride = { calendarIdentityId: "gmail:jn@x.dev" };
+  demoModeOverride = false;
+  vi.clearAllMocks();
+  listPendingOutcomeMeetingsMock.mockReturnValue([]);
+  listMeetingsForReviewMock.mockReturnValue([]);
+  getMeetingMock.mockReturnValue(null);
+  getProspectByIdMock.mockReturnValue(null);
+});
+
+describe("GET /api/meetings", () => {
+  it("returns empty lists (no ledger call) when calendarIdentityId is unset — feature off", async () => {
+    cfgOverride = { calendarIdentityId: null };
+    const res = await listMeetingsRoute(getReq("http://localhost/api/meetings"));
+    expect(await res.json()).toEqual({ awaitingOutcome: [], needsReview: [] });
+    expect(listPendingOutcomeMeetingsMock).not.toHaveBeenCalled();
+  });
+
+  it("projects a matched, awaiting-outcome row with the prospect's name/email joined in", async () => {
+    listPendingOutcomeMeetingsMock.mockReturnValue([BASE_ROW]);
+    getProspectByIdMock.mockReturnValue({ id: 1, name: "Pat Doe", email: "pat@acme.com" });
+    const res = await listMeetingsRoute(getReq("http://localhost/api/meetings"));
+    const body = (await res.json()) as {
+      awaitingOutcome: Array<Record<string, unknown>>;
+      needsReview: unknown[];
+    };
+    expect(body.awaitingOutcome).toHaveLength(1);
+    const row = body.awaitingOutcome[0]!;
+    expect(row["prospectName"]).toBe("Pat Doe");
+    expect(row["prospectEmail"]).toBe("pat@acme.com");
+    expect(row["externalAttendees"]).toEqual(["pat@acme.com"]);
+    expect(row["matchReason"]).toBe("matched by email address");
+  });
+
+  it("renders the fuzzy match method as a human sentence, never the bare method string", async () => {
+    listMeetingsForReviewMock.mockReturnValue([
+      {
+        ...BASE_ROW,
+        match_status: "suggested",
+        match_method: "name_domain",
+        prospect_id: null,
+        suggested_prospect_id: 2,
+      },
+    ]);
+    getProspectByIdMock.mockReturnValue({ id: 2, name: "Sam Roe", email: "sam@acme.com" });
+    const res = await listMeetingsRoute(getReq("http://localhost/api/meetings"));
+    const body = (await res.json()) as { needsReview: Array<Record<string, unknown>> };
+    expect(body.needsReview[0]?.["matchReason"]).toBe("same company domain and name");
+    expect(body.needsReview[0]?.["matchReason"]).not.toMatch(/name_domain/);
+  });
+});
+
+describe("POST /api/meetings/outcome", () => {
+  it("404s when the meeting doesn't exist", async () => {
+    const res = await logMeetingOutcomeRoute(
+      postReq("http://localhost/api/meetings/outcome", {
+        calendarId: "primary",
+        eventId: "missing",
+        outcome: "held",
+      }),
+    );
+    expect(res.status).toBe(404);
+    expect(setMeetingOutcomeMock).not.toHaveBeenCalled();
+  });
+
+  it("400s on an invalid outcome value", async () => {
+    getMeetingMock.mockReturnValue(BASE_ROW);
+    const res = await logMeetingOutcomeRoute(
+      postReq("http://localhost/api/meetings/outcome", {
+        calendarId: "primary",
+        eventId: "e1",
+        outcome: "maybe",
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(setMeetingOutcomeMock).not.toHaveBeenCalled();
+  });
+
+  it("records a valid outcome with a trimmed note", async () => {
+    getMeetingMock.mockReturnValue(BASE_ROW);
+    const res = await logMeetingOutcomeRoute(
+      postReq("http://localhost/api/meetings/outcome", {
+        calendarId: "primary",
+        eventId: "e1",
+        outcome: "no_show",
+        note: "  didn't join  ",
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(setMeetingOutcomeMock).toHaveBeenCalledWith({
+      calendarId: "primary",
+      eventId: "e1",
+      outcome: "no_show",
+      note: "didn't join",
+    });
+  });
+});
+
+describe("POST /api/meetings/confirm", () => {
+  it("404s when the prospect doesn't exist", async () => {
+    getMeetingMock.mockReturnValue(BASE_ROW);
+    getProspectByIdMock.mockReturnValue(null);
+    const res = await confirmMeetingMatchRoute(
+      postReq("http://localhost/api/meetings/confirm", {
+        calendarId: "primary",
+        eventId: "e1",
+        prospectId: 99,
+      }),
+    );
+    expect(res.status).toBe(404);
+    expect(confirmMeetingMatchMock).not.toHaveBeenCalled();
+  });
+
+  it("confirms a match", async () => {
+    getMeetingMock.mockReturnValue(BASE_ROW);
+    getProspectByIdMock.mockReturnValue({ id: 2, name: "Sam", email: "sam@acme.com" });
+    const res = await confirmMeetingMatchRoute(
+      postReq("http://localhost/api/meetings/confirm", {
+        calendarId: "primary",
+        eventId: "e1",
+        prospectId: 2,
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(confirmMeetingMatchMock).toHaveBeenCalledWith("primary", "e1", 2);
+  });
+});
+
+describe("POST /api/meetings/dismiss", () => {
+  it("404s when the meeting doesn't exist", async () => {
+    const res = await dismissMeetingMatchRoute(
+      postReq("http://localhost/api/meetings/dismiss", {
+        calendarId: "primary",
+        eventId: "missing",
+      }),
+    );
+    expect(res.status).toBe(404);
+    expect(dismissMeetingMatchMock).not.toHaveBeenCalled();
+  });
+
+  it("dismisses a suggested match", async () => {
+    getMeetingMock.mockReturnValue(BASE_ROW);
+    const res = await dismissMeetingMatchRoute(
+      postReq("http://localhost/api/meetings/dismiss", { calendarId: "primary", eventId: "e1" }),
+    );
+    expect(res.status).toBe(200);
+    expect(dismissMeetingMatchMock).toHaveBeenCalledWith("primary", "e1");
+  });
+});

--- a/apps/server/__tests__/setup-public-cfg.test.ts
+++ b/apps/server/__tests__/setup-public-cfg.test.ts
@@ -36,6 +36,8 @@ const FULL_CFG: OneShotConfig = {
   clientId: "11111111-2222-3333-4444-555555555555",
   slackWebhookUrl: null,
   dailySpendCeilingUsd: null,
+  calendarIdentityId: null,
+  calendarId: "primary",
 };
 
 describe("publicCfg — privacy boundary", () => {

--- a/apps/server/__tests__/setup-route.test.ts
+++ b/apps/server/__tests__/setup-route.test.ts
@@ -85,6 +85,8 @@ const BASE: OneShotConfig = {
   clientId: "11111111-2222-3333-4444-555555555555",
   slackWebhookUrl: null,
   dailySpendCeilingUsd: null,
+  calendarIdentityId: null,
+  calendarId: "primary",
 };
 
 beforeEach(() => {
@@ -166,6 +168,31 @@ describe("POST /api/setup — section-scoped bodies", () => {
     expect(await post({ queueReviewOrder: "sideways" })).toEqual({ status: 200 });
     expect(savedCfg().queueReviewOrder).toBe("ranked");
   });
+
+  it("calendarIdentityId pointing at a connected Gmail identity is accepted and calendarId trims/defaults", async () => {
+    expect(
+      await post({
+        calendarIdentityId: "gmail:jane@gmail.com",
+        calendarId: " work@group.calendar.google.com ",
+      }),
+    ).toEqual({ status: 200 });
+    const cfg = savedCfg();
+    expect(cfg.calendarIdentityId).toBe("gmail:jane@gmail.com");
+    expect(cfg.calendarId).toBe("work@group.calendar.google.com");
+  });
+
+  it("calendarIdentityId: null turns the feature off and is accepted with no identity check", async () => {
+    current.calendarIdentityId = "gmail:jane@gmail.com";
+    expect(await post({ calendarIdentityId: null })).toEqual({ status: 200 });
+    expect(savedCfg().calendarIdentityId).toBeNull();
+  });
+
+  it("a blank calendarId defaults back to 'primary'", async () => {
+    expect(await post({ calendarIdentityId: "gmail:jane@gmail.com", calendarId: "  " })).toEqual({
+      status: 200,
+    });
+    expect(savedCfg().calendarId).toBe("primary");
+  });
 });
 
 describe("POST /api/setup — rejected bodies answer 400 and write nothing", () => {
@@ -244,6 +271,20 @@ describe("POST /api/setup — rejected bodies answer 400 and write nothing", () 
     const res = await post({ timezone: "Mars/Olympus" });
     expect(res.status).toBe(400);
     expect(res.error).toMatch(/invalid timezone 'Mars\/Olympus'/);
+    untouched();
+  });
+
+  it("a calendarIdentityId pointing at a non-existent identity is a 400 (never persisted, never polled)", async () => {
+    const res = await post({ calendarIdentityId: "gmail:never-connected@x.dev" });
+    expect(res.status).toBe(400);
+    expect(res.error).toMatch(/is not a connected Gmail identity/);
+    untouched();
+  });
+
+  it("a calendarIdentityId pointing at a non-Gmail identity is a 400", async () => {
+    const res = await post({ calendarIdentityId: "oneshot:jane@mail.acme.dev" });
+    expect(res.status).toBe(400);
+    expect(res.error).toMatch(/is not a connected Gmail identity/);
     untouched();
   });
 

--- a/apps/server/src/api/calendar-setup.ts
+++ b/apps/server/src/api/calendar-setup.ts
@@ -1,0 +1,50 @@
+import {
+  gmailAccountFor,
+  listWritableCalendars,
+  loadConfig,
+  recentEventCount,
+  resolveIdentities,
+} from "@oneshot-gtm/core";
+import type { CalendarPickerEntry } from "@oneshot-gtm/shared-types";
+import { jsonResponse } from "../server.ts";
+
+/**
+ * GET /api/setup/calendars?identityId=gmail:jn@x.dev — the /setup calendar
+ * picker's source list. Refuses (server-side, via `listWritableCalendars`'
+ * `minAccessRole=writer`) anything below writer access — a reader/
+ * freeBusyReader calendar returns every event as `summary: "busy"` with no
+ * attendees, which reads as a self-block. Each entry carries a 7-day event
+ * count because a founder cannot reliably say which calendar their booking
+ * tool actually writes to.
+ */
+export async function listCalendarsRoute(req: Request): Promise<Response> {
+  const url = new URL(req.url);
+  const identityId = url.searchParams.get("identityId");
+  if (!identityId) {
+    return jsonResponse({ error: "identityId is required" }, 400, req);
+  }
+  const cfg = loadConfig();
+  const identity = resolveIdentities(cfg).find((i) => i.id === identityId);
+  if (!identity || identity.provider !== "gmail") {
+    return jsonResponse({ error: `'${identityId}' is not a connected Gmail identity` }, 404, req);
+  }
+  const account = gmailAccountFor(identity);
+  if (!account) {
+    return jsonResponse({ error: `no refresh token stored for '${identityId}'` }, 404, req);
+  }
+  let calendars: Awaited<ReturnType<typeof listWritableCalendars>>;
+  try {
+    calendars = await listWritableCalendars(account);
+  } catch (err) {
+    return jsonResponse({ error: (err as Error).message }, 502, req);
+  }
+  const withCounts: CalendarPickerEntry[] = await Promise.all(
+    calendars.map(async (c) => ({
+      id: c.id,
+      summary: c.summary,
+      accessRole: c.accessRole,
+      recentEventCount: await recentEventCount(account, c.id),
+    })),
+  );
+  return jsonResponse({ calendars: withCounts }, 200, req);
+}

--- a/apps/server/src/api/gmail-auth.ts
+++ b/apps/server/src/api/gmail-auth.ts
@@ -5,6 +5,7 @@ import {
   getGmailProfile,
   gmailConsentUrl,
   registerGmailIdentity,
+  saveGmailToken,
 } from "@oneshot-gtm/core";
 import { jsonResponse } from "../server.ts";
 
@@ -17,7 +18,10 @@ import { jsonResponse } from "../server.ts";
  */
 
 const STATE_TTL_MS = 10 * 60 * 1000;
-const pendingStates = new Map<string, { createdAt: number; redirectUri: string }>();
+const pendingStates = new Map<
+  string,
+  { createdAt: number; redirectUri: string; purpose: "send" | "calendar" }
+>();
 
 function prune(): void {
   const cutoff = Date.now() - STATE_TTL_MS;
@@ -45,7 +49,13 @@ export function startGmailAuthRoute(req: Request): Response {
   const url = new URL(req.url);
   const redirectUri = `${url.origin}/api/gmail/auth/callback`;
   const state = randomUUID();
-  pendingStates.set(state, { createdAt: Date.now(), redirectUri });
+  // `?purpose=calendar` (used by the /setup calendar picker's "Connect a
+  // calendar-only mailbox" affordance): a mailbox connected purely to read
+  // its calendar must NOT silently enrol as a sender (issue #577) — see
+  // registerGmailIdentity's `calendarOnly` handling. Anything else defaults
+  // to the ordinary sending purpose.
+  const purpose = url.searchParams.get("purpose") === "calendar" ? "calendar" : "send";
+  pendingStates.set(state, { createdAt: Date.now(), redirectUri, purpose });
   return Response.redirect(gmailConsentUrl({ clientId: creds.clientId, redirectUri, state }), 302);
 }
 
@@ -69,7 +79,7 @@ export async function gmailAuthCallbackRoute(req: Request): Promise<Response> {
   if (!creds) return backToSetup("error:client credentials missing");
 
   try {
-    const refreshToken = await exchangeGmailAuthCode({
+    const exchanged = await exchangeGmailAuthCode({
       code,
       clientId: creds.clientId,
       clientSecret: creds.clientSecret,
@@ -78,9 +88,25 @@ export async function gmailAuthCallbackRoute(req: Request): Promise<Response> {
     // Resolve which account consented BEFORE registering, so the identity id
     // is the real address, not a guess. Throwaway cache key, cleared after.
     _resetGmailCache();
-    const { emailAddress } = await getGmailProfile({ id: "web-auth-pending", refreshToken });
+    const { emailAddress } = await getGmailProfile({
+      id: "web-auth-pending",
+      refreshToken: exchanged.refreshToken,
+    });
     _resetGmailCache();
-    registerGmailIdentity({ address: emailAddress, refreshToken });
+    const { identityId } = registerGmailIdentity({
+      address: emailAddress,
+      refreshToken: exchanged.refreshToken,
+      calendarOnly: pending.purpose === "calendar",
+    });
+    // registerGmailIdentity always writes the token via saveGmailToken
+    // without a scope (it predates issue #577); overwrite with the scope
+    // Google actually granted on THIS consent so doctor/setup can tell a
+    // calendar-capable identity from a Gmail-only one.
+    saveGmailToken(identityId, {
+      refreshToken: exchanged.refreshToken,
+      address: emailAddress,
+      scope: exchanged.scope,
+    });
     return backToSetup(`ok:${emailAddress}`);
   } catch (err) {
     return backToSetup(

--- a/apps/server/src/api/meetings.ts
+++ b/apps/server/src/api/meetings.ts
@@ -1,0 +1,154 @@
+import { demoFixture, demoMode, getLedger, loadConfig } from "@oneshot-gtm/core";
+import type {
+  ConfirmMeetingMatchRequest,
+  DismissMeetingMatchRequest,
+  LogMeetingOutcomeRequest,
+  MeetingMatchStatusView,
+  MeetingsResult,
+  MeetingView,
+} from "@oneshot-gtm/shared-types";
+import type { MeetingRecord } from "@oneshot-gtm/core";
+import { jsonResponse } from "../server.ts";
+
+/**
+ * Read-only + outcome-capture surface for the calendar ingest half of issue
+ * #577. The queue UI clones the /inbox `awaitingReply` pattern: computed
+ * server-side, split into "past meetings needing an outcome" and "matches
+ * needing a founder decision".
+ */
+
+/** The match method rendered as a sentence, never the bare number — per the card. */
+function matchReasonSentence(row: MeetingRecord): string | null {
+  switch (row.match_method) {
+    case "name_domain":
+      return "same company domain and name";
+    case "domain":
+      return "unique prospect at the same company domain";
+    case "name":
+      return "same full name at a different domain";
+    case "description":
+      return "email found in the event description";
+    default:
+      return row.match_status === "exact" ? "matched by email address" : null;
+  }
+}
+
+function toView(
+  row: MeetingRecord,
+  prospectById: Map<number, { name: string | null; email: string | null }>,
+): MeetingView {
+  const prospect = row.prospect_id != null ? prospectById.get(row.prospect_id) : undefined;
+  const suggested =
+    row.suggested_prospect_id != null ? prospectById.get(row.suggested_prospect_id) : undefined;
+  let externalAttendees: string[] = [];
+  if (row.external_attendees_json) {
+    try {
+      const parsed = JSON.parse(row.external_attendees_json) as unknown;
+      if (Array.isArray(parsed)) externalAttendees = parsed.filter((x) => typeof x === "string");
+    } catch {
+      // corrupt row — render with no attendee list rather than throwing the whole page.
+    }
+  }
+  return {
+    calendarId: row.calendar_id,
+    eventId: row.event_id,
+    summary: row.summary,
+    startsAt: row.starts_at,
+    endsAt: row.ends_at,
+    organizerEmail: row.organizer_email,
+    externalAttendees,
+    prospectId: row.prospect_id,
+    prospectName: prospect?.name ?? null,
+    prospectEmail: prospect?.email ?? null,
+    suggestedProspectId: row.suggested_prospect_id,
+    suggestedProspectName: suggested?.name ?? null,
+    suggestedProspectEmail: suggested?.email ?? null,
+    matchStatus: row.match_status as MeetingMatchStatusView,
+    matchReason: matchReasonSentence(row),
+    outcome: row.outcome as MeetingView["outcome"],
+    outcomeNote: row.outcome_note,
+  };
+}
+
+export async function listMeetingsRoute(req: Request): Promise<Response> {
+  if (demoMode()) {
+    const fixture = demoFixture<MeetingsResult>("meetings.json");
+    return jsonResponse(fixture ?? { awaitingOutcome: [], needsReview: [] }, 200, req);
+  }
+  const cfg = loadConfig();
+  if (!cfg.calendarIdentityId) {
+    return jsonResponse({ awaitingOutcome: [], needsReview: [] }, 200, req);
+  }
+  const ledger = getLedger();
+  const awaiting = ledger.listPendingOutcomeMeetings();
+  const review = ledger.listMeetingsForReview();
+
+  const prospectIds = new Set<number>();
+  for (const row of [...awaiting, ...review]) {
+    if (row.prospect_id != null) prospectIds.add(row.prospect_id);
+    if (row.suggested_prospect_id != null) prospectIds.add(row.suggested_prospect_id);
+  }
+  const prospectById = new Map<number, { name: string | null; email: string | null }>();
+  for (const id of prospectIds) {
+    const p = ledger.getProspectById(id);
+    if (p) prospectById.set(id, { name: p.name, email: p.email });
+  }
+
+  const result: MeetingsResult = {
+    awaitingOutcome: awaiting.map((r) => toView(r, prospectById)),
+    needsReview: review.map((r) => toView(r, prospectById)),
+  };
+  return jsonResponse(result, 200, req);
+}
+
+const VALID_OUTCOMES = new Set(["held", "no_show", "cancelled", "rescheduled"]);
+
+export async function logMeetingOutcomeRoute(req: Request): Promise<Response> {
+  const body = (await req.json()) as LogMeetingOutcomeRequest;
+  if (!body.calendarId || !body.eventId) {
+    return jsonResponse({ error: "calendarId and eventId are required" }, 400, req);
+  }
+  if (!VALID_OUTCOMES.has(body.outcome)) {
+    return jsonResponse({ error: `invalid outcome '${body.outcome}'` }, 400, req);
+  }
+  const ledger = getLedger();
+  if (!ledger.getMeeting(body.calendarId, body.eventId)) {
+    return jsonResponse({ error: "meeting not found" }, 404, req);
+  }
+  ledger.setMeetingOutcome({
+    calendarId: body.calendarId,
+    eventId: body.eventId,
+    outcome: body.outcome,
+    note: body.note?.trim() || null,
+  });
+  return jsonResponse({ ok: true }, 200, req);
+}
+
+export async function confirmMeetingMatchRoute(req: Request): Promise<Response> {
+  const body = (await req.json()) as ConfirmMeetingMatchRequest;
+  if (!body.calendarId || !body.eventId || typeof body.prospectId !== "number") {
+    return jsonResponse({ error: "calendarId, eventId and prospectId are required" }, 400, req);
+  }
+  const ledger = getLedger();
+  if (!ledger.getMeeting(body.calendarId, body.eventId)) {
+    return jsonResponse({ error: "meeting not found" }, 404, req);
+  }
+  if (!ledger.getProspectById(body.prospectId)) {
+    return jsonResponse({ error: "prospect not found" }, 404, req);
+  }
+  ledger.confirmMeetingMatch(body.calendarId, body.eventId, body.prospectId);
+  return jsonResponse({ ok: true }, 200, req);
+}
+
+export async function dismissMeetingMatchRoute(req: Request): Promise<Response> {
+  const body = (await req.json()) as DismissMeetingMatchRequest;
+  if (!body.calendarId || !body.eventId) {
+    return jsonResponse({ error: "calendarId and eventId are required" }, 400, req);
+  }
+  const ledger = getLedger();
+  if (!ledger.getMeeting(body.calendarId, body.eventId)) {
+    return jsonResponse({ error: "meeting not found" }, 404, req);
+  }
+  ledger.dismissMeetingMatch(body.calendarId, body.eventId);
+  return jsonResponse({ ok: true }, 200, req);
+}

--- a/apps/server/src/api/setup.ts
+++ b/apps/server/src/api/setup.ts
@@ -1,9 +1,11 @@
 import {
   deleteGmailToken,
+  hasCalendarScope,
   identityCapacities,
   isValidTimeZone,
   listSendingDomains,
   loadConfig,
+  loadGmailTokens,
   registerOneShotIdentity,
   registerSmartleadIdentity,
   resolveIdentities,
@@ -46,6 +48,7 @@ function identityViews(cfg: OneShotConfig): SenderIdentityView[] {
   // Per cap-group: capToday + domainSentToday reflect the shared per-domain
   // budget (all mailboxes on one OneShot domain pool one reputation/limit).
   const caps = identityCapacities();
+  const tokens = loadGmailTokens();
   return resolveIdentities(cfg).map((i) => {
     const cap = caps.get(i.id);
     return {
@@ -61,6 +64,7 @@ function identityViews(cfg: OneShotConfig): SenderIdentityView[] {
       domainSentToday: cap?.domainSentToday ?? 0,
       capToday: cap && Number.isFinite(cap.capToday) ? cap.capToday : null,
       legacy,
+      hasCalendarScope: i.provider === "gmail" ? hasCalendarScope(tokens[i.id] ?? null) : null,
     };
   });
 }
@@ -301,6 +305,20 @@ function applySetup(body: SetupRequest): void {
   // mergeSetupConfig is the last validator (ceiling, time zone): nothing
   // below this line runs if it throws.
   const merged = mergeSetupConfig(current, body, emailIdentities, llmProvider, walletMode);
+
+  // A calendarIdentityId must point at a Gmail identity actually in the pool
+  // (post-edits) — refusing here is much cheaper than a scheduler tick
+  // discovering it can't find the identity every 10 minutes forever.
+  if (body.calendarIdentityId !== undefined && body.calendarIdentityId !== null) {
+    const pool = merged.emailIdentities ?? resolveIdentities(merged);
+    const identity = pool.find((i) => i.id === body.calendarIdentityId);
+    if (!identity || identity.provider !== "gmail") {
+      throw new SetupValidationError(
+        `calendarIdentityId '${body.calendarIdentityId}' is not a connected Gmail identity`,
+      );
+    }
+  }
+
   saveConfig(merged);
 
   for (const id of remove) {
@@ -380,6 +398,10 @@ export function mergeSetupConfig(
       body.dailySpendCeilingUsd === undefined
         ? current.dailySpendCeilingUsd
         : validateSpendCeiling(body.dailySpendCeilingUsd),
+    calendarIdentityId:
+      body.calendarIdentityId === undefined ? current.calendarIdentityId : body.calendarIdentityId,
+    calendarId:
+      body.calendarId === undefined ? current.calendarId : body.calendarId.trim() || "primary",
   };
 }
 

--- a/apps/server/src/scheduler.ts
+++ b/apps/server/src/scheduler.ts
@@ -4,6 +4,7 @@ import {
   type TelemetryOutcome,
   postDailySendSummaryIfDue,
   refreshPendingDirectMail,
+  withDeadline,
 } from "@oneshot-gtm/core";
 import {
   nextSleepMs,
@@ -11,7 +12,12 @@ import {
   runPendingRetries,
   type TriggerRunOutcome,
 } from "@oneshot-gtm/find";
-import { backfillMailAddresses, pollInboxBounces, pollInboxReplies } from "@oneshot-gtm/plays";
+import {
+  backfillMailAddresses,
+  pollCalendarMeetings,
+  pollInboxBounces,
+  pollInboxReplies,
+} from "@oneshot-gtm/plays";
 import { reportServerExecution } from "./telemetry.ts";
 
 /**
@@ -46,6 +52,12 @@ const REPLY_POLL_MAX_MS = 5 * 60_000;
  * nothing, while replies are time-sensitive (cadence might send again).
  */
 const BOUNCE_POLL_INTERVAL_MS = 30 * 60_000;
+/**
+ * Calendar poll throttle (issue #577): mirrors the bounce sweep's cadence —
+ * nothing about a meeting is minute-sensitive, so there's no reason to poll
+ * it on the same ~tick-length cadence as replies.
+ */
+const CALENDAR_POLL_INTERVAL_MS = 10 * 60_000;
 
 export function startScheduler(): SchedulerHandle {
   // Demo mode idles: firing triggers would hit placeholder credentials and
@@ -83,6 +95,17 @@ export function startScheduler(): SchedulerHandle {
   // kept identical to bouncePollClean for the same "carry forward, don't
   // reset" reason) doesn't silently re-arm to clean.
   let replyPollClean = true;
+  // 0 = never polled, so the first tick can fire the calendar poll too.
+  let lastCalendarPollAt = 0;
+  // The calendar poll is intentionally NOT included in sweepClean (issue
+  // #577) — it must not join bouncePollClean/replyPollClean for
+  // postDailySendSummaryIfDue's gate. A calendar outage has nothing to do
+  // with whether every SEND-side event for the day is recorded, and folding
+  // it in would let a calendar hiccup permanently defer the daily summary
+  // watermark. Kept as its own variable, outside the tick closure, purely
+  // so its OWN next poll can see whether the last one was clean if that
+  // ever becomes relevant — nothing currently reads it.
+  let calendarPollClean = true;
 
   const tick = async (): Promise<void> => {
     if (cancelled) return;
@@ -181,6 +204,31 @@ export function startScheduler(): SchedulerHandle {
           "warn",
         );
       }
+      // Calendar poll (issue #577): a free read, not a spend-gated trigger,
+      // so it belongs in the tick body rather than the TRIGGERS registry.
+      // Throttled like the bounce sweep — nothing about a meeting is
+      // minute-sensitive. Isolated in its own try/catch (wrapping its own
+      // internal withDeadline) so a calendar outage can't skip trigger
+      // scheduling or the reply poll. Idle (no-op) in demo mode or when no
+      // calendarIdentityId is configured — pollCalendarMeetings itself
+      // handles both and returns `idle: true` rather than this call site
+      // needing to check.
+      let meetingsIngested = 0;
+      if (Date.now() - lastCalendarPollAt >= CALENDAR_POLL_INTERVAL_MS) {
+        lastCalendarPollAt = Date.now();
+        try {
+          const calendarPoll = await withDeadline(pollCalendarMeetings(), 60_000, "calendar poll");
+          meetingsIngested = calendarPoll.meetingsIngested;
+          calendarPollClean = calendarPoll.clean;
+        } catch (err) {
+          calendarPollClean = false;
+          logEvent(
+            "scheduler.calendar_poll.failed",
+            { message_120: ((err as Error).message ?? "").slice(0, 120) },
+            "warn",
+          );
+        }
+      }
       // Daily send summary to Slack: fires once per completed UTC day when
       // slackWebhookUrl is set. Isolated like the reply poll — failure must
       // not skip trigger scheduling. Gated on BOTH pollers' cleanliness
@@ -208,6 +256,8 @@ export function startScheduler(): SchedulerHandle {
         bouncesRecorded,
         mailRefreshed,
         mailRefreshFailed,
+        meetingsIngested,
+        calendarPollClean,
         source: "server",
       });
       if (cancelled) return;

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -32,6 +32,13 @@ import {
 } from "./api/measure.ts";
 import { setup, getSetupDomains, getSetupStatus } from "./api/setup.ts";
 import { gmailAuthCallbackRoute, startGmailAuthRoute } from "./api/gmail-auth.ts";
+import {
+  confirmMeetingMatchRoute,
+  dismissMeetingMatchRoute,
+  listMeetingsRoute,
+  logMeetingOutcomeRoute,
+} from "./api/meetings.ts";
+import { listCalendarsRoute } from "./api/calendar-setup.ts";
 import { smartleadAccountsRoute } from "./api/smartlead.ts";
 import { deriveBriefRoute } from "./api/derive-brief.ts";
 import { deriveIcpRoute } from "./api/derive-icp.ts";
@@ -117,11 +124,16 @@ const routes: RouteEntry[] = [
   route("POST", "/api/measure/outcome", recordOutcome),
   route("GET", "/api/setup", getSetupStatus),
   route("GET", "/api/setup/domains", getSetupDomains),
+  route("GET", "/api/setup/calendars", listCalendarsRoute),
   route("POST", "/api/setup", setup),
   route("POST", "/api/domains/resume", resumeDomainRoute),
   route("POST", "/api/domains/pause", pauseDomainRoute),
   route("GET", "/api/gmail/auth/start", startGmailAuthRoute),
   route("GET", "/api/gmail/auth/callback", gmailAuthCallbackRoute),
+  route("GET", "/api/meetings", listMeetingsRoute),
+  route("POST", "/api/meetings/outcome", logMeetingOutcomeRoute),
+  route("POST", "/api/meetings/confirm", confirmMeetingMatchRoute),
+  route("POST", "/api/meetings/dismiss", dismissMeetingMatchRoute),
   route("POST", "/api/smartlead/accounts", smartleadAccountsRoute),
   route("POST", "/api/setup/derive-icp", deriveIcpRoute),
   route("POST", "/api/setup/derive-brief", deriveBriefRoute),

--- a/apps/web/scripts/capture-fixtures.ts
+++ b/apps/web/scripts/capture-fixtures.ts
@@ -62,6 +62,7 @@ const SEEDS = [
   "/packs",
   "/plays",
   "/inbox",
+  "/meetings",
   "/setup",
   "/setup/domains",
 

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -4,7 +4,10 @@ import type {
   CadencesResult,
   CadenceStopReason,
   CadenceView,
+  CalendarPickerEntry,
   CancelRunResponse,
+  ConfirmMeetingMatchRequest,
+  DismissMeetingMatchRequest,
   DoctorCheck,
   DrainRequest,
   DrainResult,
@@ -21,6 +24,8 @@ import type {
   InboxSteerRequest,
   InboxSteerResult,
   LastDraft,
+  LogMeetingOutcomeRequest,
+  MeetingsResult,
   OutcomeByPlay,
   OutcomeRequest,
   PackApplyResult,
@@ -239,6 +244,8 @@ export const api = {
         // server has always returned them (publicCfg spreads the whole cfg).
         queueReviewOrder?: "ranked" | "newest";
         timezone?: string | null;
+        calendarIdentityId?: string | null;
+        calendarId?: string;
       };
       secretsPath: string;
       sources: Record<string, "env" | "file" | null>;
@@ -251,8 +258,19 @@ export const api = {
    */
   setupDomains: () => getJson<{ provisionedDomains: DomainPoolView[] }>("/setup/domains"),
   setup: (req: SetupRequest) => postJson<{ ok: boolean }>("/setup", req),
+  setupCalendars: (identityId: string) =>
+    getJson<{ calendars: CalendarPickerEntry[] }>(
+      `/setup/calendars?identityId=${encodeURIComponent(identityId)}`,
+    ),
   deriveIcp: (domain: string) => postJson<DeriveIcpResult>("/setup/derive-icp", { domain }),
   deriveBrief: (urls: string[]) => postJson<DeriveBriefResult>("/setup/derive-brief", { urls }),
+  meetings: () => getJson<MeetingsResult>("/meetings"),
+  logMeetingOutcome: (req: LogMeetingOutcomeRequest) =>
+    postJson<{ ok: boolean }>("/meetings/outcome", req),
+  confirmMeetingMatch: (req: ConfirmMeetingMatchRequest) =>
+    postJson<{ ok: boolean }>("/meetings/confirm", req),
+  dismissMeetingMatch: (req: DismissMeetingMatchRequest) =>
+    postJson<{ ok: boolean }>("/meetings/dismiss", req),
   // Manual add-prospect from a LinkedIn/X URL. Returns 202 immediately; the
   // researched + drafted row appears on /queue when the background job finishes.
   addProspect: (url: string, email?: string, businessAddress?: BusinessMailAddress) =>

--- a/apps/web/src/components/setup/CalendarSection.tsx
+++ b/apps/web/src/components/setup/CalendarSection.tsx
@@ -1,0 +1,102 @@
+import { useMemo } from "react";
+import { useQuery } from "@tanstack/react-query";
+import type { SenderIdentityView } from "@oneshot-gtm/shared-types";
+import { api } from "../../api/client.ts";
+import { Field, Select } from "../primitives/Field.tsx";
+import { SectionShell } from "./SectionShell.tsx";
+import { useConfigSection } from "./useConfigSection.ts";
+import type { SectionProps } from "./types.ts";
+
+/**
+ * Which Gmail identity's calendar the scheduler polls for past meetings
+ * needing an outcome (issue #577). `calendarIdentityId: ""` (empty select
+ * value) maps to `null` server-side — the feature entirely off, nothing
+ * polls. Only `provider: 'gmail'` identities can be picked; a Gmail identity
+ * with no calendar.readonly scope is shown but flagged so a founder doesn't
+ * pick one that will just fail doctor.
+ */
+export function CalendarSection({
+  cfg,
+  onDirtyChange,
+  identities,
+}: SectionProps & { identities: SenderIdentityView[] }) {
+  const gmailIdentities = identities.filter((i) => i.provider === "gmail");
+  const server = useMemo(
+    () => ({
+      calendarIdentityId: cfg.calendarIdentityId ?? "",
+      calendarId: cfg.calendarId ?? "primary",
+    }),
+    [cfg],
+  );
+  const s = useConfigSection({
+    id: "calendar",
+    server,
+    toRequest: (sent) => ({
+      ...(sent.calendarIdentityId !== undefined
+        ? { calendarIdentityId: sent.calendarIdentityId.trim() || null }
+        : {}),
+      ...(sent.calendarId !== undefined ? { calendarId: sent.calendarId } : {}),
+    }),
+    onDirtyChange,
+  });
+
+  const calendars = useQuery({
+    queryKey: ["setup", "calendars", s.values.calendarIdentityId],
+    queryFn: () => api.setupCalendars(s.values.calendarIdentityId),
+    enabled: Boolean(s.values.calendarIdentityId),
+    staleTime: 60_000,
+  });
+
+  return (
+    <SectionShell
+      {...s.shell}
+      lede="Reads past meetings from one Gmail calendar so they can be matched to prospects and prompted for an outcome. Read-only — nothing is written to the calendar."
+    >
+      {gmailIdentities.length === 0 ? (
+        <span className="text-[12px] text-ink-faint">
+          Connect a Gmail account in Email transport first.
+        </span>
+      ) : (
+        <>
+          <Field
+            label="Calendar identity"
+            hint="Off (no identity picked) means nothing polls and nothing is written."
+          >
+            <Select
+              value={s.values.calendarIdentityId}
+              onChange={(e) => s.set("calendarIdentityId", e.target.value)}
+            >
+              <option value="">Off</option>
+              {gmailIdentities.map((i) => (
+                <option key={i.id} value={i.id} disabled={i.hasCalendarScope === false}>
+                  {i.address ?? i.id}
+                  {i.hasCalendarScope === false ? " — needs calendar reconnect" : ""}
+                </option>
+              ))}
+            </Select>
+          </Field>
+          {s.values.calendarIdentityId && (
+            <Field
+              label="Calendar"
+              hint="7-day event count helps tell which calendar your booking tool actually writes to."
+            >
+              <Select
+                value={s.values.calendarId}
+                onChange={(e) => s.set("calendarId", e.target.value)}
+              >
+                <option value="primary">primary</option>
+                {(calendars.data?.calendars ?? [])
+                  .filter((c) => c.id !== "primary")
+                  .map((c) => (
+                    <option key={c.id} value={c.id}>
+                      {c.summary} ({c.recentEventCount} in last 7d)
+                    </option>
+                  ))}
+              </Select>
+            </Field>
+          )}
+        </>
+      )}
+    </SectionShell>
+  );
+}

--- a/apps/web/src/components/setup/EmailTransportSection.tsx
+++ b/apps/web/src/components/setup/EmailTransportSection.tsx
@@ -362,6 +362,14 @@ function IdentityRow({
           {i.provider === "oneshot" && <Explain concept="domainCaps" />}
           {i.warmup && <Explain concept="warmup" />}
         </span>
+        {i.provider === "gmail" && i.hasCalendarScope === false && (
+          <a
+            href="/api/gmail/auth/start?purpose=calendar"
+            className="mt-1 w-fit font-mono text-[11px] text-[color:var(--ink-spend-2)] underline decoration-dotted underline-offset-2 hover:text-[color:var(--ink-spend)]"
+          >
+            Reconnect for calendar access
+          </a>
+        )}
       </div>
       <div className="ml-auto flex items-start gap-2">
         <Field

--- a/apps/web/src/components/setup/constants.ts
+++ b/apps/web/src/components/setup/constants.ts
@@ -83,6 +83,7 @@ export const SECTIONS = [
   { id: "notifications", eyebrow: "06.5 · Notifications", label: "Notifications" },
   { id: "x", eyebrow: "07 · X / Twitter", label: "X / Twitter" },
   { id: "email", eyebrow: "08 · Email transport", label: "Email transport" },
+  { id: "calendar", eyebrow: "08.5 · Calendar", label: "Calendar" },
   { id: "review", eyebrow: "09 · Review queue & time zone", label: "Queue & time zone" },
   { id: "telemetry", eyebrow: "10 · Telemetry", label: "Telemetry" },
   { id: "credentials", eyebrow: "11 · Credentials", label: "Credentials" },

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as ReceiptsRouteImport } from './routes/receipts'
 import { Route as QueueRouteImport } from './routes/queue'
 import { Route as ProspectsRouteImport } from './routes/prospects'
 import { Route as PlaysRouteImport } from './routes/plays'
+import { Route as MeetingsRouteImport } from './routes/meetings'
 import { Route as MeasureRouteImport } from './routes/measure'
 import { Route as InboxRouteImport } from './routes/inbox'
 import { Route as CadencesRouteImport } from './routes/cadences'
@@ -44,6 +45,11 @@ const ProspectsRoute = ProspectsRouteImport.update({
 const PlaysRoute = PlaysRouteImport.update({
   id: '/plays',
   path: '/plays',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const MeetingsRoute = MeetingsRouteImport.update({
+  id: '/meetings',
+  path: '/meetings',
   getParentRoute: () => rootRouteImport,
 } as any)
 const MeasureRoute = MeasureRouteImport.update({
@@ -83,6 +89,7 @@ export interface FileRoutesByFullPath {
   '/cadences': typeof CadencesRoute
   '/inbox': typeof InboxRoute
   '/measure': typeof MeasureRoute
+  '/meetings': typeof MeetingsRoute
   '/plays': typeof PlaysRoute
   '/prospects': typeof ProspectsRoute
   '/queue': typeof QueueRoute
@@ -96,6 +103,7 @@ export interface FileRoutesByTo {
   '/cadences': typeof CadencesRoute
   '/inbox': typeof InboxRoute
   '/measure': typeof MeasureRoute
+  '/meetings': typeof MeetingsRoute
   '/plays': typeof PlaysRoute
   '/prospects': typeof ProspectsRoute
   '/queue': typeof QueueRoute
@@ -110,6 +118,7 @@ export interface FileRoutesById {
   '/cadences': typeof CadencesRoute
   '/inbox': typeof InboxRoute
   '/measure': typeof MeasureRoute
+  '/meetings': typeof MeetingsRoute
   '/plays': typeof PlaysRoute
   '/prospects': typeof ProspectsRoute
   '/queue': typeof QueueRoute
@@ -125,6 +134,7 @@ export interface FileRouteTypes {
     | '/cadences'
     | '/inbox'
     | '/measure'
+    | '/meetings'
     | '/plays'
     | '/prospects'
     | '/queue'
@@ -138,6 +148,7 @@ export interface FileRouteTypes {
     | '/cadences'
     | '/inbox'
     | '/measure'
+    | '/meetings'
     | '/plays'
     | '/prospects'
     | '/queue'
@@ -151,6 +162,7 @@ export interface FileRouteTypes {
     | '/cadences'
     | '/inbox'
     | '/measure'
+    | '/meetings'
     | '/plays'
     | '/prospects'
     | '/queue'
@@ -165,6 +177,7 @@ export interface RootRouteChildren {
   CadencesRoute: typeof CadencesRoute
   InboxRoute: typeof InboxRoute
   MeasureRoute: typeof MeasureRoute
+  MeetingsRoute: typeof MeetingsRoute
   PlaysRoute: typeof PlaysRoute
   ProspectsRoute: typeof ProspectsRoute
   QueueRoute: typeof QueueRoute
@@ -208,6 +221,13 @@ declare module '@tanstack/react-router' {
       path: '/plays'
       fullPath: '/plays'
       preLoaderRoute: typeof PlaysRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/meetings': {
+      id: '/meetings'
+      path: '/meetings'
+      fullPath: '/meetings'
+      preLoaderRoute: typeof MeetingsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/measure': {
@@ -261,6 +281,7 @@ const rootRouteChildren: RootRouteChildren = {
   CadencesRoute: CadencesRoute,
   InboxRoute: InboxRoute,
   MeasureRoute: MeasureRoute,
+  MeetingsRoute: MeetingsRoute,
   PlaysRoute: PlaysRoute,
   ProspectsRoute: ProspectsRoute,
   QueueRoute: QueueRoute,

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import type { QueryClient } from "@tanstack/react-query";
 import {
   Activity,
   BarChart3,
+  CalendarClock,
   Feather,
   Inbox,
   Layers,
@@ -43,6 +44,7 @@ interface NavItem {
     | "/prospects"
     | "/inbox"
     | "/cadences"
+    | "/meetings"
     | "/receipts"
     | "/measure"
     | "/plays"
@@ -50,7 +52,7 @@ interface NavItem {
   label: string;
   icon: ComponentType<{ size?: number; className?: string }>;
   /** Which alert-data key, if any, lights a dot next to this nav item. */
-  alert?: "queue-pending" | "doctor-fail" | "inbox-positive";
+  alert?: "queue-pending" | "doctor-fail" | "inbox-positive" | "meetings-pending";
 }
 
 const NAV: NavItem[] = [
@@ -59,6 +61,7 @@ const NAV: NavItem[] = [
   { to: "/prospects", label: "Prospects", icon: Users },
   { to: "/inbox", label: "Replies", icon: Mail, alert: "inbox-positive" },
   { to: "/cadences", label: "Cadences", icon: Layers },
+  { to: "/meetings", label: "Meetings", icon: CalendarClock, alert: "meetings-pending" },
   { to: "/receipts", label: "Receipts", icon: Receipt },
   { to: "/measure", label: "Measure", icon: BarChart3 },
   { to: "/plays", label: "Plays", icon: Feather },
@@ -92,6 +95,14 @@ function RootLayout() {
   const inboxAlertQuery = useQuery({
     queryKey: ["inbox"],
     queryFn: () => api.inbox(),
+    refetchInterval: 60_000,
+  });
+  // A past meeting with no outcome logged (issue #577) — same idea as the
+  // inbox dot: the founder should never have to open /meetings to notice one
+  // is waiting.
+  const meetingsAlertQuery = useQuery({
+    queryKey: ["meetings"],
+    queryFn: api.meetings,
     refetchInterval: 60_000,
   });
 
@@ -130,6 +141,7 @@ function RootLayout() {
     // — it clears once the founder replies to the thread or records a deal
     // outcome, so the dot doesn't stay lit forever after the first use.
     "inbox-positive": (inboxAlertQuery.data?.conversations ?? []).some((c) => c.awaitingReply),
+    "meetings-pending": (meetingsAlertQuery.data?.awaitingOutcome.length ?? 0) > 0,
   };
 
   return (
@@ -308,5 +320,6 @@ function alertLabel(alert: NavItem["alert"]): string {
   if (alert === "queue-pending") return "pending candidates waiting for review";
   if (alert === "doctor-fail") return "doctor has a failing check";
   if (alert === "inbox-positive") return "a positive reply is waiting for a decision";
+  if (alert === "meetings-pending") return "a past meeting is waiting for an outcome";
   return "";
 }

--- a/apps/web/src/routes/meetings.tsx
+++ b/apps/web/src/routes/meetings.tsx
@@ -1,0 +1,252 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { createFileRoute } from "@tanstack/react-router";
+import { useState } from "react";
+import { toast } from "sonner";
+import type { MeetingOutcomeView, MeetingView } from "@oneshot-gtm/shared-types";
+import { api } from "../api/client.ts";
+import { Button } from "../components/primitives/Button.tsx";
+import { EmptyNote } from "../components/primitives/EmptyNote.tsx";
+import { Field } from "../components/primitives/Field.tsx";
+import { Modal } from "../components/primitives/Modal.tsx";
+import { Select, Textarea } from "../components/primitives/Field.tsx";
+import { SkeletonRow } from "../components/primitives/Skeleton.tsx";
+import { cn, timeAgo } from "../lib/cn.ts";
+import { useMask } from "../lib/privacy.tsx";
+
+export const Route = createFileRoute("/meetings")({
+  staticData: { title: "Meetings" },
+  component: MeetingsPage,
+});
+
+const OUTCOME_LABELS: Record<MeetingOutcomeView, string> = {
+  held: "held",
+  no_show: "no-show",
+  cancelled: "cancelled",
+  rescheduled: "rescheduled",
+};
+
+function MeetingsPage() {
+  const query = useQuery({
+    queryKey: ["meetings"],
+    queryFn: api.meetings,
+    refetchInterval: 60_000,
+  });
+  const queryClient = useQueryClient();
+  const mask = useMask();
+  const [outcomeTarget, setOutcomeTarget] = useState<MeetingView | null>(null);
+  const [outcomeKind, setOutcomeKind] = useState<MeetingOutcomeView>("held");
+  const [outcomeNote, setOutcomeNote] = useState("");
+
+  const invalidate = () => void queryClient.invalidateQueries({ queryKey: ["meetings"] });
+
+  const logOutcome = useMutation({
+    mutationFn: async () => {
+      if (!outcomeTarget) throw new Error("no meeting selected");
+      return api.logMeetingOutcome({
+        calendarId: outcomeTarget.calendarId,
+        eventId: outcomeTarget.eventId,
+        outcome: outcomeKind,
+        ...(outcomeNote.trim() ? { note: outcomeNote.trim() } : {}),
+      });
+    },
+    onSuccess: () => {
+      setOutcomeTarget(null);
+      invalidate();
+      toast.success("outcome recorded");
+    },
+    onError: (err) => toast.error(`couldn't record outcome · ${err.message}`),
+  });
+
+  const confirmMatch = useMutation({
+    mutationFn: (m: MeetingView) =>
+      api.confirmMeetingMatch({
+        calendarId: m.calendarId,
+        eventId: m.eventId,
+        prospectId: m.suggestedProspectId!,
+      }),
+    onSuccess: () => {
+      invalidate();
+      toast.success("match confirmed");
+    },
+    onError: (err) => toast.error(`couldn't confirm · ${err.message}`),
+  });
+
+  const dismissMatch = useMutation({
+    mutationFn: (m: MeetingView) =>
+      api.dismissMeetingMatch({ calendarId: m.calendarId, eventId: m.eventId }),
+    onSuccess: () => {
+      invalidate();
+      toast.success("match dismissed");
+    },
+    onError: (err) => toast.error(`couldn't dismiss · ${err.message}`),
+  });
+
+  const awaitingOutcome = query.data?.awaitingOutcome ?? [];
+  const needsReview = query.data?.needsReview ?? [];
+
+  return (
+    <div className="flex flex-col gap-8">
+      <div>
+        <h1 className="ln-eyebrow mb-1">Meetings</h1>
+        <p className="text-[13px] text-ink-muted">
+          Past calls from your calendar that need an outcome, and matches that need a decision.
+        </p>
+      </div>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-[13px] font-medium text-ink-cream">
+          Awaiting outcome {awaitingOutcome.length > 0 && `(${awaitingOutcome.length})`}
+        </h2>
+        {query.isLoading ? (
+          <div className="rounded-[var(--radius-md)] border border-ink-rule">
+            {[0, 1, 2].map((i) => (
+              <SkeletonRow key={i} />
+            ))}
+          </div>
+        ) : awaitingOutcome.length === 0 ? (
+          <EmptyNote note="Nothing waiting. Every past meeting with a matched prospect has an outcome logged." />
+        ) : (
+          <div className="flex flex-col divide-y divide-ink-rule rounded-[var(--radius-md)] border border-ink-rule">
+            {awaitingOutcome.map((m) => (
+              <div
+                key={`${m.calendarId}:${m.eventId}`}
+                className="flex items-center justify-between gap-4 px-4 py-3"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-[13px] text-ink-cream">
+                    {m.summary ?? "(no title)"}
+                  </div>
+                  <div className="mt-0.5 flex flex-wrap items-center gap-2 font-mono text-[11px] text-ink-muted">
+                    <span>{m.startsAt ? timeAgo(m.startsAt) : "—"}</span>
+                    {m.prospectEmail && <span>· {mask("email", m.prospectEmail)}</span>}
+                    {m.prospectName && <span>· {mask("name", m.prospectName)}</span>}
+                  </div>
+                </div>
+                <Button
+                  variant="secondary"
+                  size="sm"
+                  onClick={() => {
+                    setOutcomeTarget(m);
+                    setOutcomeKind("held");
+                    setOutcomeNote("");
+                  }}
+                >
+                  Log outcome
+                </Button>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-[13px] font-medium text-ink-cream">
+          Needs review {needsReview.length > 0 && `(${needsReview.length})`}
+        </h2>
+        {query.isLoading ? null : needsReview.length === 0 ? (
+          <EmptyNote note="No uncertain matches. Every calendar meeting the poller found is either linked to a known prospect or has no plausible one." />
+        ) : (
+          <div className="flex flex-col divide-y divide-ink-rule rounded-[var(--radius-md)] border border-ink-rule">
+            {needsReview.map((m) => (
+              <div
+                key={`${m.calendarId}:${m.eventId}`}
+                className="flex items-center justify-between gap-4 px-4 py-3"
+              >
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-[13px] text-ink-cream">
+                    {m.summary ?? "(no title)"}
+                  </div>
+                  <div className="mt-0.5 flex flex-wrap items-center gap-2 font-mono text-[11px] text-ink-muted">
+                    <span>{m.startsAt ? timeAgo(m.startsAt) : "—"}</span>
+                    {m.suggestedProspectEmail && (
+                      <span>
+                        · maybe {mask("email", m.suggestedProspectEmail)}
+                        {m.matchReason ? ` (${m.matchReason})` : ""}
+                      </span>
+                    )}
+                    {m.matchStatus === "ambiguous" && !m.suggestedProspectEmail && (
+                      <span
+                        className={cn(
+                          "rounded-[var(--radius-xs)] border border-ink-rule/60 px-1.5 py-[1px]",
+                          "uppercase tracking-[0.08em]",
+                        )}
+                      >
+                        ambiguous
+                      </span>
+                    )}
+                  </div>
+                </div>
+                {m.suggestedProspectId != null && (
+                  <div className="flex shrink-0 gap-2">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => dismissMatch.mutate(m)}
+                      disabled={dismissMatch.isPending}
+                    >
+                      Dismiss
+                    </Button>
+                    <Button
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => confirmMatch.mutate(m)}
+                      disabled={confirmMatch.isPending}
+                    >
+                      Confirm
+                    </Button>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+
+      <Modal
+        open={outcomeTarget != null}
+        onClose={() => setOutcomeTarget(null)}
+        title={`Log outcome${outcomeTarget?.summary ? ` — ${outcomeTarget.summary}` : ""}`}
+        footer={
+          <>
+            <Button variant="ghost" onClick={() => setOutcomeTarget(null)}>
+              Cancel
+            </Button>
+            <Button onClick={() => logOutcome.mutate()} disabled={logOutcome.isPending}>
+              {logOutcome.isPending ? "Saving…" : "Save outcome"}
+            </Button>
+          </>
+        }
+      >
+        <div className="flex flex-col gap-4">
+          {outcomeTarget?.prospectEmail && (
+            <div className="font-mono text-[12px] text-ink-muted">
+              Prospect:{" "}
+              <span className="text-ink-cream-2">{mask("email", outcomeTarget.prospectEmail)}</span>
+            </div>
+          )}
+          <Field label="Outcome">
+            <Select
+              value={outcomeKind}
+              onChange={(e) => setOutcomeKind(e.target.value as MeetingOutcomeView)}
+            >
+              {(Object.entries(OUTCOME_LABELS) as Array<[MeetingOutcomeView, string]>).map(
+                ([value, label]) => (
+                  <option key={value} value={value}>
+                    {label}
+                  </option>
+                ),
+              )}
+            </Select>
+          </Field>
+          <Field label="Notes (optional)" hint="Paste a transcript or summarize what happened.">
+            <Textarea
+              rows={4}
+              value={outcomeNote}
+              onChange={(e) => setOutcomeNote(e.target.value)}
+            />
+          </Field>
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/apps/web/src/routes/setup.tsx
+++ b/apps/web/src/routes/setup.tsx
@@ -7,6 +7,7 @@ import { api } from "../api/client.ts";
 import { Skeleton } from "../components/primitives/Skeleton.tsx";
 import { CredentialsSection } from "../components/setup/CredentialsSection.tsx";
 import { EmailTransportSection } from "../components/setup/EmailTransportSection.tsx";
+import { CalendarSection } from "../components/setup/CalendarSection.tsx";
 import { FounderSection } from "../components/setup/FounderSection.tsx";
 import { IcpSection } from "../components/setup/IcpSection.tsx";
 import { LlmSection } from "../components/setup/LlmSection.tsx";
@@ -236,6 +237,7 @@ function Sections({
         smartleadKeyEpoch={smartleadKeyEpoch}
         onDirtyChange={onDirtyChange}
       />
+      <CalendarSection {...common} identities={status.identities ?? []} />
       <ReviewQueueSection {...common} />
       <TelemetrySection {...common} />
       <CredentialsSection

--- a/packages/core/__tests__/__snapshots__/ledger.test.ts.snap
+++ b/packages/core/__tests__/__snapshots__/ledger.test.ts.snap
@@ -68,6 +68,36 @@ exports[`Ledger schema migration > fresh-install schema (tables, columns, indexe
       "type": "index",
     },
     {
+      "name": "idx_meetings_ical_uid",
+      "sql": "CREATE INDEX idx_meetings_ical_uid
+        ON meetings(ical_uid) WHERE ical_uid IS NOT NULL",
+      "tbl_name": "meetings",
+      "type": "index",
+    },
+    {
+      "name": "idx_meetings_match_status",
+      "sql": "CREATE INDEX idx_meetings_match_status
+        ON meetings(match_status, starts_at)",
+      "tbl_name": "meetings",
+      "type": "index",
+    },
+    {
+      "name": "idx_meetings_pending_outcome",
+      "sql": "CREATE INDEX idx_meetings_pending_outcome
+        ON meetings(ends_at)
+        WHERE outcome IS NULL AND status = 'confirmed' AND all_day = 0
+          AND prospect_id IS NOT NULL",
+      "tbl_name": "meetings",
+      "type": "index",
+    },
+    {
+      "name": "idx_meetings_prospect",
+      "sql": "CREATE INDEX idx_meetings_prospect
+        ON meetings(prospect_id, starts_at)",
+      "tbl_name": "meetings",
+      "type": "index",
+    },
+    {
       "name": "idx_outcomes_outcome",
       "sql": "CREATE INDEX idx_outcomes_outcome ON deal_outcomes(outcome)",
       "tbl_name": "deal_outcomes",
@@ -415,6 +445,64 @@ exports[`Ledger schema migration > fresh-install schema (tables, columns, indexe
     PRIMARY KEY(prospect_id,play_name,enrollment,step_index)
   )",
       "tbl_name": "mail_preparations",
+      "type": "table",
+    },
+    {
+      "name": "meetings",
+      "sql": "CREATE TABLE meetings (
+        calendar_id                TEXT NOT NULL,
+        event_id                   TEXT NOT NULL,
+        ical_uid                   TEXT,
+        recurring_event_id         TEXT,
+        status                     TEXT NOT NULL DEFAULT 'confirmed',
+        summary                    TEXT,
+        all_day                    INTEGER NOT NULL DEFAULT 0,
+        starts_at                  TEXT,
+        ends_at                    TEXT,
+        event_timezone             TEXT,
+        organizer_email            TEXT,
+        -- The founder's own (self:true) attendee responseStatus. Distinct
+        -- from match_status (which is about PROSPECT identification, not
+        -- the founder's RSVP) — a declined event is excluded from the
+        -- pending-outcome nudge but the row is kept, never dropped.
+        self_response              TEXT,
+        external_attendee_count    INTEGER NOT NULL DEFAULT 0,
+        -- Capped ~20 entries; sourced from attendees ∪ {organizer, creator}
+        -- minus the founder's own addresses. Never the raw attendees[]
+        -- payload — description/dial-in PINs must never land here either.
+        external_attendees_json    TEXT,
+        attendees_omitted          INTEGER NOT NULL DEFAULT 0,
+        prospect_id                INTEGER,
+        suggested_prospect_id      INTEGER,
+        -- 'exact' | 'suggested' | 'ambiguous' | 'dismissed' | NULL (no
+        -- candidate at all — a self-block or an unmatched event).
+        match_status               TEXT,
+        -- 'name_domain' | 'domain' | 'name' | 'description' | NULL for an
+        -- 'exact' match (email-identity, no fuzzy method to name).
+        match_method               TEXT,
+        match_confidence           REAL,
+        -- 'held' | 'no_show' | 'cancelled' | 'rescheduled', founder-set only.
+        outcome                    TEXT,
+        outcome_note               TEXT,
+        outcome_recorded_at        TEXT,
+        -- Cleared (not the outcome) when a reschedule changes starts_at —
+        -- a stale nudge must withdraw, but a recorded outcome must survive.
+        outcome_prompted_at        TEXT,
+        -- The API's own 'updated' timestamp on this event — the
+        -- idempotency guard: if this hasn't advanced since last_seen_at,
+        -- the poll should touch only last_seen_at and skip re-deriving
+        -- everything else.
+        event_updated_at           TEXT,
+        first_seen_at              TEXT NOT NULL DEFAULT (datetime('now')),
+        last_seen_at               TEXT NOT NULL DEFAULT (datetime('now')),
+        -- Sorted, joined external emails. The fingerprint is what makes a
+        -- founder's dismiss STICK: re-matching only runs when this value
+        -- changes between polls, so a dismissed suggestion is never
+        -- silently re-proposed on an unchanged attendee list.
+        attendees_fingerprint      TEXT,
+        PRIMARY KEY (calendar_id, event_id)
+      )",
+      "tbl_name": "meetings",
       "type": "table",
     },
     {

--- a/packages/core/__tests__/config.test.ts
+++ b/packages/core/__tests__/config.test.ts
@@ -98,6 +98,8 @@ describe("bootstrapClientId", () => {
     timezone: null,
     clientId: null,
     dailySpendCeilingUsd: null,
+    calendarIdentityId: null,
+    calendarId: "primary",
   };
 
   it("mints a UUID-shaped clientId when none is stored", () => {

--- a/packages/core/__tests__/freemail.test.ts
+++ b/packages/core/__tests__/freemail.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { FREEMAIL_DOMAINS, isFreemailDomain } from "../src/freemail.ts";
+
+describe("isFreemailDomain", () => {
+  it("recognizes the common personal providers", () => {
+    for (const d of ["gmail.com", "yahoo.com", "outlook.com", "icloud.com", "protonmail.com"]) {
+      expect(isFreemailDomain(d)).toBe(true);
+    }
+  });
+
+  it("is case- and whitespace-insensitive", () => {
+    expect(isFreemailDomain("  GMAIL.COM  ")).toBe(true);
+  });
+
+  it("is false for a company domain", () => {
+    expect(isFreemailDomain("acme.com")).toBe(false);
+  });
+
+  it("is false for null/undefined/empty", () => {
+    expect(isFreemailDomain(null)).toBe(false);
+    expect(isFreemailDomain(undefined)).toBe(false);
+    expect(isFreemailDomain("")).toBe(false);
+  });
+
+  it("the exported set is non-empty and lowercase", () => {
+    expect(FREEMAIL_DOMAINS.size).toBeGreaterThan(5);
+    for (const d of FREEMAIL_DOMAINS) expect(d).toBe(d.toLowerCase());
+  });
+});

--- a/packages/core/__tests__/gcal.test.ts
+++ b/packages/core/__tests__/gcal.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { _resetGmailCache } from "../src/gmail.ts";
+import { CalendarApiError, listCalendarEvents, listWritableCalendars } from "../src/gcal.ts";
+
+const GMAIL_KEYS = ["GMAIL_CLIENT_ID", "GMAIL_CLIENT_SECRET"] as const;
+let envSnapshot: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  envSnapshot = {};
+  for (const k of GMAIL_KEYS) {
+    envSnapshot[k] = process.env[k];
+    process.env[k] = `test-${k.toLowerCase()}`;
+  }
+  _resetGmailCache();
+});
+
+afterEach(() => {
+  for (const k of GMAIL_KEYS) {
+    if (envSnapshot[k] === undefined) delete process.env[k];
+    else process.env[k] = envSnapshot[k];
+  }
+  _resetGmailCache();
+  vi.unstubAllGlobals();
+});
+
+function tokenResponse(token = "at-1", expiresIn = 3600): Response {
+  return new Response(JSON.stringify({ access_token: token, expires_in: expiresIn }), {
+    status: 200,
+  });
+}
+
+const ACCOUNT = { id: "gmail:jn@x.dev", refreshToken: "rt-1" };
+
+describe("listCalendarEvents", () => {
+  it("requests the exact request shape the card specifies", async () => {
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      const u = String(url);
+      if (u.startsWith("https://oauth2.googleapis.com/")) return tokenResponse();
+      return new Response(JSON.stringify({ items: [] }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await listCalendarEvents(ACCOUNT, {
+      calendarId: "primary",
+      updatedMin: "2026-01-01T00:00:00.000Z",
+      timeMin: "2025-06-01T00:00:00.000Z",
+      timeMax: "2027-02-01T00:00:00.000Z",
+    });
+    const call = fetchMock.mock.calls.find((c) => String(c[0]).includes("/calendars/"));
+    const url = decodeURIComponent(String(call![0]));
+    expect(url).toContain("/calendars/primary/events");
+    expect(url).toContain("singleEvents=true");
+    expect(url).toContain("showDeleted=true");
+    expect(url).toContain("orderBy=updated");
+    expect(url).toContain("updatedMin=2026-01-01T00:00:00.000Z");
+    expect(url).toContain("timeMin=2025-06-01T00:00:00.000Z");
+    expect(url).toContain("timeMax=2027-02-01T00:00:00.000Z");
+    // Never sent — an event over the cap would drop the prospect otherwise.
+    expect(url).not.toContain("maxAttendees");
+    // Never sent — filtering happens in code so drops can be logged.
+    expect(url).not.toContain("eventTypes");
+    expect(url).toContain(
+      "fields=nextPageToken,items(id,iCalUID,status,summary,start,end,updated,organizer,creator,attendees,attendeesOmitted,recurringEventId,originalStartTime,eventType,hangoutLink,visibility,transparency,description)",
+    );
+  });
+
+  it("URL-encodes a calendar id that needs it", async () => {
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      const u = String(url);
+      if (u.startsWith("https://oauth2.googleapis.com/")) return tokenResponse();
+      return new Response(JSON.stringify({ items: [] }), { status: 200 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await listCalendarEvents(ACCOUNT, {
+      calendarId: "team@acme.com",
+      timeMin: "2025-01-01T00:00:00.000Z",
+      timeMax: "2026-01-01T00:00:00.000Z",
+    });
+    const call = fetchMock.mock.calls.find((c) => String(c[0]).includes("/calendars/"));
+    expect(String(call![0])).toContain("/calendars/team%40acme.com/events");
+  });
+
+  it("paginates via nextPageToken and returns items + the token", async () => {
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      const u = String(url);
+      if (u.startsWith("https://oauth2.googleapis.com/")) return tokenResponse();
+      return new Response(JSON.stringify({ items: [{ id: "e1" }], nextPageToken: "p2" }), {
+        status: 200,
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const res = await listCalendarEvents(ACCOUNT, {
+      calendarId: "primary",
+      timeMin: "2025-01-01T00:00:00.000Z",
+      timeMax: "2026-01-01T00:00:00.000Z",
+    });
+    expect(res.items).toEqual([{ id: "e1" }]);
+    expect(res.nextPageToken).toBe("p2");
+  });
+
+  it("surfaces a 410 as CalendarApiError with the raw status", async () => {
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      const u = String(url);
+      if (u.startsWith("https://oauth2.googleapis.com/")) return tokenResponse();
+      return new Response(JSON.stringify({ error: { message: "gone", status: "SOME_GONE" } }), {
+        status: 410,
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    try {
+      await listCalendarEvents(ACCOUNT, {
+        calendarId: "primary",
+        timeMin: "2025-01-01T00:00:00.000Z",
+        timeMax: "2026-01-01T00:00:00.000Z",
+      });
+      expect.unreachable();
+    } catch (err) {
+      expect(err).toBeInstanceOf(CalendarApiError);
+      expect((err as CalendarApiError).httpStatus).toBe(410);
+    }
+  });
+
+  it("surfaces ACCESS_TOKEN_SCOPE_INSUFFICIENT via googleStatus", async () => {
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      const u = String(url);
+      if (u.startsWith("https://oauth2.googleapis.com/")) return tokenResponse();
+      return new Response(
+        JSON.stringify({
+          error: { message: "insufficient scope", status: "ACCESS_TOKEN_SCOPE_INSUFFICIENT" },
+        }),
+        { status: 403 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    try {
+      await listCalendarEvents(ACCOUNT, {
+        calendarId: "primary",
+        timeMin: "2025-01-01T00:00:00.000Z",
+        timeMax: "2026-01-01T00:00:00.000Z",
+      });
+      expect.unreachable();
+    } catch (err) {
+      expect(err).toBeInstanceOf(CalendarApiError);
+      expect((err as CalendarApiError).googleStatus).toBe("ACCESS_TOKEN_SCOPE_INSUFFICIENT");
+    }
+  });
+
+  it("evicts the cached access token on a 401 so the next call re-refreshes", async () => {
+    let tokenCalls = 0;
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      const u = String(url);
+      if (u.startsWith("https://oauth2.googleapis.com/")) {
+        tokenCalls++;
+        return tokenResponse(`at-${tokenCalls}`);
+      }
+      return new Response(JSON.stringify({}), { status: 401 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(
+      listCalendarEvents(ACCOUNT, {
+        calendarId: "primary",
+        timeMin: "2025-01-01T00:00:00.000Z",
+        timeMax: "2026-01-01T00:00:00.000Z",
+      }),
+    ).rejects.toThrow(CalendarApiError);
+    // A second call must re-mint a token (cache was invalidated), not reuse
+    // the dead at-1.
+    await expect(
+      listCalendarEvents(ACCOUNT, {
+        calendarId: "primary",
+        timeMin: "2025-01-01T00:00:00.000Z",
+        timeMax: "2026-01-01T00:00:00.000Z",
+      }),
+    ).rejects.toThrow(CalendarApiError);
+    expect(tokenCalls).toBe(2);
+  });
+
+  it("does not read the response body on a 401", async () => {
+    const textSpy = vi.fn().mockResolvedValue("{}");
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      if (String(url).startsWith("https://oauth2.googleapis.com/")) return tokenResponse();
+      return { ok: false, status: 401, text: textSpy, body: undefined } as unknown as Response;
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(
+      listCalendarEvents(ACCOUNT, {
+        calendarId: "primary",
+        timeMin: "2025-01-01T00:00:00.000Z",
+        timeMax: "2026-01-01T00:00:00.000Z",
+      }),
+    ).rejects.toThrow(/Calendar auth rejected \(401\)/);
+    expect(textSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe("listWritableCalendars", () => {
+  it("requests minAccessRole=writer and maps entries", async () => {
+    const fetchMock = vi.fn(async (url: string | URL) => {
+      const u = String(url);
+      if (u.startsWith("https://oauth2.googleapis.com/")) return tokenResponse();
+      return new Response(
+        JSON.stringify({
+          items: [
+            { id: "primary", summary: "Jane", accessRole: "owner" },
+            { id: "team@acme.com", accessRole: "writer" },
+          ],
+        }),
+        { status: 200 },
+      );
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const cals = await listWritableCalendars(ACCOUNT);
+    const call = fetchMock.mock.calls.find((c) => String(c[0]).includes("/calendarList"));
+    expect(String(call![0])).toContain("minAccessRole=writer");
+    expect(cals).toEqual([
+      { id: "primary", summary: "Jane", accessRole: "owner" },
+      { id: "team@acme.com", summary: "team@acme.com", accessRole: "writer" },
+    ]);
+  });
+});

--- a/packages/core/__tests__/gmail-calendar-scope.test.ts
+++ b/packages/core/__tests__/gmail-calendar-scope.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+import {
+  clearGmailTokenScope,
+  hasCalendarScope,
+  loadGmailTokens,
+  saveGmailToken,
+} from "../src/config.ts";
+import { CALENDAR_READONLY_SCOPE } from "../src/gmail.ts";
+
+// vitest.setup.ts redirects ONESHOT_GTM_HOME to a fresh temp dir per test
+// file, so gmail-tokens.json here is throwaway and isolated.
+
+describe("GmailTokenEntry.scope (issue #577)", () => {
+  it("loadGmailTokens defaults scope to null for a legacy entry with no scope field", () => {
+    saveGmailToken("gmail:legacy@x.dev", { refreshToken: "rt", address: "legacy@x.dev" });
+    const all = loadGmailTokens();
+    expect(all["gmail:legacy@x.dev"]?.scope ?? null).toBeNull();
+  });
+
+  it("round-trips a persisted scope string", () => {
+    saveGmailToken("gmail:jn@x.dev", {
+      refreshToken: "rt",
+      address: "jn@x.dev",
+      scope: `https://www.googleapis.com/auth/gmail.send ${CALENDAR_READONLY_SCOPE}`,
+    });
+    const all = loadGmailTokens();
+    expect(all["gmail:jn@x.dev"]?.scope).toContain(CALENDAR_READONLY_SCOPE);
+  });
+});
+
+describe("hasCalendarScope", () => {
+  it("is false for an absent entry — never 'unknown, try anyway'", () => {
+    expect(hasCalendarScope(null)).toBe(false);
+    expect(hasCalendarScope(undefined)).toBe(false);
+  });
+
+  it("is false for an entry with no scope recorded (pre-#577 token)", () => {
+    expect(hasCalendarScope({ refreshToken: "rt", address: "a@x.dev" })).toBe(false);
+  });
+
+  it("is false for a Gmail-only scope string", () => {
+    expect(
+      hasCalendarScope({
+        refreshToken: "rt",
+        address: "a@x.dev",
+        scope: "https://www.googleapis.com/auth/gmail.send",
+      }),
+    ).toBe(false);
+  });
+
+  it("is true when the scope string contains calendar.readonly", () => {
+    expect(
+      hasCalendarScope({
+        refreshToken: "rt",
+        address: "a@x.dev",
+        scope: `https://www.googleapis.com/auth/gmail.send ${CALENDAR_READONLY_SCOPE}`,
+      }),
+    ).toBe(true);
+  });
+});
+
+describe("clearGmailTokenScope", () => {
+  it("clears the scope without touching the refresh token", () => {
+    saveGmailToken("gmail:jn@x.dev", {
+      refreshToken: "rt-keep-me",
+      address: "jn@x.dev",
+      scope: CALENDAR_READONLY_SCOPE,
+    });
+    clearGmailTokenScope("gmail:jn@x.dev");
+    const entry = loadGmailTokens()["gmail:jn@x.dev"];
+    expect(entry?.refreshToken).toBe("rt-keep-me");
+    expect(entry?.scope ?? null).toBeNull();
+  });
+
+  it("is a no-op for an identity with no stored token", () => {
+    expect(() => clearGmailTokenScope("gmail:never-connected@x.dev")).not.toThrow();
+  });
+});

--- a/packages/core/__tests__/identities-calendar.test.ts
+++ b/packages/core/__tests__/identities-calendar.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OneShotConfig } from "../src/types.ts";
+
+// registerGmailIdentity(calendarOnly) and removeIdentity(calendarIdentityId
+// clearing) — issue #577. Config is mocked stateful so no real ~/.oneshot-gtm
+// is touched; saveGmailToken/deleteGmailToken are mocked out too so this file
+// never writes gmail-tokens.json.
+
+let cfg: OneShotConfig;
+const savedTokens: Record<string, unknown> = {};
+const deletedTokens: string[] = [];
+
+vi.mock("../src/config.ts", async () => {
+  const actual = await vi.importActual<typeof import("../src/config.ts")>("../src/config.ts");
+  return {
+    ...actual,
+    loadConfig: () => cfg,
+    saveConfig: (next: OneShotConfig) => {
+      cfg = next;
+    },
+    saveGmailToken: (id: string, entry: unknown) => {
+      savedTokens[id] = entry;
+    },
+    deleteGmailToken: (id: string) => {
+      deletedTokens.push(id);
+    },
+  };
+});
+
+const { registerGmailIdentity, removeIdentity, resolveIdentities, LEGACY_ONESHOT_ID } =
+  await import("../src/identities.ts");
+
+const BASE: OneShotConfig = {
+  walletMode: "cdp",
+  llmProvider: "openrouter",
+  llmModel: "x",
+  telemetryEnabled: true,
+  founderName: "Jane Doe",
+  founderEmail: null,
+  productOneLiner: null,
+  productDomain: null,
+  sendingDomain: "legacy.com",
+  emailProvider: "oneshot",
+  emailIdentities: null,
+  icpOneLiner: null,
+  cadenceOverrides: null,
+  founderCredentials: null,
+  productPortfolio: null,
+  partners: null,
+  founderAdmission: null,
+  productBrief: null,
+  mobileSignature: false,
+  slackWebhookUrl: null,
+  timezone: null,
+  clientId: null,
+  dailySpendCeilingUsd: null,
+  calendarIdentityId: null,
+  calendarId: "primary",
+};
+
+beforeEach(() => {
+  cfg = { ...BASE };
+  for (const k of Object.keys(savedTokens)) delete savedTokens[k];
+  deletedTokens.length = 0;
+});
+
+describe("registerGmailIdentity({ calendarOnly: true })", () => {
+  it("registers a NEW identity at maxPerDay: 0, no warm-up — never a silent sender", () => {
+    const { identityId, created } = registerGmailIdentity({
+      address: "cal@x.dev",
+      refreshToken: "rt",
+      calendarOnly: true,
+    });
+    expect(created).toBe(true);
+    const added = cfg.emailIdentities!.find((i) => i.id === identityId)!;
+    expect(added.maxPerDay).toBe(0);
+    expect(added.warmup).toBeNull();
+  });
+
+  it("still applies the ordinary warm-up ramp when calendarOnly is not set", () => {
+    const { identityId } = registerGmailIdentity({ address: "send@x.dev", refreshToken: "rt" });
+    const added = cfg.emailIdentities!.find((i) => i.id === identityId)!;
+    expect(added.maxPerDay).toBe(50);
+    expect(added.warmup).toEqual({ startPerDay: 10, incrementPerWeek: 10 });
+  });
+
+  it("re-authing an EXISTING sender with calendarOnly:true does NOT touch its tuned cap", () => {
+    const first = registerGmailIdentity({ address: "existing@x.dev", refreshToken: "rt1" });
+    expect(first.created).toBe(true);
+    // Tune the cap by hand, the way a founder would via /setup.
+    const pool = [...cfg.emailIdentities!];
+    const idx = pool.findIndex((i) => i.id === first.identityId);
+    pool[idx] = Object.assign({}, pool[idx], { maxPerDay: 17 });
+    cfg = { ...cfg, emailIdentities: pool };
+    const second = registerGmailIdentity({
+      address: "existing@x.dev",
+      refreshToken: "rt2",
+      calendarOnly: true,
+    });
+    expect(second.created).toBe(false);
+    expect(second.identityId).toBe(first.identityId);
+    expect(cfg.emailIdentities!.find((i) => i.id === first.identityId)!.maxPerDay).toBe(17);
+  });
+});
+
+describe("removeIdentity clears calendarIdentityId (issue #577)", () => {
+  it("clears the pointer when the removed identity matches it", () => {
+    const { identityId } = registerGmailIdentity({ address: "cal@x.dev", refreshToken: "rt" });
+    cfg = { ...cfg, calendarIdentityId: identityId };
+    const { removed } = removeIdentity(identityId);
+    expect(removed).toBe(true);
+    expect(cfg.calendarIdentityId).toBeNull();
+  });
+
+  it("leaves an unrelated calendarIdentityId untouched", () => {
+    const { identityId: calId } = registerGmailIdentity({
+      address: "cal@x.dev",
+      refreshToken: "rt",
+    });
+    const { identityId: senderId } = registerGmailIdentity({
+      address: "sender@x.dev",
+      refreshToken: "rt2",
+    });
+    cfg = { ...cfg, calendarIdentityId: calId };
+    removeIdentity(senderId);
+    expect(cfg.calendarIdentityId).toBe(calId);
+  });
+
+  it("removing an identity that isn't the calendar pointer is still a no-op on it (legacy pool materialized)", () => {
+    void resolveIdentities;
+    void LEGACY_ONESHOT_ID;
+    cfg = { ...cfg, calendarIdentityId: null };
+    const { removed } = removeIdentity("gmail:never-added@x.dev");
+    expect(removed).toBe(false);
+    expect(cfg.calendarIdentityId).toBeNull();
+  });
+});

--- a/packages/core/__tests__/identities-oneshot.test.ts
+++ b/packages/core/__tests__/identities-oneshot.test.ts
@@ -48,6 +48,8 @@ const BASE: OneShotConfig = {
   timezone: null,
   clientId: null,
   dailySpendCeilingUsd: null,
+  calendarIdentityId: null,
+  calendarId: "primary",
 };
 
 beforeEach(() => {

--- a/packages/core/__tests__/identities-smartlead.test.ts
+++ b/packages/core/__tests__/identities-smartlead.test.ts
@@ -44,6 +44,8 @@ const BASE: OneShotConfig = {
   timezone: null,
   clientId: null,
   dailySpendCeilingUsd: null,
+  calendarIdentityId: null,
+  calendarId: "primary",
 };
 
 beforeEach(() => {

--- a/packages/core/__tests__/meetings.test.ts
+++ b/packages/core/__tests__/meetings.test.ts
@@ -1,0 +1,265 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { Ledger } from "../src/ledger.ts";
+
+let dbPath: string;
+let ledger: Ledger;
+
+beforeEach(() => {
+  dbPath = join(
+    tmpdir(),
+    `oneshot-gtm-meetings-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`,
+  );
+  ledger = new Ledger(dbPath);
+});
+
+afterEach(() => {
+  ledger.close();
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      rmSync(`${dbPath}${suffix}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+const BASE = {
+  calendarId: "primary",
+  eventId: "e1",
+  status: "confirmed",
+  summary: "Intro call",
+  allDay: false,
+  startsAt: "2026-08-01T14:00:00.000Z",
+  endsAt: "2026-08-01T14:30:00.000Z",
+  eventUpdatedAt: "2026-08-01T10:00:00.000Z",
+  attendeesFingerprint: "pat@acme.com",
+};
+
+describe("Ledger.upsertMeeting", () => {
+  it("inserts a new row and reports isNew:true", () => {
+    const res = ledger.upsertMeeting(BASE);
+    expect(res.isNew).toBe(true);
+    expect(res.fingerprintChanged).toBe(true);
+    const row = ledger.getMeeting("primary", "e1");
+    expect(row?.summary).toBe("Intro call");
+    expect(row?.starts_at).toBe(BASE.startsAt);
+  });
+
+  it("upserts in place — a second call updates, not inserts a duplicate row", () => {
+    ledger.upsertMeeting(BASE);
+    const res = ledger.upsertMeeting({ ...BASE, summary: "Intro call (rescheduled)" });
+    expect(res.isNew).toBe(false);
+    expect(ledger.getMeeting("primary", "e1")?.summary).toBe("Intro call (rescheduled)");
+  });
+
+  it("a cancellation stub for an event never seen is a no-op — nothing inserted", () => {
+    ledger.upsertMeeting({
+      calendarId: "primary",
+      eventId: "never-seen",
+      status: "cancelled",
+      // No startsAt — the stub carries almost nothing, exactly like a real
+      // cancellation-only payload from the API.
+    });
+    expect(ledger.getMeeting("primary", "never-seen")).toBeNull();
+  });
+
+  it("a cancellation for an event ALREADY seen updates it in place without wiping the match", () => {
+    ledger.upsertMeeting({ ...BASE, prospectId: 7, matchStatus: "exact" });
+    ledger.upsertMeeting({
+      calendarId: "primary",
+      eventId: "e1",
+      status: "cancelled",
+      // The stub carries no summary/prospectId/matchStatus — those must
+      // survive via COALESCE, never wiped by INSERT OR REPLACE semantics.
+    });
+    const row = ledger.getMeeting("primary", "e1")!;
+    expect(row.status).toBe("cancelled");
+    expect(row.summary).toBe("Intro call");
+    expect(row.prospect_id).toBe(7);
+    expect(row.match_status).toBe("exact");
+  });
+
+  it("a reschedule (starts_at changes) clears outcome_prompted_at but keeps a recorded outcome", () => {
+    ledger.upsertMeeting(BASE);
+    ledger.markMeetingPrompted("primary", "e1");
+    ledger.setMeetingOutcome({ calendarId: "primary", eventId: "e1", outcome: "held" });
+    expect(ledger.getMeeting("primary", "e1")!.outcome_prompted_at).not.toBeNull();
+    ledger.upsertMeeting({ ...BASE, startsAt: "2026-08-02T14:00:00.000Z" });
+    const row = ledger.getMeeting("primary", "e1")!;
+    expect(row.starts_at).toBe("2026-08-02T14:00:00.000Z");
+    expect(row.outcome).toBe("held");
+    expect(row.outcome_prompted_at).toBeNull();
+  });
+
+  it("re-upserting with the SAME starts_at does not clear outcome_prompted_at", () => {
+    ledger.upsertMeeting(BASE);
+    ledger.markMeetingPrompted("primary", "e1");
+    ledger.upsertMeeting({ ...BASE, summary: "touched, same time" });
+    expect(ledger.getMeeting("primary", "e1")!.outcome_prompted_at).not.toBeNull();
+  });
+
+  it("touchMeetingLastSeen updates last_seen_at and returns true for an existing row", async () => {
+    ledger.upsertMeeting(BASE);
+    const before = ledger.getMeeting("primary", "e1")!.last_seen_at;
+    await new Promise((r) => setTimeout(r, 1100));
+    const touched = ledger.touchMeetingLastSeen("primary", "e1");
+    expect(touched).toBe(true);
+    const after = ledger.getMeeting("primary", "e1")!.last_seen_at;
+    expect(after >= before).toBe(true);
+  });
+
+  it("touchMeetingLastSeen is a no-op returning false for an unknown row", () => {
+    expect(ledger.touchMeetingLastSeen("primary", "nope")).toBe(false);
+  });
+
+  it("fingerprintChanged is false when the same fingerprint is upserted again", () => {
+    ledger.upsertMeeting(BASE);
+    const res = ledger.upsertMeeting({ ...BASE, summary: "unchanged fingerprint" });
+    expect(res.fingerprintChanged).toBe(false);
+  });
+
+  it("fingerprintChanged is true when the attendee set changes", () => {
+    ledger.upsertMeeting(BASE);
+    const res = ledger.upsertMeeting({ ...BASE, attendeesFingerprint: "different@acme.com" });
+    expect(res.fingerprintChanged).toBe(true);
+  });
+
+  it("event_id is only unique within a calendar — two calendars can share the same event_id", () => {
+    ledger.upsertMeeting({ ...BASE, calendarId: "cal-a" });
+    ledger.upsertMeeting({ ...BASE, calendarId: "cal-b", summary: "Different cal" });
+    expect(ledger.getMeeting("cal-a", "e1")?.summary).toBe("Intro call");
+    expect(ledger.getMeeting("cal-b", "e1")?.summary).toBe("Different cal");
+  });
+});
+
+describe("Ledger.listPendingOutcomeMeetings", () => {
+  it("includes a confirmed, prospect-linked, past meeting with no outcome", () => {
+    const pid = ledger.upsertProspect({ email: "pat@acme.com", source: "t" });
+    ledger.upsertMeeting({
+      ...BASE,
+      endsAt: "2020-01-01T00:00:00.000Z", // well in the past
+      prospectId: pid,
+      matchStatus: "exact",
+    });
+    const rows = ledger.listPendingOutcomeMeetings();
+    expect(rows.map((r) => r.event_id)).toContain("e1");
+  });
+
+  it("excludes an all-day event", () => {
+    const pid = ledger.upsertProspect({ email: "pat@acme.com", source: "t" });
+    ledger.upsertMeeting({
+      ...BASE,
+      allDay: true,
+      endsAt: "2020-01-01T00:00:00.000Z",
+      prospectId: pid,
+    });
+    expect(ledger.listPendingOutcomeMeetings()).toEqual([]);
+  });
+
+  it("excludes a meeting the founder declined", () => {
+    const pid = ledger.upsertProspect({ email: "pat@acme.com", source: "t" });
+    ledger.upsertMeeting({
+      ...BASE,
+      endsAt: "2020-01-01T00:00:00.000Z",
+      prospectId: pid,
+      selfResponse: "declined",
+    });
+    expect(ledger.listPendingOutcomeMeetings()).toEqual([]);
+  });
+
+  it("excludes a meeting still inside the 30-minute grace period", () => {
+    const pid = ledger.upsertProspect({ email: "pat@acme.com", source: "t" });
+    ledger.upsertMeeting({
+      ...BASE,
+      endsAt: new Date(Date.now() - 5 * 60_000).toISOString(),
+      prospectId: pid,
+    });
+    expect(ledger.listPendingOutcomeMeetings()).toEqual([]);
+  });
+
+  it("excludes an unmatched meeting (no prospect_id)", () => {
+    ledger.upsertMeeting({ ...BASE, endsAt: "2020-01-01T00:00:00.000Z" });
+    expect(ledger.listPendingOutcomeMeetings()).toEqual([]);
+  });
+
+  it("excludes a meeting that already has an outcome", () => {
+    const pid = ledger.upsertProspect({ email: "pat@acme.com", source: "t" });
+    ledger.upsertMeeting({
+      ...BASE,
+      endsAt: "2020-01-01T00:00:00.000Z",
+      prospectId: pid,
+    });
+    ledger.setMeetingOutcome({ calendarId: "primary", eventId: "e1", outcome: "held" });
+    expect(ledger.listPendingOutcomeMeetings()).toEqual([]);
+  });
+});
+
+describe("Ledger.confirmMeetingMatch / dismissMeetingMatch", () => {
+  it("confirm promotes a suggestion to exact and clears the suggested id", () => {
+    const pid = ledger.upsertProspect({ email: "pat@acme.com", source: "t" });
+    ledger.upsertMeeting({ ...BASE, suggestedProspectId: pid, matchStatus: "suggested" });
+    ledger.confirmMeetingMatch("primary", "e1", pid);
+    const row = ledger.getMeeting("primary", "e1")!;
+    expect(row.match_status).toBe("exact");
+    expect(row.prospect_id).toBe(pid);
+    expect(row.suggested_prospect_id).toBeNull();
+  });
+
+  it("dismiss marks match_status dismissed and clears the suggestion", () => {
+    const pid = ledger.upsertProspect({ email: "pat@acme.com", source: "t" });
+    ledger.upsertMeeting({ ...BASE, suggestedProspectId: pid, matchStatus: "suggested" });
+    ledger.dismissMeetingMatch("primary", "e1");
+    const row = ledger.getMeeting("primary", "e1")!;
+    expect(row.match_status).toBe("dismissed");
+    expect(row.suggested_prospect_id).toBeNull();
+  });
+
+  it("a dismiss survives a re-poll that carries the SAME fingerprint (upsertMeeting's COALESCE)", () => {
+    ledger.upsertMeeting(BASE);
+    ledger.dismissMeetingMatch("primary", "e1");
+    // Re-poll: same attendee set, so the caller (the real poller) would not
+    // even attempt to re-match — but prove the ledger layer alone preserves
+    // the dismissal when matchStatus is omitted on the next upsert.
+    ledger.upsertMeeting({ ...BASE, summary: "touched again" });
+    expect(ledger.getMeeting("primary", "e1")!.match_status).toBe("dismissed");
+  });
+});
+
+describe("Ledger.listMeetingsForReview", () => {
+  it("lists suggested and ambiguous rows, excludes exact/dismissed/unmatched", () => {
+    ledger.upsertMeeting({ ...BASE, eventId: "suggested-1", matchStatus: "suggested" });
+    ledger.upsertMeeting({ ...BASE, eventId: "ambiguous-1", matchStatus: "ambiguous" });
+    ledger.upsertMeeting({ ...BASE, eventId: "exact-1", matchStatus: "exact" });
+    ledger.upsertMeeting({ ...BASE, eventId: "dismissed-1", matchStatus: "dismissed" });
+    ledger.upsertMeeting({ ...BASE, eventId: "unmatched-1" });
+    const ids = ledger.listMeetingsForReview().map((r) => r.event_id);
+    expect(ids.toSorted()).toEqual(["ambiguous-1", "suggested-1"]);
+  });
+});
+
+describe("Ledger fuzzy-match helpers", () => {
+  it("listProspectsForFuzzyMatch only returns prospects with an email", () => {
+    ledger.upsertProspect({ email: "a@acme.com", name: "A", source: "t" });
+    ledger.upsertProspect({ email: null, name: "No email", source: "t" });
+    const rows = ledger.listProspectsForFuzzyMatch();
+    expect(rows.map((r) => r.email)).toEqual(["a@acme.com"]);
+  });
+
+  it("hasOutreachHistory / lastOutreachAt reflect sequence_events", () => {
+    const pid = ledger.upsertProspect({ email: "a@acme.com", source: "t" });
+    expect(ledger.hasOutreachHistory(pid)).toBe(false);
+    expect(ledger.lastOutreachAt(pid)).toBeNull();
+    ledger.recordSequenceEvent({
+      prospectId: pid,
+      playName: "x",
+      stepIndex: 0,
+      channel: "email",
+      status: "sent",
+    });
+    expect(ledger.hasOutreachHistory(pid)).toBe(true);
+    expect(ledger.lastOutreachAt(pid)).not.toBeNull();
+  });
+});

--- a/packages/core/__tests__/timezone.test.ts
+++ b/packages/core/__tests__/timezone.test.ts
@@ -9,6 +9,7 @@ import {
   localDayOffset,
   localShortDate,
   localWeekday,
+  naiveLocalToInstant,
   resolveEventZone,
 } from "../src/timezone.ts";
 
@@ -217,5 +218,45 @@ describe("calendar-day helpers", () => {
     expect(localWeekday("whenever", "America/Los_Angeles")).toBeNull();
     expect(localShortDate("whenever", "America/Los_Angeles")).toBeNull();
     expect(formatLocalDay("whenever", "America/Los_Angeles")).toBeNull();
+  });
+});
+
+describe("naiveLocalToInstant (issue #577 — all-day calendar events)", () => {
+  it("anchors a bare date to midnight in the given zone", () => {
+    // 2026-08-26 00:00 in Los Angeles is 2026-08-26T07:00:00Z (PDT, UTC-7).
+    expect(naiveLocalToInstant("2026-08-26", "America/Los_Angeles")).toBe(
+      "2026-08-26T07:00:00.000Z",
+    );
+  });
+
+  it("round-trips through formatLocalDay for the SAME zone", () => {
+    const instant = naiveLocalToInstant("2026-08-26", "America/Los_Angeles")!;
+    expect(formatLocalDay(instant, "America/Los_Angeles")).toBe("Wednesday, August 26, 2026");
+  });
+
+  it("anchors a naive date-time to that wall clock in the given zone", () => {
+    // 2026-08-26 14:00 in Vienna (CEST, UTC+2) is 2026-08-26T12:00:00Z.
+    expect(naiveLocalToInstant("2026-08-26T14:00:00", "Europe/Vienna")).toBe(
+      "2026-08-26T12:00:00.000Z",
+    );
+  });
+
+  it("handles a DST transition correctly (fall-back, LA)", () => {
+    // 2026-11-01 01:30 in LA, BEFORE the fall-back at 2am, is still PDT (UTC-7).
+    expect(naiveLocalToInstant("2026-11-01T01:30:00", "America/Los_Angeles")).toBe(
+      "2026-11-01T08:30:00.000Z",
+    );
+  });
+
+  it("returns null for an unrecognized zone", () => {
+    expect(naiveLocalToInstant("2026-08-26", "Mars/Olympus")).toBeNull();
+  });
+
+  it("returns null for unparseable input", () => {
+    expect(naiveLocalToInstant("not a date", "America/Los_Angeles")).toBeNull();
+  });
+
+  it("returns null for an impossible calendar date", () => {
+    expect(naiveLocalToInstant("2026-02-30", "America/Los_Angeles")).toBeNull();
   });
 });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -2,6 +2,7 @@ import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "n
 import { homedir } from "node:os";
 import { randomUUID } from "node:crypto";
 import { dirname, join } from "node:path";
+import { CALENDAR_READONLY_SCOPE } from "./gmail.ts";
 import { safeParseJsonRecord } from "./json.ts";
 import type { OneShotConfig } from "./types.ts";
 
@@ -55,6 +56,8 @@ const DEFAULTS: OneShotConfig = {
   timezone: null,
   clientId: null,
   dailySpendCeilingUsd: null,
+  calendarIdentityId: null,
+  calendarId: "primary",
 };
 
 export function configDir(): string {
@@ -264,6 +267,22 @@ const GMAIL_TOKENS_PATH = join(CONFIG_DIR, "gmail-tokens.json");
 export interface GmailTokenEntry {
   refreshToken: string;
   address: string;
+  /**
+   * Space-delimited scopes Google granted at consent time (issue #577).
+   * `undefined`/absent means "unknown, pre-dates scope tracking" and is
+   * always read as NOT having calendar access — an absent scope must never
+   * be treated as "unknown, try anyway": a Gmail-only token making a
+   * Calendar call just burns a 403 for nothing, and worse, the caller has
+   * no way to distinguish a real revoke from a token this old.
+   *
+   * NOT authoritative on its own: a scope can be revoked at
+   * myaccount.google.com without invalidating the refresh token, so the API
+   * itself can answer 403 ACCESS_TOKEN_SCOPE_INSUFFICIENT while this string
+   * still claims the scope. Callers that see that specific error must clear
+   * the scope here (see `clearGmailTokenCalendarScope`) so the reconnect
+   * affordance reappears.
+   */
+  scope?: string | null;
 }
 
 /**
@@ -287,6 +306,7 @@ export function loadGmailTokens(): Record<string, GmailTokenEntry> {
       out[id] = {
         refreshToken: e.refreshToken,
         address: typeof e.address === "string" ? e.address : "",
+        scope: typeof e.scope === "string" ? e.scope : null,
       };
     }
   }
@@ -309,6 +329,33 @@ export function deleteGmailToken(identityId: string): void {
   const all = loadGmailTokens();
   if (!(identityId in all)) return;
   delete all[identityId];
+  writeFileSync(GMAIL_TOKENS_PATH, JSON.stringify(all, null, 2));
+}
+
+/**
+ * True when the stored scope string for this identity includes Calendar
+ * read access. Absent scope (pre-#577 token, or one this codebase never
+ * saw the grant for) reads as false, never "unknown, try anyway" — see the
+ * `GmailTokenEntry.scope` doc.
+ */
+export function hasCalendarScope(entry: GmailTokenEntry | null | undefined): boolean {
+  if (!entry?.scope) return false;
+  return entry.scope.split(/\s+/).includes(CALENDAR_READONLY_SCOPE);
+}
+
+/**
+ * Clear the persisted scope for one identity WITHOUT touching its refresh
+ * token — used when a live API call answers `403
+ * ACCESS_TOKEN_SCOPE_INSUFFICIENT` even though the stored scope claims
+ * calendar access (a scope revoked at myaccount.google.com doesn't
+ * invalidate the refresh token, so this is the only signal that arrives).
+ * A no-op if the identity has no stored token.
+ */
+export function clearGmailTokenScope(identityId: string): void {
+  const all = loadGmailTokens();
+  const entry = all[identityId];
+  if (!entry) return;
+  entry.scope = null;
   writeFileSync(GMAIL_TOKENS_PATH, JSON.stringify(all, null, 2));
 }
 

--- a/packages/core/src/freemail.ts
+++ b/packages/core/src/freemail.ts
@@ -1,0 +1,40 @@
+/**
+ * Personal / free-tier email providers, curated small — used to keep the
+ * calendar-matching `domain` fuzzy signal (packages/plays/src/_calendar.ts,
+ * issue #577) from treating every personal-Gmail prospect as a hit on every
+ * OTHER personal-Gmail prospect just because they share a mailbox provider.
+ *
+ * Deliberately NOT the same list as `packages/find/src/_findemail-prescreen.ts`'s
+ * `DUD_DOMAINS`: that list also excludes app-preview subdomains, social
+ * platforms and link aggregators (irrelevant here — this only guards a
+ * DOMAIN-equality signal), and `plays` cannot depend on `find` without
+ * creating a package cycle (`find` already depends on `plays`). Kept in
+ * `core`, which both packages can import, rather than duplicating in each.
+ */
+export const FREEMAIL_DOMAINS: ReadonlySet<string> = new Set([
+  "gmail.com",
+  "googlemail.com",
+  "yahoo.com",
+  "ymail.com",
+  "outlook.com",
+  "hotmail.com",
+  "live.com",
+  "msn.com",
+  "icloud.com",
+  "me.com",
+  "mac.com",
+  "aol.com",
+  "proton.me",
+  "protonmail.com",
+  "fastmail.com",
+  "gmx.com",
+  "gmx.net",
+  "zoho.com",
+  "yandex.com",
+  "mail.com",
+]);
+
+export function isFreemailDomain(domain: string | null | undefined): boolean {
+  if (!domain) return false;
+  return FREEMAIL_DOMAINS.has(domain.trim().toLowerCase());
+}

--- a/packages/core/src/gcal.ts
+++ b/packages/core/src/gcal.ts
@@ -1,0 +1,241 @@
+import {
+  formatGmailApiError,
+  getGmailAccessToken,
+  GMAIL_AUTH_HINT,
+  invalidateGmailAccessToken,
+  type GmailAccount,
+  type GoogleApiErrorEnvelope,
+} from "./gmail.ts";
+
+/**
+ * Google Calendar REST client (issue #577) — mirrors gmail.ts's plain-fetch
+ * shape deliberately: same OAuth client, same refresh token, and (critically)
+ * the SAME `tokenCache` inside gmail.ts. `getGmailAccessToken` is reused
+ * as-is rather than duplicated, so a Gmail-family access token minted for a
+ * send is reused for a calendar read within its lifetime, and vice versa —
+ * building a second cache here would double the refresh-token traffic for
+ * no reason and risk the two caches disagreeing about whether a token is
+ * still valid.
+ */
+
+const CALENDAR_API = "https://www.googleapis.com/calendar/v3";
+
+/**
+ * Thrown by `calendarJson` on any non-2xx response. Carries the HTTP status
+ * and (when parseable) Google's own `error.status` gRPC-style code — the
+ * field that separates `PERMISSION_DENIED` (scope/auth lost) from
+ * `RESOURCE_EXHAUSTED` (quota, self-heals) from
+ * `ACCESS_TOKEN_SCOPE_INSUFFICIENT` (persisted scope says calendar, live
+ * token disagrees). Callers that need to branch on the specific failure
+ * (the poller does, for 410/403) match on these fields instead of
+ * re-parsing `.message`.
+ */
+export class CalendarApiError extends Error {
+  constructor(
+    message: string,
+    readonly httpStatus: number,
+    readonly googleStatus: string | null,
+  ) {
+    super(message);
+    this.name = "CalendarApiError";
+  }
+}
+
+async function calendarFetch(
+  path: string,
+  init: RequestInit | undefined,
+  account: GmailAccount,
+): Promise<Response> {
+  const token = await getGmailAccessToken(account);
+  return fetch(`${CALENDAR_API}${path}`, {
+    ...init,
+    headers: { ...init?.headers, Authorization: `Bearer ${token}` },
+  });
+}
+
+async function calendarJson<T>(
+  path: string,
+  init: RequestInit | undefined,
+  account: GmailAccount,
+): Promise<T> {
+  const res = await calendarFetch(path, init, account);
+  if (!res.ok) {
+    // Mirror gmailJson's 401 handling exactly (gmail.ts:218-225 in the
+    // implementer's own words): check the status before reading the body —
+    // there's nothing in an auth-rejected body worth parsing, and a
+    // stuck/slow/unclosed stream must not delay the re-auth message the
+    // caller needs to act on. Additionally (calendar-specific): tokenCache
+    // can hold a live access token for up to an hour, so a token REVOKED at
+    // myaccount.google.com surfaces as a 401 on this very call, not as
+    // `invalid_grant` on the next refresh — evict the cached token now or
+    // every poll until natural expiry keeps handing back the dead one.
+    if (res.status === 401) {
+      res.body?.cancel().catch(() => {});
+      invalidateGmailAccessToken(account);
+      throw new CalendarApiError(
+        `Calendar auth rejected (401) for ${account.id} — ${GMAIL_AUTH_HINT}`,
+        401,
+        null,
+      );
+    }
+    const raw = await res.text();
+    let googleStatus: string | null = null;
+    try {
+      googleStatus = (JSON.parse(raw) as GoogleApiErrorEnvelope).error?.status ?? null;
+    } catch {
+      // formatGmailApiError below falls back to a raw slice for this same case.
+    }
+    throw new CalendarApiError(
+      `Calendar API failed (${res.status}): ${formatGmailApiError(raw)} [${path.split("?")[0]}]`,
+      res.status,
+      googleStatus,
+    );
+  }
+  return (await res.json()) as T;
+}
+
+export interface CalendarEventDateTime {
+  /** Set for a timed event — RFC3339 instant. */
+  dateTime?: string;
+  /** Set for an all-day event — bare YYYY-MM-DD, no time, no zone. */
+  date?: string;
+  /** IANA zone the event was created in; absent for UTC/all-day. */
+  timeZone?: string;
+}
+
+export interface CalendarEventAttendee {
+  email?: string;
+  /** True on the row representing the authenticated calendar owner. */
+  self?: boolean;
+  organizer?: boolean;
+  /** A room / equipment resource, not a person — never a match candidate. */
+  resource?: boolean;
+  responseStatus?: string;
+}
+
+export interface CalendarEventPerson {
+  email?: string;
+  self?: boolean;
+}
+
+/** One `events.list` item, trimmed to the `fields` this poller requests. */
+export interface CalendarEventItem {
+  id: string;
+  iCalUID?: string;
+  status?: "confirmed" | "tentative" | "cancelled" | string;
+  summary?: string;
+  start?: CalendarEventDateTime;
+  end?: CalendarEventDateTime;
+  /** Last-modified instant — the field this poller sorts/watermarks on. */
+  updated?: string;
+  organizer?: CalendarEventPerson;
+  creator?: CalendarEventPerson;
+  attendees?: CalendarEventAttendee[];
+  /** True when the room had more attendees than the API would list without `maxAttendees` (which this client deliberately never sends). */
+  attendeesOmitted?: boolean;
+  recurringEventId?: string;
+  originalStartTime?: CalendarEventDateTime;
+  eventType?: string;
+  hangoutLink?: string;
+  visibility?: string;
+  transparency?: string;
+  /** NEVER persisted past the ingest step — may carry dial-in PINs or private notes. */
+  description?: string;
+}
+
+export interface ListCalendarEventsOpts {
+  calendarId: string;
+  /** Exclusive lower bound on `updated`. Omit for a full (unbounded) pull. */
+  updatedMin?: string;
+  /** Exclusive lower bound on the event's END. */
+  timeMin: string;
+  /** Exclusive upper bound on the event's START. */
+  timeMax: string;
+  pageToken?: string;
+  maxResults?: number;
+}
+
+const EVENT_FIELDS =
+  "nextPageToken,items(id,iCalUID,status,summary,start,end,updated," +
+  "organizer,creator,attendees,attendeesOmitted,recurringEventId," +
+  "originalStartTime,eventType,hangoutLink,visibility,transparency,description)";
+
+/**
+ * One page of `calendars.events.list`. Deliberately does NOT send
+ * `maxAttendees` (an event over the cap would return only the authenticated
+ * participant — the prospect vanishes and the meeting misreads as a
+ * self-block) or `eventTypes` (filtering happens in code so dropped events
+ * can be logged, not silently excluded server-side).
+ */
+export async function listCalendarEvents(
+  account: GmailAccount,
+  opts: ListCalendarEventsOpts,
+): Promise<{ items: CalendarEventItem[]; nextPageToken: string | null }> {
+  const params = new URLSearchParams({
+    singleEvents: "true",
+    showDeleted: "true",
+    // Ascending — load-bearing. An interrupted walk leaves a SUFFIX of
+    // unexamined updates, not a hole, which is what lets this poller skip
+    // the backlog machinery pollInboxReplies needs (see the scheduler-side
+    // comment for the full argument).
+    orderBy: "updated",
+    timeMin: opts.timeMin,
+    timeMax: opts.timeMax,
+    maxResults: String(opts.maxResults ?? 250),
+    fields: EVENT_FIELDS,
+  });
+  if (opts.updatedMin) params.set("updatedMin", opts.updatedMin);
+  if (opts.pageToken) params.set("pageToken", opts.pageToken);
+  const res = await calendarJson<{ items?: CalendarEventItem[]; nextPageToken?: string }>(
+    `/calendars/${encodeURIComponent(opts.calendarId)}/events?${params}`,
+    undefined,
+    account,
+  );
+  return { items: res.items ?? [], nextPageToken: res.nextPageToken ?? null };
+}
+
+export interface CalendarListEntry {
+  id: string;
+  summary: string;
+  accessRole: string;
+}
+
+/**
+ * `GET /users/me/calendarList?minAccessRole=writer` — the /setup picker's
+ * source list. `writer` is the floor deliberately: on a `reader` or
+ * `freeBusyReader` calendar every event comes back as `summary: "busy"`
+ * with no attendees, which reads exactly like a self-block and would poison
+ * matching with false negatives.
+ */
+export async function listWritableCalendars(account: GmailAccount): Promise<CalendarListEntry[]> {
+  const res = await calendarJson<{
+    items?: Array<{ id: string; summary?: string; accessRole?: string }>;
+  }>(`/users/me/calendarList?minAccessRole=writer`, undefined, account);
+  return (res.items ?? []).map((i) => ({
+    id: i.id,
+    summary: i.summary?.trim() || i.id,
+    accessRole: i.accessRole ?? "",
+  }));
+}
+
+/**
+ * How many events landed on `calendarId` in the trailing 7 days — shown
+ * beside each calendar in the /setup picker, because a founder cannot
+ * reliably say which calendar their booking tool actually writes to.
+ * Best-effort: any failure (including a calendar this account can no longer
+ * read) reads as 0 rather than failing the whole picker.
+ */
+export async function recentEventCount(account: GmailAccount, calendarId: string): Promise<number> {
+  const now = Date.now();
+  try {
+    const res = await listCalendarEvents(account, {
+      calendarId,
+      timeMin: new Date(now - 7 * 24 * 60 * 60_000).toISOString(),
+      timeMax: new Date(now).toISOString(),
+      maxResults: 250,
+    });
+    return res.items.length;
+  } catch {
+    return 0;
+  }
+}

--- a/packages/core/src/gmail.ts
+++ b/packages/core/src/gmail.ts
@@ -14,8 +14,16 @@ const GMAIL_API = "https://gmail.googleapis.com/gmail/v1/users/me";
 
 export const GMAIL_AUTH_HINT = "run: bun run cli -- gmail auth";
 
-export const GMAIL_OAUTH_SCOPES =
-  "https://www.googleapis.com/auth/gmail.send https://www.googleapis.com/auth/gmail.readonly";
+/**
+ * Read-only Calendar access — bundled into the same consent request as the
+ * Gmail scopes (issue #577) so a founder authorizes once and gets both. A
+ * refresh token is scope-bound and never rotated by this codebase, so an
+ * account authorized BEFORE this scope existed does not have it; see
+ * `GmailTokenEntry.scope` for how that's tracked.
+ */
+export const CALENDAR_READONLY_SCOPE = "https://www.googleapis.com/auth/calendar.readonly";
+
+export const GMAIL_OAUTH_SCOPES = `https://www.googleapis.com/auth/gmail.send https://www.googleapis.com/auth/gmail.readonly ${CALENDAR_READONLY_SCOPE}`;
 
 /** Google consent URL for the loopback OAuth flow (CLI command and /setup button share it). */
 export function gmailConsentUrl(opts: {
@@ -34,13 +42,20 @@ export function gmailConsentUrl(opts: {
   })}`;
 }
 
+/** Result of exchanging an authorization code for tokens. */
+export interface GmailAuthExchangeResult {
+  refreshToken: string;
+  /** Space-delimited scopes Google actually granted — may be narrower than what was requested. */
+  scope: string | null;
+}
+
 /** Exchange an authorization code for a refresh token. Throws with an actionable message on any failure. */
 export async function exchangeGmailAuthCode(opts: {
   code: string;
   clientId: string;
   clientSecret: string;
   redirectUri: string;
-}): Promise<string> {
+}): Promise<GmailAuthExchangeResult> {
   const res = await fetch(TOKEN_URL, {
     method: "POST",
     headers: { "Content-Type": "application/x-www-form-urlencoded" },
@@ -54,6 +69,7 @@ export async function exchangeGmailAuthCode(opts: {
   });
   const data = (await res.json()) as {
     refresh_token?: string;
+    scope?: string;
     error?: string;
     error_description?: string;
   };
@@ -67,7 +83,7 @@ export async function exchangeGmailAuthCode(opts: {
         : "";
     throw new Error(`Gmail token exchange failed: ${detail}${hint}`);
   }
-  return data.refresh_token;
+  return { refreshToken: data.refresh_token, scope: data.scope ?? null };
 }
 
 export function missingGmailSecrets(): string[] {
@@ -113,6 +129,18 @@ export function _resetGmailCache(): void {
   tokenCache.clear();
   profileCache.clear();
   messageCache.clear();
+}
+
+/**
+ * Drop ONE account's cached access token (shared by every Gmail-family API,
+ * calendar included — see gcal.ts). `tokenCache` can hold a live token for
+ * up to an hour, so a token revoked at myaccount.google.com surfaces as a
+ * 401 on the next API CALL, not as `invalid_grant` on the next refresh — the
+ * caller must evict the stale entry here or the next poll keeps reusing the
+ * dead token until it naturally expires.
+ */
+export function invalidateGmailAccessToken(account?: GmailAccount): void {
+  tokenCache.delete(account?.id ?? LEGACY_CACHE_KEY);
 }
 
 export async function getGmailAccessToken(account?: GmailAccount): Promise<string> {
@@ -173,7 +201,7 @@ async function gmailFetch(
 }
 
 /** Google's stable API error envelope: `{ error: { code, message, status, errors[] } }`. */
-interface GoogleApiErrorEnvelope {
+export interface GoogleApiErrorEnvelope {
   error?: {
     code?: number;
     message?: string;
@@ -212,7 +240,7 @@ function compactQuotaMessage(message: string): string | null {
  * JSON is mostly whitespace/scaffolding, so 200 chars of it is the same
  * "better than nothing" fallback the old code always used.
  */
-function formatGmailApiError(raw: string): string {
+export function formatGmailApiError(raw: string): string {
   try {
     const parsed = JSON.parse(raw) as GoogleApiErrorEnvelope;
     const message = parsed.error?.message;
@@ -515,7 +543,7 @@ const DAEMON_ADDRESS_RE = /^(mailer-daemon|postmaster)@/i;
  * body with no `@` backtracks from every start position, and DSN bodies are
  * attacker-influenced. See also PROSE_SCAN_LIMIT.
  */
-const EMAIL_RE = /[\w.!#$%&'*+/=?^`{|}~-]{1,64}@[\w-]{1,63}(?:\.[\w-]{1,63}){1,8}/g;
+export const EMAIL_RE = /[\w.!#$%&'*+/=?^`{|}~-]{1,64}@[\w-]{1,63}(?:\.[\w-]{1,63}){1,8}/g;
 /**
  * Prose cap (chars) for the fallback parser — a real DSN states the failure
  * up front; the cap bounds regex work on hostile input.

--- a/packages/core/src/identities.ts
+++ b/packages/core/src/identities.ts
@@ -69,8 +69,19 @@ export function resolveIdentities(cfg: OneShotConfig): EmailIdentity[] {
  * Persist a freshly authorized Gmail account (token → chmod-600 store,
  * identity → pool). The legacy pool is materialized first so existing prospect
  * pins survive; re-auth only refreshes the token, tuned caps are left alone.
+ *
+ * `calendarOnly` (issue #577): the connect flow's `?purpose=calendar` path —
+ * a mailbox authorized purely to read its calendar must register at
+ * `maxPerDay: 0` (never sends) instead of the warm-up ramp, or connecting it
+ * silently enrols the account as a sender. Only applies to a genuinely NEW
+ * identity: re-authing an existing sender (`created: false`) must never touch
+ * its tuned caps, calendar purpose or not.
  */
-export function registerGmailIdentity(input: { address: string; refreshToken: string }): {
+export function registerGmailIdentity(input: {
+  address: string;
+  refreshToken: string;
+  calendarOnly?: boolean;
+}): {
   identityId: string;
   created: boolean;
 } {
@@ -86,7 +97,7 @@ export function registerGmailIdentity(input: { address: string; refreshToken: st
     provider: "gmail",
     label: input.address,
     address: input.address,
-    ...WARMUP_DEFAULTS,
+    ...(input.calendarOnly ? { maxPerDay: 0, warmup: null } : WARMUP_DEFAULTS),
   });
   saveConfig({ ...cfg, emailIdentities: pool });
   return { identityId, created: true };
@@ -215,7 +226,16 @@ export function removeIdentity(identityId: string): { removed: boolean } {
   } catch {
     // token-store cleanup is best-effort; the identity is gone either way.
   }
-  saveConfig({ ...cfg, emailIdentities: next });
+  saveConfig({
+    ...cfg,
+    emailIdentities: next,
+    // A removed identity can't be polled — leaving the pointer dangling
+    // would either silently stop the calendar poll (poller sees an unknown
+    // id and skips) or, worse, resolve against whatever identity id happens
+    // to be reused later. Clearing it here makes the feature visibly "off"
+    // in /setup rather than invisibly broken.
+    calendarIdentityId: cfg.calendarIdentityId === identityId ? null : cfg.calendarIdentityId,
+  });
   return { removed: true };
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,8 @@ export * from "./priority.ts";
 export * from "./labels.ts";
 export * from "./calibration.ts";
 export * from "./gmail.ts";
+export * from "./gcal.ts";
+export * from "./freemail.ts";
 export * from "./smartlead.ts";
 export * from "./canary.ts";
 export * from "./identities.ts";

--- a/packages/core/src/ledger-schema.ts
+++ b/packages/core/src/ledger-schema.ts
@@ -540,6 +540,93 @@ export function migrateLedgerSchema(db: Database): void {
   // eventsByPlay can window bounces the same way it windows replies, via
   // COALESCE(bounced_at, created_at).
   addColumnIfMissing(db, "sequence_events", "bounced_at", "TEXT");
+  // v34 (issue #577): past calendar meetings needing an outcome. Composite
+  // PK because a Google Calendar event id is only unique WITHIN one
+  // calendar. `singleEvents=true` derives a recurring instance's id from its
+  // ORIGINAL start, so it survives a reschedule — recurring_event_id is kept
+  // so a moved instance is never forked into a ghost row. `ical_uid` is
+  // indexed (not unique) because the same meeting on two calendars produces
+  // two distinct (calendar_id, event_id) rows sharing one iCalUID.
+  //
+  // Every write here MUST be an idempotent `ON CONFLICT DO UPDATE`, never
+  // `INSERT OR REPLACE` (a cancellation stub carries almost no fields and
+  // would wipe summary/prospect_id/outcome) and never `INSERT OR IGNORE`
+  // (unlike an immutable inbox_replies row, an event mutates in place —
+  // reschedules and cancellations are updates to the SAME row, not new
+  // ones). See `upsertMeeting` in ledger.ts for the COALESCE(excluded.col,
+  // meetings.col) pattern this requires.
+  db.exec(`
+      CREATE TABLE IF NOT EXISTS meetings (
+        calendar_id                TEXT NOT NULL,
+        event_id                   TEXT NOT NULL,
+        ical_uid                   TEXT,
+        recurring_event_id         TEXT,
+        status                     TEXT NOT NULL DEFAULT 'confirmed',
+        summary                    TEXT,
+        all_day                    INTEGER NOT NULL DEFAULT 0,
+        starts_at                  TEXT,
+        ends_at                    TEXT,
+        event_timezone             TEXT,
+        organizer_email            TEXT,
+        -- The founder's own (self:true) attendee responseStatus. Distinct
+        -- from match_status (which is about PROSPECT identification, not
+        -- the founder's RSVP) — a declined event is excluded from the
+        -- pending-outcome nudge but the row is kept, never dropped.
+        self_response              TEXT,
+        external_attendee_count    INTEGER NOT NULL DEFAULT 0,
+        -- Capped ~20 entries; sourced from attendees ∪ {organizer, creator}
+        -- minus the founder's own addresses. Never the raw attendees[]
+        -- payload — description/dial-in PINs must never land here either.
+        external_attendees_json    TEXT,
+        attendees_omitted          INTEGER NOT NULL DEFAULT 0,
+        prospect_id                INTEGER,
+        suggested_prospect_id      INTEGER,
+        -- 'exact' | 'suggested' | 'ambiguous' | 'dismissed' | NULL (no
+        -- candidate at all — a self-block or an unmatched event).
+        match_status               TEXT,
+        -- 'name_domain' | 'domain' | 'name' | 'description' | NULL for an
+        -- 'exact' match (email-identity, no fuzzy method to name).
+        match_method               TEXT,
+        match_confidence           REAL,
+        -- 'held' | 'no_show' | 'cancelled' | 'rescheduled', founder-set only.
+        outcome                    TEXT,
+        outcome_note               TEXT,
+        outcome_recorded_at        TEXT,
+        -- Cleared (not the outcome) when a reschedule changes starts_at —
+        -- a stale nudge must withdraw, but a recorded outcome must survive.
+        outcome_prompted_at        TEXT,
+        -- The API's own 'updated' timestamp on this event — the
+        -- idempotency guard: if this hasn't advanced since last_seen_at,
+        -- the poll should touch only last_seen_at and skip re-deriving
+        -- everything else.
+        event_updated_at           TEXT,
+        first_seen_at              TEXT NOT NULL DEFAULT (datetime('now')),
+        last_seen_at               TEXT NOT NULL DEFAULT (datetime('now')),
+        -- Sorted, joined external emails. The fingerprint is what makes a
+        -- founder's dismiss STICK: re-matching only runs when this value
+        -- changes between polls, so a dismissed suggestion is never
+        -- silently re-proposed on an unchanged attendee list.
+        attendees_fingerprint      TEXT,
+        PRIMARY KEY (calendar_id, event_id)
+      );
+      -- The pending-outcome nudge query's exact WHERE clause, as a partial
+      -- index: only rows that could ever match it are indexed.
+      CREATE INDEX IF NOT EXISTS idx_meetings_pending_outcome
+        ON meetings(ends_at)
+        WHERE outcome IS NULL AND status = 'confirmed' AND all_day = 0
+          AND prospect_id IS NOT NULL;
+      -- The founder-facing review list (unmatched/suggested/ambiguous rows).
+      CREATE INDEX IF NOT EXISTS idx_meetings_match_status
+        ON meetings(match_status, starts_at);
+      -- Per-prospect meeting timeline.
+      CREATE INDEX IF NOT EXISTS idx_meetings_prospect
+        ON meetings(prospect_id, starts_at);
+      -- Duplicate detection: the same meeting on two calendars has two ids
+      -- and one iCalUID. Partial (most rows carry one) — indexing NULLs
+      -- would cost space for a column that's never queried on for them.
+      CREATE INDEX IF NOT EXISTS idx_meetings_ical_uid
+        ON meetings(ical_uid) WHERE ical_uid IS NOT NULL;
+    `);
 }
 
 /**

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -25,6 +25,10 @@ import type {
   InboxReplyRecord,
   IcpDecisionExample,
   InterviewRecord,
+  MeetingMatchMethod,
+  MeetingMatchStatus,
+  MeetingOutcome,
+  MeetingRecord,
   ProspectPriority,
   ProspectRecord,
   SentOutcomeRawRow,
@@ -4593,6 +4597,314 @@ export class Ledger {
 
   close(): void {
     this.db.close();
+  }
+
+  // ── Meetings (issue #577) ─────────────────────────────────────────────
+
+  /**
+   * Upsert one calendar event. NEVER `INSERT OR REPLACE` (a cancellation
+   * stub carries almost no fields and would wipe summary/prospect_id/
+   * outcome) and NEVER `INSERT OR IGNORE` (unlike an immutable inbox_replies
+   * row, an event mutates in place — a reschedule or cancellation is an
+   * UPDATE to the same row). `undefined` on any field means "this poll
+   * response didn't carry it" and preserves the existing value via
+   * `COALESCE(excluded.col, meetings.col)`; pass `null` explicitly to CLEAR
+   * a field.
+   *
+   * Two special cases the caller relies on:
+   *  - A cancellation stub (`status: 'cancelled'`, no `startsAt`) for an
+   *    event this ledger has never seen is a no-op — there's no start time
+   *    to even file a ghost row under, so nothing is inserted.
+   *  - A reschedule (an existing row whose `startsAt` differs from the new
+   *    value) clears `outcomePromptedAt` — a stale nudge must withdraw —
+   *    while leaving any already-recorded `outcome` untouched.
+   *
+   * Returns whether this event is new to the ledger and whether its
+   * `attendeesFingerprint` changed since last seen — the poller uses the
+   * latter to decide whether re-matching is worth running at all (a
+   * founder's dismiss must stick until the attendee set actually changes).
+   */
+  upsertMeeting(input: {
+    calendarId: string;
+    eventId: string;
+    icalUid?: string | null;
+    recurringEventId?: string | null;
+    status: string;
+    summary?: string | null;
+    allDay?: boolean;
+    startsAt?: string | null;
+    endsAt?: string | null;
+    eventTimezone?: string | null;
+    organizerEmail?: string | null;
+    selfResponse?: string | null;
+    externalAttendeeCount?: number;
+    externalAttendeesJson?: string | null;
+    attendeesOmitted?: boolean;
+    matchStatus?: MeetingMatchStatus;
+    matchMethod?: MeetingMatchMethod;
+    matchConfidence?: number | null;
+    prospectId?: number | null;
+    suggestedProspectId?: number | null;
+    eventUpdatedAt?: string | null;
+    attendeesFingerprint?: string | null;
+  }): { isNew: boolean; fingerprintChanged: boolean } {
+    const existing = this.db
+      .query(
+        `SELECT starts_at, attendees_fingerprint FROM meetings
+         WHERE calendar_id = ? AND event_id = ?`,
+      )
+      .get(input.calendarId, input.eventId) as
+      | { starts_at: string | null; attendees_fingerprint: string | null }
+      | undefined;
+    const isNew = !existing;
+    const fingerprintChanged =
+      !existing ||
+      (existing.attendees_fingerprint ?? null) !== (input.attendeesFingerprint ?? null);
+
+    const isUnseenCancellationStub =
+      isNew && input.status === "cancelled" && input.startsAt == null;
+    if (isUnseenCancellationStub) {
+      // Nothing to file this under — deliberately never inserted.
+      return { isNew: true, fingerprintChanged: false };
+    }
+
+    this.db
+      .prepare(
+        `INSERT INTO meetings (
+           calendar_id, event_id, ical_uid, recurring_event_id, status, summary,
+           all_day, starts_at, ends_at, event_timezone, organizer_email,
+           self_response, external_attendee_count, external_attendees_json,
+           attendees_omitted, prospect_id, suggested_prospect_id, match_status,
+           match_method, match_confidence, event_updated_at, attendees_fingerprint,
+           first_seen_at, last_seen_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                   datetime('now'), datetime('now'))
+         ON CONFLICT(calendar_id, event_id) DO UPDATE SET
+           ical_uid                = COALESCE(excluded.ical_uid, meetings.ical_uid),
+           recurring_event_id      = COALESCE(excluded.recurring_event_id, meetings.recurring_event_id),
+           status                  = COALESCE(excluded.status, meetings.status),
+           summary                 = COALESCE(excluded.summary, meetings.summary),
+           all_day                 = COALESCE(excluded.all_day, meetings.all_day),
+           -- A reschedule (starts_at genuinely changes) withdraws any stale
+           -- nudge; the recorded outcome itself is untouched either way.
+           outcome_prompted_at     = CASE
+             WHEN excluded.starts_at IS NOT NULL AND excluded.starts_at IS NOT meetings.starts_at
+               THEN NULL ELSE meetings.outcome_prompted_at END,
+           starts_at               = COALESCE(excluded.starts_at, meetings.starts_at),
+           ends_at                 = COALESCE(excluded.ends_at, meetings.ends_at),
+           event_timezone          = COALESCE(excluded.event_timezone, meetings.event_timezone),
+           organizer_email         = COALESCE(excluded.organizer_email, meetings.organizer_email),
+           self_response           = COALESCE(excluded.self_response, meetings.self_response),
+           external_attendee_count = COALESCE(excluded.external_attendee_count, meetings.external_attendee_count),
+           external_attendees_json = COALESCE(excluded.external_attendees_json, meetings.external_attendees_json),
+           attendees_omitted       = COALESCE(excluded.attendees_omitted, meetings.attendees_omitted),
+           -- A founder dismissal ('dismissed') must survive a re-poll that
+           -- carries no new match verdict (matchStatus undefined) — but a
+           -- fresh verdict from the matcher (always passed together with a
+           -- changed fingerprint) overwrites it, which is how a dismiss is
+           -- allowed to lapse once the attendee set actually changes.
+           prospect_id             = COALESCE(excluded.prospect_id, meetings.prospect_id),
+           suggested_prospect_id   = excluded.suggested_prospect_id,
+           match_status            = COALESCE(excluded.match_status, meetings.match_status),
+           match_method            = excluded.match_method,
+           match_confidence        = excluded.match_confidence,
+           event_updated_at        = COALESCE(excluded.event_updated_at, meetings.event_updated_at),
+           attendees_fingerprint   = COALESCE(excluded.attendees_fingerprint, meetings.attendees_fingerprint),
+           last_seen_at            = datetime('now')`,
+      )
+      .run(
+        input.calendarId,
+        input.eventId,
+        input.icalUid ?? null,
+        input.recurringEventId ?? null,
+        input.status,
+        input.summary ?? null,
+        // NOT NULL columns (schema DEFAULT 0) — must never bind NULL, or a
+        // fresh INSERT (no existing row for the ON CONFLICT COALESCE to
+        // fall back to) violates the constraint. The real caller
+        // (packages/plays' calendar poller) always supplies these three
+        // explicitly on every call, so defaulting an omitted one to
+        // false/0 here never actually fires in production.
+        input.allDay ? 1 : 0,
+        input.startsAt ?? null,
+        input.endsAt ?? null,
+        input.eventTimezone ?? null,
+        input.organizerEmail ?? null,
+        input.selfResponse ?? null,
+        input.externalAttendeeCount ?? 0,
+        input.externalAttendeesJson ?? null,
+        input.attendeesOmitted ? 1 : 0,
+        input.prospectId ?? null,
+        input.suggestedProspectId ?? null,
+        input.matchStatus ?? null,
+        input.matchMethod ?? null,
+        input.matchConfidence ?? null,
+        input.eventUpdatedAt ?? null,
+        input.attendeesFingerprint ?? null,
+      );
+    return { isNew, fingerprintChanged };
+  }
+
+  getMeeting(calendarId: string, eventId: string): MeetingRecord | null {
+    return (
+      (this.db
+        .query(`SELECT * FROM meetings WHERE calendar_id = ? AND event_id = ?`)
+        .get(calendarId, eventId) as MeetingRecord) ?? null
+    );
+  }
+
+  /**
+   * The fast path for an unchanged event (`event_updated_at` hasn't
+   * advanced since last poll): touch `last_seen_at` only, skip re-deriving
+   * anything else. Returns false (no-op) if the row doesn't exist.
+   */
+  touchMeetingLastSeen(calendarId: string, eventId: string): boolean {
+    const res = this.db
+      .prepare(
+        `UPDATE meetings SET last_seen_at = datetime('now') WHERE calendar_id = ? AND event_id = ?`,
+      )
+      .run(calendarId, eventId);
+    return res.changes > 0;
+  }
+
+  /**
+   * Every prospect's (id, name, email, company), for the calendar matcher's
+   * fuzzy domain/name signals — there's no `company_domain` column, so the
+   * matcher derives a domain from `email` and slug-compares `company`
+   * against it in JS. A full scan is fine at founder scale (same precedent
+   * `resolveProspectForLinkedInReply` already relies on).
+   */
+  listProspectsForFuzzyMatch(): Array<{
+    id: number;
+    name: string | null;
+    email: string | null;
+    company: string | null;
+  }> {
+    return this.db
+      .query(`SELECT id, name, email, company FROM prospects WHERE email IS NOT NULL`)
+      .all() as Array<{
+      id: number;
+      name: string | null;
+      email: string | null;
+      company: string | null;
+    }>;
+  }
+
+  /**
+   * Whether `prospectId` has any outreach history (sequence_events) — the
+   * calendar matcher's tie-break when two prospects share an exact-match
+   * email account: the one with outreach history wins; only when NEITHER
+   * has history is the match `ambiguous`.
+   */
+  hasOutreachHistory(prospectId: number): boolean {
+    return (
+      this.db
+        .query(`SELECT 1 FROM sequence_events WHERE prospect_id = ? LIMIT 1`)
+        .get(prospectId) != null
+    );
+  }
+
+  /** Most recent sequence_events timestamp for a prospect, or null with no history. Tie-break helper alongside `hasOutreachHistory`. */
+  lastOutreachAt(prospectId: number): string | null {
+    const row = this.db
+      .query(`SELECT MAX(created_at) AS at FROM sequence_events WHERE prospect_id = ?`)
+      .get(prospectId) as { at: string | null } | undefined;
+    return row?.at ?? null;
+  }
+
+  /**
+   * Past meetings linked to a prospect with no recorded outcome yet — the
+   * /inbox-style "awaiting" list. Grace period so a call that ran long
+   * isn't nagged about the instant it crosses `ends_at`. Declined-by-founder
+   * and all-day rows are excluded: a self-block or an all-day conference is
+   * not a call, and COALESCE(self_response,'accepted') reads a NULL
+   * response (never triaged, or an old row) as accepted rather than
+   * silently dropping it from the nudge.
+   */
+  listPendingOutcomeMeetings(): MeetingRecord[] {
+    return this.db
+      .query(
+        `SELECT * FROM meetings
+         WHERE outcome IS NULL AND status = 'confirmed' AND all_day = 0
+           AND prospect_id IS NOT NULL
+           AND COALESCE(self_response, 'accepted') <> 'declined'
+           AND ends_at < datetime('now', '-30 minutes')
+         ORDER BY ends_at DESC`,
+      )
+      .all() as MeetingRecord[];
+  }
+
+  /** Founder-facing review queue: events with a fuzzy suggestion or an ambiguous multi-candidate match, unresolved. */
+  listMeetingsForReview(): MeetingRecord[] {
+    return this.db
+      .query(
+        `SELECT * FROM meetings
+         WHERE match_status IN ('suggested', 'ambiguous')
+         ORDER BY starts_at DESC`,
+      )
+      .all() as MeetingRecord[];
+  }
+
+  /** Record a founder-set outcome. Clears outcome_prompted_at is NOT done here — the row is resolved, not withdrawn. */
+  setMeetingOutcome(input: {
+    calendarId: string;
+    eventId: string;
+    outcome: MeetingOutcome;
+    note?: string | null;
+  }): void {
+    this.db
+      .prepare(
+        `UPDATE meetings
+         SET outcome = ?, outcome_note = ?, outcome_recorded_at = datetime('now')
+         WHERE calendar_id = ? AND event_id = ?`,
+      )
+      .run(input.outcome, input.note ?? null, input.calendarId, input.eventId);
+  }
+
+  /**
+   * Stamp `outcome_prompted_at` — called when the founder is shown the
+   * nudge for this meeting, so a UI that dedupes reminders doesn't have to
+   * infer "already asked" from anything else. `upsertMeeting`'s reschedule
+   * branch clears this back to NULL when `starts_at` genuinely changes, so
+   * a stale nudge withdraws on its own.
+   */
+  markMeetingPrompted(calendarId: string, eventId: string): void {
+    this.db
+      .prepare(
+        `UPDATE meetings SET outcome_prompted_at = datetime('now') WHERE calendar_id = ? AND event_id = ?`,
+      )
+      .run(calendarId, eventId);
+  }
+
+  /**
+   * Founder confirms a suggested/ambiguous match — promotes it to prospect_id
+   * and marks match_status 'exact' so it stops appearing in the review queue
+   * (it's still surfaced via prospect_id everywhere else).
+   */
+  confirmMeetingMatch(calendarId: string, eventId: string, prospectId: number): void {
+    this.db
+      .prepare(
+        `UPDATE meetings
+         SET prospect_id = ?, match_status = 'exact', suggested_prospect_id = NULL
+         WHERE calendar_id = ? AND event_id = ?`,
+      )
+      .run(prospectId, calendarId, eventId);
+  }
+
+  /**
+   * Founder dismisses a suggestion. match_status flips to 'dismissed', which
+   * the matcher (packages/plays' calendar poll) must treat as "do not
+   * re-suggest" UNTIL `attendees_fingerprint` changes — that's the whole
+   * point of storing the fingerprint.
+   */
+  dismissMeetingMatch(calendarId: string, eventId: string): void {
+    this.db
+      .prepare(
+        `UPDATE meetings
+         SET match_status = 'dismissed', suggested_prospect_id = NULL
+         WHERE calendar_id = ? AND event_id = ?`,
+      )
+      .run(calendarId, eventId);
   }
 
   /** Atomically consume a signed webhook replay key. */

--- a/packages/core/src/timezone.ts
+++ b/packages/core/src/timezone.ts
@@ -378,3 +378,72 @@ export function localDayOffset(
   const b = Date.UTC(event.year, event.month - 1, event.day);
   return Math.round((b - a) / 86_400_000);
 }
+
+/**
+ * The inverse of `wallClock`: a naive local date or date-time (no zone —
+ * Calendar's `start.date`/`start.dateTime` when the source is date-only, or
+ * any other "this clock reading, in this zone" input) → the real UTC
+ * instant it names. Every OTHER helper in this file goes instant → local
+ * string; this is the one exception, needed because an all-day event's
+ * `start.date`/`end.date` carries no offset at all and has to be anchored
+ * to a zone before it can be stored or compared as an instant.
+ *
+ * Standard two-pass technique: guess the instant as if the wall clock were
+ * UTC, read back what THAT instant looks like in `zone`, then shift the
+ * guess by the difference. Convergent to the second for any zone with a
+ * whole-minute DST transition (all IANA zones qualify) — the only failure
+ * mode is a wall-clock value that never occurs (spring-forward gap), which
+ * this treats as its nearest valid instant rather than throwing, since a
+ * calendar's own date-only fields can never land in a gap.
+ *
+ * Returns null for unparseable input or an unrecognized zone.
+ */
+export function naiveLocalToInstant(naive: string, zone: string): string | null {
+  if (!isValidTimeZone(zone)) return null;
+  const dateOnly = DATE_ONLY.exec(naive.trim());
+  const naiveDateTime = NAIVE_DATETIME.exec(naive.trim());
+  let year: number, month: number, day: number, hour: number, minute: number, second: number;
+  if (dateOnly) {
+    year = Number(dateOnly[1]);
+    month = Number(dateOnly[2]);
+    day = Number(dateOnly[3]);
+    hour = 0;
+    minute = 0;
+    second = 0;
+  } else if (naiveDateTime) {
+    year = Number(naiveDateTime[1]);
+    month = Number(naiveDateTime[2]);
+    day = Number(naiveDateTime[3]);
+    hour = Number(naiveDateTime[4]);
+    minute = Number(naiveDateTime[5]);
+    second = naiveDateTime[6] === undefined ? 0 : Number(naiveDateTime[6]);
+  } else {
+    return null;
+  }
+  if (!isValidDate(year, month, day) || hour > 23 || minute > 59 || second > 59) return null;
+
+  const asIfUtc = Date.UTC(year, month - 1, day, hour, minute, second);
+  const fmt = new Intl.DateTimeFormat("en-US", {
+    timeZone: zone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  });
+  const parts = partsOf(fmt, new Date(asIfUtc));
+  // hour12:false can still emit "24" for midnight in some ICU builds.
+  const readHour = Number(parts["hour"]) % 24;
+  const seenAsUtc = Date.UTC(
+    Number(parts["year"]),
+    Number(parts["month"]) - 1,
+    Number(parts["day"]),
+    readHour,
+    Number(parts["minute"]),
+    Number(parts["second"]),
+  );
+  const instant = asIfUtc - (seenAsUtc - asIfUtc);
+  return new Date(instant).toISOString();
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -255,6 +255,45 @@ export interface InterviewRecord {
   created_at: string;
 }
 
+export type MeetingOutcome = "held" | "no_show" | "cancelled" | "rescheduled";
+/** 'exact' (email-identity, auto-linked) | 'suggested'/'ambiguous' (fuzzy, review-only) | 'dismissed' (founder said no, sticks until the attendee set changes) | null (no candidate at all). */
+export type MeetingMatchStatus = "exact" | "suggested" | "ambiguous" | "dismissed" | null;
+export type MeetingMatchMethod = "name_domain" | "domain" | "name" | "description" | null;
+
+/** One `meetings` row (v34) — a calendar event, possibly a prospect call. */
+export interface MeetingRecord {
+  calendar_id: string;
+  event_id: string;
+  ical_uid: string | null;
+  recurring_event_id: string | null;
+  status: string;
+  summary: string | null;
+  all_day: number;
+  starts_at: string | null;
+  ends_at: string | null;
+  event_timezone: string | null;
+  organizer_email: string | null;
+  /** The founder's own (self:true) attendee responseStatus, e.g. 'accepted' | 'declined' | 'tentative' | 'needsAction'. */
+  self_response: string | null;
+  external_attendee_count: number;
+  /** JSON array of external attendee emails, capped ~20. */
+  external_attendees_json: string | null;
+  attendees_omitted: number;
+  prospect_id: number | null;
+  suggested_prospect_id: number | null;
+  match_status: MeetingMatchStatus;
+  match_method: MeetingMatchMethod;
+  match_confidence: number | null;
+  outcome: MeetingOutcome | null;
+  outcome_note: string | null;
+  outcome_recorded_at: string | null;
+  outcome_prompted_at: string | null;
+  event_updated_at: string | null;
+  first_seen_at: string;
+  last_seen_at: string;
+  attendees_fingerprint: string | null;
+}
+
 export interface OneShotConfig {
   walletMode: "cdp" | "private-key";
   llmProvider: "openrouter" | "openai" | "anthropic";
@@ -389,6 +428,25 @@ export interface OneShotConfig {
    * never consult it. Set from `config spend-ceiling <amount>` or `/setup`.
    */
   dailySpendCeilingUsd: number | null;
+  /**
+   * The Gmail identity (pool `id`, e.g. `gmail:jn@freebutter.ai`) whose
+   * calendar the scheduler polls for past meetings needing an outcome
+   * (issue #577). Null = feature off, entirely inert — no poll, no logging,
+   * no `meetings` writes. Must be a `provider: 'gmail'` identity carrying
+   * the calendar.readonly scope; `removeIdentity` clears this back to null
+   * when the pointed-at identity is removed, and the poller itself tolerates
+   * a dangling id (skip, log once) in case this file is hand-edited.
+   */
+  calendarIdentityId: string | null;
+  /**
+   * Which calendar of `calendarIdentityId`'s account to poll — a Google
+   * Calendar id, e.g. "primary" or an email-shaped secondary-calendar id.
+   * Default "primary": most founders' bookings land on their main calendar,
+   * and the /setup picker shows a 7-day event count per calendar because a
+   * founder cannot reliably state which one their booking tool actually
+   * writes to. Only meaningful when `calendarIdentityId` is set.
+   */
+  calendarId: string;
 }
 
 export type QueueStatus = "pending" | "approved" | "rejected" | "sent" | "expired";

--- a/packages/doctor/__tests__/calendar-check.test.ts
+++ b/packages/doctor/__tests__/calendar-check.test.ts
@@ -1,0 +1,112 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The 'calendar access' doctor check (issue #577): live-probes the
+// designated calendar identity's token for calendar scope, failing loudly
+// with a reconnect hint when the scope is missing or a live call rejects it.
+
+let cfgOverride: Record<string, unknown> = {};
+let getGmailProfileImpl: (() => Promise<{ emailAddress: string }>) | null = null;
+
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    loadConfig: () => ({ ...actual.loadConfig(), ...cfgOverride }),
+    oneshotEnvReady: () => false,
+    getGmailProfile: async () => {
+      if (getGmailProfileImpl) return getGmailProfileImpl();
+      return { emailAddress: "jn@x.dev" };
+    },
+  };
+});
+
+const { runDoctor } = await import("../src/check.ts");
+const { createWorkspace, saveGmailToken, CALENDAR_READONLY_SCOPE } =
+  await import("@oneshot-gtm/core");
+
+let wsDir: string;
+beforeEach(() => {
+  wsDir = mkdtempSync(join(tmpdir(), "oneshot-doctor-cal-"));
+  process.env["ONESHOT_GTM_WORKSPACES"] = wsDir;
+  process.env["ONESHOT_GTM_WORKSPACE"] = "gtm";
+  createWorkspace("gtm");
+  cfgOverride = {};
+  getGmailProfileImpl = null;
+});
+afterEach(() => {
+  delete process.env["ONESHOT_GTM_WORKSPACES"];
+  delete process.env["ONESHOT_GTM_WORKSPACE"];
+  rmSync(wsDir, { recursive: true, force: true });
+});
+
+function withCalendarIdentity(scope: string | null): void {
+  cfgOverride = {
+    calendarIdentityId: "gmail:jn@x.dev",
+    calendarId: "primary",
+    emailIdentities: [
+      {
+        id: "gmail:jn@x.dev",
+        provider: "gmail",
+        address: "jn@x.dev",
+        maxPerDay: 0,
+        warmup: null,
+      },
+    ],
+  };
+  saveGmailToken("gmail:jn@x.dev", { refreshToken: "rt", address: "jn@x.dev", scope });
+}
+
+describe("doctor calendar access check", () => {
+  it("is absent (null) when calendarIdentityId is unset — feature off, entirely quiet", async () => {
+    const checks = await runDoctor();
+    expect(checks.find((c) => c.name === "calendar access")).toBeUndefined();
+  });
+
+  it("fails when the identity's token carries no calendar scope, with a reconnect hint", async () => {
+    withCalendarIdentity(null);
+    const checks = await runDoctor();
+    const hit = checks.find((c) => c.name === "calendar access");
+    expect(hit?.severity).toBe("fail");
+    expect(hit?.message).toContain("no recorded calendar.readonly scope");
+    expect(hit?.hint).toContain("Reconnect for calendar");
+  });
+
+  it("fails when the scope is Gmail-only (no calendar.readonly)", async () => {
+    withCalendarIdentity("https://www.googleapis.com/auth/gmail.send");
+    const checks = await runDoctor();
+    expect(checks.find((c) => c.name === "calendar access")?.severity).toBe("fail");
+  });
+
+  it("passes when the scope is present and the live probe succeeds", async () => {
+    withCalendarIdentity(CALENDAR_READONLY_SCOPE);
+    const checks = await runDoctor();
+    const hit = checks.find((c) => c.name === "calendar access");
+    expect(hit?.severity).toBe("ok");
+    expect(hit?.message).toContain("jn@x.dev");
+    expect(hit?.message).toContain("primary");
+  });
+
+  it("fails when the persisted scope claims calendar but the live call rejects with ACCESS_TOKEN_SCOPE_INSUFFICIENT", async () => {
+    withCalendarIdentity(CALENDAR_READONLY_SCOPE);
+    getGmailProfileImpl = async () => {
+      throw new Error(
+        "Gmail API failed (403): ACCESS_TOKEN_SCOPE_INSUFFICIENT — insufficient scope",
+      );
+    };
+    const checks = await runDoctor();
+    const hit = checks.find((c) => c.name === "calendar access");
+    expect(hit?.severity).toBe("fail");
+    expect(hit?.hint).toContain("Reconnect for calendar");
+  });
+
+  it("fails when calendarIdentityId points at a non-existent or non-gmail identity", async () => {
+    cfgOverride = { calendarIdentityId: "gmail:never-added@x.dev" };
+    const checks = await runDoctor();
+    const hit = checks.find((c) => c.name === "calendar access");
+    expect(hit?.severity).toBe("fail");
+    expect(hit?.message).toContain("does not point at a connected Gmail identity");
+  });
+});

--- a/packages/doctor/src/check.ts
+++ b/packages/doctor/src/check.ts
@@ -10,6 +10,7 @@ import {
   getLedger,
   GMAIL_AUTH_HINT,
   gmailAccountFor,
+  hasCalendarScope,
   identityCapacities,
   listSendingDomains,
   listSmartleadAccounts,
@@ -572,6 +573,76 @@ function dailySpendCeilingCheck(): CheckResult | null {
   };
 }
 
+/**
+ * Live-probes the designated calendar identity's Gmail-family token for
+ * calendar scope (issue #577). `calendarIdentityId: null` = feature off —
+ * returns null so the check is invisible when the founder never opted in,
+ * matching the daily-spend-ceiling check's own "null = don't report"
+ * convention just above.
+ *
+ * The persisted `GmailTokenEntry.scope` is checked FIRST (cheap, no
+ * network) — an absent/Gmail-only scope is reported as a failing check with
+ * the reconnect instruction without ever making a live call. Only when the
+ * stored scope claims calendar access does this go on to actually probe
+ * `getGmailProfile` (mirroring the existing per-identity sender probe
+ * above), because a scope can be revoked at myaccount.google.com without
+ * invalidating the refresh token — the persisted string alone is not
+ * authoritative, and a live 403 ACCESS_TOKEN_SCOPE_INSUFFICIENT is the only
+ * way to catch that case.
+ */
+async function calendarIdentityCheck(
+  cfg: ReturnType<typeof loadConfig>,
+): Promise<CheckResult | null> {
+  if (!cfg.calendarIdentityId) return null;
+  const identity = resolveIdentities(cfg).find((i) => i.id === cfg.calendarIdentityId);
+  if (!identity || identity.provider !== "gmail") {
+    return {
+      name: "calendar access",
+      group: "senders",
+      severity: "fail",
+      message: `calendarIdentityId '${cfg.calendarIdentityId}' does not point at a connected Gmail identity`,
+      hint: "Pick a calendar identity on /setup.",
+    };
+  }
+  const tokenEntry = loadGmailTokens()[identity.id] ?? null;
+  if (!hasCalendarScope(tokenEntry)) {
+    return {
+      name: "calendar access",
+      group: "senders",
+      severity: "fail",
+      message: `${identity.id} has no recorded calendar.readonly scope`,
+      hint: "Reconnect for calendar access on /setup (Sender → Reconnect for calendar).",
+    };
+  }
+  const account = gmailAccountFor(identity);
+  if (!account) {
+    return {
+      name: "calendar access",
+      group: "senders",
+      severity: "fail",
+      message: `${identity.id}: no refresh token stored`,
+      hint: GMAIL_AUTH_HINT,
+    };
+  }
+  try {
+    await getGmailProfile(account);
+    return {
+      name: "calendar access",
+      group: "senders",
+      severity: "ok",
+      message: `${identity.id} · calendar '${cfg.calendarId || "primary"}'`,
+    };
+  } catch (err) {
+    return {
+      name: "calendar access",
+      group: "senders",
+      severity: "fail",
+      message: `${identity.id}: ${(err as Error).message}`,
+      hint: "Reconnect for calendar access on /setup (Sender → Reconnect for calendar).",
+    };
+  }
+}
+
 export async function runDoctor(): Promise<CheckResult[]> {
   const cfg = loadConfig();
   const results: CheckResult[] = [];
@@ -889,6 +960,9 @@ export async function runDoctor(): Promise<CheckResult[]> {
 
   const spendCeiling = dailySpendCeilingCheck();
   if (spendCeiling) results.push(spendCeiling);
+
+  const calendarCheck = await calendarIdentityCheck(cfg);
+  if (calendarCheck) results.push(calendarCheck);
 
   return results;
 }

--- a/packages/plays/__tests__/cadence-prior-emails.test.ts
+++ b/packages/plays/__tests__/cadence-prior-emails.test.ts
@@ -31,6 +31,8 @@ vi.mock("@oneshot-gtm/core", async () => {
       timezone: null,
       clientId: null,
       dailySpendCeilingUsd: null,
+      calendarIdentityId: null,
+      calendarId: "primary",
     }),
     getLedger: () => ({
       findDirectMail: () => null,
@@ -112,6 +114,8 @@ function ctx(prospectId = 42, angleJson: string | null = null) {
       timezone: null,
       clientId: null,
       dailySpendCeilingUsd: null,
+      calendarIdentityId: null,
+      calendarId: "primary",
     },
     metadata: {},
   };

--- a/packages/plays/__tests__/cadence.test.ts
+++ b/packages/plays/__tests__/cadence.test.ts
@@ -57,6 +57,8 @@ function makeCtx(overrides: Partial<ProspectRecord> = {}): CadenceContext {
       timezone: null,
       clientId: null,
       dailySpendCeilingUsd: null,
+      calendarIdentityId: null,
+      calendarId: "primary",
     },
     metadata: {},
   };

--- a/packages/plays/__tests__/calendar-poll.test.ts
+++ b/packages/plays/__tests__/calendar-poll.test.ts
@@ -1,0 +1,475 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+// Calendar poll + matcher (issue #577). Uses a REAL Ledger (temp sqlite file)
+// for realistic prospect-matching behavior, and mocks only the parts that
+// would otherwise touch the network or process env: loadConfig,
+// resolveIdentities, gmailAccountFor, listCalendarEvents, logEvent, demoMode.
+
+let cfg: {
+  calendarIdentityId: string | null;
+  calendarId: string;
+  founderEmail: string | null;
+  timezone: string | null;
+};
+let identities: Array<{ id: string; provider: string; address?: string | null }>;
+let calendarEventsQueue: Array<{
+  items: Array<Record<string, unknown>>;
+  nextPageToken?: string | null;
+}>;
+let listCalendarEventsCalls: Array<Record<string, unknown>> = [];
+let listCalendarEventsImpl:
+  | ((account: unknown, opts: Record<string, unknown>) => Promise<unknown>)
+  | null = null;
+let ledgerInstance: import("../../core/src/ledger.ts").Ledger;
+let dbPath: string;
+let loggedEvents: Array<{ name: string; payload: unknown; level?: string }> = [];
+
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    demoMode: () => false,
+    loadConfig: () => cfg,
+    resolveIdentities: () => identities,
+    loadGmailTokens: () => ({}),
+    gmailAccountFor: (identity: { id: string }) =>
+      identities.some((i) => i.id === identity.id) ? { id: identity.id, refreshToken: "rt" } : null,
+    clearGmailTokenScope: () => {},
+    getLedger: () => ledgerInstance,
+    logEvent: (name: string, payload?: unknown, level?: string) => {
+      loggedEvents.push({ name, payload, level });
+    },
+    listCalendarEvents: async (account: unknown, opts: Record<string, unknown>) => {
+      listCalendarEventsCalls.push(opts);
+      if (listCalendarEventsImpl) return listCalendarEventsImpl(account, opts);
+      const page = calendarEventsQueue.shift();
+      return page
+        ? { items: page.items, nextPageToken: page.nextPageToken ?? null }
+        : { items: [], nextPageToken: null };
+    },
+  };
+});
+
+const { pollCalendarMeetings } = await import("../src/_calendar.ts");
+const { Ledger } = await import("../../core/src/ledger.ts");
+
+beforeEach(() => {
+  dbPath = join(
+    tmpdir(),
+    `oneshot-gtm-calpoll-test-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`,
+  );
+  ledgerInstance = new Ledger(dbPath);
+  cfg = {
+    calendarIdentityId: "gmail:jn@x.dev",
+    calendarId: "primary",
+    founderEmail: "founder@x.dev",
+    timezone: "UTC",
+  };
+  identities = [{ id: "gmail:jn@x.dev", provider: "gmail", address: "jn@x.dev" }];
+  calendarEventsQueue = [];
+  listCalendarEventsCalls = [];
+  listCalendarEventsImpl = null;
+  loggedEvents = [];
+});
+
+afterEach(() => {
+  ledgerInstance.close();
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      rmSync(`${dbPath}${suffix}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+function event(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: "e1",
+    status: "confirmed",
+    summary: "Intro call",
+    start: { dateTime: "2020-01-01T14:00:00Z" },
+    end: { dateTime: "2020-01-01T14:30:00Z" },
+    updated: "2020-01-01T10:00:00Z",
+    organizer: { email: "founder@x.dev", self: true },
+    attendees: [
+      { email: "founder@x.dev", self: true, responseStatus: "accepted" },
+      { email: "pat@acme.com", displayName: "Pat Prospect" },
+    ],
+    ...over,
+  };
+}
+
+describe("pollCalendarMeetings — idle states", () => {
+  it("is idle when calendarIdentityId is null", async () => {
+    cfg.calendarIdentityId = null;
+    const res = await pollCalendarMeetings();
+    expect(res.idle).toBe(true);
+    expect(listCalendarEventsCalls).toHaveLength(0);
+  });
+
+  it("is idle and logs once when the configured identity is dangling", async () => {
+    cfg.calendarIdentityId = "gmail:gone@x.dev";
+    const res = await pollCalendarMeetings();
+    expect(res.idle).toBe(true);
+    expect(loggedEvents.some((e) => e.name === "scheduler.calendar_poll.dangling_identity")).toBe(
+      true,
+    );
+  });
+});
+
+describe("pollCalendarMeetings — ingest + matching", () => {
+  it("ingests a confirmed event and exact-matches the prospect by email", async () => {
+    const pid = ledgerInstance.upsertProspect({ email: "pat@acme.com", source: "t" });
+    calendarEventsQueue = [{ items: [event()] }];
+    const res = await pollCalendarMeetings();
+    expect(res.idle).toBe(false);
+    expect(res.meetingsIngested).toBe(1);
+    expect(res.matched).toBe(1);
+    const row = ledgerInstance.getMeeting("primary", "e1")!;
+    expect(row.prospect_id).toBe(pid);
+    expect(row.match_status).toBe("exact");
+  });
+
+  it("skips a self-block (no external candidate survives exclusion)", async () => {
+    calendarEventsQueue = [
+      {
+        items: [
+          event({
+            attendees: [{ email: "founder@x.dev", self: true, responseStatus: "accepted" }],
+          }),
+        ],
+      },
+    ];
+    const res = await pollCalendarMeetings();
+    expect(res.selfBlocksSkipped).toBe(1);
+    expect(ledgerInstance.getMeeting("primary", "e1")).toBeNull();
+  });
+
+  it("excludes an eventType in the exclusion list (e.g. outOfOffice) even with an external-looking attendee", async () => {
+    calendarEventsQueue = [{ items: [event({ eventType: "outOfOffice" })] }];
+    await pollCalendarMeetings();
+    expect(ledgerInstance.getMeeting("primary", "e1")).toBeNull();
+  });
+
+  it("stores an all-day event with all_day=1 and excludes it from the pending-outcome query", async () => {
+    ledgerInstance.upsertProspect({ email: "pat@acme.com", source: "t" });
+    calendarEventsQueue = [
+      {
+        items: [
+          event({
+            start: { date: "2020-01-01" },
+            end: { date: "2020-01-02" },
+          }),
+        ],
+      },
+    ];
+    await pollCalendarMeetings();
+    const row = ledgerInstance.getMeeting("primary", "e1")!;
+    expect(row.all_day).toBe(1);
+    expect(ledgerInstance.listPendingOutcomeMeetings()).toEqual([]);
+  });
+
+  it("stores the founder's own responseStatus (self_response) and excludes a declined event from the nudge", async () => {
+    ledgerInstance.upsertProspect({ email: "pat@acme.com", source: "t" });
+    calendarEventsQueue = [
+      {
+        items: [
+          event({
+            attendees: [
+              { email: "founder@x.dev", self: true, responseStatus: "declined" },
+              { email: "pat@acme.com", displayName: "Pat Prospect" },
+            ],
+          }),
+        ],
+      },
+    ];
+    await pollCalendarMeetings();
+    const row = ledgerInstance.getMeeting("primary", "e1")!;
+    expect(row.self_response).toBe("declined");
+    expect(ledgerInstance.listPendingOutcomeMeetings()).toEqual([]);
+  });
+
+  it("keeps recurring_event_id so a rescheduled instance is never forked", async () => {
+    calendarEventsQueue = [{ items: [event({ recurringEventId: "series-1" })] }];
+    await pollCalendarMeetings();
+    expect(ledgerInstance.getMeeting("primary", "e1")!.recurring_event_id).toBe("series-1");
+  });
+
+  it("stores ical_uid", async () => {
+    calendarEventsQueue = [{ items: [event({ iCalUID: "uid-1@google.com" })] }];
+    await pollCalendarMeetings();
+    expect(ledgerInstance.getMeeting("primary", "e1")!.ical_uid).toBe("uid-1@google.com");
+  });
+
+  it("downgrades even a single exact hit to suggested when attendeesOmitted is set", async () => {
+    const pid = ledgerInstance.upsertProspect({ email: "pat@acme.com", source: "t" });
+    calendarEventsQueue = [{ items: [event({ attendeesOmitted: true })] }];
+    await pollCalendarMeetings();
+    const row = ledgerInstance.getMeeting("primary", "e1")!;
+    expect(row.match_status).toBe("suggested");
+    expect(row.prospect_id).toBeNull();
+    expect(row.suggested_prospect_id).toBe(pid);
+  });
+
+  it("downgrades a single exact hit to suggested when externals exceed the large-invite threshold", async () => {
+    ledgerInstance.upsertProspect({ email: "pat@acme.com", source: "t" });
+    const manyExternals = Array.from({ length: 9 }, (_, i) => ({ email: `p${i}@other.com` }));
+    calendarEventsQueue = [
+      {
+        items: [
+          event({
+            attendees: [
+              { email: "founder@x.dev", self: true, responseStatus: "accepted" },
+              { email: "pat@acme.com", displayName: "Pat Prospect" },
+              ...manyExternals,
+            ],
+          }),
+        ],
+      },
+    ];
+    await pollCalendarMeetings();
+    const row = ledgerInstance.getMeeting("primary", "e1")!;
+    expect(row.match_status).toBe("suggested");
+  });
+
+  it("marks ambiguous when two prospects independently exact-match and neither has outreach history", async () => {
+    ledgerInstance.upsertProspect({ email: "pat@acme.com", source: "t" });
+    ledgerInstance.upsertProspect({ email: "sam@acme.com", source: "t" });
+    calendarEventsQueue = [
+      {
+        items: [
+          event({
+            attendees: [
+              { email: "founder@x.dev", self: true, responseStatus: "accepted" },
+              { email: "pat@acme.com" },
+              { email: "sam@acme.com" },
+            ],
+          }),
+        ],
+      },
+    ];
+    await pollCalendarMeetings();
+    const row = ledgerInstance.getMeeting("primary", "e1")!;
+    expect(row.match_status).toBe("ambiguous");
+    expect(row.prospect_id).toBeNull();
+  });
+
+  it("tie-breaks two exact hits to the one with outreach history", async () => {
+    const withHistory = ledgerInstance.upsertProspect({ email: "pat@acme.com", source: "t" });
+    ledgerInstance.upsertProspect({ email: "sam@acme.com", source: "t" });
+    ledgerInstance.recordSequenceEvent({
+      prospectId: withHistory,
+      playName: "x",
+      stepIndex: 0,
+      channel: "email",
+      status: "sent",
+    });
+    calendarEventsQueue = [
+      {
+        items: [
+          event({
+            attendees: [
+              { email: "founder@x.dev", self: true, responseStatus: "accepted" },
+              { email: "pat@acme.com" },
+              { email: "sam@acme.com" },
+            ],
+          }),
+        ],
+      },
+    ];
+    await pollCalendarMeetings();
+    const row = ledgerInstance.getMeeting("primary", "e1")!;
+    expect(row.match_status).toBe("exact");
+    expect(row.prospect_id).toBe(withHistory);
+  });
+
+  it("fuzzy-matches by domain + full-name (0.90, name_domain) — never auto-linked", async () => {
+    const pid = ledgerInstance.upsertProspect({
+      email: "pat.other@acme.com",
+      name: "Pat Prospect",
+      company: "Acme",
+      source: "t",
+    });
+    calendarEventsQueue = [{ items: [event()] }]; // attendee pat@acme.com, displayName "Pat Prospect"
+    await pollCalendarMeetings();
+    const row = ledgerInstance.getMeeting("primary", "e1")!;
+    expect(row.match_status).toBe("suggested");
+    expect(row.match_method).toBe("name_domain");
+    expect(row.suggested_prospect_id).toBe(pid);
+    expect(row.prospect_id).toBeNull(); // fuzzy is NEVER auto-linked
+  });
+
+  it("does not use a freemail domain for the plain domain fuzzy signal", async () => {
+    ledgerInstance.upsertProspect({
+      email: "someoneelse@gmail.com",
+      name: "Totally Different Name",
+      source: "t",
+    });
+    calendarEventsQueue = [
+      {
+        items: [
+          event({
+            attendees: [
+              { email: "founder@x.dev", self: true, responseStatus: "accepted" },
+              { email: "pat@gmail.com", displayName: "Pat Prospect" },
+            ],
+          }),
+        ],
+      },
+    ];
+    await pollCalendarMeetings();
+    const row = ledgerInstance.getMeeting("primary", "e1")!;
+    expect(row.match_status).toBeNull();
+  });
+
+  it("a founder's dismiss survives a re-poll with an UNCHANGED attendee fingerprint", async () => {
+    // Use a non-exact (fuzzy) match so a dismiss is meaningful — an EXACT
+    // match auto-links prospect_id, and dismissMeetingMatch only clears
+    // suggested_prospect_id, not prospect_id (exact hits aren't the case
+    // this mechanism exists to suppress). Deliberately NOT registering
+    // pat@acme.com itself, or the exact-match path would win over fuzzy.
+    ledgerInstance.upsertProspect({
+      email: "pat.other@acme.com",
+      name: "Pat Prospect",
+      company: "Acme",
+      source: "t",
+    });
+    calendarEventsQueue = [{ items: [event()] }]; // fuzzy name_domain match
+    await pollCalendarMeetings();
+    expect(ledgerInstance.getMeeting("primary", "e1")!.match_status).toBe("suggested");
+    ledgerInstance.dismissMeetingMatch("primary", "e1");
+    // Re-poll: SAME event, updated timestamp bumped so it isn't the
+    // touch-only fast path, but the attendee set is unchanged.
+    calendarEventsQueue = [{ items: [event({ updated: "2020-01-01T11:00:00Z" })] }];
+    await pollCalendarMeetings();
+    const row = ledgerInstance.getMeeting("primary", "e1")!;
+    expect(row.match_status).toBe("dismissed");
+    expect(row.suggested_prospect_id).toBeNull();
+  });
+
+  it("re-matches once the attendee set (fingerprint) actually changes after a dismiss", async () => {
+    ledgerInstance.upsertProspect({ email: "pat@acme.com", source: "t" });
+    const pid2 = ledgerInstance.upsertProspect({ email: "sam@acme.com", source: "t" });
+    calendarEventsQueue = [{ items: [event()] }];
+    await pollCalendarMeetings();
+    ledgerInstance.dismissMeetingMatch("primary", "e1");
+    calendarEventsQueue = [
+      {
+        items: [
+          event({
+            updated: "2020-01-01T11:00:00Z",
+            attendees: [
+              { email: "founder@x.dev", self: true, responseStatus: "accepted" },
+              { email: "sam@acme.com" },
+            ],
+          }),
+        ],
+      },
+    ];
+    await pollCalendarMeetings();
+    const row = ledgerInstance.getMeeting("primary", "e1")!;
+    expect(row.match_status).toBe("exact");
+    expect(row.prospect_id).toBe(pid2);
+  });
+
+  it("the fast path (unchanged event_updated_at) touches only last_seen_at, no re-matching", async () => {
+    ledgerInstance.upsertProspect({ email: "pat@acme.com", source: "t" });
+    calendarEventsQueue = [{ items: [event()] }];
+    await pollCalendarMeetings();
+    ledgerInstance.dismissMeetingMatch("primary", "e1");
+    // Same `updated` timestamp — the poller must not re-derive anything,
+    // including re-running the matcher that would otherwise flip a stale
+    // dismiss back to exact.
+    calendarEventsQueue = [{ items: [event()] }];
+    await pollCalendarMeetings();
+    expect(ledgerInstance.getMeeting("primary", "e1")!.match_status).toBe("dismissed");
+  });
+
+  it("a cancellation for an event never seen is a no-op — nothing inserted", async () => {
+    calendarEventsQueue = [{ items: [{ id: "never-seen", status: "cancelled" }] }];
+    const res = await pollCalendarMeetings();
+    expect(res.meetingsIngested).toBe(0);
+    expect(ledgerInstance.getMeeting("primary", "never-seen")).toBeNull();
+  });
+
+  it("a cancellation for an event already seen updates it in place without wiping prospect_id", async () => {
+    const pid = ledgerInstance.upsertProspect({ email: "pat@acme.com", source: "t" });
+    calendarEventsQueue = [{ items: [event()] }];
+    await pollCalendarMeetings();
+    calendarEventsQueue = [{ items: [{ id: "e1", status: "cancelled" }] }];
+    await pollCalendarMeetings();
+    const row = ledgerInstance.getMeeting("primary", "e1")!;
+    expect(row.status).toBe("cancelled");
+    expect(row.prospect_id).toBe(pid);
+  });
+});
+
+describe("pollCalendarMeetings — watermark + resync", () => {
+  it("advances the watermark to max(item.updated) on a clean poll", async () => {
+    calendarEventsQueue = [
+      {
+        items: [
+          event({ id: "e1", updated: "2020-01-01T10:00:00Z" }),
+          event({ id: "e2", updated: "2020-01-01T12:00:00Z" }),
+        ],
+      },
+    ];
+    await pollCalendarMeetings();
+    const mark = JSON.parse(ledgerInstance.getPollWatermark("calendar_events")!);
+    expect(mark.updatedMin).toBe("2020-01-01T12:00:00Z");
+    expect(mark.calendarId).toBe("primary");
+    expect(mark.identityId).toBe("gmail:jn@x.dev");
+  });
+
+  it("does not advance the watermark on a failed page", async () => {
+    listCalendarEventsImpl = async () => {
+      const { CalendarApiError } = await import("../../core/src/gcal.ts");
+      throw new CalendarApiError("boom", 500, null);
+    };
+    const res = await pollCalendarMeetings();
+    expect(res.clean).toBe(false);
+    expect(ledgerInstance.getPollWatermark("calendar_events")).toBeNull();
+  });
+
+  it("repointing the calendar forces a full resync (no updatedMin sent)", async () => {
+    ledgerInstance.setPollWatermark(
+      "calendar_events",
+      JSON.stringify({
+        calendarId: "OTHER-cal",
+        identityId: "gmail:jn@x.dev",
+        updatedMin: "2020-01-01T00:00:00Z",
+      }),
+    );
+    calendarEventsQueue = [{ items: [] }];
+    await pollCalendarMeetings();
+    expect(listCalendarEventsCalls[0]!["updatedMin"]).toBeUndefined();
+  });
+
+  it("a 410 clears the watermark path and re-runs once with no updatedMin, capped at one resync", async () => {
+    ledgerInstance.setPollWatermark(
+      "calendar_events",
+      JSON.stringify({
+        calendarId: "primary",
+        identityId: "gmail:jn@x.dev",
+        updatedMin: "2020-01-01T00:00:00Z",
+      }),
+    );
+    let call = 0;
+    listCalendarEventsImpl = async () => {
+      call++;
+      if (call === 1) {
+        const { CalendarApiError } = await import("../../core/src/gcal.ts");
+        throw new CalendarApiError("gone", 410, null);
+      }
+      return { items: [event()], nextPageToken: null };
+    };
+    const res = await pollCalendarMeetings();
+    expect(res.resynced).toBe(true);
+    expect(loggedEvents.some((e) => e.name === "scheduler.calendar_poll.resync")).toBe(true);
+    expect(res.meetingsIngested).toBe(1);
+  });
+});

--- a/packages/plays/src/_calendar.ts
+++ b/packages/plays/src/_calendar.ts
@@ -1,0 +1,663 @@
+import {
+  CalendarApiError,
+  clearGmailTokenScope,
+  gmailAccountFor,
+  isFreemailDomain,
+  listCalendarEvents,
+  loadConfig,
+  loadGmailTokens,
+  logEvent,
+  demoMode,
+  getLedger,
+  resolveIdentities,
+  naiveLocalToInstant,
+  EMAIL_RE,
+  type CalendarEventAttendee,
+  type CalendarEventItem,
+  type EmailIdentity,
+  type MeetingMatchMethod,
+  type MeetingMatchStatus,
+} from "@oneshot-gtm/core";
+
+/**
+ * Calendar ingest (issue #577): read the founder's designated calendar and
+ * turn past meetings into rows the founder can log an outcome against.
+ *
+ * Deliberately NOT a TRIGGERS registry entry — triggers are spend-gated
+ * candidate finders behind an approval-rate gate; this is a free read that
+ * belongs in the scheduler tick body (see apps/server/src/scheduler.ts).
+ */
+
+/** poll_state key: JSON `{calendarId, identityId, updatedMin}`. */
+const CALENDAR_WATERMARK_KEY = "calendar_events";
+/**
+ * poll_state key for the weekly belt-and-braces full resync (no
+ * `updatedMin`) — guards against the silent-data-loss failure mode where a
+ * meeting booked far in the future is invisible today (outside timeMax) and
+ * by the time it slides into range its `updated` is already older than the
+ * watermark, so an incremental poll would never see it.
+ */
+const CALENDAR_FULL_RESYNC_KEY = "calendar_events_full_resync";
+const FULL_RESYNC_INTERVAL_MS = 7 * 24 * 60 * 60_000;
+/** `updatedMin` is re-examined this much before the watermark — Google's timestamps are second-granular and delivery isn't strictly ordered. */
+const WATERMARK_OVERLAP_MS = 10 * 60_000;
+/** `timeMin` is an exclusive lower bound on the event's END. */
+const TIME_MIN_MS = 90 * 24 * 60 * 60_000;
+/**
+ * `timeMax` is an exclusive upper bound on the event's START — and must be
+ * ~400 days out, not 90: a meeting booked six months ahead is stamped
+ * `updated` today; if it falls outside `timeMax` it's invisible now, and by
+ * the time it slides into a narrower window its `updated` predates the
+ * watermark, so it would never be ingested. This is the silent-data-loss bug
+ * this design is built around.
+ */
+const TIME_MAX_MS = 400 * 24 * 60 * 60_000;
+/** Mirrors REPLY_POLL_MAX_PAGES's precedent — bounds one poll after an install or outage. */
+const CALENDAR_POLL_MAX_PAGES = 10;
+const CALENDAR_PAGE_SIZE = 250;
+/** More than this many externals reads as a webinar, not a 1:1 — auto-link is refused even on an exact hit. */
+const LARGE_INVITE_THRESHOLD = 8;
+const EXTERNAL_ATTENDEES_CAP = 20;
+/** Fuzzy-match record floor; below this the event is stored unmatched rather than guessed at. */
+const FUZZY_MATCH_THRESHOLD = 0.5;
+
+/**
+ * eventType values that are never a prospect call, even when they happen to
+ * carry an external-looking address — `fromGmail` in particular
+ * auto-creates flight/hotel events with a real external (airline/hotel)
+ * address that would otherwise pass the self-block check.
+ */
+const EXCLUDED_EVENT_TYPES = new Set([
+  "outOfOffice",
+  "focusTime",
+  "workingLocation",
+  "birthday",
+  "fromGmail",
+]);
+
+const RESOURCE_DOMAIN_RE = /\.(resource|group)\.calendar\.google\.com$/i;
+
+function canonicalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+function emailDomain(email: string): string | null {
+  const at = email.indexOf("@");
+  return at === -1 ? null : email.slice(at + 1).toLowerCase();
+}
+
+/** Lowercase, NFD-strip diacritics, drop punctuation/honorifics, token set. */
+function normalizeNameTokens(name: string | null | undefined): Set<string> {
+  if (!name) return new Set();
+  const HONORIFICS = new Set(["mr", "mrs", "ms", "miss", "dr", "prof", "sir", "madam"]);
+  const stripped = name
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ");
+  return new Set(
+    stripped
+      .split(/\s+/)
+      .filter(Boolean)
+      .filter((t) => !HONORIFICS.has(t)),
+  );
+}
+
+/** True when the two token sets are the same (order-insensitive) non-empty set of tokens. */
+function fullNameMatch(a: string | null | undefined, b: string | null | undefined): boolean {
+  const ta = normalizeNameTokens(a);
+  const tb = normalizeNameTokens(b);
+  if (ta.size === 0 || tb.size === 0 || ta.size !== tb.size) return false;
+  for (const t of ta) if (!tb.has(t)) return false;
+  return true;
+}
+
+interface ProspectFuzzyRow {
+  id: number;
+  name: string | null;
+  email: string | null;
+  company: string | null;
+}
+
+/** A prospect candidate for the founder's own address set. */
+function buildExclusionSet(cfg: ReturnType<typeof loadConfig>): Set<string> {
+  const out = new Set<string>();
+  if (cfg.founderEmail) out.add(canonicalizeEmail(cfg.founderEmail));
+  for (const identity of resolveIdentities(cfg)) {
+    if (identity.address) out.add(canonicalizeEmail(identity.address));
+  }
+  for (const entry of Object.values(loadGmailTokens())) {
+    if (entry.address) out.add(canonicalizeEmail(entry.address));
+  }
+  return out;
+}
+
+interface CandidateAttendee {
+  email: string;
+  displayName: string | null;
+}
+
+/**
+ * The external-candidate set: attendees[] ∪ {organizer.email} ∪
+ * {creator.email}, minus the founder's own addresses and resource rows.
+ * Deduped by email, order-stable.
+ */
+function externalCandidates(item: CalendarEventItem, exclusions: Set<string>): CandidateAttendee[] {
+  const seen = new Map<string, CandidateAttendee>();
+  const consider = (email: string | undefined, displayName?: string | null): void => {
+    if (!email) return;
+    const canon = canonicalizeEmail(email);
+    if (exclusions.has(canon)) return;
+    const domain = emailDomain(canon);
+    if (domain && RESOURCE_DOMAIN_RE.test(`x.${domain}`)) return;
+    if (!seen.has(canon)) seen.set(canon, { email: canon, displayName: displayName ?? null });
+  };
+  for (const a of item.attendees ?? []) {
+    if (a.resource || a.self) continue;
+    consider(a.email, (a as CalendarEventAttendee & { displayName?: string }).displayName);
+  }
+  consider(item.organizer?.email);
+  consider(item.creator?.email);
+  return [...seen.values()];
+}
+
+/** self:true attendee's own RSVP, or null if the founder isn't listed as an attendee at all. */
+function selfResponseOf(item: CalendarEventItem): string | null {
+  return item.attendees?.find((a) => a.self)?.responseStatus ?? null;
+}
+
+interface MatchResult {
+  prospectId: number | null;
+  suggestedProspectId: number | null;
+  matchStatus: MeetingMatchStatus;
+  matchMethod: MeetingMatchMethod;
+  matchConfidence: number | null;
+}
+
+const NO_MATCH: MatchResult = {
+  prospectId: null,
+  suggestedProspectId: null,
+  matchStatus: null,
+  matchMethod: null,
+  matchConfidence: null,
+};
+
+/**
+ * Resolve a calendar event's external candidates to a prospect.
+ *
+ * 1. Exact — `findProspectByEmail` per candidate. One hit links outright
+ *    (confidence 1.0). Multiple distinct prospects hit (two attendees who
+ *    each independently match a ledger row) is the GOOD case, not a founder
+ *    question: tie-break to the one with outreach history, most recent
+ *    first; ambiguous only when neither has history.
+ * 2. Fuzzy (suggestion only, NEVER auto-linked) — scored across every
+ *    prospect: domain + full-name match (0.90, `name_domain`), unique
+ *    prospect at the same domain (0.65, `domain`), exact full-name match at
+ *    a different domain (0.55, `name` — the job-change case),
+ *    description-scraped email (0.50, `description`). Record at >= 0.5.
+ *
+ * Downgrades even a single exact hit to `suggested` when `attendeesOmitted`
+ * is set or there are more externals than `LARGE_INVITE_THRESHOLD` — you
+ * cannot see the whole room, so auto-linking is refused.
+ */
+function matchCandidates(input: {
+  candidates: CandidateAttendee[];
+  descriptionEmails: string[];
+  attendeesOmitted: boolean;
+  ledger: ReturnType<typeof getLedger>;
+  prospects: ProspectFuzzyRow[];
+}): MatchResult {
+  const { candidates, descriptionEmails, attendeesOmitted, ledger, prospects } = input;
+  const tooLarge = candidates.length > LARGE_INVITE_THRESHOLD;
+
+  // ── 1. Exact ──────────────────────────────────────────────────────────
+  const exactHits = new Set<number>();
+  for (const c of candidates) {
+    const hit = ledger.findProspectByEmail(c.email);
+    if (hit) exactHits.add(hit.id);
+  }
+  if (exactHits.size === 1) {
+    const [prospectId] = [...exactHits];
+    const downgrade = attendeesOmitted || tooLarge;
+    return {
+      prospectId: downgrade ? null : (prospectId ?? null),
+      suggestedProspectId: downgrade ? (prospectId ?? null) : null,
+      matchStatus: downgrade ? "suggested" : "exact",
+      matchMethod: null,
+      matchConfidence: 1.0,
+    };
+  }
+  if (exactHits.size > 1) {
+    // Tie-break to whichever exact hit has outreach history, most recent
+    // first; ambiguous only when NONE of them do.
+    let best: { id: number; at: string } | null = null;
+    for (const id of exactHits) {
+      if (!ledger.hasOutreachHistory(id)) continue;
+      const at = ledger.lastOutreachAt(id) ?? "";
+      if (!best || at > best.at) best = { id, at };
+    }
+    if (best) {
+      const downgrade = attendeesOmitted || tooLarge;
+      return {
+        prospectId: downgrade ? null : best.id,
+        suggestedProspectId: downgrade ? best.id : null,
+        matchStatus: downgrade ? "suggested" : "exact",
+        matchMethod: null,
+        matchConfidence: 1.0,
+      };
+    }
+    return { ...NO_MATCH, matchStatus: "ambiguous" };
+  }
+
+  // ── 2. Fuzzy (suggestion only) ───────────────────────────────────────
+  let best: { prospectId: number; score: number; method: MeetingMatchMethod } | null = null;
+  let bestTie = false;
+
+  const domainCounts = new Map<string, number>();
+  for (const p of prospects) {
+    const d = p.email ? emailDomain(p.email) : null;
+    if (d && !isFreemailDomain(d)) domainCounts.set(d, (domainCounts.get(d) ?? 0) + 1);
+  }
+
+  const record = (prospectId: number, score: number, method: MeetingMatchMethod): void => {
+    if (!best || score > best.score) {
+      best = { prospectId, score, method };
+      bestTie = false;
+    } else if (score === best.score && prospectId !== best.prospectId) {
+      bestTie = true;
+    }
+  };
+
+  for (const c of candidates) {
+    const cDomain = emailDomain(c.email);
+    const freemail = isFreemailDomain(cDomain);
+    for (const p of prospects) {
+      const pDomain = p.email ? emailDomain(p.email) : null;
+      const nameMatches = fullNameMatch(c.displayName, p.name);
+      if (!freemail && cDomain && pDomain && cDomain === pDomain) {
+        if (nameMatches) {
+          record(p.id, 0.9, "name_domain");
+        } else if ((domainCounts.get(cDomain) ?? 0) === 1) {
+          record(p.id, 0.65, "domain");
+        }
+        // Same-domain-but-several-prospects with no name match: too weak, dropped.
+      } else if (nameMatches) {
+        record(p.id, 0.55, "name");
+      }
+    }
+  }
+  // Description-scraped emails: fuzzy-only, exact-address match against a
+  // prospect, but never auto-linked and always the lowest-confidence tier.
+  for (const email of descriptionEmails) {
+    const hit = ledger.findProspectByEmail(email);
+    if (hit) record(hit.id, 0.5, "description");
+  }
+
+  if (!best || (best as { score: number }).score < FUZZY_MATCH_THRESHOLD) return NO_MATCH;
+  if (bestTie) return { ...NO_MATCH, matchStatus: "ambiguous" };
+  const b = best as { prospectId: number; score: number; method: MeetingMatchMethod };
+  return {
+    prospectId: null,
+    suggestedProspectId: b.prospectId,
+    matchStatus: "suggested",
+    matchMethod: b.method,
+    matchConfidence: b.score,
+  };
+}
+
+/** Bounded scrape of an event description for a fuzzy-only linking signal — never persisted. */
+function scrapeDescriptionEmails(description: string | undefined): string[] {
+  if (!description) return [];
+  const PROSE_SCAN_LIMIT = 8_000;
+  const matches = description.slice(0, PROSE_SCAN_LIMIT).match(EMAIL_RE) ?? [];
+  return [...new Set(matches.map((m) => canonicalizeEmail(m)))];
+}
+
+interface StoredWatermark {
+  calendarId: string;
+  identityId: string;
+  updatedMin: string;
+}
+
+function parseWatermark(raw: string | null): StoredWatermark | null {
+  if (!raw) return null;
+  try {
+    const v = JSON.parse(raw) as Partial<StoredWatermark>;
+    if (
+      typeof v.calendarId === "string" &&
+      typeof v.identityId === "string" &&
+      typeof v.updatedMin === "string"
+    ) {
+      return { calendarId: v.calendarId, identityId: v.identityId, updatedMin: v.updatedMin };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export interface CalendarPollResult {
+  /** True when the feature is off (no identity configured) or in demo mode — not an error. */
+  idle: boolean;
+  eventsPolled: number;
+  meetingsIngested: number;
+  matched: number;
+  suggested: number;
+  selfBlocksSkipped: number;
+  resynced: boolean;
+  clean: boolean;
+}
+
+const IDLE: CalendarPollResult = {
+  idle: true,
+  eventsPolled: 0,
+  meetingsIngested: 0,
+  matched: 0,
+  suggested: 0,
+  selfBlocksSkipped: 0,
+  resynced: false,
+  clean: true,
+};
+
+/** Logged once per dangling-identity-id sighting per process, not once per poll (10-min throttle would still spam otherwise). */
+const loggedDanglingIdentity = new Set<string>();
+
+/**
+ * Poll the designated calendar, upsert every relevant event as a `meetings`
+ * row, and (re)match its external attendees to a prospect. Belongs in the
+ * scheduler tick body, throttled like the bounce sweep — nothing about a
+ * meeting is minute-sensitive.
+ */
+export async function pollCalendarMeetings(): Promise<CalendarPollResult> {
+  const cfg = loadConfig();
+  if (demoMode() || !cfg.calendarIdentityId) return IDLE;
+
+  const identity = resolveIdentities(cfg).find(
+    (i): i is EmailIdentity & { provider: "gmail" } =>
+      i.id === cfg.calendarIdentityId && i.provider === "gmail",
+  );
+  if (!identity) {
+    if (!loggedDanglingIdentity.has(cfg.calendarIdentityId)) {
+      loggedDanglingIdentity.add(cfg.calendarIdentityId);
+      logEvent(
+        "scheduler.calendar_poll.dangling_identity",
+        { identity_id: cfg.calendarIdentityId },
+        "warn",
+      );
+    }
+    return IDLE;
+  }
+  const account = gmailAccountFor(identity);
+  if (!account) {
+    logEvent("scheduler.calendar_poll.no_token", { identity_id: identity.id }, "warn");
+    return IDLE;
+  }
+
+  const calendarId = (cfg.calendarId || "primary").trim() || "primary";
+  const ledger = getLedger();
+  const exclusions = buildExclusionSet(cfg);
+  const prospects = ledger.listProspectsForFuzzyMatch();
+
+  const storedWatermark = parseWatermark(ledger.getPollWatermark(CALENDAR_WATERMARK_KEY));
+  // Repointing the calendar or identity invalidates the watermark — a
+  // mismatch forces a full-window resync, or the newly-pointed calendar
+  // would be silently under-polled forever.
+  const watermarkApplies =
+    storedWatermark != null &&
+    storedWatermark.calendarId === calendarId &&
+    storedWatermark.identityId === identity.id;
+
+  const fullResyncMarker = parseWatermark(ledger.getPollWatermark(CALENDAR_FULL_RESYNC_KEY));
+  const dueForWeeklyResync =
+    !fullResyncMarker ||
+    fullResyncMarker.calendarId !== calendarId ||
+    fullResyncMarker.identityId !== identity.id ||
+    Date.now() - Date.parse(fullResyncMarker.updatedMin) >= FULL_RESYNC_INTERVAL_MS;
+
+  const now = Date.now();
+  const timeMin = new Date(now - TIME_MIN_MS).toISOString();
+  const timeMax = new Date(now + TIME_MAX_MS).toISOString();
+
+  const out: CalendarPollResult = { ...IDLE, idle: false };
+  let resyncsUsed = 0;
+
+  const walk = async (
+    updatedMin: string | undefined,
+    pageBudget: number,
+  ): Promise<{
+    newestUpdated: string | null;
+    pagesUsed: number;
+    clean: boolean;
+    resyncRequested: boolean;
+  }> => {
+    let newestUpdated: string | null = null;
+    let pageToken: string | undefined;
+    let pagesUsed = 0;
+    let clean = true;
+    while (pagesUsed < pageBudget) {
+      let page: Awaited<ReturnType<typeof listCalendarEvents>>;
+      try {
+        page = await listCalendarEvents(account, {
+          calendarId,
+          ...(updatedMin ? { updatedMin } : {}),
+          timeMin,
+          timeMax,
+          maxResults: CALENDAR_PAGE_SIZE,
+          ...(pageToken ? { pageToken } : {}),
+        });
+      } catch (err) {
+        if (err instanceof CalendarApiError && err.httpStatus === 410) {
+          return { newestUpdated, pagesUsed, clean, resyncRequested: true };
+        }
+        if (
+          err instanceof CalendarApiError &&
+          err.googleStatus === "ACCESS_TOKEN_SCOPE_INSUFFICIENT"
+        ) {
+          // Live token disagrees with the persisted scope — clear it so the
+          // reconnect affordance reappears (it would otherwise be invisible
+          // exactly when it's needed).
+          clearGmailTokenScope(identity.id);
+        }
+        clean = false;
+        logEvent(
+          "scheduler.calendar_poll.failed",
+          { message_120: ((err as Error).message ?? "").slice(0, 120) },
+          "warn",
+        );
+        break;
+      }
+      pagesUsed++;
+      for (const item of page.items) {
+        out.eventsPolled++;
+        if (item.updated && (newestUpdated == null || item.updated > newestUpdated)) {
+          newestUpdated = item.updated;
+        }
+        try {
+          ingestEvent(item, { ledger, calendarId, exclusions, prospects, out, cfg });
+        } catch (err) {
+          logEvent(
+            "scheduler.calendar_poll.event_failed",
+            { message_120: ((err as Error).message ?? "").slice(0, 120), event_id: item.id },
+            "warn",
+          );
+        }
+      }
+      if (!page.nextPageToken) break;
+      pageToken = page.nextPageToken;
+    }
+    return { newestUpdated, pagesUsed, clean, resyncRequested: false };
+  };
+
+  const forceFullPull = !watermarkApplies || dueForWeeklyResync;
+  const updatedMin =
+    !forceFullPull && storedWatermark
+      ? new Date(Date.parse(storedWatermark.updatedMin) - WATERMARK_OVERLAP_MS).toISOString()
+      : undefined;
+
+  let result = await walk(updatedMin, CALENDAR_POLL_MAX_PAGES);
+  if (result.resyncRequested && resyncsUsed < 1) {
+    resyncsUsed++;
+    logEvent("scheduler.calendar_poll.resync", { calendar_id: calendarId }, "warn");
+    result = await walk(undefined, CALENDAR_POLL_MAX_PAGES - result.pagesUsed);
+    out.resynced = true;
+  }
+  out.clean = result.clean;
+
+  // Advance the watermark only on a clean walk — a partial poll must not
+  // move the cursor, or the gap the failure left behind is skipped rather
+  // than re-covered by the next good poll.
+  if (result.clean && result.newestUpdated) {
+    const next =
+      storedWatermark && !forceFullPull && result.newestUpdated < storedWatermark.updatedMin
+        ? storedWatermark.updatedMin
+        : result.newestUpdated;
+    ledger.setPollWatermark(
+      CALENDAR_WATERMARK_KEY,
+      JSON.stringify({ calendarId, identityId: identity.id, updatedMin: next }),
+    );
+  }
+  if (result.clean && forceFullPull) {
+    ledger.setPollWatermark(
+      CALENDAR_FULL_RESYNC_KEY,
+      JSON.stringify({ calendarId, identityId: identity.id, updatedMin: new Date().toISOString() }),
+    );
+  }
+
+  return out;
+}
+
+function ingestEvent(
+  item: CalendarEventItem,
+  ctx: {
+    ledger: ReturnType<typeof getLedger>;
+    calendarId: string;
+    exclusions: Set<string>;
+    prospects: ProspectFuzzyRow[];
+    out: CalendarPollResult;
+    cfg: ReturnType<typeof loadConfig>;
+  },
+): void {
+  const { ledger, calendarId, exclusions, prospects, out, cfg } = ctx;
+
+  // A cancellation for an event never seen is a no-op UPDATE, not an insert
+  // — the stub has no start time to file a ghost row under. `upsertMeeting`
+  // itself refuses to INSERT this shape; short-circuit here too so we skip
+  // the (pointless) matching work for a stub.
+  const existing = ledger.getMeeting(calendarId, item.id);
+  if (!existing && item.status === "cancelled" && !item.start) {
+    ledger.upsertMeeting({ calendarId, eventId: item.id, status: "cancelled" });
+    return;
+  }
+
+  // Idempotency fast path: event_updated_at hasn't advanced — touch
+  // last_seen_at only, skip re-deriving anything.
+  if (existing && item.updated && existing.event_updated_at === item.updated) {
+    ledger.touchMeetingLastSeen(calendarId, item.id);
+    return;
+  }
+
+  const eventType = item.eventType ?? "default";
+  if (EXCLUDED_EVENT_TYPES.has(eventType)) return;
+
+  // A cancellation STUB (status cancelled, no start time — the shape a
+  // cancelled event actually arrives in) for an event already in the
+  // ledger: update status in place and stop. Stub payloads carry no
+  // attendees, so falling through to the self-block check below would
+  // wrongly read every existing-row cancellation as a self-block and
+  // silently drop the status update — upsertMeeting's own COALESCE already
+  // guarantees this never wipes summary/prospect_id/match_status.
+  if (existing && item.status === "cancelled" && !item.start) {
+    ledger.upsertMeeting({
+      calendarId,
+      eventId: item.id,
+      status: "cancelled",
+      eventUpdatedAt: item.updated ?? null,
+    });
+    out.meetingsIngested++;
+    return;
+  }
+
+  const allDay = item.start?.date != null && item.start.dateTime == null;
+  const zone = item.start?.timeZone ?? item.end?.timeZone ?? null;
+  const installZone = cfg.timezone ?? undefined;
+  const startsAt = allDay
+    ? item.start?.date
+      ? naiveLocalToInstant(item.start.date, zone ?? installZone ?? "UTC")
+      : null
+    : (item.start?.dateTime ?? null);
+  const endsAt = allDay
+    ? item.end?.date
+      ? naiveLocalToInstant(item.end.date, zone ?? installZone ?? "UTC")
+      : null
+    : (item.end?.dateTime ?? null);
+
+  const candidates = externalCandidates(item, exclusions);
+  const fingerprint = candidates
+    .map((c) => c.email)
+    .toSorted()
+    .join(",");
+
+  // Self-block: no external candidate survives the exclusion set. Never
+  // stored — a cancellation of one of these later is correctly a no-op
+  // (never seen).
+  if (candidates.length === 0) {
+    out.selfBlocksSkipped++;
+    return;
+  }
+
+  const descriptionEmails = scrapeDescriptionEmails(item.description);
+  const attendeesOmitted = Boolean(item.attendeesOmitted);
+
+  // A founder's dismiss must stick until the attendee set genuinely
+  // changes — re-matching runs ONLY when the fingerprint changed since last
+  // seen, or this event has never been matched at all. Without this, every
+  // poll would re-suggest the prospect the founder just dismissed.
+  const shouldRematch = !existing || existing.attendees_fingerprint !== fingerprint;
+
+  const match = shouldRematch
+    ? matchCandidates({
+        candidates,
+        descriptionEmails,
+        attendeesOmitted,
+        ledger,
+        prospects,
+      })
+    : {
+        prospectId: existing.prospect_id,
+        suggestedProspectId: existing.suggested_prospect_id,
+        matchStatus: existing.match_status,
+        matchMethod: existing.match_method,
+        matchConfidence: existing.match_confidence,
+      };
+
+  if (match.prospectId != null) out.matched++;
+  else if (match.suggestedProspectId != null) out.suggested++;
+
+  ledger.upsertMeeting({
+    calendarId,
+    eventId: item.id,
+    icalUid: item.iCalUID ?? null,
+    recurringEventId: item.recurringEventId ?? null,
+    status: item.status ?? "confirmed",
+    summary: item.summary ?? null,
+    allDay,
+    startsAt,
+    endsAt,
+    eventTimezone: zone,
+    organizerEmail: item.organizer?.email ? canonicalizeEmail(item.organizer.email) : null,
+    selfResponse: selfResponseOf(item),
+    externalAttendeeCount: candidates.length,
+    externalAttendeesJson: JSON.stringify(
+      candidates.slice(0, EXTERNAL_ATTENDEES_CAP).map((c) => c.email),
+    ),
+    attendeesOmitted,
+    matchStatus: match.matchStatus,
+    matchMethod: match.matchMethod,
+    matchConfidence: match.matchConfidence,
+    prospectId: match.prospectId,
+    suggestedProspectId: match.suggestedProspectId,
+    eventUpdatedAt: item.updated ?? null,
+    attendeesFingerprint: fingerprint,
+  });
+  out.meetingsIngested++;
+}

--- a/packages/plays/src/index.ts
+++ b/packages/plays/src/index.ts
@@ -35,3 +35,4 @@ export * from "./design-partner-loi.ts";
 export * from "./new-business.ts";
 export * from "./_mail-research.ts";
 export * from "./_mail-letter.ts";
+export * from "./_calendar.ts";

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -373,6 +373,15 @@ export interface SetupRequest {
    * unchanged; `null` = clear it (unlimited); a positive number = set it.
    */
   dailySpendCeilingUsd?: number | null;
+  /**
+   * Which Gmail identity's calendar the scheduler polls (issue #577).
+   * `undefined` = leave unchanged; `null` = turn the feature off (entirely
+   * inert — no poll, no writes). Must be a `provider: 'gmail'` identity id
+   * already in the pool with calendar.readonly scope.
+   */
+  calendarIdentityId?: string | null;
+  /** Which calendar of `calendarIdentityId`'s account to poll. `undefined` = leave unchanged; blank/omit defaults to "primary" server-side. */
+  calendarId?: string;
   llmProvider?: LlmProvider;
   llmModel?: string;
   telemetryEnabled?: boolean;
@@ -481,6 +490,13 @@ export interface SenderIdentityView {
   capToday: number | null;
   /** True when synthesized from legacy single-provider config (not yet a persisted pool). */
   legacy: boolean;
+  /**
+   * Gmail only (issue #577): whether this identity's token carries the
+   * calendar.readonly scope. Null for non-Gmail providers, which have no
+   * calendar concept at all — the /setup "Reconnect for calendar" action is
+   * only offered on `false`.
+   */
+  hasCalendarScope: boolean | null;
 }
 
 export type QueueStatusView = "pending" | "approved" | "rejected" | "sent" | "expired";
@@ -1325,4 +1341,65 @@ export interface WorkspaceInfo {
     /** Live-probed server-side (~300ms /api/health ping). */
     running: boolean;
   }>;
+}
+
+/* ── Calendar meetings (issue #577) ──────────────────────────────────── */
+
+export type MeetingOutcomeView = "held" | "no_show" | "cancelled" | "rescheduled";
+export type MeetingMatchStatusView = "exact" | "suggested" | "ambiguous" | "dismissed" | null;
+
+/** One `meetings` row, projected for the browser. */
+export interface MeetingView {
+  calendarId: string;
+  eventId: string;
+  summary: string | null;
+  startsAt: string | null;
+  endsAt: string | null;
+  organizerEmail: string | null;
+  externalAttendees: string[];
+  prospectId: number | null;
+  prospectName: string | null;
+  prospectEmail: string | null;
+  suggestedProspectId: number | null;
+  suggestedProspectName: string | null;
+  suggestedProspectEmail: string | null;
+  matchStatus: MeetingMatchStatusView;
+  /** The match method, rendered as a human sentence — never the bare score. */
+  matchReason: string | null;
+  outcome: MeetingOutcomeView | null;
+  outcomeNote: string | null;
+}
+
+/** GET /api/meetings — split into the two lists the dashboard renders. */
+export interface MeetingsResult {
+  /** Past, matched, no outcome recorded — the nudge list. */
+  awaitingOutcome: MeetingView[];
+  /** Suggested/ambiguous matches needing a founder confirm/dismiss. */
+  needsReview: MeetingView[];
+}
+
+export interface LogMeetingOutcomeRequest {
+  calendarId: string;
+  eventId: string;
+  outcome: MeetingOutcomeView;
+  note?: string;
+}
+
+export interface ConfirmMeetingMatchRequest {
+  calendarId: string;
+  eventId: string;
+  prospectId: number;
+}
+
+export interface DismissMeetingMatchRequest {
+  calendarId: string;
+  eventId: string;
+}
+
+/** One calendar in the /setup picker, with a 7-day event count — a founder cannot reliably say which calendar their bookings land on. */
+export interface CalendarPickerEntry {
+  id: string;
+  summary: string;
+  accessRole: string;
+  recentEventCount: number;
 }


### PR DESCRIPTION
Closes #577.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 591e48343202 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (2 errs) vs base ok (2 errs)
```