### PR TITLE
Archive prospect conversations and reopen on new replies

### DIFF
--- a/apps/server/__tests__/inbox-route.test.ts
+++ b/apps/server/__tests__/inbox-route.test.ts
@@ -25,7 +25,13 @@ const notifySlackReplyReceivedMock = vi.fn(async () => {});
 const notifySlackBounceRecordedMock = vi.fn(async () => {});
 let knownProspect: { id: number } | null = null;
 
+const archiveConversationMock = vi.fn();
+const restoreConversationMock = vi.fn();
+const inboxArchivesMock = vi.fn(() => new Map<number, string>());
 const ledger = {
+  listInboxArchives: inboxArchivesMock,
+  archiveInboxConversation: archiveConversationMock,
+  restoreInboxConversation: restoreConversationMock,
   upsertInboxDraft: upsertInboxDraftMock,
   clearInboxDraft: clearInboxDraftMock,
   recordInboxSent: recordInboxSentMock,
@@ -88,6 +94,7 @@ vi.mock("../src/api/_reply-research.ts", () => ({
 }));
 
 const {
+  archiveInboxConversationRoute,
   _resetLiveInboxCache,
   draftReplyRoute,
   listInboxRoute,
@@ -303,6 +310,7 @@ describe("inbox route — persisted drafts & sent replies", () => {
         ],
       ]),
     );
+    inboxArchivesMock.mockReturnValueOnce(new Map([[7, "2026-09-09T12:00:00Z"]]));
     listProspectIdsWithRepliesMock.mockReturnValueOnce([7]);
     getProspectByIdMock.mockReturnValueOnce({
       id: 7,
@@ -342,6 +350,7 @@ describe("inbox route — persisted drafts & sent replies", () => {
     const out = (await res.json()) as {
       conversations: Array<{
         prospectId: number;
+        archivedAt: string | null;
         draftBody: string | null;
         items: Array<{ kind: string; at: string; body: string | null }>;
       }>;
@@ -349,6 +358,7 @@ describe("inbox route — persisted drafts & sent replies", () => {
     expect(out.conversations).toHaveLength(1);
     const conv = out.conversations[0]!;
     expect(conv.prospectId).toBe(7);
+    expect(conv.archivedAt).toBe("2026-09-09T12:00:00Z");
     // Saved composer draft rides along for the newest inbound's thread.
     expect(conv.draftBody).toBe("wip");
     // Timeline order: outreach (SQLite timestamp, normalized) → their reply → our manual answer.
@@ -716,5 +726,57 @@ describe("steerRoute — persists the generated redraft (round-1 correction, #48
     expect(draftInboxReplyMock).toHaveBeenCalledWith(
       expect.objectContaining({ dossier: null, angleJson: '{"hook":"steer path angle"}' }),
     );
+  });
+});
+
+describe("inbox archive endpoint", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getProspectByIdMock.mockReturnValue({ id: 42 });
+  });
+  it("archives the displayed snapshot", async () => {
+    archiveConversationMock.mockReturnValue("archived");
+    const res = await archiveInboxConversationRoute(
+      post("/api/inbox/archive", { prospectId: 42, archived: true, observedReplyIds: ["r1"] }),
+    );
+    expect(res.status).toBe(200);
+    expect(archiveConversationMock).toHaveBeenCalledWith(42, ["r1"]);
+    expect(recordInboxSentMock).not.toHaveBeenCalled();
+  });
+  it("returns a conflict when a new reply arrived", async () => {
+    archiveConversationMock.mockReturnValue("stale");
+    const res = await archiveInboxConversationRoute(
+      post("/api/inbox/archive", { prospectId: 42, archived: true, observedReplyIds: ["r1"] }),
+    );
+    expect(res.status).toBe(409);
+  });
+  it("restores without requiring a snapshot", async () => {
+    const res = await archiveInboxConversationRoute(
+      post("/api/inbox/archive", { prospectId: 42, archived: false }),
+    );
+    expect(res.status).toBe(200);
+    expect(restoreConversationMock).toHaveBeenCalledWith(42);
+  });
+  it.each([
+    null,
+    {},
+    { prospectId: -1, archived: false },
+    { prospectId: 42, archived: true },
+    { prospectId: 42, archived: true, observedReplyIds: [3] },
+  ])("rejects malformed input %j", async (body) => {
+    expect((await archiveInboxConversationRoute(post("/api/inbox/archive", body))).status).toBe(
+      400,
+    );
+    expect(archiveConversationMock).not.toHaveBeenCalled();
+  });
+  it("rejects a missing prospect", async () => {
+    getProspectByIdMock.mockReturnValueOnce(null);
+    expect(
+      (
+        await archiveInboxConversationRoute(
+          post("/api/inbox/archive", { prospectId: 42, archived: false }),
+        )
+      ).status,
+    ).toBe(404);
   });
 });

--- a/apps/server/__tests__/inbox-route.test.ts
+++ b/apps/server/__tests__/inbox-route.test.ts
@@ -780,3 +780,36 @@ describe("inbox archive endpoint", () => {
     ).toBe(404);
   });
 });
