### PR TITLE
feat(web): issue #602: /cadences adopts the ledger row and sheet; sequence state on line 2, the intro as the reminder

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 67 CLI commands, 23 plays, 15 finders, ten dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-09** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3717 tests / 282 files** · typecheck + oxlint + oxfmt pass (38 lint warnings, 0 errors).
+Last verified **2026-09-09** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3725 tests / 283 files** · typecheck + oxlint + oxfmt pass (38 lint warnings, 0 errors).
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/apps/web/__tests__/cadenceState.test.ts
+++ b/apps/web/__tests__/cadenceState.test.ts
@@ -1,0 +1,117 @@
+import type { CadenceView } from "@oneshot-gtm/shared-types";
+import { describe, expect, it } from "vitest";
+import { cadenceStateLabel } from "../src/lib/cadenceState.ts";
+
+// Issue #602: the /cadences row's second line is the sequence state, in one
+// mono label. Every branch, against a fixed clock.
+
+const now = new Date("2026-09-10T12:00:00Z");
+const daysAgo = (d: number): string => new Date(now.getTime() - d * 86_400_000).toISOString();
+const daysAhead = (d: number): string => new Date(now.getTime() + d * 86_400_000).toISOString();
+
+function cadence(over: Partial<CadenceView> = {}): CadenceView {
+  return {
+    prospectId: 1,
+    prospectEmail: "a@x.io",
+    prospectName: "Ada",
+    prospectCompany: "Acme",
+    prospectTitle: "CTO",
+    prospectLinkedinUrl: null,
+    playName: "show-hn",
+    status: "active",
+    currentStep: 1,
+    enrolledAt: daysAgo(10),
+    nextDueAt: daysAhead(1),
+    lastPolledAt: null,
+    stopReason: null,
+    stopNote: null,
+    stoppedAt: null,
+    replyChannel: null,
+    replyAt: null,
+    nextStepDraft: null,
+    nextStepLabel: "value follow-up",
+    nextStepIsBreakup: false,
+    followupCount: 3,
+    priorSteps: [{ stepIndex: 0, label: "intro", subject: "hi", body: null, sentAt: daysAgo(3) }],
+    isSending: false,
+    lastSendError: null,
+    lastSendErrorAt: null,
+    queuePayload: null,
+    ...over,
+  };
+}
+
+describe("cadenceStateLabel", () => {
+  it("active: step, last send, next due", () => {
+    expect(cadenceStateLabel(cadence(), now)).toEqual({
+      text: "step 2 of 4 · sent 3d ago · next in 1d",
+      tone: "muted",
+    });
+  });
+
+  it("active and overdue reads in spend", () => {
+    expect(cadenceStateLabel(cadence({ nextDueAt: daysAgo(2) }), now)).toEqual({
+      text: "step 2 of 4 · sent 3d ago · overdue · due 2d ago",
+      tone: "spend",
+    });
+  });
+
+  it("active with nothing scheduled and nothing left says so; freshly enrolled shows enrolment", () => {
+    expect(
+      cadenceStateLabel(cadence({ nextDueAt: null, nextStepLabel: null, priorSteps: [] }), now)
+        .text,
+    ).toBe("step 2 of 4 · enrolled 10d ago · no steps left");
+  });
+
+  it("a send failure wins the tone", () => {
+    expect(cadenceStateLabel(cadence({ lastSendError: "boom" }), now)).toEqual({
+      text: "step 2 of 4 · sent 3d ago · next in 1d · send failed",
+      tone: "blocked",
+    });
+  });
+
+  it("sending in flight", () => {
+    expect(cadenceStateLabel(cadence({ isSending: true }), now)).toEqual({
+      text: "step 2 of 4 · sending…",
+      tone: "receipt",
+    });
+  });
+
+  it("replied, with the channel and when", () => {
+    expect(
+      cadenceStateLabel(
+        cadence({ status: "replied", replyChannel: "linkedin", replyAt: daysAgo(2) }),
+        now,
+      ),
+    ).toEqual({ text: "replied on linkedin · 2d ago", tone: "receipt" });
+    expect(cadenceStateLabel(cadence({ status: "replied" }), now).text).toBe("replied");
+  });
+
+  it("stopped, with the reason in words", () => {
+    expect(
+      cadenceStateLabel(
+        cadence({ status: "stopped", stopReason: "not_a_fit", stoppedAt: daysAgo(5) }),
+        now,
+      ),
+    ).toEqual({ text: "stopped · not a fit · 5d ago", tone: "blocked" });
+  });
+
+  it("bounced, breakup, completed, paused", () => {
+    expect(cadenceStateLabel(cadence({ status: "bounced" }), now)).toEqual({
+      text: "bounced · 3d ago",
+      tone: "blocked",
+    });
+    expect(cadenceStateLabel(cadence({ status: "breakup" }), now)).toEqual({
+      text: "breakup sent · 3d ago",
+      tone: "spend",
+    });
+    expect(cadenceStateLabel(cadence({ status: "completed", currentStep: 3 }), now)).toEqual({
+      text: "completed · 4 of 4 · 3d ago",
+      tone: "muted",
+    });
+    expect(cadenceStateLabel(cadence({ status: "paused" }), now)).toEqual({
+      text: "paused · step 2 of 4",
+      tone: "muted",
+    });
+  });
+});

