### PR TITLE
fix: issue #586: Reasoning-mandatory OpenRouter models (gemini-3.8-flash) truncate every draft at max_tokens=500

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 67 CLI commands, 23 plays, 15 finders, ten dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-09** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3612 tests / 270 files** · typecheck + oxlint + oxfmt pass (38 lint warnings, 0 errors).
+Last verified **2026-09-09** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3614 tests / 270 files** · typecheck + oxlint + oxfmt pass (38 lint warnings, 0 errors).
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 67 CLI commands, 23 plays, 15 finders, ten dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-09** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3614 tests / 270 files** · typecheck + oxlint + oxfmt pass (38 lint warnings, 0 errors).
+Last verified **2026-09-09** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3618 tests / 270 files** · typecheck + oxlint + oxfmt pass (38 lint warnings, 0 errors).
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/packages/intel/__tests__/truncation.test.ts
+++ b/packages/intel/__tests__/truncation.test.ts
@@ -40,6 +40,19 @@ function requestOf(fn: ReturnType<typeof respondWith>): {
   };
 }
 
+/** A mocked 400 whose body rejects the given reasoning effort tier. */
+function rejectedReasoning(effort: string) {
+  return {
+    ok: false,
+    status: 400,
+    headers: { get: () => null },
+    text: () =>
+      Promise.resolve(
+        `{"error":{"message":"reasoning.effort must be 'high' for this model, got '${effort}'"}}`,
+      ),
+  };
+}
+
 async function errorFrom(p: Promise<unknown>): Promise<Error> {
   return await p.then(
     () => {
@@ -138,16 +151,6 @@ describe("complete() truncation — openrouter", () => {
 });
 
 describe("complete() reasoning switch — openrouter vs openai", () => {
-  const rejectedReasoning = (effort: string) => ({
-    ok: false,
-    status: 400,
-    headers: { get: () => null },
-    text: () =>
-      Promise.resolve(
-        `{"error":{"message":"reasoning.effort must be 'high' for this model, got '${effort}'"}}`,
-      ),
-  });
-
   it("turns reasoning off on OpenRouter requests, where it would eat the small max_tokens budgets", async () => {
     const fetchMock = respondWith({
       choices: [{ message: { content: "{}" }, finish_reason: "stop" }],
@@ -318,6 +321,43 @@ describe("complete() reasoning switch — openrouter vs openai", () => {
     const retryBody = JSON.parse((fn.mock.calls[1]![1] as RequestInit).body as string);
     expect(retryBody).toHaveProperty("reasoning", { effort: "minimal" });
     expect(retryBody).toHaveProperty("max_tokens", 2000);
+  });
+
+  it("stops climbing and surfaces the real error when a ladder rung 400s for a reason unrelated to reasoning effort", async () => {
+    // Round-2 finding: completeWithLowestSupportedEffort's catch used to
+    // advance the ladder on ANY 400, without checking the body was actually
+    // about reasoning/effort (unlike the outer isMandatoryReasoningRejection
+    // gate used to enter the ladder). If the ladder's own raised max_tokens
+    // allowance pushed a request over the model's hard token ceiling, that
+    // unrelated 400 got misread as "this effort is unsupported" and burned
+    // every remaining rung on requests that could never succeed, then
+    // reported the wrong (last, unrelated) error instead of the real one.
+    cfg.model = "hard-ceiling-model";
+    const notReasoningRelated = {
+      ok: false,
+      status: 400,
+      headers: { get: () => null },
+      text: () =>
+        Promise.resolve(
+          '{"error":{"message":"This model\'s maximum context length is 4096 tokens"}}',
+        ),
+    };
+    const fn = vi
+      .fn()
+      // probe: disableReasoning -> rejected as mandatory
+      .mockResolvedValueOnce(rejectedReasoning("disabled"))
+      // first ladder rung's raised max_tokens trips an unrelated 400.
+      .mockResolvedValueOnce(notReasoningRelated);
+    global.fetch = fn as unknown as typeof fetch;
+
+    const err = await errorFrom(
+      complete({ messages: [{ role: "user", content: "hi" }], maxTokens: 500, maxAttempts: 1 }),
+    );
+
+    expect(err.message).toContain("maximum context length is 4096 tokens");
+    // Exactly the probe + the one doomed rung — never climbs the remaining
+    // three rungs on a request that could never succeed.
+    expect(fn).toHaveBeenCalledTimes(2);
   });
 
   it("persists a learned mandatory-reasoning model AND its verified working effort to disk, so the next process skips the probe round trip", async () => {

--- a/packages/intel/__tests__/truncation.test.ts
+++ b/packages/intel/__tests__/truncation.test.ts
@@ -147,7 +147,12 @@ describe("complete() reasoning switch — openrouter vs openai", () => {
     expect(requestOf(fetchMock).body["reasoning"]).toEqual({ enabled: false });
   });
 
-  it("falls back to the plain request when OpenRouter says the model's reasoning is mandatory, and remembers it", async () => {
+  it("falls back to a raised-budget, lowest-effort request when OpenRouter says the model's reasoning is mandatory, and remembers it", async () => {
+    // Card #586: the retry used to keep the caller's small max_tokens budget
+    // and send NO effort dial, so a reasoning-mandatory model reliably burned
+    // the whole budget on reasoning and truncated every draft. The retry now
+    // asks for the lowest supported effort AND raises max_tokens by the
+    // reasoning allowance on top of the caller's own budget.
     cfg.model = "mandatory-reasoning-model";
     const ok = {
       ok: true,
@@ -172,14 +177,80 @@ describe("complete() reasoning switch — openrouter vs openai", () => {
       JSON.parse((init as RequestInit).body as string),
     );
     expect(bodies[0]).toHaveProperty("reasoning", { enabled: false });
-    expect(bodies[1]).not.toHaveProperty("reasoning");
+    expect(bodies[0]).toHaveProperty("max_tokens", 500);
+    // The retry carries BOTH the lowest supported effort and a raised budget
+    // (caller's 500 + the reasoning allowance), never neither.
+    expect(bodies[1]).toHaveProperty("reasoning", { effort: "low" });
+    expect(bodies[1]).toHaveProperty("max_tokens", 500 + 1500);
 
-    // Remembered: the next call to the same model skips the switch and the round trip.
+    // Remembered: the next call to the same model skips the probe round trip
+    // and goes straight to the effort dial + raised budget.
     await complete({ messages: [{ role: "user", content: "again" }], maxTokens: 500 });
     expect(fn).toHaveBeenCalledTimes(3);
-    expect(JSON.parse((fn.mock.calls[2]![1] as RequestInit).body as string)).not.toHaveProperty(
-      "reasoning",
+    const thirdBody = JSON.parse((fn.mock.calls[2]![1] as RequestInit).body as string);
+    expect(thirdBody).toHaveProperty("reasoning", { effort: "low" });
+    expect(thirdBody).toHaveProperty("max_tokens", 500 + 1500);
+  });
+
+  it("still raises the truncation diagnostic on a mandatory-reasoning model, never a silent empty draft, even when the raised budget still isn't enough", async () => {
+    cfg.model = "mandatory-reasoning-model-2";
+    const rejected = {
+      ok: false,
+      status: 400,
+      headers: { get: () => null },
+      text: () => Promise.resolve('{"error":{"message":"reasoning cannot be disabled"}}'),
+    };
+    const stillTruncated = {
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          choices: [{ message: { content: "" }, finish_reason: "length" }],
+          usage: { completion_tokens: 2000, completion_tokens_details: { reasoning_tokens: 1999 } },
+        }),
+    };
+    const fn = vi.fn().mockResolvedValueOnce(rejected).mockResolvedValue(stillTruncated);
+    global.fetch = fn as unknown as typeof fetch;
+
+    const err = await errorFrom(
+      complete({ messages: [{ role: "user", content: "hi" }], maxTokens: 500 }),
     );
+    expect(err.message).toContain("truncated at max_tokens=2000");
+    expect(err.message).toContain("1999/2000 tokens were reasoning");
+    const retryBody = JSON.parse((fn.mock.calls[1]![1] as RequestInit).body as string);
+    expect(retryBody).toHaveProperty("reasoning", { effort: "low" });
+    expect(retryBody).toHaveProperty("max_tokens", 2000);
+  });
+
+  it("persists a learned mandatory-reasoning model to disk, so the next process skips the probe round trip", async () => {
+    cfg.model = "mandatory-reasoning-model-3";
+    const ok = {
+      ok: true,
+      json: () =>
+        Promise.resolve({ choices: [{ message: { content: "{}" }, finish_reason: "stop" }] }),
+    };
+    const rejected = {
+      ok: false,
+      status: 400,
+      headers: { get: () => null },
+      text: () => Promise.resolve('{"error":{"message":"reasoning cannot be disabled"}}'),
+    };
+    const firstProcessFetch = vi.fn().mockResolvedValueOnce(rejected).mockResolvedValue(ok);
+    global.fetch = firstProcessFetch as unknown as typeof fetch;
+    await complete({ messages: [{ role: "user", content: "hi" }], maxTokens: 500 });
+    expect(firstProcessFetch).toHaveBeenCalledTimes(2);
+
+    // Simulate a fresh process: reset the module registry and re-import
+    // client.ts so its module-level Set is rebuilt from scratch, reading
+    // only what was persisted to disk by the call above.
+    vi.resetModules();
+    const { complete: completeInFreshProcess } = await import("../src/client.ts");
+    const secondProcessFetch = vi.fn().mockResolvedValue(ok);
+    global.fetch = secondProcessFetch as unknown as typeof fetch;
+    await completeInFreshProcess({ messages: [{ role: "user", content: "hi" }], maxTokens: 500 });
+    // No probe 400 this time — the fresh process already knew from disk.
+    expect(secondProcessFetch).toHaveBeenCalledTimes(1);
+    const body = JSON.parse((secondProcessFetch.mock.calls[0]![1] as RequestInit).body as string);
+    expect(body).toHaveProperty("reasoning", { effort: "low" });
   });
 
   it("does not swallow an unrelated 400 as a reasoning rejection", async () => {

--- a/packages/intel/__tests__/truncation.test.ts
+++ b/packages/intel/__tests__/truncation.test.ts
@@ -138,6 +138,16 @@ describe("complete() truncation — openrouter", () => {
 });
 
 describe("complete() reasoning switch — openrouter vs openai", () => {
+  const rejectedReasoning = (effort: string) => ({
+    ok: false,
+    status: 400,
+    headers: { get: () => null },
+    text: () =>
+      Promise.resolve(
+        `{"error":{"message":"reasoning.effort must be 'high' for this model, got '${effort}'"}}`,
+      ),
+  });
+
   it("turns reasoning off on OpenRouter requests, where it would eat the small max_tokens budgets", async () => {
     const fetchMock = respondWith({
       choices: [{ message: { content: "{}" }, finish_reason: "stop" }],
@@ -147,12 +157,13 @@ describe("complete() reasoning switch — openrouter vs openai", () => {
     expect(requestOf(fetchMock).body["reasoning"]).toEqual({ enabled: false });
   });
 
-  it("falls back to a raised-budget, lowest-effort request when OpenRouter says the model's reasoning is mandatory, and remembers it", async () => {
+  it("falls back to a raised-budget, lowest-supported-effort request when OpenRouter says the model's reasoning is mandatory, and remembers the effort that worked", async () => {
     // Card #586: the retry used to keep the caller's small max_tokens budget
     // and send NO effort dial, so a reasoning-mandatory model reliably burned
     // the whole budget on reasoning and truncated every draft. The retry now
-    // asks for the lowest supported effort AND raises max_tokens by the
-    // reasoning allowance on top of the caller's own budget.
+    // climbs the effort ladder from "minimal" up, stopping at the first tier
+    // this model actually accepts, and raises max_tokens by the reasoning
+    // allowance on top of the caller's own budget.
     cfg.model = "mandatory-reasoning-model";
     const ok = {
       ok: true,
@@ -178,9 +189,10 @@ describe("complete() reasoning switch — openrouter vs openai", () => {
     );
     expect(bodies[0]).toHaveProperty("reasoning", { enabled: false });
     expect(bodies[0]).toHaveProperty("max_tokens", 500);
-    // The retry carries BOTH the lowest supported effort and a raised budget
+    // The retry carries BOTH the lowest supported effort ("minimal" — the
+    // first rung on the ladder this model accepted) and a raised budget
     // (caller's 500 + the reasoning allowance), never neither.
-    expect(bodies[1]).toHaveProperty("reasoning", { effort: "low" });
+    expect(bodies[1]).toHaveProperty("reasoning", { effort: "minimal" });
     expect(bodies[1]).toHaveProperty("max_tokens", 500 + 1500);
 
     // Remembered: the next call to the same model skips the probe round trip
@@ -188,8 +200,91 @@ describe("complete() reasoning switch — openrouter vs openai", () => {
     await complete({ messages: [{ role: "user", content: "again" }], maxTokens: 500 });
     expect(fn).toHaveBeenCalledTimes(3);
     const thirdBody = JSON.parse((fn.mock.calls[2]![1] as RequestInit).body as string);
-    expect(thirdBody).toHaveProperty("reasoning", { effort: "low" });
+    expect(thirdBody).toHaveProperty("reasoning", { effort: "minimal" });
     expect(thirdBody).toHaveProperty("max_tokens", 500 + 1500);
+  });
+
+  it('climbs past efforts the model rejects with a 400, landing on the lowest one it actually accepts — the o4-mini-high / o3-mini-high shape (supported_efforts: ["high"] only)', async () => {
+    // Finding from #586 round-1 review: some real mandatory-reasoning
+    // OpenRouter models (openai/o4-mini-high, openai/o3-mini-high) reject
+    // EVERY effort below "high" with a 400, not just "minimal". A hardcoded
+    // single tier ("low") 400s forever on these and, worse, used to get
+    // persisted as the remembered choice before the retry's outcome was
+    // known — permanently wedging every future call. The ladder must climb
+    // past every rejected rung and only remember the one that actually
+    // returned 200.
+    cfg.model = "high-only-model";
+    const ok = {
+      ok: true,
+      json: () =>
+        Promise.resolve({ choices: [{ message: { content: "{}" }, finish_reason: "stop" }] }),
+    };
+    const fn = vi
+      .fn()
+      // probe: disableReasoning -> rejected as mandatory
+      .mockResolvedValueOnce(rejectedReasoning("disabled"))
+      // ladder: minimal -> 400, low -> 400, medium -> 400, high -> 200
+      .mockResolvedValueOnce(rejectedReasoning("minimal"))
+      .mockResolvedValueOnce(rejectedReasoning("low"))
+      .mockResolvedValueOnce(rejectedReasoning("medium"))
+      // Every later call (including the second complete() below, which is
+      // remembered and skips straight to "high") gets a 200.
+      .mockResolvedValue(ok);
+    global.fetch = fn as unknown as typeof fetch;
+
+    await complete({ messages: [{ role: "user", content: "hi" }], maxTokens: 500 });
+    expect(fn).toHaveBeenCalledTimes(5);
+    const bodies = fn.mock.calls.map(([, init]) =>
+      JSON.parse((init as RequestInit).body as string),
+    );
+    expect(bodies[1]).toHaveProperty("reasoning", { effort: "minimal" });
+    expect(bodies[2]).toHaveProperty("reasoning", { effort: "low" });
+    expect(bodies[3]).toHaveProperty("reasoning", { effort: "medium" });
+    expect(bodies[4]).toHaveProperty("reasoning", { effort: "high" });
+
+    // Only "high" — the one that actually returned 200 — gets remembered.
+    // A NEXT call to the same model must go straight to "high", not restart
+    // the climb at "minimal" and not get stuck on an effort that never
+    // worked.
+    await complete({ messages: [{ role: "user", content: "again" }], maxTokens: 500 });
+    expect(fn).toHaveBeenCalledTimes(6);
+    const rememberedBody = JSON.parse((fn.mock.calls[5]![1] as RequestInit).body as string);
+    expect(rememberedBody).toHaveProperty("reasoning", { effort: "high" });
+  });
+
+  it("never remembers an effort when every rung on the ladder 400s, so the next call re-probes instead of replaying a value nothing verified", async () => {
+    // The core of the round-1 finding: rememberMandatoryReasoningModel() must
+    // only fire on a VERIFIED success. If it fired before the retry's
+    // outcome were known (the pre-correction behaviour), a model that
+    // rejects every effort would get permanently wedged on a doomed retry —
+    // this process and every future process, since the mapping persists to
+    // disk.
+    cfg.model = "rejects-everything-model";
+    const rejected = {
+      ok: false,
+      status: 400,
+      headers: { get: () => null },
+      text: () => Promise.resolve('{"error":{"message":"reasoning cannot be disabled"}}'),
+    };
+    const fn = vi.fn().mockResolvedValue(rejected);
+    global.fetch = fn as unknown as typeof fetch;
+
+    const err = await errorFrom(
+      complete({ messages: [{ role: "user", content: "hi" }], maxTokens: 500, maxAttempts: 1 }),
+    );
+    expect(err.message).toContain("400");
+    // probe + 4 ladder rungs (minimal, low, medium, high), all rejected.
+    expect(fn).toHaveBeenCalledTimes(5);
+
+    // Nothing was remembered — the very next call re-probes from scratch
+    // rather than skipping straight to a persisted-but-never-verified value.
+    fn.mockClear();
+    await errorFrom(
+      complete({ messages: [{ role: "user", content: "again" }], maxTokens: 500, maxAttempts: 1 }),
+    );
+    expect(fn).toHaveBeenCalledTimes(5);
+    const firstRetryBody = JSON.parse((fn.mock.calls[0]![1] as RequestInit).body as string);
+    expect(firstRetryBody).toHaveProperty("reasoning", { enabled: false });
   });
 
   it("still raises the truncation diagnostic on a mandatory-reasoning model, never a silent empty draft, even when the raised budget still isn't enough", async () => {
@@ -216,12 +311,16 @@ describe("complete() reasoning switch — openrouter vs openai", () => {
     );
     expect(err.message).toContain("truncated at max_tokens=2000");
     expect(err.message).toContain("1999/2000 tokens were reasoning");
+    // A 200 that truncates is not a 400 "this effort is unsupported" signal —
+    // the ladder climb stops on the first rung tried (a genuine truncation
+    // error carries no status, so it is not retried as unsupported-effort).
+    expect(fn).toHaveBeenCalledTimes(2);
     const retryBody = JSON.parse((fn.mock.calls[1]![1] as RequestInit).body as string);
-    expect(retryBody).toHaveProperty("reasoning", { effort: "low" });
+    expect(retryBody).toHaveProperty("reasoning", { effort: "minimal" });
     expect(retryBody).toHaveProperty("max_tokens", 2000);
   });
 
-  it("persists a learned mandatory-reasoning model to disk, so the next process skips the probe round trip", async () => {
+  it("persists a learned mandatory-reasoning model AND its verified working effort to disk, so the next process skips the probe round trip", async () => {
     cfg.model = "mandatory-reasoning-model-3";
     const ok = {
       ok: true,
@@ -240,17 +339,62 @@ describe("complete() reasoning switch — openrouter vs openai", () => {
     expect(firstProcessFetch).toHaveBeenCalledTimes(2);
 
     // Simulate a fresh process: reset the module registry and re-import
-    // client.ts so its module-level Set is rebuilt from scratch, reading
+    // client.ts so its module-level Map is rebuilt from scratch, reading
     // only what was persisted to disk by the call above.
     vi.resetModules();
     const { complete: completeInFreshProcess } = await import("../src/client.ts");
     const secondProcessFetch = vi.fn().mockResolvedValue(ok);
     global.fetch = secondProcessFetch as unknown as typeof fetch;
     await completeInFreshProcess({ messages: [{ role: "user", content: "hi" }], maxTokens: 500 });
-    // No probe 400 this time — the fresh process already knew from disk.
+    // No probe 400 this time — the fresh process already knew from disk,
+    // including which effort actually worked ("minimal" — the first rung).
     expect(secondProcessFetch).toHaveBeenCalledTimes(1);
     const body = JSON.parse((secondProcessFetch.mock.calls[0]![1] as RequestInit).body as string);
-    expect(body).toHaveProperty("reasoning", { effort: "low" });
+    expect(body).toHaveProperty("reasoning", { effort: "minimal" });
+  });
+
+  it("discards a pre-correction persisted file (bare array of model names, no verified effort) instead of trusting an unverified default", async () => {
+    // #586 round-1's rejected shape wrote `["model-a", "model-b"]` — a set
+    // with no effort recorded, implicitly paired with the single hardcoded
+    // "low" that 400s on real mandatory models. Loading that shape today
+    // must not silently coerce it into "assume low works"; it must be
+    // treated the same as never having seen the model, i.e. re-probed.
+    const { configDir } = await import("@oneshot-gtm/core");
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    const { join } = await import("node:path");
+    const dir = configDir();
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "mandatory-reasoning-models.json"),
+      JSON.stringify(["legacy-array-model"]),
+    );
+
+    vi.resetModules();
+    const { complete: completeAfterLegacyFile } = await import("../src/client.ts");
+    cfg.model = "legacy-array-model";
+    const ok = {
+      ok: true,
+      json: () =>
+        Promise.resolve({ choices: [{ message: { content: "{}" }, finish_reason: "stop" }] }),
+    };
+    const rejected = {
+      ok: false,
+      status: 400,
+      headers: { get: () => null },
+      text: () => Promise.resolve('{"error":{"message":"reasoning cannot be disabled"}}'),
+    };
+    const fn = vi.fn().mockResolvedValueOnce(rejected).mockResolvedValue(ok);
+    global.fetch = fn as unknown as typeof fetch;
+
+    await completeAfterLegacyFile({ messages: [{ role: "user", content: "hi" }], maxTokens: 500 });
+    // Re-probed from scratch (disableReasoning first, then the ladder) —
+    // NOT skipped straight to a remembered-but-never-verified "low".
+    expect(fn).toHaveBeenCalledTimes(2);
+    const bodies = fn.mock.calls.map(([, init]) =>
+      JSON.parse((init as RequestInit).body as string),
+    );
+    expect(bodies[0]).toHaveProperty("reasoning", { enabled: false });
+    expect(bodies[1]).toHaveProperty("reasoning", { effort: "minimal" });
   });
 
   it("does not swallow an unrelated 400 as a reasoning rejection", async () => {

--- a/packages/intel/__tests__/truncation.test.ts
+++ b/packages/intel/__tests__/truncation.test.ts
@@ -290,6 +290,70 @@ describe("complete() reasoning switch — openrouter vs openai", () => {
     expect(firstRetryBody).toHaveProperty("reasoning", { enabled: false });
   });
 
+  it("forgets a remembered effort that starts 400ing and re-probes, instead of wedging every future call on a now-rejected effort (finding PRRT_kwDOSKzrBs6gzFE2)", async () => {
+    // Round-1 finding: the `known` branch sent the remembered effort with no
+    // catch at all, so a stale persisted effort (model revision, provider
+    // change) 400ed forever — in this process AND every future process,
+    // since the mapping is written to disk — until someone found and deleted
+    // mandatory-reasoning-models.json by hand.
+    cfg.model = "goes-stale-model";
+    const ok = {
+      ok: true,
+      json: () =>
+        Promise.resolve({ choices: [{ message: { content: "{}" }, finish_reason: "stop" }] }),
+    };
+    const rejectedReasoning = {
+      ok: false,
+      status: 400,
+      headers: { get: () => null },
+      text: () => Promise.resolve('{"error":{"message":"reasoning cannot be disabled"}}'),
+    };
+    const fn = vi
+      .fn()
+      // probe: disableReasoning -> rejected as mandatory
+      .mockResolvedValueOnce(rejectedReasoning)
+      // ladder: minimal -> 200, remembered.
+      .mockResolvedValueOnce(ok);
+    global.fetch = fn as unknown as typeof fetch;
+
+    await complete({ messages: [{ role: "user", content: "hi" }], maxTokens: 500 });
+    expect(fn).toHaveBeenCalledTimes(2);
+    const firstBody = JSON.parse((fn.mock.calls[1]![1] as RequestInit).body as string);
+    expect(firstBody).toHaveProperty("reasoning", { effort: "minimal" });
+
+    // The remembered "minimal" effort now starts 400ing (model revision).
+    // Without the fix this single response wedges the model forever: the
+    // `known` branch has no catch, so the LlmError propagates straight to
+    // the caller and the stale entry is never cleared.
+    fn.mockReset();
+    fn
+      // remembered path retried with "minimal" -> now rejected
+      .mockResolvedValueOnce(rejectedReasoning)
+      // forgotten -> completeWithLowestSupportedEffort climbs straight into
+      // the ladder (no disableReasoning re-probe): minimal -> also rejected
+      .mockResolvedValueOnce(rejectedReasoning)
+      // low -> 200, the new remembered value
+      .mockResolvedValueOnce(ok);
+
+    await complete({ messages: [{ role: "user", content: "again" }], maxTokens: 500 });
+    expect(fn).toHaveBeenCalledTimes(3);
+    const bodies = fn.mock.calls.map(([, init]) =>
+      JSON.parse((init as RequestInit).body as string),
+    );
+    expect(bodies[0]).toHaveProperty("reasoning", { effort: "minimal" });
+    expect(bodies[1]).toHaveProperty("reasoning", { effort: "minimal" });
+    expect(bodies[2]).toHaveProperty("reasoning", { effort: "low" });
+
+    // The next call skips straight to "low" — the entry was overwritten,
+    // not just cleared, and reflects the NEW verified working effort.
+    fn.mockReset();
+    fn.mockResolvedValue(ok);
+    await complete({ messages: [{ role: "user", content: "once more" }], maxTokens: 500 });
+    expect(fn).toHaveBeenCalledTimes(1);
+    const finalBody = JSON.parse((fn.mock.calls[0]![1] as RequestInit).body as string);
+    expect(finalBody).toHaveProperty("reasoning", { effort: "low" });
+  });
+
   it("still raises the truncation diagnostic on a mandatory-reasoning model, never a silent empty draft, even when the raised budget still isn't enough", async () => {
     cfg.model = "mandatory-reasoning-model-2";
     const rejected = {

--- a/packages/intel/src/client.ts
+++ b/packages/intel/src/client.ts
@@ -337,12 +337,16 @@ export async function complete(input: LlmCompleteInput): Promise<LlmCompleteOutp
 
 /**
  * A mandatory-reasoning retry raises `max_tokens` by the reasoning
- * allowance so the caller's own budget still reaches the answer, but that
- * larger ceiling must never mask a GENUINE plain overrun on top of it — so
- * the mandatory-reasoning args below still expose the caller's original
- * budget for `truncationMessage`'s "raise maxTokens" arithmetic. Kept as a
- * distinct helper (not folded into `dispatch`) so it stays unit-testable
- * against a fake `openaiCompatibleComplete` without a real HTTP layer.
+ * allowance so the caller's own budget still reaches the answer after the
+ * model spends part of the larger ceiling on reasoning it cannot switch
+ * off. The caller's original budget is NOT preserved anywhere — the raised
+ * ceiling (`callerMaxTokens + MANDATORY_REASONING_TOKEN_ALLOWANCE`) fully
+ * replaces `input.maxTokens`, so `truncationMessage`'s "raise maxTokens"
+ * diagnostic reports the raised ceiling itself (e.g. 2000 for a 500-token
+ * caller — see `truncation.test.ts`), not the caller's original request.
+ * Kept as a distinct helper (not folded into `dispatch`) so it stays
+ * unit-testable against a fake `openaiCompatibleComplete` without a real
+ * HTTP layer.
  */
 function mandatoryReasoningArgs(args: OpenAIArgs, effort: string): OpenAIArgs {
   const callerMaxTokens = args.input.maxTokens ?? 1024;
@@ -439,7 +443,22 @@ function dispatch(
       // actually worked, so later process starts skip the whole climb too.
       const known = mandatoryReasoningModels.get(model);
       if (known !== undefined) {
-        return openaiCompatibleComplete(mandatoryReasoningArgs(args, known));
+        return openaiCompatibleComplete(mandatoryReasoningArgs(args, known)).catch(
+          (err: unknown) => {
+            // The remembered effort itself can go stale (model revision,
+            // provider change) and start 400ing — see #586 round-1 finding
+            // PRRT_kwDOSKzrBs6gzFE2. Without this branch a stale entry wedges
+            // every future call, in this process and every later one, until
+            // someone finds and deletes mandatory-reasoning-models.json by
+            // hand. Forget it and re-probe the ladder exactly as a model seen
+            // for the first time would.
+            if (isMandatoryReasoningRejection(err)) {
+              forgetMandatoryReasoningModel(model);
+              return completeWithLowestSupportedEffort(args, model);
+            }
+            throw err;
+          },
+        );
       }
       return openaiCompatibleComplete({ ...args, disableReasoning: true }).catch((err: unknown) => {
         if (isMandatoryReasoningRejection(err)) {
@@ -476,6 +495,17 @@ const mandatoryReasoningModels = new Map<string, string>(loadMandatoryReasoningM
 function rememberMandatoryReasoningModel(model: string, effort: string): void {
   if (mandatoryReasoningModels.get(model) === effort) return;
   mandatoryReasoningModels.set(model, effort);
+  saveMandatoryReasoningModels(mandatoryReasoningModels);
+}
+
+/**
+ * Discards a remembered model → effort mapping that has started 400ing —
+ * see the `known` branch of the openrouter dispatch (#586 round-1 finding
+ * PRRT_kwDOSKzrBs6gzFE2). A no-op if the model was never remembered, so
+ * callers don't need to check `has()` first.
+ */
+function forgetMandatoryReasoningModel(model: string): void {
+  if (!mandatoryReasoningModels.delete(model)) return;
   saveMandatoryReasoningModels(mandatoryReasoningModels);
 }
 

--- a/packages/intel/src/client.ts
+++ b/packages/intel/src/client.ts
@@ -1,4 +1,6 @@
-import { llmApiKey, loadConfig, logEvent, type OneShotConfig } from "@oneshot-gtm/core";
+import { llmApiKey, loadConfig, logEvent, type OneShotConfig, configDir } from "@oneshot-gtm/core";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
 import { loadPrompt } from "./prompts.ts";
 
 export interface LlmMessage {
@@ -167,6 +169,38 @@ function truncationMessage(d: {
   return `truncated at max_tokens=${d.maxTokens} (raise maxTokens) — ${where}.`;
 }
 
+/**
+ * OpenRouter's per-model reasoning metadata (`GET /api/v1/models` →
+ * `reasoning.supported_efforts`) differs by mandatory-reasoning model:
+ * `google/gemini-3.8-flash` only accepts `"low" | "medium" | "high"` — no
+ * `"minimal"`, and sending it 400s — while `google/gemini-3.5-flash` and
+ * others do support `"minimal"`. `"low"` is the lowest tier every mandatory
+ * model this repo has seen accepts, so it is the uniform choice for the
+ * retry rather than risking a THIRD failure mode (an unsupported-effort
+ * 400) stacked on top of the `enabled:false` rejection this dispatch
+ * already handles.
+ */
+const MANDATORY_REASONING_EFFORT = "low";
+
+/**
+ * Extra `max_tokens` layered on top of the caller's own budget for a
+ * reasoning-mandatory retry, so a small JSON budget (every drafting prompt
+ * in packages/plays asks for 200-2000 tokens) still has room to answer once
+ * the model spends part of the ceiling on reasoning it cannot switch off.
+ * Sized from the one live data point issue #586 reports: openrouter
+ * google/gemini-3.8-flash at max_tokens=500, DEFAULT effort (medium — the
+ * only effort measured live) spent 481/496 tokens on reasoning. No
+ * OPENROUTER_API_KEY was available in the environment this fix was written
+ * in to measure a live call at the lower "low" effort the retry now
+ * requests, so this allowance is sized well above that one medium-effort
+ * data point rather than assumed to shrink proportionally — OpenRouter's own
+ * docs say Gemini 3 reasoning-token consumption under a thinkingLevel dial
+ * is "determined internally by Google", i.e. opaque, not a fixed ratio of
+ * max_tokens. A model whose consumption is opaque needs headroom, not a
+ * tight guess; re-measure and tighten this once a live key is available.
+ */
+const MANDATORY_REASONING_TOKEN_ALLOWANCE = 1500;
+
 let humanizerPrologueCache: string | null = null;
 function humanizerPrologue(): string {
   if (humanizerPrologueCache !== null) return humanizerPrologueCache;
@@ -298,6 +332,24 @@ export async function complete(input: LlmCompleteInput): Promise<LlmCompleteOutp
   return result;
 }
 
+/**
+ * A mandatory-reasoning retry raises `max_tokens` by the reasoning
+ * allowance so the caller's own budget still reaches the answer, but that
+ * larger ceiling must never mask a GENUINE plain overrun on top of it — so
+ * the mandatory-reasoning args below still expose the caller's original
+ * budget for `truncationMessage`'s "raise maxTokens" arithmetic. Kept as a
+ * distinct helper (not folded into `dispatch`) so it stays unit-testable
+ * against a fake `openaiCompatibleComplete` without a real HTTP layer.
+ */
+function mandatoryReasoningArgs(args: OpenAIArgs): OpenAIArgs {
+  const callerMaxTokens = args.input.maxTokens ?? 1024;
+  return {
+    ...args,
+    reasoningEffort: MANDATORY_REASONING_EFFORT,
+    input: { ...args.input, maxTokens: callerMaxTokens + MANDATORY_REASONING_TOKEN_ALLOWANCE },
+  };
+}
+
 function dispatch(
   provider: OneShotConfig["llmProvider"],
   model: string,
@@ -329,14 +381,23 @@ function dispatch(
       // to each provider's own switch, so this is one line for all of them —
       // except the ~100 models OpenRouter marks `reasoning.mandatory`
       // (gpt-5, the newer Gemini flashes, Fable 5.1), which answer the
-      // switch with a 400. Those get one retry without it and are
-      // remembered for the rest of the process, so the founder's model choice
-      // never has to know which kind it is.
-      if (mandatoryReasoningModels.has(model)) return openaiCompatibleComplete(args);
+      // switch with a 400. For THOSE, `enabled: false` never has a code
+      // path that succeeds, so retrying it is pointless: the retry instead
+      // asks for the lowest supported effort (never zero — that is exactly
+      // what "mandatory" forecloses) and raises max_tokens by a reasoning
+      // allowance on top of the caller's own budget (see
+      // MANDATORY_REASONING_TOKEN_ALLOWANCE), so the caller's requested
+      // answer size still fits after the model spends part of the larger
+      // ceiling on reasoning it cannot switch off. Learned once per model
+      // per process (the 400 costs nothing useful — a 4xx isn't billed) and
+      // persisted to disk so later process starts skip the round trip too.
+      if (mandatoryReasoningModels.has(model)) {
+        return openaiCompatibleComplete(mandatoryReasoningArgs(args));
+      }
       return openaiCompatibleComplete({ ...args, disableReasoning: true }).catch((err: unknown) => {
         if (isMandatoryReasoningRejection(err)) {
-          mandatoryReasoningModels.add(model);
-          return openaiCompatibleComplete(args);
+          rememberMandatoryReasoningModel(model);
+          return openaiCompatibleComplete(mandatoryReasoningArgs(args));
         }
         throw err;
       });
@@ -355,12 +416,58 @@ function dispatch(
   }
 }
 
-/** OpenRouter models that rejected `reasoning: { enabled: false }` — see the openrouter dispatch. */
-const mandatoryReasoningModels = new Set<string>();
+/**
+ * OpenRouter models that rejected `reasoning: { enabled: false }` — see the
+ * openrouter dispatch. Seeded from disk on first use (`loadMandatoryReasoningModels`)
+ * so a fresh process doesn't have to pay for the 400 again for a model a
+ * PRIOR process already learned about; every addition is persisted back so
+ * the set survives restarts, not just the current process's lifetime.
+ */
+const mandatoryReasoningModels = new Set<string>(loadMandatoryReasoningModels());
+
+function rememberMandatoryReasoningModel(model: string): void {
+  if (mandatoryReasoningModels.has(model)) return;
+  mandatoryReasoningModels.add(model);
+  saveMandatoryReasoningModels(mandatoryReasoningModels);
+}
 
 /** A 400 whose body talks about reasoning: the model cannot have it switched off. */
 function isMandatoryReasoningRejection(err: unknown): boolean {
   return err instanceof LlmError && err.status === 400 && /reasoning/i.test(err.message);
+}
+
+function mandatoryReasoningModelsPath(): string {
+  return join(configDir(), "mandatory-reasoning-models.json");
+}
+
+/**
+ * Best-effort disk read for the persisted set — any failure (missing file,
+ * corrupt JSON, a non-array shape) falls back to empty, exactly as if this
+ * were the first time the process had ever seen a mandatory-reasoning
+ * model. A read failure here must never crash `complete()` — the first
+ * call just re-learns via the normal 400-and-remember path.
+ */
+function loadMandatoryReasoningModels(): string[] {
+  try {
+    const path = mandatoryReasoningModelsPath();
+    if (!existsSync(path)) return [];
+    const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((v): v is string => typeof v === "string");
+  } catch {
+    return [];
+  }
+}
+
+/** Best-effort disk write. Failure (read-only fs, etc.) never blocks the in-memory learning. */
+function saveMandatoryReasoningModels(models: Set<string>): void {
+  try {
+    const dir = configDir();
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    writeFileSync(mandatoryReasoningModelsPath(), JSON.stringify([...models].toSorted(), null, 2));
+  } catch {
+    // best-effort persistence — the in-memory Set still works for this process.
+  }
 }
 
 /**
@@ -450,6 +557,12 @@ interface OpenAIArgs {
   extraHeaders?: Record<string, string>;
   /** Send OpenRouter's `reasoning: { enabled: false }` — see the openrouter dispatch. */
   disableReasoning?: boolean;
+  /**
+   * Send OpenRouter's `reasoning: { effort: ... }` — the reasoning-mandatory
+   * retry path, mutually exclusive with `disableReasoning` (a model that
+   * rejected `enabled: false` gets an effort dial instead, never both).
+   */
+  reasoningEffort?: string;
 }
 
 async function openaiCompatibleComplete(args: OpenAIArgs): Promise<LlmCompleteOutput> {
@@ -462,7 +575,11 @@ async function openaiCompatibleComplete(args: OpenAIArgs): Promise<LlmCompleteOu
       temperature: args.input.temperature ?? 0.7,
       max_tokens: args.input.maxTokens ?? 1024,
       // OpenRouter only — the OpenAI API rejects unknown parameters.
-      ...(args.disableReasoning ? { reasoning: { enabled: false } } : {}),
+      ...(args.disableReasoning
+        ? { reasoning: { enabled: false } }
+        : args.reasoningEffort
+          ? { reasoning: { effort: args.reasoningEffort } }
+          : {}),
     },
     provider: args.provider,
     timeoutMs: args.timeoutMs,

--- a/packages/intel/src/client.ts
+++ b/packages/intel/src/client.ts
@@ -379,11 +379,16 @@ async function completeWithLowestSupportedEffort(
       return result;
     } catch (err) {
       lastErr = err;
-      // Anything other than a 400 (a 429, a 5xx, a timeout) is not "this
-      // effort is unsupported" — it is weather the outer retry loop in
-      // complete() already knows how to classify. Only a 400 means "try the
-      // next rung up".
-      if (!(err instanceof LlmError) || err.status !== 400) throw err;
+      // Anything other than a reasoning-specific 400 (a 429, a 5xx, a
+      // timeout, or a 400 caused by something else entirely — e.g. the
+      // raised max_tokens allowance itself tripping the model's own hard
+      // token ceiling) is not "this effort is unsupported" — it is either
+      // weather the outer retry loop in complete() already knows how to
+      // classify, or a real error this ladder must surface immediately
+      // instead of burning every remaining rung on a guaranteed-failing
+      // request. Reuse the same reasoning-body check the outer dispatch used
+      // to enter the ladder in the first place.
+      if (!isMandatoryReasoningRejection(err)) throw err;
     }
   }
   throw lastErr;

--- a/packages/intel/src/client.ts
+++ b/packages/intel/src/client.ts
@@ -171,16 +171,19 @@ function truncationMessage(d: {
 
 /**
  * OpenRouter's per-model reasoning metadata (`GET /api/v1/models` →
- * `reasoning.supported_efforts`) differs by mandatory-reasoning model:
- * `google/gemini-3.8-flash` only accepts `"low" | "medium" | "high"` — no
- * `"minimal"`, and sending it 400s — while `google/gemini-3.5-flash` and
- * others do support `"minimal"`. `"low"` is the lowest tier every mandatory
- * model this repo has seen accepts, so it is the uniform choice for the
- * retry rather than risking a THIRD failure mode (an unsupported-effort
- * 400) stacked on top of the `enabled:false` rejection this dispatch
- * already handles.
+ * `reasoning.supported_efforts`) differs by mandatory-reasoning model, and no
+ * single tier is safe to hardcode: `google/gemini-3.8-flash` accepts
+ * `"low" | "medium" | "high"` but 400s on `"minimal"`, while
+ * `openai/o4-mini-high` and `openai/o3-mini-high` accept ONLY `"high"` —
+ * `"low"` itself 400s on those. A fixed `"low"` therefore either fails
+ * outright (o4-mini-high) or overpays (any model that does support
+ * `"minimal"`). Instead the retry climbs this ladder lowest-to-highest,
+ * stopping at the first effort the model accepts — see
+ * `completeWithLowestSupportedEffort`, which is what actually "reads" the
+ * supported set, by trial against the live 400s rather than a second network
+ * round trip to the models endpoint.
  */
-const MANDATORY_REASONING_EFFORT = "low";
+const REASONING_EFFORT_LADDER = ["minimal", "low", "medium", "high"] as const;
 
 /**
  * Extra `max_tokens` layered on top of the caller's own budget for a
@@ -341,13 +344,49 @@ export async function complete(input: LlmCompleteInput): Promise<LlmCompleteOutp
  * distinct helper (not folded into `dispatch`) so it stays unit-testable
  * against a fake `openaiCompatibleComplete` without a real HTTP layer.
  */
-function mandatoryReasoningArgs(args: OpenAIArgs): OpenAIArgs {
+function mandatoryReasoningArgs(args: OpenAIArgs, effort: string): OpenAIArgs {
   const callerMaxTokens = args.input.maxTokens ?? 1024;
   return {
     ...args,
-    reasoningEffort: MANDATORY_REASONING_EFFORT,
+    reasoningEffort: effort,
     input: { ...args.input, maxTokens: callerMaxTokens + MANDATORY_REASONING_TOKEN_ALLOWANCE },
   };
+}
+
+/**
+ * Climbs `REASONING_EFFORT_LADDER` from the lowest tier up, stopping at the
+ * first effort OpenRouter actually accepts for this model. Each rung is one
+ * real request — a rejected 400 isn't billed, so this costs nothing beyond
+ * latency — and it is what "reads" the model's supported-effort set by
+ * trial rather than a second authenticated call to `/api/v1/models` (which
+ * would need its own caching and staleness story for a single lookup).
+ *
+ * `rememberMandatoryReasoningModel` is only called on an actual success —
+ * never before the retry's outcome is known — so a model that rejects every
+ * rung is never marked mandatory-with-a-working-effort; the caller sees the
+ * real terminal error, and the NEXT call re-probes instead of replaying a
+ * value nothing ever verified.
+ */
+async function completeWithLowestSupportedEffort(
+  args: OpenAIArgs,
+  model: string,
+): Promise<LlmCompleteOutput> {
+  let lastErr: unknown;
+  for (const effort of REASONING_EFFORT_LADDER) {
+    try {
+      const result = await openaiCompatibleComplete(mandatoryReasoningArgs(args, effort));
+      rememberMandatoryReasoningModel(model, effort);
+      return result;
+    } catch (err) {
+      lastErr = err;
+      // Anything other than a 400 (a 429, a 5xx, a timeout) is not "this
+      // effort is unsupported" — it is weather the outer retry loop in
+      // complete() already knows how to classify. Only a 400 means "try the
+      // next rung up".
+      if (!(err instanceof LlmError) || err.status !== 400) throw err;
+    }
+  }
+  throw lastErr;
 }
 
 function dispatch(
@@ -383,21 +422,23 @@ function dispatch(
       // (gpt-5, the newer Gemini flashes, Fable 5.1), which answer the
       // switch with a 400. For THOSE, `enabled: false` never has a code
       // path that succeeds, so retrying it is pointless: the retry instead
-      // asks for the lowest supported effort (never zero — that is exactly
-      // what "mandatory" forecloses) and raises max_tokens by a reasoning
+      // climbs REASONING_EFFORT_LADDER to find the lowest effort THIS model
+      // actually accepts (never assumed — different mandatory models accept
+      // different minimum tiers) and raises max_tokens by a reasoning
       // allowance on top of the caller's own budget (see
       // MANDATORY_REASONING_TOKEN_ALLOWANCE), so the caller's requested
       // answer size still fits after the model spends part of the larger
       // ceiling on reasoning it cannot switch off. Learned once per model
-      // per process (the 400 costs nothing useful — a 4xx isn't billed) and
-      // persisted to disk so later process starts skip the round trip too.
-      if (mandatoryReasoningModels.has(model)) {
-        return openaiCompatibleComplete(mandatoryReasoningArgs(args));
+      // per process (each rejected rung costs nothing useful — a 4xx isn't
+      // billed) and persisted to disk, together with the effort that
+      // actually worked, so later process starts skip the whole climb too.
+      const known = mandatoryReasoningModels.get(model);
+      if (known !== undefined) {
+        return openaiCompatibleComplete(mandatoryReasoningArgs(args, known));
       }
       return openaiCompatibleComplete({ ...args, disableReasoning: true }).catch((err: unknown) => {
         if (isMandatoryReasoningRejection(err)) {
-          rememberMandatoryReasoningModel(model);
-          return openaiCompatibleComplete(mandatoryReasoningArgs(args));
+          return completeWithLowestSupportedEffort(args, model);
         }
         throw err;
       });
@@ -417,17 +458,19 @@ function dispatch(
 }
 
 /**
- * OpenRouter models that rejected `reasoning: { enabled: false }` — see the
- * openrouter dispatch. Seeded from disk on first use (`loadMandatoryReasoningModels`)
- * so a fresh process doesn't have to pay for the 400 again for a model a
- * PRIOR process already learned about; every addition is persisted back so
- * the set survives restarts, not just the current process's lifetime.
+ * OpenRouter models known to reject `reasoning: { enabled: false }`, mapped
+ * to the lowest effort tier that DID succeed for that model — see the
+ * openrouter dispatch and `completeWithLowestSupportedEffort`. Seeded from
+ * disk on first use (`loadMandatoryReasoningModels`) so a fresh process
+ * doesn't have to pay for the climb again for a model a PRIOR process
+ * already learned about; every addition is persisted back so the mapping
+ * survives restarts, not just the current process's lifetime.
  */
-const mandatoryReasoningModels = new Set<string>(loadMandatoryReasoningModels());
+const mandatoryReasoningModels = new Map<string, string>(loadMandatoryReasoningModels());
 
-function rememberMandatoryReasoningModel(model: string): void {
-  if (mandatoryReasoningModels.has(model)) return;
-  mandatoryReasoningModels.add(model);
+function rememberMandatoryReasoningModel(model: string, effort: string): void {
+  if (mandatoryReasoningModels.get(model) === effort) return;
+  mandatoryReasoningModels.set(model, effort);
   saveMandatoryReasoningModels(mandatoryReasoningModels);
 }
 
@@ -441,32 +484,48 @@ function mandatoryReasoningModelsPath(): string {
 }
 
 /**
- * Best-effort disk read for the persisted set — any failure (missing file,
- * corrupt JSON, a non-array shape) falls back to empty, exactly as if this
- * were the first time the process had ever seen a mandatory-reasoning
- * model. A read failure here must never crash `complete()` — the first
- * call just re-learns via the normal 400-and-remember path.
+ * Best-effort disk read for the persisted model → working-effort mapping —
+ * any failure (missing file, corrupt JSON, a non-object shape) falls back to
+ * empty, exactly as if this were the first time the process had ever seen a
+ * mandatory-reasoning model. A read failure here must never crash
+ * `complete()` — the first call just re-learns via the normal climb-and-
+ * remember path.
+ *
+ * The pre-correction shape (#586 round 1) persisted a bare array of model
+ * names with NO effort recorded, implicitly paired with a single hardcoded
+ * `"low"` that 400s on real mandatory models such as `openai/o4-mini-high`.
+ * That shape carries no verified effort, so it is discarded here rather than
+ * migrated — a model in an old-shape file just re-probes once, the same as
+ * a model never seen before.
  */
-function loadMandatoryReasoningModels(): string[] {
+function loadMandatoryReasoningModels(): Array<[string, string]> {
   try {
     const path = mandatoryReasoningModelsPath();
     if (!existsSync(path)) return [];
     const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
-    if (!Array.isArray(parsed)) return [];
-    return parsed.filter((v): v is string => typeof v === "string");
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return [];
+    return Object.entries(parsed as Record<string, unknown>).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    );
   } catch {
     return [];
   }
 }
 
 /** Best-effort disk write. Failure (read-only fs, etc.) never blocks the in-memory learning. */
-function saveMandatoryReasoningModels(models: Set<string>): void {
+function saveMandatoryReasoningModels(models: Map<string, string>): void {
   try {
     const dir = configDir();
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-    writeFileSync(mandatoryReasoningModelsPath(), JSON.stringify([...models].toSorted(), null, 2));
+    const obj: Record<string, string> = {};
+    for (const [model, effort] of [...models.entries()].toSorted(([a], [b]) =>
+      a.localeCompare(b),
+    )) {
+      obj[model] = effort;
+    }
+    writeFileSync(mandatoryReasoningModelsPath(), JSON.stringify(obj, null, 2));
   } catch {
-    // best-effort persistence — the in-memory Set still works for this process.
+    // best-effort persistence — the in-memory Map still works for this process.
   }
 }
 


### PR DESCRIPTION
Closes #586.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 2074fcf517dd (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (2 errs) vs base ok (2 errs)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility with models that require reasoning by automatically finding a supported reasoning level.
  - Retries now preserve the requested response budget while allowing additional tokens for reasoning.
  - Successful reasoning settings are remembered to make future requests faster and more reliable.
  - Unrelated request errors are surfaced normally instead of triggering unnecessary retries.

- **Tests**
  - Expanded coverage for reasoning fallback, persistence, cross-process behavior, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->