### PR TITLE
fix(intel): issue #586: reasoning-mandatory OpenRouter models get low effort and a raised budget

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 67 CLI commands, 23 plays, 15 finders, ten dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-09** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3634 tests / 270 files** · typecheck + oxlint + oxfmt pass (38 lint warnings, 0 errors).
+Last verified **2026-09-09** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3640 tests / 271 files** · typecheck + oxlint + oxfmt pass (38 lint warnings, 0 errors).
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/packages/intel/__tests__/reasoning-mandatory.test.ts
+++ b/packages/intel/__tests__/reasoning-mandatory.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Issue #586. A reasoning-mandatory OpenRouter model answers
+// `reasoning: { enabled: false }` with a 400 — and, before this, the retry
+// kept the caller's small max_tokens, so the model spent every token
+// thinking and every draft came back truncated and empty. The retry must
+// now carry the lowest effort AND a raised budget, and the model must be
+// remembered so later calls skip the 400.
+
+const cfg = vi.hoisted(() => ({
+  provider: "openrouter" as const,
+  model: "test-model",
+}));
+
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    loadConfig: () => ({ ...actual.loadConfig(), llmProvider: cfg.provider, llmModel: cfg.model }),
+  };
+});
+
+const { complete, MANDATORY_REASONING_ALLOWANCE_TOKENS, MANDATORY_REASONING_EFFORT } =
+  await import("../src/client.ts");
+
+const realFetch = global.fetch;
+
+const okBody = {
+  choices: [{ message: { content: '{"ok":true}' }, finish_reason: "stop" }],
+  usage: { prompt_tokens: 40, completion_tokens: 12 },
+};
+
+function reasoningRejection() {
+  return {
+    ok: false,
+    status: 400,
+    headers: { get: () => null },
+    text: () =>
+      Promise.resolve('{"error":{"message":"Reasoning cannot be disabled for this model"}}'),
+  };
+}
+function okResponse() {
+  return { ok: true, json: () => Promise.resolve(okBody) };
+}
+
+/** Rejects any request that tries to switch reasoning off; accepts the rest. */
+function mandatoryModelFetch() {
+  const fn = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+    const body = JSON.parse(init.body as string) as { reasoning?: { enabled?: boolean } };
+    if (body.reasoning?.enabled === false) return Promise.resolve(reasoningRejection());
+    return Promise.resolve(okResponse());
+  });
+  global.fetch = fn as unknown as typeof fetch;
+  return fn;
+}
+
+function bodyOf(fn: ReturnType<typeof vi.fn>, call: number): Record<string, unknown> {
+  const [, init] = fn.mock.calls[call] as [string, RequestInit];
+  return JSON.parse(init.body as string) as Record<string, unknown>;
+}
+
+beforeEach(() => {
+  cfg.model = `mandatory-${Math.random().toString(36).slice(2)}`; // fresh: not yet remembered
+  vi.stubEnv("OPENROUTER_API_KEY", "test-key");
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  global.fetch = realFetch;
+});
+
+describe("reasoning-mandatory models (issue #586)", () => {
+  it("retries with the lowest effort AND a raised budget, not just without the switch", async () => {
+    const fetchMock = mandatoryModelFetch();
+    await complete({ messages: [{ role: "user", content: "hi" }], maxTokens: 500 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(bodyOf(fetchMock, 0)["reasoning"]).toEqual({ enabled: false });
+    expect(bodyOf(fetchMock, 0)["max_tokens"]).toBe(500);
+
+    const retry = bodyOf(fetchMock, 1);
+    expect(retry["reasoning"]).toEqual({ effort: MANDATORY_REASONING_EFFORT });
+    expect(retry["max_tokens"]).toBe(500 + MANDATORY_REASONING_ALLOWANCE_TOKENS);
+  });
+
+  it("remembers the model: the next call goes straight to the mandatory path", async () => {
+    const fetchMock = mandatoryModelFetch();
+    await complete({ messages: [{ role: "user", content: "one" }], maxTokens: 300 });
+    await complete({ messages: [{ role: "user", content: "two" }], maxTokens: 300 });
+
+    // 2 for the first call (400 + retry), exactly 1 for the second.
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    const second = bodyOf(fetchMock, 2);
+    expect(second["reasoning"]).toEqual({ effort: MANDATORY_REASONING_EFFORT });
+    expect(second["max_tokens"]).toBe(300 + MANDATORY_REASONING_ALLOWANCE_TOKENS);
+  });
+
+  it("a seeded family never pays for the 400", async () => {
+    cfg.model = "google/gemini-3.8-flash";
+    const fetchMock = mandatoryModelFetch();
+    await complete({ messages: [{ role: "user", content: "hi" }], maxTokens: 500 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const only = bodyOf(fetchMock, 0);
+    expect(only["reasoning"]).toEqual({ effort: MANDATORY_REASONING_EFFORT });
+    expect(only["max_tokens"]).toBe(500 + MANDATORY_REASONING_ALLOWANCE_TOKENS);
+  });
+
+  it("a model that rejects `effort` too still gets the raised budget", async () => {
+    const fn = vi.fn().mockImplementation((_url: string, init: RequestInit) => {
+      const body = JSON.parse(init.body as string) as { reasoning?: unknown };
+      if (body.reasoning !== undefined) return Promise.resolve(reasoningRejection());
+      return Promise.resolve(okResponse());
+    });
+    global.fetch = fn as unknown as typeof fetch;
+
+    await complete({ messages: [{ role: "user", content: "hi" }], maxTokens: 500 });
+
+    // enabled:false → 400, effort:low → 400, bare → 200.
+    expect(fn).toHaveBeenCalledTimes(3);
+    const bare = bodyOf(fn, 2);
+    expect(bare["reasoning"]).toBeUndefined();
+    expect(bare["max_tokens"]).toBe(500 + MANDATORY_REASONING_ALLOWANCE_TOKENS);
+  });
+
+  it("a truncation on the mandatory path reports the effective budget, never an empty draft", async () => {
+    cfg.model = "google/gemini-3.8-flash";
+    const fn = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          choices: [{ message: { content: "" }, finish_reason: "length" }],
+          usage: {
+            prompt_tokens: 40,
+            completion_tokens: 2036,
+            completion_tokens_details: { reasoning_tokens: 2030 },
+          },
+        }),
+    });
+    global.fetch = fn as unknown as typeof fetch;
+
+    await expect(
+      complete({ messages: [{ role: "user", content: "hi" }], maxTokens: 500 }),
+    ).rejects.toThrow(
+      `truncated at max_tokens=${500 + MANDATORY_REASONING_ALLOWANCE_TOKENS} (2030/2036 tokens were reasoning)`,
+    );
+  });
+});