--- a/apps/web/src/lib/cadenceState.ts
+++ b/apps/web/src/lib/cadenceState.ts
@@ -1,0 +1,92 @@
+/**
+ * The /cadences row's second line (issue #602): where this person is in the
+ * sequence, in one mono label — "step 2 of 4 · sent 3d ago · next in 1d",
+ * "replied on linkedin · 2d ago", "stopped · not a fit · 5d ago". Pure: the
+ * clock is injected so the cases are testable, and the label uppercases in
+ * the row, so the text here is plain case.
+ */
+import type { CadenceStopReason, CadenceView } from "@oneshot-gtm/shared-types";
+import { timeAgo } from "./cn.ts";
+
+export const STOP_REASON_LABELS: Record<CadenceStopReason, string> = {
+  bad_timing: "bad timing / revisit later",
+  other: "other",
+  not_a_fit: "not a fit",
+  do_not_contact: "do not contact",
+};
+
+export type CadenceStateTone = "muted" | "spend" | "blocked" | "receipt";
+
+export interface CadenceState {
+  text: string;
+  tone: CadenceStateTone;
+}
+
+const join = (parts: Array<string | null | undefined>): string =>
+  parts.filter((p): p is string => Boolean(p)).join(" · ");
+
+export function cadenceStateLabel(c: CadenceView, now: Date): CadenceState {
+  const nowMs = now.getTime();
+  const ago = (iso: string): string => timeAgo(iso, nowMs);
+  const total = c.followupCount + 1;
+  const step = `step ${Math.min(c.currentStep + 1, total)} of ${total}`;
+  const lastSent = c.priorSteps.at(-1)?.sentAt ?? null;
+
+  if (c.isSending) return { text: join([step, "sending…"]), tone: "receipt" };
+
+  switch (c.status) {
+    case "replied":
+      return {
+        text: join([
+          `replied${c.replyChannel ? ` on ${c.replyChannel}` : ""}`,
+          c.replyAt ? ago(c.replyAt) : null,
+        ]),
+        tone: "receipt",
+      };
+    case "stopped":
+      return {
+        text: join([
+          "stopped",
+          c.stopReason ? STOP_REASON_LABELS[c.stopReason] : "reason unavailable",
+          c.stoppedAt ? ago(c.stoppedAt) : null,
+        ]),
+        tone: "blocked",
+      };
+    case "bounced":
+    case "unsubscribed": {
+      const at = c.stoppedAt ?? lastSent;
+      return { text: join([c.status, at ? ago(at) : null]), tone: "blocked" };
+    }
+    case "breakup":
+      return { text: join(["breakup sent", lastSent ? ago(lastSent) : null]), tone: "spend" };
+    case "completed":
+      return {
+        text: join(["completed", `${total} of ${total}`, lastSent ? ago(lastSent) : null]),
+        tone: "muted",
+      };
+    case "paused":
+      return { text: join(["paused", step]), tone: "muted" };
+    case "active": {
+      const parts: string[] = [
+        step,
+        lastSent ? `sent ${ago(lastSent)}` : `enrolled ${ago(c.enrolledAt)}`,
+      ];
+      let tone: CadenceStateTone = "muted";
+      if (c.nextDueAt == null) {
+        if (c.nextStepLabel == null) parts.push("no steps left");
+      } else if (new Date(c.nextDueAt).getTime() <= nowMs) {
+        parts.push(`overdue · due ${ago(c.nextDueAt)}`);
+        tone = "spend";
+      } else {
+        parts.push(`next ${ago(c.nextDueAt)}`);
+      }
+      if (c.lastSendError) {
+        parts.push("send failed");
+        tone = "blocked";
+      }
+      return { text: parts.join(" · "), tone };
+    }
+    default:
+      return { text: c.status, tone: "muted" };
+  }
+}

--- a/apps/web/src/routes/cadences.tsx
+++ b/apps/web/src/routes/cadences.tsx
@@ -24,13 +24,20 @@ import { Badge } from "../components/primitives/Badge.tsx";
 import { Button } from "../components/primitives/Button.tsx";
 import { EmptyNote } from "../components/primitives/EmptyNote.tsx";
 import { Pii } from "../components/primitives/Pii.tsx";
-import { useMask } from "../lib/privacy.tsx";
+import { useMask, usePrivacy } from "../lib/privacy.tsx";
 import { Field, Input, Select, Textarea } from "../components/primitives/Field.tsx";
 import { Modal } from "../components/primitives/Modal.tsx";
 import { SkeletonRow } from "../components/primitives/Skeleton.tsx";
