### PR TITLE
fix(web): the run form no longer refuses repo-interest and stack-consolidation rows without a company

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 67 CLI commands, 23 plays, 15 finders, ten dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-09** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3746 tests / 284 files** · typecheck + oxlint + oxfmt pass (38 lint warnings, 0 errors).
+Last verified **2026-09-09** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3747 tests / 284 files** · typecheck + oxlint + oxfmt pass (38 lint warnings, 0 errors).
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/apps/web/__tests__/playSchemas.test.ts
+++ b/apps/web/__tests__/playSchemas.test.ts
@@ -165,3 +165,16 @@ describe("missingRequiredFields — requireOneOf (civic-pilot purchasing route)"
     );
   });
 });
+
+// A stargazer or a stack-consolidation lead often has no company on record —
+// the GitHub profile is blank and the email is a gmail. The finder enqueues
+// them anyway and the queue's own send path drafts them fine, so the run
+// form must not refuse the same rows ("row 2: Company; row 4: Company").
+describe("company is optional where the finder cannot always supply it", () => {
+  it("repo-interest and stack-consolidation do not require company", () => {
+    for (const play of ["repo-interest", "stack-consolidation"] as const) {
+      const field = PLAY_SCHEMAS[play]!.fields.find((f) => f.key === "company");
+      expect(field?.required ?? false).toBe(false);
+    }
+  });
+});

--- a/apps/web/src/lib/playSchemas.ts
+++ b/apps/web/src/lib/playSchemas.ts
@@ -325,7 +325,7 @@ export const PLAY_SCHEMAS: Record<string, PlaySchema> = {
     fields: [
       { key: "name", label: "Prospect name", type: "text", required: true },
       { key: "email", label: "Prospect email", type: "email", required: true },
-      { key: "company", label: "Company", type: "text", required: true },
+      { key: "company", label: "Company (optional)", type: "text" },
       {
         key: "vendorStack",
         label: "Vendor stack (comma-separated)",
@@ -365,7 +365,7 @@ export const PLAY_SCHEMAS: Record<string, PlaySchema> = {
     fields: [
       { key: "name", label: "Prospect name", type: "text", required: true },
       { key: "email", label: "Prospect email", type: "email", required: true },
-      { key: "company", label: "Company", type: "text", required: true },
+      { key: "company", label: "Company (optional)", type: "text" },
       {
         key: "repo",
         label: "Repo they starred (owner/name)",

--- a/apps/web/src/routes/run.$playName.tsx
+++ b/apps/web/src/routes/run.$playName.tsx
@@ -3,6 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { ArrowLeft, CheckCircle2, Loader2, Play, Plus, RefreshCw, Trash2, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { toast } from "sonner";
 import {
   parseQueueIds,
   type RunPlayEvent,
@@ -90,6 +91,13 @@ function RunPage() {
   const [cancelling, setCancelling] = useState(false);
   const [events, setEvents] = useState<RunPlayEvent[]>([]);
   const [error, setError] = useState<string | null>(null);
+  // Every other page says what went wrong in a toast, where the eye already
+  // is. The banner under the form stays as the record; a validation refusal
+  // that only appeared down there read as a button that did nothing.
+  const fail = (message: string): void => {
+    setError(message);
+    toast.error(message);
+  };
   const navigate = Route.useNavigate();
   // Cross-route navigation (e.g. to /cadences for the deep-link from done mode).
   const globalNavigate = useNavigate();
@@ -182,7 +190,7 @@ function RunPage() {
         setDedupeKeys(pairs.map((p) => p.dedupeKey));
       } catch (err) {
         if (cancelledRef?.cancelled) return;
-        setError(`failed to load approved targets from queue: ${(err as Error).message}`);
+        fail(`failed to load approved targets from queue: ${(err as Error).message}`);
       }
     },
     [playName, schema, search.limit, search.ids],
@@ -337,7 +345,7 @@ function RunPage() {
       const extraDetail =
         missingExtras.length > 0 ? `run options: ${missingExtras.join(", ")}` : "";
       const detail = [rowDetail, extraDetail].filter(Boolean).join("; ");
-      setError(`fill in the required fields before dispatching — ${detail}`);
+      fail(`fill in the required fields before dispatching — ${detail}`);
       return;
     }
 
@@ -406,7 +414,7 @@ function RunPage() {
         }
       }
     } catch (err) {
-      setError((err as Error).message);
+      fail((err as Error).message);
     } finally {
       setRunning(false);
       // After a real-send run, drop rows whose draft actually shipped so
@@ -673,7 +681,7 @@ function RunPage() {
                 // cancelled state as soon as the row lands.
                 void api
                   .cancelRun(search.runId, "cancelled from the dashboard")
-                  .catch((e: unknown) => setError((e as Error).message))
+                  .catch((e: unknown) => fail((e as Error).message))
                   .finally(() => {
                     setCancelling(false);
                     void runQuery.refetch();

--- a/packages/plays/src/repo-interest.ts
+++ b/packages/plays/src/repo-interest.ts
@@ -94,7 +94,7 @@ const repoInterestDef: EmailPlayDef<RepoInterestTarget> = {
     [
       `FOUNDER: ${cfg.founderName}`,
       `PRODUCT: ${cfg.productOneLiner}`,
-      `PROSPECT: ${t.name} at ${t.company}`,
+      `PROSPECT: ${t.name}${t.company ? ` at ${t.company}` : ""}`,
       `STARRED REPO: ${t.repoLabel ?? t.repo}`,
       `YOUR EDGE: ${t.yourEdge}`,
       ...(t.repoEdge

--- a/packages/plays/src/stack-consolidation.ts
+++ b/packages/plays/src/stack-consolidation.ts
@@ -67,7 +67,7 @@ const stackConsolidationDef: EmailPlayDef<StackConsolidationTarget> = {
     [
       `FOUNDER: ${cfg.founderName}`,
       `PRODUCT: ${cfg.productOneLiner}`,
-      `PROSPECT: ${t.name} at ${t.company}`,
+      `PROSPECT: ${t.name}${t.company ? ` at ${t.company}` : ""}`,
       `STACK: ${t.vendorStack}`,
       `YOUR EDGE: ${t.yourEdge}`,
       `DOSSIER:\n${prep.dossier || "(dry-run)"}`,


### PR DESCRIPTION
Draining repo-interest from /queue stopped with *fill in the required fields before dispatching — row 2: Company; row 4: Company*, and the refusal only showed in a banner under the form.

- `playSchemas`: company is *Company (optional)* for `repo-interest` and `stack-consolidation` (as for `luma-events`) — a stargazer's profile is often blank and the email a gmail; the finder enqueues those rows and the queue's own send path drafts them fine. The two plays' `PROSPECT:` line drops the dangling `at` when company is blank. Test pins it.
- The run page reports every error in a toast as well as the banner: hydration failures, the required-field refusal, dispatch errors, a failed cancel.

`bun run test`: 3747 / 284 green; typecheck, oxlint, oxfmt clean.

https://claude.ai/code/session_011meFPo97LhmTcoNRwyPQeS