+
+describe("archive origin validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getProspectByIdMock.mockReturnValue({ id: 42 });
+  });
+  it.each(["https://evil.example", "null", "http://localhost.evil.example", "not-a-url"])(
+    "rejects a simple POST from %s before mutation",
+    async (origin) => {
+      const req = new Request("http://localhost/api/inbox/archive", {
+        method: "POST",
+        headers: { origin, "content-type": "text/plain" },
+        body: JSON.stringify({ prospectId: 42, archived: false }),
+      });
+      expect((await archiveInboxConversationRoute(req)).status).toBe(403);
+      expect(getProspectByIdMock).not.toHaveBeenCalled();
+      expect(archiveConversationMock).not.toHaveBeenCalled();
+      expect(restoreConversationMock).not.toHaveBeenCalled();
+    },
+  );
+  it.each(["http://localhost:3032", "http://127.0.0.1:5173", "http://[::1]:3032"])(
+    "allows dashboard origin %s",
+    async (origin) => {
+      const req = new Request("http://localhost/api/inbox/archive", {
+        method: "POST",
+        headers: { origin, "content-type": "application/json" },
+        body: JSON.stringify({ prospectId: 42, archived: false }),
+      });
+      expect((await archiveInboxConversationRoute(req)).status).toBe(200);
+      expect(restoreConversationMock).toHaveBeenCalledWith(42);
+    },
+  );
+});

--- a/apps/server/src/api/inbox.ts
+++ b/apps/server/src/api/inbox.ts
@@ -33,7 +33,7 @@ import {
   inboxThreadKey,
   POSITIVE_REPLY_INTENTS,
 } from "@oneshot-gtm/shared-types";