--- a/packages/intel/__tests__/truncation.test.ts
+++ b/packages/intel/__tests__/truncation.test.ts
@@ -172,13 +172,18 @@ describe("complete() reasoning switch — openrouter vs openai", () => {
       JSON.parse((init as RequestInit).body as string),
     );
     expect(bodies[0]).toHaveProperty("reasoning", { enabled: false });
-    expect(bodies[1]).not.toHaveProperty("reasoning");
+    // Issue #586: the retry is not "the same request without the switch" — a
+    // mandatory model spends its thinking inside max_tokens, so it gets the
+    // lowest effort and a raised budget (see reasoning-mandatory.test.ts).
+    expect(bodies[1]).toHaveProperty("reasoning", { effort: "low" });
+    expect(bodies[1].max_tokens).toBeGreaterThan(500);
 
     // Remembered: the next call to the same model skips the switch and the round trip.
     await complete({ messages: [{ role: "user", content: "again" }], maxTokens: 500 });
     expect(fn).toHaveBeenCalledTimes(3);
-    expect(JSON.parse((fn.mock.calls[2]![1] as RequestInit).body as string)).not.toHaveProperty(
+    expect(JSON.parse((fn.mock.calls[2]![1] as RequestInit).body as string)).toHaveProperty(
       "reasoning",
+      { effort: "low" },
     );
   });
 