-import { StepProgress } from "../components/primitives/StepProgress.tsx";
 import { cn, formatSendsToday, timeAgo } from "../lib/cn.ts";
 import { readOnly } from "../lib/readOnly.ts";
+import { STOP_REASON_LABELS, cadenceStateLabel } from "../lib/cadenceState.ts";
+import { fitReasonFor } from "../lib/queueRationale.ts";
+import { queueEvidence } from "../lib/queueEvidence.ts";
+import { IdentityCell, SignalLabel } from "../components/ledger/IdentityCell.tsx";
+import { SheetHeading } from "../components/ledger/SheetHeading.tsx";
+import { Rule, Sheet } from "../components/ledger/Sheet.tsx";
+import { CaseList, Disclosure, type CaseListRow } from "../components/ledger/CaseList.tsx";
+import { DraftStateLine, LetterCard, LetterEmpty } from "../components/ledger/LetterCard.tsx";
 
 /** Tailwind can't build class names dynamically — enumerate the tile-count variants. */
 const TILE_GRID_COLS: Record<number, string> = {
@@ -106,13 +113,6 @@ interface LinkedInReplyModalState {
   prospectId: number;
   prospectName: string | null;
 }
-
-const STOP_REASON_LABELS: Record<CadenceStopReason, string> = {
-  bad_timing: "Bad timing / revisit later",
-  other: "Other",
-  not_a_fit: "Not a fit",
-  do_not_contact: "Do not contact",
-};
 
 const rowKey = (c: CadenceView): string => `${c.prospectId}|${c.playName}`;
 
@@ -308,7 +308,9 @@ function CadencesPage() {
   // table is filtered to active.
   const counts = cadences.data?.counts ?? EMPTY_COUNTS;
   const mask = useMask();
-  const nowIso = new Date().toISOString();
+  const { masked } = usePrivacy();
+  const now = new Date();
+  const nowIso = now.toISOString();
 
   // Bulk-action derived state.
   const selectableActive = useMemo(
@@ -598,11 +600,9 @@ function CadencesPage() {
                     className="cursor-pointer"
                   />
                 </th>
-                <th className="px-6 py-2 text-left font-medium">prospect</th>
+                <th className="py-2 pl-3 text-left font-medium">prospect</th>
                 <th className="py-2 text-left font-medium">play</th>
                 <th className="py-2 text-left font-medium">status</th>
-                <th className="py-2 text-left font-medium">step</th>
-                <th className="py-2 text-right font-medium">next due</th>
                 <th className="py-2 text-right font-medium">enrolled</th>
                 <th className="px-6 py-2 text-right font-medium">actions</th>
               </tr>
@@ -610,44 +610,261 @@ function CadencesPage() {
             <tbody>
               {list.map((c, i) => {
                 const totalSteps = c.followupCount + 1;
+                const key = rowKey(c);
                 const knownCompany =
                   c.prospectCompany && !/^\(?unknown\)?$/i.test(c.prospectCompany.trim())
                     ? c.prospectCompany
                     : null;
                 const isOverdue =
                   c.status === "active" && c.nextDueAt !== null && c.nextDueAt <= nowIso;
-                // Expandable when there's something to show OR something to do:
-                // prior sends, a persisted draft, or a remaining step to generate.
-                const hasExpandable =
-                  c.priorSteps.length > 0 ||
-                  c.status === "stopped" ||
-                  c.nextStepDraft != null ||
-                  (c.status === "active" && c.nextStepLabel != null);
+                // Line 2 is the sequence state (#602); every row opens into the
+                // sheet, which always has at least the enrolment to show.
+                const state = cadenceStateLabel(c, now);
+                const open = expandedKeys.has(key);
+                const draft = c.nextStepDraft;
+                const previewPending = pendingPreviewKey === key;
+                const sendPending = c.isSending || pendingSendKey === key;
+                const sendDisabled =
+                  !draft ||
+                  draft.flags.length > 0 ||
+                  pendingSendKey != null ||
+                  pendingPreviewKey != null ||
+                  c.isSending;
+                // Send fires immediately (no confirm modal), so the
+                // early/breakup warnings live in the button tooltip.
+                const earlyNote =
+                  c.nextDueAt != null && c.nextDueAt > nowIso
+                    ? ` · ${earlyByCopy(c.nextDueAt)} ahead of schedule — remaining steps recompute from today`
+                    : "";
+                const sendTitle = !draft
+                  ? "generate a draft first"
+                  : draft.flags.length > 0
+                    ? `draft held by lint (${draft.flags.length} flag(s)) — regenerate`
+                    : c.nextStepIsBreakup
+                      ? `send breakup (final touch) — sends now, no more emails after this${earlyNote}`
+                      : `send next step — sends now${earlyNote}`;
+                // The reminder: why this person was written to in the first
+                // place — the intro's signal and fit sentence, off the sent
+                // queue row (#599). Freeform, so it drops under privacy mode.
+                const reminderSignal =
+                  !masked && c.queuePayload ? queueEvidence(c.playName, c.queuePayload) : null;
+                const fitReason = masked ? null : fitReasonFor(c.queuePayload);
+                const caseRows: CaseListRow[] = [
+                  { key: "enrolled", value: timeAgo(c.enrolledAt) },
+                  ...(c.status === "active" && c.nextDueAt
+                    ? [
+                        {
+                          key: "next due",
+                          value: `${timeAgo(c.nextDueAt)}${isOverdue ? " · overdue" : ""}`,
+                          ...(isOverdue ? { tone: "spend" as const } : {}),
+                        },
+                      ]
+                    : []),
+                  {
+                    key: "step",
+                    value: `${Math.min(c.currentStep + 1, totalSteps)} of ${totalSteps}${
+                      c.nextStepLabel
+                        ? ` · next: ${c.nextStepLabel}${c.nextStepIsBreakup ? " (breakup)" : ""}`
+                        : ""
+                    }`,
+                  },
+                  ...(c.status === "replied"
+                    ? [
+                        {
+                          key: "replied",
+                          value: [
+                            c.replyChannel ? `on ${c.replyChannel}` : null,
+                            c.replyAt ? timeAgo(c.replyAt) : null,
+                          ]
+                            .filter(Boolean)
+                            .join(" · "),
+                        },
+                      ]
+                    : []),
+                  ...(c.status === "stopped"
+                    ? [
+                        {
+                          key: "stopped",
+                          value: `${c.stopReason ? STOP_REASON_LABELS[c.stopReason] : "reason unavailable"}${
+                            c.stoppedAt ? ` · ${timeAgo(c.stoppedAt)}` : ""
+                          }`,
+                          tone: "blocked" as const,
+                        },
+                      ]
+                    : []),
+                  ...(c.stopNote ? [{ key: "note", value: c.stopNote }] : []),
+                  ...(c.lastSendError && !c.isSending
+                    ? [
+                        {
+                          key: "send failed",
+                          value: `${c.lastSendError}${
+                            c.lastSendErrorAt ? ` · ${timeAgo(c.lastSendErrorAt)}` : ""
+                          }`,
+                          tone: "blocked" as const,
+                        },
+                      ]
+                    : []),
+                ];
+                const stopButton =
+                  c.status === "active" ? (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      title={
+                        c.isSending
+                          ? "wait for the in-flight send to finish before stopping"
+                          : "stop cadence"
+                      }
+                      disabled={stop.isPending || c.isSending}
+                      onClick={() =>
+                        setStopModal({
+                          prospectId: c.prospectId,
+                          prospectName: c.prospectName,
+                          playName: c.playName,
+                        })
+                      }
+                    >
+                      <CircleStop size={11} /> Stop
+                    </Button>
+                  ) : null;
+                const regenerateButton =
+                  c.status === "active" &&
+                  c.nextStepLabel != null &&
+                  c.nextStepChannel !== "direct_mail" ? (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      disabled={pendingPreviewKey != null}
+                      title={
+                        draft
+                          ? `regenerate next step (drafted ${timeAgo(draft.draftedAt)})`
+                          : "generate next-step draft — dry-run LLM, never sends"
+                      }
+                      onClick={() =>
+                        previewNext.mutate({ prospectId: c.prospectId, playName: c.playName })
+                      }
+                      {...readOnly}
+                    >
+                      {previewPending ? (
+                        <Loader2 size={11} className="animate-spin" />
+                      ) : (
+                        <RotateCw size={11} />
+                      )}
+                      {previewPending
+                        ? draft
+                          ? "Regenerating…"
+                          : "Generating…"
+                        : draft
+                          ? "Regenerate draft"
+                          : "Generate draft"}
+                    </Button>
+                  ) : null;
+                const sendButton =
+                  c.status === "active" &&
+                  c.nextStepLabel != null &&
+                  c.nextStepChannel !== "direct_mail" ? (
+                    <Button
+                      variant={sendDisabled ? "ghost" : "receipt"}
+                      size="sm"
+                      title={sendTitle}
+                      disabled={sendDisabled}
+                      onClick={() => {
+                        if (!draft) return;
+                        sendNext.mutate({ prospectId: c.prospectId, playName: c.playName });
+                      }}
+                      {...readOnly}
+                    >
+                      {sendPending ? (
+                        <Loader2 size={11} className="animate-spin" />
+                      ) : (
+                        <Send size={11} />
+                      )}
+                      {sendPending
+                        ? "Sending…"
+                        : c.nextStepIsBreakup
+                          ? "Send breakup"
+                          : "Send this one"}
+                    </Button>
+                  ) : null;
+                const letter =
+                  c.status === "active" && c.nextStepChannel === "direct_mail" ? (
+                    <LetterEmpty
+                      note={`Next step goes by post${c.nextStepLabel ? ` · ${c.nextStepLabel}` : ""}.`}
+                      actions={
+                        <>
+                          <Button size="sm" disabled={c.isSending} onClick={() => setMailKey(key)}>
+                            {c.businessAddress ? "Review mail" : "Add business address"}
+                          </Button>
+                          {stopButton}
+                        </>
+                      }
+                    />
+                  ) : c.status === "active" && c.nextStepLabel != null ? (
+                    draft ? (
+                      <LetterCard
+                        meta={`drafted ${timeAgo(draft.draftedAt)} · preview, not sent`}
+                        subject={draft.subject}
+                        stateLine={<DraftStateLine sent={false} flags={draft.flags} />}
+                        body={draft.body}
+                        foot={{
+                          left: regenerateButton,
+                          right: (
+                            <>
+                              {!sendDisabled && (
+                                <span className="font-mono text-[11px] text-[color:var(--ink-receipt-2)]">
+                                  ready · no flags
+                                </span>
+                              )}
+                              {sendButton}
+                              {stopButton}
+                            </>
+                          ),
+                        }}
+                        sendable={!sendDisabled}
+                      />
+                    ) : (
+                      <LetterEmpty
+                        note={`No draft yet for the ${c.nextStepLabel}. Drafting is a dry run and never sends.`}
+                        actions={
+                          <>
+                            {regenerateButton}
+                            {stopButton}
+                          </>
+                        }
+                      />
+                    )
+                  ) : (
+                    <LetterEmpty
+                      note={
+                        c.status === "replied"
+                          ? "They replied — the conversation lives on /inbox."
+                          : c.status === "active"
+                            ? "No steps left in this cadence."
+                            : "Nothing left to send."
+                      }
+                    />
+                  );
                 return (
                   <Fragment key={`${c.prospectId}-${c.playName}`}>
                     <tr
-                      onClick={
-                        hasExpandable
-                          ? (e) => {
-                              // Ignore clicks that originated on interactive
-                              // controls inside the row (buttons / inputs /
-                              // links / labels). Without this guard, clicking
-                              // Preview / Send / Stop / the checkbox would
-                              // ALSO toggle the row expansion.
-                              const t = e.target as HTMLElement;
-                              if (t.closest("button, input, a, label, [role='button']")) return;
-                              toggleExpanded(rowKey(c));
-                            }
-                          : undefined
-                      }
+                      onClick={(e) => {
+                        // Ignore clicks that originated on interactive
+                        // controls inside the row (buttons / inputs /
+                        // links / labels). Without this guard, clicking
+                        // Preview / Send / Stop / the checkbox would
+                        // ALSO toggle the row expansion.
+                        const t = e.target as HTMLElement;
+                        if (t.closest("button, input, a, label, [role='button']")) return;
+                        toggleExpanded(key);
+                      }}
                       className={cn(
-                        "border-b border-ink-rule/60 transition-colors duration-[var(--dur-stamp)]",
+                        "cursor-pointer border-b border-ink-rule/60 transition-colors duration-[var(--dur-stamp)]",
                         "hover:bg-ink-surface/60",
                         i % 2 === 1 && "bg-ink-surface/20",
-                        hasExpandable && "cursor-pointer",
+                        open && "bg-ink-surface",
                       )}
                     >
-                      <td className="px-3 py-2" style={{ width: 32 }}>
+                      <td className="px-3 py-[10px]" style={{ width: 32 }}>
                         <input
                           type="checkbox"
                           aria-label={`select ${c.prospectName ?? c.prospectEmail ?? "row"}`}
@@ -662,104 +879,40 @@ function CadencesPage() {
                           className="cursor-pointer disabled:cursor-not-allowed disabled:opacity-30"
                         />
                       </td>
-                      <td className="px-6 py-2">
-                        <div className="flex items-center gap-2 text-ink-cream">
-                          <span>
-                            {c.prospectName ? <Pii kind="name">{c.prospectName}</Pii> : "(unknown)"}
-                          </span>
-                          {c.prospectLinkedinUrl && (
-                            <a
-                              href={c.prospectLinkedinUrl}
-                              target="_blank"
-                              rel="noreferrer"
-                              className="font-mono text-[10px] text-ink-muted underline decoration-ink-rule underline-offset-2 hover:text-ink-cream-2"
-                              title="Open LinkedIn profile"
-                            >
-                              LinkedIn ↗
-                            </a>
-                          )}
-                        </div>
-                        {(c.prospectTitle || knownCompany) && (
-                          <div className="max-w-[280px] truncate text-[11px] text-ink-muted">
-                            {c.prospectTitle ?? "Role unknown"}
-                            {knownCompany && (
-                              <>
-                                {" · "}
-                                <Pii kind="company">{knownCompany}</Pii>
-                              </>
-                            )}
-                          </div>
-                        )}
-                        {!c.prospectTitle && !knownCompany && c.prospectLinkedinUrl && (
-                          <div className="text-[11px] text-ink-faint">
-                            Role/company not enriched
-                          </div>
-                        )}
-                        <div className="font-mono text-[11px] text-ink-faint">
-                          {c.prospectEmail ? <Pii kind="email">{c.prospectEmail}</Pii> : "—"}
-                        </div>
+                      <IdentityCell
+                        className="pl-3"
+                        identity={{
+                          name: c.prospectName,
+                          email: c.prospectEmail,
+                          title: c.prospectTitle,
+                          company: knownCompany,
+                          linkedinUrl: c.prospectLinkedinUrl,
+                        }}
+                        line2Privacy="show"
+                        line2={<SignalLabel tone={state.tone}>{state.text}</SignalLabel>}
+                      />
+                      <td className="whitespace-nowrap py-[10px] pr-6 text-ink-cream-2">
+                        {c.playName}
                       </td>
-                      <td className="py-2 text-ink-cream-2">{c.playName}</td>
-                      <td className="py-2">
-                        <Badge tone={statusTone(c.status)}>{c.status}</Badge>
-                        {c.isSending && (
-                          <Badge tone="receipt" className="ml-1.5 animate-pulse">
-                            sending…
-                          </Badge>
-                        )}
-                        {c.status === "replied" && c.replyChannel && (
-                          <Badge tone="signal" className="ml-1.5">
-                            {c.replyChannel === "linkedin" ? "LinkedIn reply" : "email reply"}
-                            {c.replyAt ? ` · ${timeAgo(c.replyAt)}` : ""}
-                          </Badge>
-                        )}
-                        {!c.isSending && c.status === "active" && c.lastSendError && (
-                          <span
-                            title={`${c.lastSendError}${
-                              c.lastSendErrorAt ? ` · ${timeAgo(c.lastSendErrorAt)}` : ""
-                            } — click Send to retry`}
-                          >
-                            <Badge tone="blocked" className="ml-1.5">
-                              send failed
-                            </Badge>
-                          </span>
-                        )}
+                      <td className="whitespace-nowrap py-[10px] pr-6">
+                        {/* Sending, reply and send-failed now live on line 2;
+                            the failure's message keeps its tooltip here. */}
+                        <span
+                          title={
+                            !c.isSending && c.status === "active" && c.lastSendError
+                              ? `${c.lastSendError}${
+                                  c.lastSendErrorAt ? ` · ${timeAgo(c.lastSendErrorAt)}` : ""
+                                } — click Send to retry`
+                              : undefined
+                          }
+                        >
+                          <Badge tone={statusTone(c.status)}>{c.status}</Badge>
+                        </span>
                       </td>
-                      <td className="py-2">
-                        <div className="flex items-center gap-2">
-                          <StepProgress
-                            current={Math.min(c.currentStep + 1, totalSteps)}
-                            total={totalSteps}
-                            tone={
-                              c.status === "replied"
-                                ? "signal"
-                                : c.status === "breakup"
-                                  ? "spend"
-                                  : c.status === "bounced" ||
-                                      c.status === "unsubscribed" ||
-                                      c.status === "stopped"
-                                    ? "blocked"
-                                    : "receipt"
-                            }
-                          />
-                          <span className="font-mono text-[11px] text-ink-faint">
-                            {c.currentStep + 1}/{totalSteps}
-                          </span>
-                        </div>
-                      </td>
-                      <td
-                        className={cn(
-                          "py-2 text-right font-mono text-[12px]",
-                          isOverdue ? "text-[color:var(--ink-spend-2)]" : "text-ink-muted",
-                        )}
-                      >
-                        {timeAgo(c.nextDueAt)}
-                        {isOverdue && <span className="ml-1 text-[10px]">· overdue</span>}
-                      </td>
-                      <td className="py-2 text-right font-mono text-[11px] text-ink-faint">
+                      <td className="whitespace-nowrap py-[10px] text-right font-mono text-[11px] text-ink-faint">
                         {timeAgo(c.enrolledAt)}
                       </td>
-                      <td className="px-6 py-2 text-right">
+                      <td className="whitespace-nowrap px-6 py-[10px] text-right">
                         <div className="flex items-center justify-end gap-1">
                           {(c.status === "active" || c.status === "paused") && (
                             <Button
@@ -778,7 +931,6 @@ function CadencesPage() {
                           )}
                           {c.status === "active" &&
                             (() => {
-                              const key = `${c.prospectId}|${c.playName}`;
                               if (c.nextStepChannel === "direct_mail")
                                 return (
                                   <>
@@ -816,19 +968,6 @@ function CadencesPage() {
                                     </Button>
                                   </>
                                 );
-                              const draft = c.nextStepDraft;
-                              const sendDisabled =
-                                !draft ||
-                                draft.flags.length > 0 ||
-                                pendingSendKey != null ||
-                                pendingPreviewKey != null ||
-                                c.isSending;
-                              // Send fires immediately (no confirm modal), so the
-                              // early/breakup warnings live in the button tooltip.
-                              const earlyNote =
-                                c.nextDueAt != null && c.nextDueAt > new Date().toISOString()
-                                  ? ` · ${earlyByCopy(c.nextDueAt)} ahead of schedule — remaining steps recompute from today`
-                                  : "";
                               return (
                                 <>
                                   <Button
@@ -925,7 +1064,6 @@ function CadencesPage() {
                           {c.status !== "active" &&
                             (c.priorSteps.length > 0 || c.status === "stopped") &&
                             (() => {
-                              const key = `${c.prospectId}|${c.playName}`;
                               return (
                                 <Button
                                   variant="ghost"
@@ -966,134 +1104,68 @@ function CadencesPage() {
                         </div>
                       </td>
                     </tr>
-                    {(c.priorSteps.length > 0 || c.nextStepDraft || c.status === "stopped") &&
-                      expandedKeys.has(rowKey(c)) && (
-                        <tr className="border-b border-ink-rule/60 bg-ink-surface/30">
-                          <td colSpan={8} className="px-6 py-3">
-                            {c.status === "stopped" && (
-                              <div className="mb-4 border-l-2 border-[color:var(--ink-blocked)] pl-3">
-                                <div className="ln-eyebrow">Stopped</div>
-                                <div className="mt-1 text-[12px] text-ink-cream-2">
-                                  {c.stopReason
-                                    ? STOP_REASON_LABELS[c.stopReason]
-                                    : "Reason unavailable"}
-                                  {c.stoppedAt ? ` · ${timeAgo(c.stoppedAt)}` : ""}
-                                </div>
-                                {c.stopNote && (
-                                  <div className="mt-1 whitespace-pre-wrap text-[12px] text-ink-muted">
-                                    {c.stopNote}
-                                  </div>
-                                )}
-                              </div>
+                    {open && (
+                      <Sheet
+                        colSpan={6}
+                        indent="pl-14"
+                        theCase={
+                          <>
+                            <SheetHeading label="the case" />
+                            {reminderSignal && (
+                              <SignalLabel className="-mt-1">{reminderSignal}</SignalLabel>
                             )}
+                            {fitReason && (
+                              <p className="m-0 text-[13px] leading-5 text-ink-cream-2 [text-wrap:pretty]">
+                                {fitReason}
+                              </p>
+                            )}
+                            {(reminderSignal || fitReason) && <Rule />}
+                            <CaseList rows={caseRows} />
                             {c.priorSteps.length > 0 && (
                               <>
-                                <div className="ln-eyebrow mb-1">
-                                  Sent so far ({c.priorSteps.length})
-                                </div>
-                                <div className="flex flex-col gap-3">
-                                  {c.priorSteps.map((s) => (
-                                    <div
-                                      key={s.stepIndex}
-                                      className="border-l-2 border-ink-rule pl-3"
-                                    >
-                                      <div className="font-mono text-[11px] text-ink-faint">
-                                        step {s.stepIndex} ({s.label}) · sent {timeAgo(s.sentAt)}
-                                      </div>
-                                      <div className="mt-1 font-mono text-[12px] text-ink-cream">
-                                        Subject: {s.subject}
-                                      </div>
-                                      {s.body ? (
-                                        <pre className="mt-1 whitespace-pre-wrap text-[12px] text-ink-cream-2">
-                                          {s.body}
-                                        </pre>
-                                      ) : (
-                                        <div className="mt-1 font-mono text-[11px] italic text-ink-faint">
-                                          (body not captured — sent before per-touch body
-                                          persistence landed)
+                                <Rule />
+                                <div>
+                                  <div className="mb-1 font-mono text-[10px] uppercase tracking-[0.14em] text-ink-faint">
+                                    sent so far · {c.priorSteps.length}
+                                  </div>
+                                  <ol className="flex flex-col gap-2">
+                                    {c.priorSteps.map((st) => (
+                                      <li key={st.stepIndex} className="flex flex-col gap-1">
+                                        <div className="flex items-baseline gap-3 leading-4">
+                                          <span className="w-[64px] shrink-0 text-right font-mono text-[11px] text-ink-faint">
+                                            {timeAgo(st.sentAt)}
+                                          </span>
+                                          <span className="shrink-0 whitespace-nowrap text-ink-cream-2">
+                                            step {st.stepIndex} · {st.label}
+                                          </span>
+                                          <span className="min-w-0 truncate text-ink-muted">
+                                            {st.subject}
+                                          </span>
                                         </div>
-                                      )}
-                                    </div>
-                                  ))}
+                                        <div className="pl-[76px]">
+                                          {st.body ? (
+                                            <Disclosure label="body">
+                                              <pre className="ln-prose mt-2 whitespace-pre-wrap text-[12px] text-ink-cream-2">
+                                                {st.body}
+                                              </pre>
+                                            </Disclosure>
+                                          ) : (
+                                            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-ink-faint">
+                                              body not captured
+                                            </span>
+                                          )}
+                                        </div>
+                                      </li>
+                                    ))}
+                                  </ol>
                                 </div>
                               </>
                             )}
-                            {c.status === "active" && c.nextStepLabel != null && (
-                              <div className={c.priorSteps.length > 0 ? "mt-5" : ""}>
-                                <div className="mb-1 flex items-center justify-between gap-2">
-                                  <div className="ln-eyebrow">
-                                    Next-step preview
-                                    {c.nextStepIsBreakup && (
-                                      <span className="ml-2 normal-case tracking-normal text-ink-faint">
-                                        · breakup
-                                      </span>
-                                    )}
-                                  </div>
-                                  {(() => {
-                                    const pending =
-                                      pendingPreviewKey === `${c.prospectId}|${c.playName}`;
-                                    return (
-                                      <Button
-                                        variant="ghost"
-                                        size="sm"
-                                        disabled={pendingPreviewKey != null}
-                                        title={
-                                          c.nextStepDraft
-                                            ? `regenerate next step (drafted ${timeAgo(c.nextStepDraft.draftedAt)})`
-                                            : "generate next-step draft — dry-run LLM, never sends"
-                                        }
-                                        onClick={() =>
-                                          previewNext.mutate({
-                                            prospectId: c.prospectId,
-                                            playName: c.playName,
-                                          })
-                                        }
-                                        {...readOnly}
-                                      >
-                                        {pending ? (
-                                          <Loader2 size={11} className="animate-spin" />
-                                        ) : (
-                                          <RotateCw size={11} />
-                                        )}
-                                        {pending
-                                          ? c.nextStepDraft
-                                            ? "regenerating…"
-                                            : "generating…"
-                                          : c.nextStepDraft
-                                            ? "regenerate"
-                                            : "generate draft"}
-                                      </Button>
-                                    );
-                                  })()}
-                                </div>
-                                {c.nextStepDraft ? (
-                                  <>
-                                    <div className="font-mono text-[11px] text-ink-faint">
-                                      drafted {timeAgo(c.nextStepDraft.draftedAt)}
-                                      {c.nextStepDraft.flags.length > 0 && (
-                                        <span className="ml-2 text-[color:var(--ink-spend-2)]">
-                                          · {c.nextStepDraft.flags.length} flag(s):{" "}
-                                          {c.nextStepDraft.flags.join(", ")}
-                                        </span>
-                                      )}
-                                    </div>
-                                    <div className="mt-2 font-mono text-[12px] text-ink-cream">
-                                      Subject: {c.nextStepDraft.subject}
-                                    </div>
-                                    <pre className="mt-1 whitespace-pre-wrap text-[12px] text-ink-cream-2">
-                                      {c.nextStepDraft.body}
-                                    </pre>
-                                  </>
-                                ) : (
-                                  <div className="font-mono text-[11px] uppercase tracking-[0.14em] text-ink-faint">
-                                    no draft yet
-                                  </div>
-                                )}
-                              </div>
-                            )}
-                          </td>
-                        </tr>
-                      )}
+                          </>
+                        }
+                        theLetter={letter}
+                      />
+                    )}
                   </Fragment>
                 );
               })}


### PR DESCRIPTION
Closes #602. Part 4 of the shared row/sheet work — **stacked on #606** (which is stacked on #605); retargets to `main` as the stack lands.

## What
- Row: line 2 = sequence state via `cadenceStateLabel` (new `lib/cadenceState.ts`, pure, clock injected): `step 2 of 4 · sent 3d ago · next in 1d`, `replied on linkedin · 2d ago`, `stopped · not a fit · 5d ago`, `overdue` in amber, `send failed` in oxblood, `sending…` in green. `step` and `next due` columns dropped (8 → 6). Every row opens; click guard, bulk selection, presets and the sinceRun banner unchanged.
- Sheet: the case opens with the reminder — the intro's signal + fit sentence from `queuePayload` (#603), hidden under privacy mode — then enrolled / next due / step / replied / stopped / note / send failed, and sent-so-far as a list with bodies behind disclosures. The letter is the next-step preview in `LetterCard`; Regenerate draft left, Send this one / Send breakup + Stop on the foot, green rule when it can go. Direct-mail rows get the dashed bar with Review mail / Add business address and never call previewNext.

## Verification
`bun run test`: **3725 / 283 green**; typecheck, oxlint, oxfmt clean. Browser pass against an isolated home with a checkpointed copy of the live ledger: /cadences list + open row (reminder, sent-so-far, letter bar, direct-mail rows), /prospects rejected list + open row (auto-reject reason, case list, Approve anyway on the bar), /queue.

Note: existing cadences show only the signal in the reminder — their sent queue rows predate `fitReason` (the backfill touches pending/approved only). New sends carry the sentence.

https://claude.ai/code/session_011meFPo97LhmTcoNRwyPQeS