### PR TITLE
fix(web): cadence rows show step dots and only what needs a hand; line-2 labels lose the small caps

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 67 CLI commands, 23 plays, 15 finders, ten dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-09** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3725 tests / 283 files** · typecheck + oxlint + oxfmt pass (38 lint warnings, 0 errors).
+Last verified **2026-09-09** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3746 tests / 284 files** · typecheck + oxlint + oxfmt pass (38 lint warnings, 0 errors).
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/apps/web/src/components/ledger/IdentityCell.tsx
+++ b/apps/web/src/components/ledger/IdentityCell.tsx
@@ -108,7 +108,7 @@ const SIGNAL_TONE: Record<SignalTone, string> = {
   receipt: "text-[color:var(--ink-receipt-2)]",
 };
 
-/** The small mono label that is a ledger row's second line. */
+/** The small mono label that is a ledger row's second line — plain case, never shouting. */
 export function SignalLabel({
   children,
   tone = "muted",
@@ -121,7 +121,7 @@ export function SignalLabel({
   return (
     <span
       className={cn(
-        "inline-block max-w-full truncate align-bottom font-mono text-[10px] uppercase tracking-[0.08em]",
+        "inline-block max-w-full truncate align-bottom font-mono text-[11px]",
         SIGNAL_TONE[tone],
         className,
       )}

--- a/apps/web/src/routes/cadences.tsx
+++ b/apps/web/src/routes/cadences.tsx
@@ -28,6 +28,7 @@ import { useMask, usePrivacy } from "../lib/privacy.tsx";
 import { Field, Input, Select, Textarea } from "../components/primitives/Field.tsx";
 import { Modal } from "../components/primitives/Modal.tsx";
 import { SkeletonRow } from "../components/primitives/Skeleton.tsx";
+import { StepProgress } from "../components/primitives/StepProgress.tsx";
 import { cn, formatSendsToday, timeAgo } from "../lib/cn.ts";
 import { readOnly } from "../lib/readOnly.ts";
 import { STOP_REASON_LABELS, cadenceStateLabel } from "../lib/cadenceState.ts";
@@ -620,6 +621,27 @@ function CadencesPage() {
                 // Line 2 is the sequence state (#602); every row opens into the
                 // sheet, which always has at least the enrolment to show.
                 const state = cadenceStateLabel(c, now);
+                // Line 2 is the step dots, and beside them only what needs a
+                // hand today: overdue, a send in flight, a failed send. The
+                // words ("step 1 of 2 · sent 2d ago · next in 22h") wait in the
+                // sheet, where there is room to read them once.
+                const dotsTone =
+                  c.status === "replied"
+                    ? "signal"
+                    : c.status === "breakup"
+                      ? "spend"
+                      : c.status === "bounced" ||
+                          c.status === "unsubscribed" ||
+                          c.status === "stopped"
+                        ? "blocked"
+                        : "receipt";
+                const rowNote = c.isSending
+                  ? { text: "sending…", cls: "text-[color:var(--ink-receipt-2)]" }
+                  : isOverdue && c.nextDueAt
+                    ? { text: `overdue · due ${timeAgo(c.nextDueAt)}`, cls: "text-ink-spend-2" }
+                    : c.status === "active" && c.lastSendError
+                      ? { text: "send failed", cls: "text-ink-blocked-2" }
+                      : null;
                 const open = expandedKeys.has(key);
                 const draft = c.nextStepDraft;
                 const previewPending = pendingPreviewKey === key;
@@ -650,6 +672,13 @@ function CadencesPage() {
                   !masked && c.queuePayload ? queueEvidence(c.playName, c.queuePayload) : null;
                 const fitReason = masked ? null : fitReasonFor(c.queuePayload);
                 const caseRows: CaseListRow[] = [
+                  {
+                    key: "state",
+                    value: state.text,
+                    ...(state.tone === "spend" || state.tone === "blocked"
+                      ? { tone: state.tone }
+                      : {}),
+                  },
                   { key: "enrolled", value: timeAgo(c.enrolledAt) },
                   ...(c.status === "active" && c.nextDueAt
                     ? [
@@ -660,14 +689,6 @@ function CadencesPage() {
                         },
                       ]
                     : []),
-                  {
-                    key: "step",
-                    value: `${Math.min(c.currentStep + 1, totalSteps)} of ${totalSteps}${
-                      c.nextStepLabel
-                        ? ` · next: ${c.nextStepLabel}${c.nextStepIsBreakup ? " (breakup)" : ""}`
-                        : ""
-                    }`,
-                  },
                   ...(c.status === "replied"
                     ? [
                         {
@@ -889,7 +910,20 @@ function CadencesPage() {
                           linkedinUrl: c.prospectLinkedinUrl,
                         }}
                         line2Privacy="show"
-                        line2={<SignalLabel tone={state.tone}>{state.text}</SignalLabel>}
+                        line2={
+                          <span className="inline-flex max-w-full items-center gap-2">
+                            <StepProgress
+                              current={Math.min(c.currentStep + 1, totalSteps)}
+                              total={totalSteps}
+                              tone={dotsTone}
+                            />
+                            {rowNote && (
+                              <span className={cn("truncate font-mono text-[11px]", rowNote.cls)}>
+                                {rowNote.text}
+                              </span>
+                            )}
+                          </span>
+                        }
                       />
                       <td className="whitespace-nowrap py-[10px] pr-6 text-ink-cream-2">
                         {c.playName}


### PR DESCRIPTION
Founder feedback on #602.

- /cadences line 2: the `StepProgress` dots are back, with a mono note beside them only when something needs a hand today — `overdue · due 2d ago` (amber), `sending…` (green), `send failed` (oxblood). The full state sentence leads the sheet's case list as `state`.
- `SignalLabel` (line 2 on /queue, /prospects, /cadences) drops the uppercase + tracking: plain-case mono 11px.
- STATUS.md corrected to what main has (3746 / 284; #604 landed between the stack's rebases).

`bun run test`: 3746 / 284 green; typecheck, oxlint, oxfmt clean.

https://claude.ai/code/session_011meFPo97LhmTcoNRwyPQeS