### PR TITLE
feat(cadences): issue #599: a cadence view carries the intro's queue payload

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 67 CLI commands, 23 plays, 15 finders, ten dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-09** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3710 tests / 281 files** · typecheck + oxlint + oxfmt pass (38 lint warnings, 0 errors).
+Last verified **2026-09-09** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3714 tests / 282 files** · typecheck + oxlint + oxfmt pass (38 lint warnings, 0 errors).
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/apps/server/__tests__/cadences-since-run.test.ts
+++ b/apps/server/__tests__/cadences-since-run.test.ts
@@ -8,6 +8,11 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const getRunMock = vi.fn();
 const listActiveCadencesMock = vi.fn();
 const listAllCadencesMock = vi.fn();
+const latestSentQueuePayloadsMock = vi.fn<
+  (
+    pairs: ReadonlyArray<{ playName: string; email: string | null }>,
+  ) => Map<string, Record<string, unknown>>
+>(() => new Map());
 
 vi.mock("@oneshot-gtm/core", async () => {
   const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
@@ -21,6 +26,7 @@ vi.mock("@oneshot-gtm/core", async () => {
       listAllCadences: listAllCadencesMock,
       // Stubs for unrelated viewsForRows internals.
       listSequenceEventsForCadences: () => new Map(),
+      latestSentQueuePayloads: latestSentQueuePayloadsMock,
     }),
   };
 });