-import { jsonResponse } from "../server.ts";
+import { isLoopbackOrigin, jsonResponse } from "../server.ts";
 import { gatherReplyContext } from "./_reply-research.ts";
 
 /**
@@ -883,6 +883,10 @@ export async function sendReplyRoute(req: Request): Promise<Response> {
 
 /** Local organization only: never mutates a provider mailbox or sends mail. */
 export async function archiveInboxConversationRoute(req: Request): Promise<Response> {
+  // CORS only prevents reading the response; simple cross-origin POSTs still execute.
+  if (!isLoopbackOrigin(req.headers.get("origin") ?? "")) {
+    return jsonResponse({ error: "forbidden origin" }, 403, req);
+  }
   let body: unknown;
   try {
     body = await req.json();

--- a/apps/server/src/api/inbox.ts
+++ b/apps/server/src/api/inbox.ts
@@ -395,6 +395,7 @@ function buildConversations(
   outcomeRecordedAtByProspect: Map<number, string>,
 ): ConversationView[] {
   const out: ConversationView[] = [];
+  const archives = ledger.listInboxArchives();
   for (const prospectId of ledger.listProspectIdsWithReplies()) {
     const prospect = ledger.getProspectById(prospectId);
     if (!prospect?.email) continue;
@@ -466,6 +467,7 @@ function buildConversations(
     const awaitingReply = positiveIntent && !repliedSince && !outcomeSince;
     out.push({
       prospectId,
+      archivedAt: archives.get(prospectId) ?? null,
       name: prospect.name,
       company: prospect.company,
       email: prospect.email,
@@ -877,4 +879,52 @@ export async function sendReplyRoute(req: Request): Promise<Response> {
     logEvent("inbox.reply.send_failed", { message_120: message.slice(0, 120) }, "warn");
     return jsonResponse({ error: message }, 400, req);
   }
+}
+
+/** Local organization only: never mutates a provider mailbox or sends mail. */
+export async function archiveInboxConversationRoute(req: Request): Promise<Response> {
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonResponse({ error: "invalid JSON body" }, 400, req);
+  }
+  if (!body || typeof body !== "object")
+    return jsonResponse({ error: "invalid archive request" }, 400, req);
+  const { prospectId, archived, observedReplyIds } = body as Record<string, unknown>;
+  if (
+    typeof prospectId !== "number" ||
+    !Number.isSafeInteger(prospectId) ||
+    prospectId <= 0 ||
+    typeof archived !== "boolean"
+  ) {
+    return jsonResponse({ error: "prospectId and archived are required" }, 400, req);
+  }
+  const ledger = getLedger();
+  if (!ledger.getProspectById(prospectId))
+    return jsonResponse({ error: "prospect not found" }, 404, req);
+  if (archived) {
+    if (
+      !Array.isArray(observedReplyIds) ||
+      !observedReplyIds.length ||
+      !observedReplyIds.every((id) => typeof id === "string" && id.length > 0)
+    ) {
+      return jsonResponse(
+        { error: "observedReplyIds must contain the displayed reply IDs" },
+        400,
+        req,
+      );
+    }
+    const result = ledger.archiveInboxConversation(prospectId, observedReplyIds);
+    if (result === "missing") return jsonResponse({ error: "conversation not found" }, 404, req);
+    if (result === "stale")
+      return jsonResponse(
+        { error: "The conversation changed. Review the new reply before archiving." },
+        409,
+        req,
+      );
+  } else {
+    ledger.restoreInboxConversation(prospectId);
+  }
+  return jsonResponse({ ok: true }, 200, req);
 }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -333,7 +333,7 @@ export async function startServer(
   return { url: `http://127.0.0.1:${server.port}`, server };
 }
 
-function isLoopbackOrigin(origin: string): boolean {
+export function isLoopbackOrigin(origin: string): boolean {
   // Empty origin = same-origin request (curl, server-side fetch); allow.
   if (origin === "") return true;
   try {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -16,6 +16,7 @@ import {
 } from "./api/cadences.ts";
 import { listReceipts, getReceipt } from "./api/receipts.ts";
 import {
+  archiveInboxConversationRoute,
   draftReplyRoute,
   listInboxRoute,
   saveDraftRoute,
@@ -111,6 +112,7 @@ const routes: RouteEntry[] = [
   route("GET", "/api/receipts", listReceipts),
   route("GET", "/api/receipts/:id", getReceipt),
   route("GET", "/api/inbox", listInboxRoute),
+  route("POST", "/api/inbox/archive", archiveInboxConversationRoute),
   route("POST", "/api/inbox/draft-reply", draftReplyRoute),
   route("POST", "/api/inbox/draft", saveDraftRoute),
   route("POST", "/api/inbox/reply", sendReplyRoute),

--- a/apps/web/__tests__/inboxArchive.test.ts
+++ b/apps/web/__tests__/inboxArchive.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "vitest";
+import { inboxConversations, inboxNeedsAttention } from "../src/lib/inboxArchive.ts";
+describe("inbox archive visibility", () => {
+  const active = { archivedAt: null, awaitingReply: true, status: null };
+  const archived = { ...active, archivedAt: "2026-09-09T12:00:00Z" };
+  it("separates inbox and archived conversations", () => {
+    expect(inboxConversations([active, archived], false)).toEqual([active]);
+    expect(inboxConversations([active, archived], true)).toEqual([archived]);
+  });
+  it("suppresses attention until a new reply clears the archive", () => {
+    expect(inboxNeedsAttention(archived)).toBe(false);
+    expect(inboxNeedsAttention({ ...archived, status: "needs_decision" })).toBe(false);
+    expect(inboxNeedsAttention({ ...archived, archivedAt: null })).toBe(true);
+  });
+});

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -1,3 +1,4 @@
+import type { InboxArchiveRequest, InboxArchiveResult } from "@oneshot-gtm/shared-types";
 import type {
   AddProspectResult,
   BusinessMailAddress,
@@ -168,6 +169,8 @@ export const api = {
     return getJson<{ receipts: ReceiptView[] }>(`/receipts${qs ? `?${qs}` : ""}`);
   },
   inbox: () => getJson<InboxResult>("/inbox"),
+  archiveInboxConversation: (req: InboxArchiveRequest) =>
+    postJson<InboxArchiveResult>("/inbox/archive", req),
   draftInboxReply: (req: InboxDraftReplyRequest) =>
     postJson<InboxDraftReplyResult>("/inbox/draft-reply", req),
   saveInboxDraft: (req: InboxSaveDraftRequest) =>

--- a/apps/web/src/lib/inboxArchive.ts
+++ b/apps/web/src/lib/inboxArchive.ts
@@ -1,0 +1,15 @@
+import type { ConversationView } from "@oneshot-gtm/shared-types";
+
+type Attention = Pick<ConversationView, "archivedAt" | "awaitingReply" | "status">;
+export function inboxNeedsAttention(conversation: Attention): boolean {
+  return (
+    !conversation.archivedAt &&
+    (conversation.awaitingReply || conversation.status === "needs_decision")
+  );
+}
+export function inboxConversations<T extends Pick<ConversationView, "archivedAt">>(
+  conversations: T[],
+  archived: boolean,
+): T[] {
+  return conversations.filter((c) => Boolean(c.archivedAt) === archived);
+}

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -140,7 +140,9 @@ function RootLayout() {
     // Round-2 correction (#480): `awaitingReply` (not a bare `intent` check)
     // — it clears once the founder replies to the thread or records a deal
     // outcome, so the dot doesn't stay lit forever after the first use.
-    "inbox-positive": (inboxAlertQuery.data?.conversations ?? []).some((c) => c.awaitingReply),
+    "inbox-positive": (inboxAlertQuery.data?.conversations ?? []).some(
+      (c) => !c.archivedAt && c.awaitingReply,
+    ),
     "meetings-pending": (meetingsAlertQuery.data?.awaitingOutcome.length ?? 0) > 0,
   };
 

--- a/apps/web/src/routes/inbox.tsx
+++ b/apps/web/src/routes/inbox.tsx
@@ -1,3 +1,4 @@
+import { inboxConversations, inboxNeedsAttention } from "../lib/inboxArchive.ts";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { createFileRoute } from "@tanstack/react-router";
 import { ChevronDown, ChevronRight, Loader2, RefreshCw, Send, Sparkles } from "lucide-react";
@@ -46,6 +47,7 @@ function statusTone(status: string | null): "receipt" | "spend" | "blocked" | "s
 }
 
 function InboxPage() {
+  const [archiveView, setArchiveView] = useState(false);
   const [expanded, setExpanded] = useState<string | null>(null);
   // Default to `matched` — most inbox mail is unmatched noise (newsletters,
   // bounces, system mail); landing on matched surfaces real prospect replies
@@ -60,6 +62,8 @@ function InboxPage() {
   const replies = inbox.data?.replies ?? [];
   // Ledger-backed threaded view — complete regardless of the live window.
   const conversations = inbox.data?.conversations ?? [];
+  const archivedCount = conversations.filter((c) => c.archivedAt).length;
+  const displayedConversations = inboxConversations(conversations, archiveView);
   const error = inbox.data?.error;
   // The server fetches a clamped window (newest 200 across all identities).
   // When listInbox says there was more, all/no-match totals get a "+" so the
@@ -72,9 +76,7 @@ function InboxPage() {
   const suffixFor = (key: ReplyMatchFilter): string => (key === "matched" ? "" : windowSuffix);
   const visible = replies.filter((r) => matchesReplyFilter(r, matchFilter));
   const showConversations = matchFilter === "matched";
-  const needsDecisionCount = conversations.filter(
-    (c) => c.status === "needs_decision" || c.awaitingReply,
-  ).length;
+  const needsDecisionCount = conversations.filter(inboxNeedsAttention).length;
 
   return (
     <div className="-mx-6 -my-6 flex flex-col">
@@ -104,7 +106,7 @@ function InboxPage() {
             {!inbox.data
               ? "…"
               : showConversations
-                ? `${conversations.length} conversation${conversations.length === 1 ? "" : "s"}`
+                ? `${displayedConversations.length} conversation${displayedConversations.length === 1 ? "" : "s"}`
                 : matchFilter === "all"
                   ? `${replies.length}${windowSuffix} repl${replies.length === 1 && !windowSuffix ? "y" : "ies"}`
                   : `${visible.length} of ${replies.length}${windowSuffix}`}
@@ -156,6 +158,30 @@ function InboxPage() {
         ))}
       </div>
 
+      {showConversations && (
+        <div className="flex gap-2 border-b border-ink-rule/60 px-6 py-3">
+          <Button
+            size="sm"
+            variant={!archiveView ? "secondary" : "ghost"}
+            onClick={() => {
+              setArchiveView(false);
+              setExpanded(null);
+            }}
+          >
+            Inbox <span className="ml-1 opacity-60">{conversations.length - archivedCount}</span>
+          </Button>
+          <Button
+            size="sm"
+            variant={archiveView ? "secondary" : "ghost"}
+            onClick={() => {
+              setArchiveView(true);
+              setExpanded(null);
+            }}
+          >
+            Archived <span className="ml-1 opacity-60">{archivedCount}</span>
+          </Button>
+        </div>
+      )}
       {error && (
         <section className="border-b border-ink-rule/60 px-6 py-3">
           <div className="font-mono text-[12px] text-[color:var(--ink-blocked-2)]">{error}</div>
@@ -165,13 +191,19 @@ function InboxPage() {
       {inbox.isLoading ? (
         Array.from({ length: 5 }, (_, i) => <SkeletonRow key={i} />)
       ) : showConversations ? (
-        conversations.length === 0 ? (
+        displayedConversations.length === 0 ? (
           <div className="p-5">
-            <EmptyNote note="No conversations yet. When a prospect writes back, the whole exchange shows here." />
+            <EmptyNote
+              note={
+                archiveView
+                  ? "No archived conversations."
+                  : "No active conversations. New replies appear here; handled conversations are in Archived."
+              }
+            />
           </div>
         ) : (
           <div>
-            {conversations.map((c, i) => (
+            {displayedConversations.map((c, i) => (
               <ConversationRow
                 key={c.prospectId}
                 conversation={c}
@@ -229,6 +261,29 @@ function ConversationRow({
   onToggle: () => void;
 }) {
   const c = conversation;
+  const queryClient = useQueryClient();
+  const archive = useMutation({
+    mutationFn: () =>
+      api.archiveInboxConversation(
+        c.archivedAt
+          ? { prospectId: c.prospectId, archived: false }
+          : {
+              prospectId: c.prospectId,
+              archived: true,
+              observedReplyIds: c.items.filter((i) => i.kind === "reply").map((i) => i.id),
+            },
+      ),
+    onSuccess: async () => {
+      toast.success(
+        c.archivedAt ? "Conversation restored" : "Archived. A new reply will bring it back.",
+      );
+      await queryClient.invalidateQueries({ queryKey: ["inbox"] });
+    },
+    onError: async (error: Error) => {
+      toast.error(error.message);
+      await queryClient.invalidateQueries({ queryKey: ["inbox"] });
+    },
+  });
   const who = c.name ?? c.email;
   const replyCount = c.items.filter((i) => i.kind === "reply").length;
   const newest = [...c.items].reverse().find((i) => i.kind === "reply");
@@ -261,46 +316,59 @@ function ConversationRow({
   const kb = intentBadge(c.intent);
   return (
     <>
-      <button
-        type="button"
-        onClick={onToggle}
-        className={cn(
-          "group flex w-full items-center gap-3 border-b border-ink-rule/60 px-6 py-3 text-left",
-          "transition-colors duration-[var(--dur-stamp)] hover:bg-ink-surface/60",
-          zebra && "bg-ink-surface/20",
-        )}
-      >
-        <span className="text-ink-faint">
-          {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-        </span>
-        <span className="min-w-0 flex-1">
-          <span className="flex items-center gap-2">
-            <span className="truncate text-[13px] text-ink-cream">
-              <Pii kind="auto">{who}</Pii>
-            </span>
-            {c.company ? (
-              <span className="truncate font-mono text-[11px] text-ink-faint">
-                · <Pii kind="company">{c.company}</Pii>
+      <div className="flex items-center border-b border-ink-rule/60 pr-6">
+        <button
+          type="button"
+          onClick={onToggle}
+          className={cn(
+            "group flex min-w-0 flex-1 items-center gap-3 px-6 py-3 text-left",
+            "transition-colors duration-[var(--dur-stamp)] hover:bg-ink-surface/60",
+            zebra && "bg-ink-surface/20",
+          )}
+        >
+          <span className="text-ink-faint">
+            {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+          </span>
+          <span className="min-w-0 flex-1">
+            <span className="flex items-center gap-2">
+              <span className="truncate text-[13px] text-ink-cream">
+                <Pii kind="auto">{who}</Pii>
               </span>
-            ) : null}
+              {c.company ? (
+                <span className="truncate font-mono text-[11px] text-ink-faint">
+                  · <Pii kind="company">{c.company}</Pii>
+                </span>
+              ) : null}
+            </span>
+            <span className="block truncate text-[12px] text-ink-muted">
+              {newest?.subject || `${c.items.length} messages`}
+            </span>
           </span>
-          <span className="block truncate text-[12px] text-ink-muted">
-            {newest?.subject || `${c.items.length} messages`}
+          <span className="shrink-0 font-mono text-[11px] text-ink-faint">
+            {replyCount} repl{replyCount === 1 ? "y" : "ies"}
           </span>
-        </span>
-        <span className="shrink-0 font-mono text-[11px] text-ink-faint">
-          {replyCount} repl{replyCount === 1 ? "y" : "ies"}
-        </span>
-        <Badge tone={statusTone(c.cadenceStatus)}>
-          {c.playName ?? "prospect"}
-          {c.cadenceStatus ? ` · ${c.cadenceStatus}` : ""}
-        </Badge>
-        {kb ? <Badge tone={kb.tone}>{kb.label}</Badge> : null}
-        {c.status === "needs_decision" && <Badge tone="blocked">needs decision</Badge>}
-        <span className="shrink-0 font-mono text-[12px] text-ink-muted">
-          {timeAgo(c.lastActivityAt)}
-        </span>
-      </button>
+          <Badge tone={statusTone(c.cadenceStatus)}>
+            {c.playName ?? "prospect"}
+            {c.cadenceStatus ? ` · ${c.cadenceStatus}` : ""}
+          </Badge>
+          {kb ? <Badge tone={kb.tone}>{kb.label}</Badge> : null}
+          {c.status === "needs_decision" && <Badge tone="blocked">needs decision</Badge>}
+          <span className="shrink-0 font-mono text-[12px] text-ink-muted">
+            {timeAgo(c.lastActivityAt)}
+          </span>
+        </button>
+        <Button
+          size="sm"
+          variant="ghost"
+          disabled={archive.isPending}
+          {...readOnly}
+          onClick={() => archive.mutate()}
+          aria-label={`${c.archivedAt ? "Restore" : "Archive"} conversation with ${who}`}
+        >
+          {archive.isPending ? <Loader2 size={12} className="animate-spin" /> : null}
+          {c.archivedAt ? "Restore" : "Archive"}
+        </Button>
+      </div>
       {expanded && (
         <div className="border-b border-ink-rule/60 bg-ink-bg-deep/50 px-6 py-3">
           <div className="flex flex-col gap-2">

--- a/packages/core/__tests__/__snapshots__/ledger.test.ts.snap
+++ b/packages/core/__tests__/__snapshots__/ledger.test.ts.snap
@@ -361,6 +361,15 @@ exports[`Ledger schema migration > fresh-install schema (tables, columns, indexe
       "type": "table",
     },
     {
+      "name": "inbox_archives",
+      "sql": "CREATE TABLE inbox_archives (
+    prospect_id INTEGER PRIMARY KEY,
+    archived_at TEXT NOT NULL
+  )",
+      "tbl_name": "inbox_archives",
+      "type": "table",
+    },
+    {
       "name": "inbox_drafts",
       "sql": "CREATE TABLE inbox_drafts (
         thread_key       TEXT PRIMARY KEY,

--- a/packages/core/__tests__/inbox-replies.test.ts
+++ b/packages/core/__tests__/inbox-replies.test.ts
@@ -291,3 +291,54 @@ describe("inbox_replies.intent (issue #480)", () => {
     expect(ledger.listUntriagedHumanReplies().map((r) => r.id)).toEqual(["msg-legacy"]);
   });
 });
+
+describe("conversation archive", () => {
+  it("persists across reopen and restores without deleting messages or drafts", () => {
+    record();
+    ledger.upsertInboxDraft({
+      threadKey: "thread-1",
+      inboundEmailId: "msg-1",
+      toEmail: "jane@prospect.example",
+      subject: "reply",
+      identityId: null,
+      body: "saved draft",
+    });
+    expect(ledger.archiveInboxConversation(1, ["msg-1"])).toBe("archived");
+    ledger.close();
+    ledger = new Ledger(dbPath);
+    expect(ledger.listInboxArchives().has(1)).toBe(true);
+    expect(ledger.getInboxThreads().get("thread-1")?.draftBody).toBe("saved draft");
+    ledger.restoreInboxConversation(1);
+    expect(ledger.listInboxArchives().has(1)).toBe(false);
+    expect(ledger.listInboxRepliesForProspect(1)).toHaveLength(1);
+  });
+  it("only reopens for a newly inserted inbound, including older timestamps on a different thread", () => {
+    record();
+    ledger.archiveInboxConversation(1, ["msg-1"]);
+    record();
+    ledger.setInboxReplyIntent("msg-1", "interested", "test");
+    ledger.recordInboxSent({
+      threadKey: "thread-1",
+      toEmail: "jane@prospect.example",
+      subject: "reply",
+      body: "sent",
+      identityId: null,
+      requestId: null,
+    });
+    expect(ledger.listInboxArchives().has(1)).toBe(true);
+    record({ id: "msg-2", threadKey: "thread-2", receivedAt: "2026-08-24T22:00:00.000Z" });
+    expect(ledger.listInboxArchives().has(1)).toBe(false);
+    expect(ledger.listInboxRepliesForProspect(1)).toHaveLength(2);
+  });
+  it("rejects an archive based on stale messages and does not affect another prospect", () => {
+    record();
+    record({ id: "other", prospectId: 2 });
+    ledger.archiveInboxConversation(2, ["other"]);
+    record({ id: "msg-2" });
+    expect(ledger.archiveInboxConversation(1, ["msg-1"])).toBe("stale");
+    expect(ledger.listInboxArchives().has(1)).toBe(false);
+    expect(ledger.listInboxArchives().has(2)).toBe(true);
+    expect(ledger.archiveInboxConversation(1, ["msg-1", "msg-2"])).toBe("archived");
+    expect(ledger.archiveInboxConversation(999, ["missing"])).toBe("missing");
+  });
+});

--- a/packages/core/src/ledger-schema.ts
+++ b/packages/core/src/ledger-schema.ts
@@ -379,6 +379,11 @@ export function migrateLedgerSchema(db: Database): void {
         updated_at TEXT NOT NULL DEFAULT (datetime('now'))
       );
     `);
+  // Local, per-prospect inbox organization; independent of drafts and provider mailboxes.
+  db.exec(`CREATE TABLE IF NOT EXISTS inbox_archives (
+    prospect_id INTEGER PRIMARY KEY,
+    archived_at TEXT NOT NULL
+  )`);
   // v21: inbound replies persisted at detection (body included) — the ledger,
   // not the mailbox, is the store; a reply must never depend on a live fetch
   // window. PK is the provider email id so the poll's overlap re-sweeps and

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -1222,6 +1222,39 @@ export class Ledger {
     return rows.map((r) => r.email);
   }
 
+  listInboxArchives(): Map<number, string> {
+    const rows = this.db
+      .query("SELECT prospect_id, archived_at FROM inbox_archives")
+      .all() as Array<{ prospect_id: number; archived_at: string }>;
+    return new Map(rows.map((r) => [r.prospect_id, r.archived_at]));
+  }
+
+  /** Compare the caller's visible replies under the same write lock as archiving. */
+  archiveInboxConversation(
+    prospectId: number,
+    observedReplyIds: string[],
+  ): "archived" | "stale" | "missing" {
+    return this.db
+      .transaction(() => {
+        const current = this.listInboxRepliesForProspect(prospectId).map((r) => r.id);
+        if (!current.length) return "missing" as const;
+        const observed = new Set(observedReplyIds);
+        if (observed.size !== current.length || current.some((id) => !observed.has(id)))
+          return "stale" as const;
+        this.db
+          .query(
+            "INSERT INTO inbox_archives(prospect_id, archived_at) VALUES (?, ?) ON CONFLICT(prospect_id) DO UPDATE SET archived_at=excluded.archived_at",
+          )
+          .run(prospectId, new Date().toISOString());
+        return "archived" as const;
+      })
+      .immediate();
+  }
+
+  restoreInboxConversation(prospectId: number): void {
+    this.db.query("DELETE FROM inbox_archives WHERE prospect_id=?").run(prospectId);
+  }
+
   /**
    * Persist one inbound reply (full body) keyed by provider email id.
    * INSERT OR IGNORE — re-sweeps and double captures are no-ops. Returns true
@@ -1241,28 +1274,33 @@ export class Ledger {
     messageId?: string | null;
     kind?: ReplyKind | null;
   }): boolean {
-    const res = this.db
-      .query(
-        `INSERT OR IGNORE INTO inbox_replies
+    return this.db
+      .transaction(() => {
+        const res = this.db
+          .query(
+            `INSERT OR IGNORE INTO inbox_replies
            (id, thread_key, prospect_id, play_name, from_email, subject, body,
             received_at, source_identity_id, thread_id, message_id, kind)
          VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-      )
-      .run(
-        row.id,
-        row.threadKey,
-        row.prospectId,
-        row.playName ?? null,
-        canonEmail(row.fromEmail),
-        row.subject ?? null,
-        row.body,
-        row.receivedAt,
-        row.sourceIdentityId ?? null,
-        row.threadId ?? null,
-        row.messageId ?? null,
-        row.kind ?? null,
-      );
-    return res.changes > 0;
+          )
+          .run(
+            row.id,
+            row.threadKey,
+            row.prospectId,
+            row.playName ?? null,
+            canonEmail(row.fromEmail),
+            row.subject ?? null,
+            row.body,
+            row.receivedAt,
+            row.sourceIdentityId ?? null,
+            row.threadId ?? null,
+            row.messageId ?? null,
+            row.kind ?? null,
+          );
+        if (res.changes > 0) this.restoreInboxConversation(row.prospectId);
+        return res.changes > 0;
+      })
+      .immediate();
   }
 
   /**

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -970,6 +970,8 @@ export type ConversationItem =
 /** The full exchange with one prospect — ledger-backed, complete forever. */
 export interface ConversationView {
   prospectId: number;
+  /** Workspace-local archive; a new inbound reply clears it. */
+  archivedAt: string | null;
   name: string | null;
   company: string | null;
   email: string;
@@ -1004,6 +1006,14 @@ export interface InboxResult {
   hasMore: boolean;
   /** Present when the inbox fetch failed; replies will be empty. */
   error?: string;
+}
+
+export type InboxArchiveRequest =
+  | { prospectId: number; archived: true; observedReplyIds: string[] }
+  | { prospectId: number; archived: false };
+
+export interface InboxArchiveResult {
+  ok: true;
 }
 
 /** POST /api/inbox/draft-reply — generate an LLM reply draft for an inbound email. */


### PR DESCRIPTION
Handled prospect conversations can now be archived from Replies → Matched and restored from an Archived view. A genuinely new inbound message automatically returns the conversation to Inbox; duplicate polling, outgoing replies, and draft edits do not reopen it. Archive state is local to the workspace and preserves history and drafts.

Archive requests check the displayed reply IDs under a transaction, preventing an unseen reply from being hidden by a stale browser. Archived conversations no longer contribute to inbox attention counts or the navigation alert.

Validation: 3,724 tests passed, typecheck and web/server builds passed, lint had no errors. Browser fixtures verified archive, restore, and resurfacing without sending mail or changing real threads. Both local workspace servers currently run the tested worktree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inbox conversation archiving and restoration.
  * Added separate active and archived inbox views with counts and tailored empty states.
  * Archived conversations no longer trigger attention indicators until a new reply arrives.
  * Added validation and clear error handling for stale, malformed, or missing conversation requests.
  * New replies automatically return archived conversations to the active inbox.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->