--- a/packages/intel/src/client.ts
+++ b/packages/intel/src/client.ts
@@ -327,16 +327,26 @@ function dispatch(
       // tokens and truncated JSON; reasoning off → a clean 184-token answer
       // at 40% of the cost. OpenRouter's unified `reasoning` parameter maps
       // to each provider's own switch, so this is one line for all of them —
-      // except the ~100 models OpenRouter marks `reasoning.mandatory`
-      // (gpt-5, the newer Gemini flashes, Fable 5.1), which answer the
-      // switch with a 400. Those get one retry without it and are
-      // remembered for the rest of the process, so the founder's model choice
-      // never has to know which kind it is.
-      if (mandatoryReasoningModels.has(model)) return openaiCompatibleComplete(args);
+      // except the models OpenRouter marks `reasoning.mandatory` (gpt-5, the
+      // Gemini 3.5+ flashes, Fable 5.1), which answer the switch with a 400.
+      //
+      // For those, retrying WITHOUT the switch is not enough (issue #586):
+      // the retry keeps the caller's budget and the model spends all of it
+      // thinking — google/gemini-3.8-flash at max_tokens=500 returned
+      // finish_reason=length with 481/496 tokens of reasoning and an empty
+      // body, on every single draft. So the mandatory path asks for the
+      // lowest effort AND tops the budget up by an allowance, so the caller's
+      // maxTokens keeps meaning "tokens of answer I want". The model is
+      // remembered for the rest of the process (and the common families are
+      // seeded) so the founder's model choice never has to know which kind
+      // it is, and only the first call of a boot pays for the 400.
+      if (mandatoryReasoningModels.has(model) || seededMandatory(model)) {
+        return completeWithMandatoryReasoning(args);
+      }
       return openaiCompatibleComplete({ ...args, disableReasoning: true }).catch((err: unknown) => {
         if (isMandatoryReasoningRejection(err)) {
           mandatoryReasoningModels.add(model);
-          return openaiCompatibleComplete(args);
+          return completeWithMandatoryReasoning(args);
         }
         throw err;
       });
@@ -355,8 +365,47 @@ function dispatch(
   }
 }
 
-/** OpenRouter models that rejected `reasoning: { enabled: false }` — see the openrouter dispatch. */
+/**
+ * Completion budget granted on top of the caller's `maxTokens` for a
+ * reasoning-mandatory model. One data point behind the number: gemini-3.8-flash
+ * at effort=medium used 481 reasoning tokens for what would have been a
+ * ~200-token answer. `low` should need less, but a too-small allowance costs a
+ * truncated draft and a too-large one costs nothing (unused budget is not
+ * billed), so it errs high.
+ */
+export const MANDATORY_REASONING_ALLOWANCE_TOKENS = 1536;
+/** Every reasoning-mandatory model on OpenRouter accepts `low`; not all accept `minimal`. */
+export const MANDATORY_REASONING_EFFORT = "low";
+
+/**
+ * OpenRouter models that cannot have reasoning switched off — see the
+ * openrouter dispatch. Learned at runtime from the 400, seeded with the
+ * families known to be mandatory so the first call of a boot doesn't pay for
+ * it. The seed is an optimisation, never the authority: an unlisted model is
+ * still detected, and a listed one that later allows the switch merely wastes
+ * a little budget.
+ */
 const mandatoryReasoningModels = new Set<string>();