@@ -82,6 +88,7 @@ describe("listCadences — ?sinceRun filter", () => {
     getRunMock.mockReset();
     listActiveCadencesMock.mockReset();
     listAllCadencesMock.mockReset();
+    latestSentQueuePayloadsMock.mockClear();
   });
 
   it("no sinceRun → returns the unfiltered active set", async () => {
@@ -90,6 +97,34 @@ describe("listCadences — ?sinceRun filter", () => {
     const body = (await res.json()) as { cadences: Array<{ prospectEmail: string }> };
     expect(body.cadences.map((c) => c.prospectEmail).toSorted()).toEqual(["a@x.dev", "b@x.dev"]);
     expect(getRunMock).not.toHaveBeenCalled();
+  });
+
+  it("each view carries the sent queue payload for its play + email, or null (#599)", async () => {
+    const rows = [makeRow("Sarah@AcmeAI.com"), makeRow("b@x.dev")];
+    listAllCadencesMock.mockReturnValue(rows);
+    latestSentQueuePayloadsMock.mockReturnValueOnce(
+      new Map([
+        [
+          `${rows[0]!.play_name}|sarah@acmeai.com`,
+          { fitReason: "Runs GTM at Acme.", cohort: "yc-s26" },
+        ],
+      ]),
+    );
+    const res = listCadences(req("/api/cadences"));
+    const body = (await res.json()) as {
+      cadences: Array<{ prospectEmail: string; queuePayload: unknown }>;
+    };
+    const byEmail = new Map(body.cadences.map((c) => [c.prospectEmail, c.queuePayload]));
+    expect(byEmail.get("Sarah@AcmeAI.com")).toEqual({
+      fitReason: "Runs GTM at Acme.",
+      cohort: "yc-s26",
+    });
+    expect(byEmail.get("b@x.dev")).toBeNull();
+    // Asked once, for the whole page — not once per row.
+    expect(latestSentQueuePayloadsMock).toHaveBeenCalledTimes(1);
+    expect(latestSentQueuePayloadsMock.mock.calls[0]![0]).toEqual(
+      rows.map((r) => ({ playName: r.play_name, email: r.prospect_email })),
+    );
   });
 
   it("sinceRun=N → filters to prospect_emails on the run row", async () => {

--- a/apps/server/src/api/cadences.ts
+++ b/apps/server/src/api/cadences.ts
@@ -34,6 +34,7 @@ const MAX_SEND_AGE_MS = 5 * 60 * 1000;
 function toView(
   row: ReturnType<ReturnType<typeof getLedger>["listAllCadences"]>[number],
   priorByKey: Map<string, PriorStepRow[]>,
+  payloadByKey: Map<string, Record<string, unknown>>,
 ): CadenceView {
   let nextStepDraft: CadenceNextStepDraft | null = null;
   if (row.next_step_draft_json) {
@@ -106,7 +107,13 @@ function toView(
     isSending: row.sending_started_at != null,
     lastSendError: row.last_send_error,
     lastSendErrorAt: row.last_send_error_at,
+    queuePayload: payloadByKey.get(payloadKey(row.play_name, row.prospect_email)) ?? null,
   };
+}
+
+/** Same canonical key `latestSentQueuePayloads` builds: play, then the lower-cased trimmed email. */
+function payloadKey(playName: string, email: string | null): string {
+  return `${playName}|${email?.trim().toLowerCase() ?? ""}`;
 }
 
 export function viewsForRows(
@@ -115,7 +122,18 @@ export function viewsForRows(
   // Single SQL fetch for ALL (prospect_id, play_name) pairs — avoids N+1.
   const pairs = rows.map((r) => ({ prospectId: r.prospect_id, playName: r.play_name }));
   const priorByKey = getPriorStepsBulk(pairs);
-  return rows.map((r) => toView(r, priorByKey));
+  // The intro's queue payload (signal + fitReason) for the sheet's reminder —
+  // one query for the page (#599). Best-effort like the prior steps: a ledger
+  // that cannot answer leaves every row without one, never without a page.
+  let payloadByKey: Map<string, Record<string, unknown>>;
+  try {
+    payloadByKey = getLedger().latestSentQueuePayloads(
+      rows.map((r) => ({ playName: r.play_name, email: r.prospect_email })),
+    );
+  } catch {
+    payloadByKey = new Map();
+  }
+  return rows.map((r) => toView(r, priorByKey, payloadByKey));
 }
 
 export function listCadences(req: Request): Response {

--- a/packages/core/__tests__/ledger-queue-payload-bulk.test.ts
+++ b/packages/core/__tests__/ledger-queue-payload-bulk.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Ledger } from "../src/ledger.ts";
+
+// Issue #599: the /cadences page asks for every row's intro payload at once.
+// The bulk lookup must agree with the single-row one — latest SENT row per
+// (play, email), email canonicalised — and never widen to unsent rows.
+
+let ledger: Ledger;
+let dbPath: string;
+
+beforeEach(() => {
+  dbPath = join(
+    tmpdir(),
+    `oneshot-gtm-payload-bulk-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`,
+  );
+  ledger = new Ledger(dbPath);
+});
+afterEach(() => {
+  ledger.close();
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      rmSync(`${dbPath}${suffix}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+function enqueue(playName: string, payload: Record<string, unknown>, sent: boolean): number {
+  const id = ledger.enqueueTarget({
+    playName,
+    payload,
+    dedupeKey: `k-${Math.random().toString(36).slice(2)}`,
+    source: `find:${playName}`,
+  })!;
+  if (sent) {
+    ledger.setQueueStatus({ id, status: "approved" });
+    ledger.setQueueStatus({ id, status: "sent" });
+  }
+  return id;
+}
+
+describe("Ledger.latestSentQueuePayloads", () => {
+  it("returns the latest sent payload per play + email, canonicalising the email", () => {
+    enqueue("show-hn", { email: "ada@x.io", fitReason: "older" }, true);
+    enqueue("show-hn", { email: "Ada@X.io ", fitReason: "newer" }, true);
+    enqueue("luma-events", { email: "ada@x.io", fitReason: "luma one" }, true);
+    const out = ledger.latestSentQueuePayloads([
+      { playName: "show-hn", email: "  ADA@x.io" },
+      { playName: "luma-events", email: "ada@x.io" },
+    ]);
+    expect(out.get("show-hn|ada@x.io")?.["fitReason"]).toBe("newer");
+    expect(out.get("luma-events|ada@x.io")?.["fitReason"]).toBe("luma one");
+    expect(out.size).toBe(2);
+  });
+
+  it("agrees with the single-row lookup", () => {
+    enqueue("show-hn", { email: "bob@x.io", fitReason: "first" }, true);
+    enqueue("show-hn", { email: "bob@x.io", fitReason: "second" }, true);
+    const one = ledger.latestSentQueuePayload("show-hn", "bob@x.io");
+    const many = ledger.latestSentQueuePayloads([{ playName: "show-hn", email: "bob@x.io" }]);
+    expect(many.get("show-hn|bob@x.io")).toEqual(one);
+  });
+
+  it("ignores pending and approved rows, unknown pairs, and pairs without an email", () => {
+    enqueue("show-hn", { email: "cy@x.io", fitReason: "not sent" }, false);
+    enqueue("show-hn", { email: "dee@x.io", fitReason: "sent" }, true);
+    const out = ledger.latestSentQueuePayloads([
+      { playName: "show-hn", email: "cy@x.io" },
+      { playName: "show-hn", email: null },
+      { playName: "post-funding", email: "dee@x.io" },
+    ]);
+    expect(out.size).toBe(0);
+    expect(ledger.latestSentQueuePayloads([])).toEqual(new Map());
+  });
+});

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -4473,8 +4473,9 @@ export class Ledger {
    * #599): one query over the sent rows of the plays involved, newest first,
    * keeping the first row per `play|email`. Keyed exactly like the single-row
    * lookup canonicalises (lower-cased, trimmed email). Pairs with no email are
-   * skipped; an empty input touches nothing. Never throws — an unparsable
-   * payload is simply absent from the map.
+   * skipped; an empty input touches nothing. Never throws — `json_valid`
+   * keeps a malformed row out of `json_extract` (which would fail the whole
+   * query), so a bad payload is simply absent from the map.
    */
   latestSentQueuePayloads(
     pairs: ReadonlyArray<{ playName: string; email: string | null }>,
@@ -4494,7 +4495,8 @@ export class Ledger {
       .query(
         `SELECT play_name, lower(trim(json_extract(payload_json, '$.email'))) AS email, payload_json
            FROM target_queue
-          WHERE status = 'sent' AND play_name IN (${playList.map(() => "?").join(",")})
+          WHERE status = 'sent' AND json_valid(payload_json)
+            AND play_name IN (${playList.map(() => "?").join(",")})
           ORDER BY sent_at DESC, id DESC`,
       )
       .all(...playList) as Array<{ play_name: string; email: string | null; payload_json: string }>;

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -4469,6 +4469,53 @@ export class Ledger {
   }
 
   /**
+   * `latestSentQueuePayload` for a whole page of cadences at once (issue
+   * #599): one query over the sent rows of the plays involved, newest first,
+   * keeping the first row per `play|email`. Keyed exactly like the single-row
+   * lookup canonicalises (lower-cased, trimmed email). Pairs with no email are
+   * skipped; an empty input touches nothing. Never throws — an unparsable
+   * payload is simply absent from the map.
+   */
+  latestSentQueuePayloads(
+    pairs: ReadonlyArray<{ playName: string; email: string | null }>,
+  ): Map<string, Record<string, unknown>> {
+    const out = new Map<string, Record<string, unknown>>();
+    const wanted = new Set<string>();
+    const plays = new Set<string>();
+    for (const p of pairs) {
+      const email = p.email?.trim().toLowerCase();
+      if (!email) continue;
+      wanted.add(`${p.playName}|${email}`);
+      plays.add(p.playName);
+    }
+    if (wanted.size === 0) return out;
+    const playList = [...plays];
+    const rows = this.db
+      .query(
+        `SELECT play_name, lower(trim(json_extract(payload_json, '$.email'))) AS email, payload_json
+           FROM target_queue
+          WHERE status = 'sent' AND play_name IN (${playList.map(() => "?").join(",")})
+          ORDER BY sent_at DESC, id DESC`,
+      )
+      .all(...playList) as Array<{ play_name: string; email: string | null; payload_json: string }>;
+    for (const row of rows) {
+      if (!row.email) continue;
+      const key = `${row.play_name}|${row.email}`;
+      if (!wanted.has(key) || out.has(key)) continue;
+      try {
+        const parsed: unknown = JSON.parse(row.payload_json);
+        if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+          out.set(key, parsed as Record<string, unknown>);
+        }
+      } catch {
+        // an unparsable payload is no reminder; the row simply has none
+      }
+      if (out.size === wanted.size) break;
+    }
+    return out;
+  }
+
+  /**
    * Merge a few keys into a LIVE queue row's payload (issue #592) — pending or
    * approved, not sent, not mid-send. One statement, so there is no window
    * between checking eligibility and writing: a row that got sent between the

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -97,6 +97,14 @@ export interface CadenceView {
   lastSendError: string | null;
   /** ISO timestamp of `lastSendError`. */
   lastSendErrorAt: string | null;
+  /**
+   * The payload of the latest SENT queue row for this play + email — the
+   * signal the finder matched on and the `fitReason` the intro was drawn from
+   * (issue #599). The /cadences sheet shows both as the reminder of why this
+   * person is being followed up. Null when no sent row exists (a cadence
+   * enrolled by hand, an older ledger) — the UI simply omits the reminder.
+   */
+  queuePayload: unknown | null;
 }
 
 /**


### PR DESCRIPTION
Closes #599. Part 1 of the shared row/sheet work (#600, #601, #602 follow).

## Why
A cadence row had no queue payload, so the /cadences sheet could not show why this person is being followed up. The signal and the fit sentence (#592) live on the sent queue row, one join away.

## What
- `CadenceView.queuePayload: unknown | null` — payload of the latest **sent** queue row for the cadence's play + email.
- `Ledger.latestSentQueuePayloads(pairs)` — one query per page (sent rows of the plays involved, newest first, first per canonical `play|email`). The single-row lookup stays for `followUpEdgeAngle`. Deliberately not a correlated subquery in `listAllCadences`.
- `viewsForRows` builds the map beside the prior steps, best-effort like them; stubs and old fixtures yield null.

## Verification
`bun run test`: **3714 / 282 green**; typecheck, oxlint, oxfmt clean. New ledger test (latest wins, canonical email, agrees with the single-row lookup, ignores unsent/unknown/no-email) and a route test asserting the payload lands on the right view, null on the other, one call per page. STATUS.md in the same commit.

The web fixtures under `apps/web/fixtures` are gitignored (vendored by the site build), so nothing to recapture here; the web reads `queuePayload ?? null`.

https://claude.ai/code/session_011meFPo97LhmTcoNRwyPQeS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Cadence views now include context from the latest sent outreach, helping explain why a prospect is being followed up.
  - Reminder details are matched by play and email, with email formatting handled consistently.
  - Cadences without a matching sent outreach continue to display without reminder details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->