+const MANDATORY_REASONING_SEED = [/^google\/gemini-3\.[5-9]-flash/, /^openai\/gpt-5/];
+function seededMandatory(model: string): boolean {
+  return MANDATORY_REASONING_SEED.some((re) => re.test(model));
+}
+
+/**
+ * The mandatory path: lowest effort plus the allowance. A model that rejects
+ * the `effort` parameter too (a second 400 about reasoning) is called with no
+ * reasoning parameter at all — but still with the raised budget, which is the
+ * half of the fix that actually matters.
+ */
+function completeWithMandatoryReasoning(args: OpenAIArgs): Promise<LlmCompleteOutput> {
+  const raised = { ...args, extraMaxTokens: MANDATORY_REASONING_ALLOWANCE_TOKENS };
+  return openaiCompatibleComplete({ ...raised, reasoningEffort: MANDATORY_REASONING_EFFORT }).catch(
+    (err: unknown) => {
+      if (isMandatoryReasoningRejection(err)) return openaiCompatibleComplete(raised);
+      throw err;
+    },
+  );
+}
 
 /** A 400 whose body talks about reasoning: the model cannot have it switched off. */
 function isMandatoryReasoningRejection(err: unknown): boolean {
@@ -450,9 +499,21 @@ interface OpenAIArgs {
   extraHeaders?: Record<string, string>;
   /** Send OpenRouter's `reasoning: { enabled: false }` — see the openrouter dispatch. */
   disableReasoning?: boolean;
+  /**
+   * Send OpenRouter's `reasoning: { effort }` instead — for models whose
+   * reasoning cannot be switched off. Mutually exclusive with disableReasoning.
+   */
+  reasoningEffort?: string;
+  /**
+   * Extra completion budget on top of the caller's `maxTokens`. A reasoning-
+   * mandatory model spends its thinking inside `max_tokens`, so the caller's
+   * "tokens of answer I want" has to be topped up or the answer never starts.
+   */
+  extraMaxTokens?: number;
 }
 
 async function openaiCompatibleComplete(args: OpenAIArgs): Promise<LlmCompleteOutput> {
+  const maxTokens = (args.input.maxTokens ?? 1024) + (args.extraMaxTokens ?? 0);
   const data = (await postJson({
     url: `${args.baseUrl}/chat/completions`,
     headers: { Authorization: `Bearer ${args.key}`, ...args.extraHeaders },
@@ -460,9 +521,13 @@ async function openaiCompatibleComplete(args: OpenAIArgs): Promise<LlmCompleteOu
       model: args.model,
       messages: args.input.messages,
       temperature: args.input.temperature ?? 0.7,
-      max_tokens: args.input.maxTokens ?? 1024,
+      max_tokens: maxTokens,
       // OpenRouter only — the OpenAI API rejects unknown parameters.
-      ...(args.disableReasoning ? { reasoning: { enabled: false } } : {}),
+      ...(args.disableReasoning
+        ? { reasoning: { enabled: false } }
+        : args.reasoningEffort
+          ? { reasoning: { effort: args.reasoningEffort } }
+          : {}),
     },
     provider: args.provider,
     timeoutMs: args.timeoutMs,
@@ -501,7 +566,7 @@ async function openaiCompatibleComplete(args: OpenAIArgs): Promise<LlmCompleteOu
       truncationMessage({
         provider: args.provider,
         model: args.model,
-        maxTokens: args.input.maxTokens ?? 1024,
+        maxTokens,
         completionTokens: data.usage?.completion_tokens,
         reasoningTokens: data.usage?.completion_tokens_details?.reasoning_tokens,
       }),


### PR DESCRIPTION
Closes #586.

## What broke

`llmModel: google/gemini-3.8-flash` → every draft on both live workspaces came back `subject: "(error)", body: ""` with `truncated at max_tokens=500 (481/496 tokens were reasoning)`. 33 of 33 attempted drafts, each billed.

## Why

OpenRouter marks the model `reasoning.mandatory: true` (no `minimal` effort either). The client sends `reasoning: {enabled: false}`, gets a 400, and retried without it — but with the caller's `maxTokens: 500` unchanged, which the model spends entirely on thinking. `truncationMessage` already named both fixes; the dispatch applied neither.

## What changes

- Mandatory path: `reasoning: { effort: "low" }` **and** `max_tokens = caller's + MANDATORY_REASONING_ALLOWANCE_TOKENS (1536)`. The constant carries its one measured data point.
- A model that rejects `effort` too is called with no reasoning parameter but still the raised budget — the half that matters.
- Seeded families (`google/gemini-3.[5-9]-flash`, `openai/gpt-5`) skip the 400 on first call; runtime detection remains authoritative.
- Truncation on that path reports the effective budget.

## Verification

- `bun run test`: 3640 / 271 files green (baseline on `main`: 3635 / 270). New `packages/intel/__tests__/reasoning-mandatory.test.ts` (5 tests) drives a fake that 400s on `enabled:false` and asserts effort + budget on the retry, the remembered path, the seeded path, the effort-rejected fallback, and the truncation message. The old assertion in `truncation.test.ts` that the retry carried no reasoning parameter is updated to the new contract.
- typecheck, oxlint, oxfmt clean.
- `STATUS.md` updated in the same commit.

https://claude.ai/code/session_011meFPo97LhmTcoNRwyPQeS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility with models that require reasoning to be enabled.
  * Automatically retries requests with a low reasoning effort and an expanded token budget when required.
  * Remembers models that require reasoning to avoid unnecessary failed attempts on future requests.
  * Falls back gracefully when a model does not support configurable reasoning effort.
  * Improved truncation errors to report the effective token budget instead of returning an empty draft.

* **Tests**
  * Expanded coverage for mandatory-reasoning model behavior and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->