### PR TITLE
feat(web): issue #611: Skip mail on the cadence row, in its sheet, and for every cadence waiting on a letter

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 67 CLI commands, 23 plays, 15 finders, ten dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-09** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3760 tests / 286 files** · typecheck + oxlint + oxfmt pass (38 lint warnings, 0 errors).
+Last verified **2026-09-09** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3762 tests / 286 files** · typecheck + oxlint + oxfmt pass (38 lint warnings, 0 errors).
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/apps/web/__tests__/cadenceState.test.ts
+++ b/apps/web/__tests__/cadenceState.test.ts
@@ -1,6 +1,6 @@
 import type { CadenceView } from "@oneshot-gtm/shared-types";
 import { describe, expect, it } from "vitest";
-import { cadenceStateLabel } from "../src/lib/cadenceState.ts";
+import { cadenceStateLabel, mailWaitingRows } from "../src/lib/cadenceState.ts";
 
 // Issue #602: the /cadences row's second line is the sequence state, in one
 // mono label. Every branch, against a fixed clock.
@@ -113,5 +113,38 @@ describe("cadenceStateLabel", () => {
       text: "paused · step 2 of 4",
       tone: "muted",
     });
+  });
+});
+
+describe("a skipped letter (#611)", () => {
+  it("does not count as the last send", () => {
+    const c = cadence({
+      priorSteps: [
+        { stepIndex: 0, label: "intro", subject: "hi", body: null, sentAt: daysAgo(3) },
+        {
+          stepIndex: 1,
+          label: "letter skipped",
+          subject: "",
+          body: null,
+          sentAt: daysAgo(1),
+          status: "skipped",
+        },
+      ],
+      currentStep: 2,
+    });
+    expect(cadenceStateLabel(c, now).text).toBe("step 3 of 4 · sent 3d ago · next in 1d");
+  });
+});
+
+describe("mailWaitingRows", () => {
+  it("is the active rows whose next step goes by post and nothing in flight", () => {
+    const rows = [
+      cadence({ prospectId: 1, nextStepChannel: "direct_mail" }),
+      cadence({ prospectId: 2, nextStepChannel: "direct_mail", isSending: true }),
+      cadence({ prospectId: 3, nextStepChannel: "direct_mail", status: "stopped" }),
+      cadence({ prospectId: 4, nextStepChannel: "email" }),
+      cadence({ prospectId: 5 }),
+    ];
+    expect(mailWaitingRows(rows).map((c) => c.prospectId)).toEqual([1]);
   });
 });

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -129,6 +129,20 @@ export const api = {
       `/cadences/${id}/stop?play=${encodeURIComponent(playName)}`,
       input,
     ),
+  /** Skip a cadence's pending letter and continue with its next step (#611). */
+  skipCadenceMail: (id: number, playName: string) =>
+    postJson<{
+      ok: boolean;
+      currentStep: number;
+      status: string;
+      nextStepChannel: string | null;
+    }>(`/cadences/${id}/skip-mail?play=${encodeURIComponent(playName)}`, {}),
+  skipCadenceMailBatch: (items: Array<{ prospectId: number; playName: string }>) =>
+    postJson<{
+      results: Array<{ prospectId: number; playName: string; ok: boolean; error?: string }>;
+      skipped: number;
+      failed: number;
+    }>(`/cadences/skip-mail-batch`, { items }),
   markLinkedInReply: (id: number, body?: string) =>
     postJson<LinkedInReplyResult>(
       `/prospects/${id}/linkedin-reply`,

--- a/apps/web/src/lib/cadenceState.ts
+++ b/apps/web/src/lib/cadenceState.ts
@@ -30,7 +30,8 @@ export function cadenceStateLabel(c: CadenceView, now: Date): CadenceState {
   const ago = (iso: string): string => timeAgo(iso, nowMs);
   const total = c.followupCount + 1;
   const step = `step ${Math.min(c.currentStep + 1, total)} of ${total}`;
-  const lastSent = c.priorSteps.at(-1)?.sentAt ?? null;
+  // A skipped letter is history, not a send — "sent 3d ago" stays the last email.
+  const lastSent = c.priorSteps.findLast((s) => s.status !== "skipped")?.sentAt ?? null;
 
   if (c.isSending) return { text: join([step, "sending…"]), tone: "receipt" };
 
@@ -89,4 +90,15 @@ export function cadenceStateLabel(c: CadenceView, now: Date): CadenceState {
     default:
       return { text: c.status, tone: "muted" };
   }
+}
+
+/**
+ * The cadences waiting on a letter (issue #611): active, next step goes by
+ * post, nothing in flight. These rows are unselectable for email batches, so
+ * the bulk skip takes this set directly rather than the checkboxes.
+ */
+export function mailWaitingRows(list: ReadonlyArray<CadenceView>): CadenceView[] {
+  return list.filter(
+    (c) => c.status === "active" && c.nextStepChannel === "direct_mail" && !c.isSending,
+  );
 }

--- a/apps/web/src/routes/cadences.tsx
+++ b/apps/web/src/routes/cadences.tsx
@@ -6,6 +6,7 @@ import {
   CircleStop,
   Eye,
   Loader2,
+  MailX,
   MessageCircle,
   RotateCw,
   Send,
@@ -31,7 +32,7 @@ import { SkeletonRow } from "../components/primitives/Skeleton.tsx";
 import { StepProgress } from "../components/primitives/StepProgress.tsx";
 import { cn, formatSendsToday, timeAgo } from "../lib/cn.ts";
 import { readOnly } from "../lib/readOnly.ts";
-import { STOP_REASON_LABELS, cadenceStateLabel } from "../lib/cadenceState.ts";
+import { STOP_REASON_LABELS, cadenceStateLabel, mailWaitingRows } from "../lib/cadenceState.ts";
 import { fitReasonFor } from "../lib/queueRationale.ts";
 import { queueEvidence } from "../lib/queueEvidence.ts";
 import { IdentityCell, SignalLabel } from "../components/ledger/IdentityCell.tsx";
@@ -171,6 +172,32 @@ function CadencesPage() {
     onError: (err) => toast.error(`couldn't stop cadence: ${err.message}`),
   });
 
+  // Skip a pending letter and move on to the next email (#611). No reason
+  // field: the cadence simply continues, and the skip is recorded as
+  // "letter skipped" in its history.
+  const skipMail = useMutation({
+    mutationFn: (vars: { prospectId: number; playName: string }) =>
+      api.skipCadenceMail(vars.prospectId, vars.playName),
+    onSuccess: (_data, vars) => {
+      void qc.invalidateQueries({ queryKey: ["cadences"] });
+      void qc.invalidateQueries({ queryKey: ["direct-mail"] });
+      toast.success(`letter skipped · ${vars.playName}`);
+    },
+    onError: (err) => toast.error(`couldn't skip the letter: ${err.message}`),
+  });
+  const skipMailBatch = useMutation({
+    mutationFn: (items: Array<{ prospectId: number; playName: string }>) =>
+      api.skipCadenceMailBatch(items),
+    onSuccess: (data) => {
+      void qc.invalidateQueries({ queryKey: ["cadences"] });
+      void qc.invalidateQueries({ queryKey: ["direct-mail"] });
+      setSkipMailConfirmOpen(false);
+      const tail = data.failed > 0 ? ` · ${data.failed} need attention in the mail review` : "";
+      toast.success(`skipped ${data.skipped} letter${data.skipped === 1 ? "" : "s"}${tail}`);
+    },
+    onError: (err) => toast.error(`couldn't skip the letters: ${err.message}`),
+  });
+
   const markLinkedInReply = useMutation({
     mutationFn: (vars: { prospectId: number; body?: string }) =>
       api.markLinkedInReply(vars.prospectId, vars.body),
@@ -251,6 +278,7 @@ function CadencesPage() {
   const [expandedKeys, setExpandedKeys] = useState<Set<string>>(new Set());
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [bulkSendConfirmOpen, setBulkSendConfirmOpen] = useState(false);
+  const [skipMailConfirmOpen, setSkipMailConfirmOpen] = useState(false);
   const toggleExpanded = (key: string): void =>
     setExpandedKeys((prev) => {
       const next = new Set(prev);
@@ -318,6 +346,7 @@ function CadencesPage() {
     () => list.filter((c) => c.status === "active" && c.nextStepChannel !== "direct_mail"),
     [list],
   );
+  const mailWaiting = useMemo(() => mailWaitingRows(list), [list]);
   const allActiveSelected =
     selectableActive.length > 0 && selectableActive.every((c) => selected.has(rowKey(c)));
   const someActiveSelected =
@@ -508,6 +537,19 @@ function CadencesPage() {
                 </Button>
               ))}
             </div>
+          )}
+          {mailWaiting.length > 0 && (
+            <Button
+              variant="secondary"
+              size="sm"
+              title="Skip the letter on every cadence waiting on one and continue each with its next email"
+              onClick={() => setSkipMailConfirmOpen(true)}
+              {...readOnly}
+            >
+              <MailX size={12} />
+              Skip mail for the {mailWaiting.length} cadence{mailWaiting.length === 1 ? "" : "s"}{" "}
+              waiting on a letter
+            </Button>
           )}
           <div className="font-mono text-[11px] text-ink-faint">refresh · 15s</div>
         </div>
@@ -726,6 +768,21 @@ function CadencesPage() {
                       ]
                     : []),
                 ];
+                const skipMailButton =
+                  c.status === "active" && c.nextStepChannel === "direct_mail" ? (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      title="Skip the letter and continue with the next step"
+                      disabled={c.isSending || skipMail.isPending}
+                      onClick={() =>
+                        skipMail.mutate({ prospectId: c.prospectId, playName: c.playName })
+                      }
+                      {...readOnly}
+                    >
+                      <MailX size={11} /> Skip mail
+                    </Button>
+                  ) : null;
                 const stopButton =
                   c.status === "active" ? (
                     <Button
@@ -816,6 +873,7 @@ function CadencesPage() {
                           <Button size="sm" disabled={c.isSending} onClick={() => setMailKey(key)}>
                             {c.businessAddress ? "Review mail" : "Add business address"}
                           </Button>
+                          {skipMailButton}
                           {stopButton}
                         </>
                       }
@@ -975,6 +1033,7 @@ function CadencesPage() {
                                     >
                                       {c.businessAddress ? "Review mail" : "Add business address"}
                                     </Button>
+                                    {skipMailButton}
                                     {c.priorSteps.length > 0 && (
                                       <Button
                                         size="sm"
@@ -1163,34 +1222,48 @@ function CadencesPage() {
                                     sent so far · {c.priorSteps.length}
                                   </div>
                                   <ol className="flex flex-col gap-2">
-                                    {c.priorSteps.map((st) => (
-                                      <li key={st.stepIndex} className="flex flex-col gap-1">
-                                        <div className="flex items-baseline gap-3 leading-4">
+                                    {c.priorSteps.map((st) =>
+                                      st.status === "skipped" ? (
+                                        <li
+                                          key={st.stepIndex}
+                                          className="flex items-baseline gap-3 leading-4"
+                                        >
                                           <span className="w-[64px] shrink-0 text-right font-mono text-[11px] text-ink-faint">
                                             {timeAgo(st.sentAt)}
                                           </span>
-                                          <span className="shrink-0 whitespace-nowrap text-ink-cream-2">
-                                            step {st.stepIndex} · {st.label}
+                                          <span className="shrink-0 whitespace-nowrap text-ink-faint">
+                                            step {st.stepIndex} · letter skipped
                                           </span>
-                                          <span className="min-w-0 truncate text-ink-muted">
-                                            {st.subject}
-                                          </span>
-                                        </div>
-                                        <div className="pl-[76px]">
-                                          {st.body ? (
-                                            <Disclosure label="body">
-                                              <pre className="ln-prose mt-2 whitespace-pre-wrap text-[12px] text-ink-cream-2">
-                                                {st.body}
-                                              </pre>
-                                            </Disclosure>
-                                          ) : (
-                                            <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-ink-faint">
-                                              body not captured
+                                        </li>
+                                      ) : (
+                                        <li key={st.stepIndex} className="flex flex-col gap-1">
+                                          <div className="flex items-baseline gap-3 leading-4">
+                                            <span className="w-[64px] shrink-0 text-right font-mono text-[11px] text-ink-faint">
+                                              {timeAgo(st.sentAt)}
                                             </span>
-                                          )}
-                                        </div>
-                                      </li>
-                                    ))}
+                                            <span className="shrink-0 whitespace-nowrap text-ink-cream-2">
+                                              step {st.stepIndex} · {st.label}
+                                            </span>
+                                            <span className="min-w-0 truncate text-ink-muted">
+                                              {st.subject}
+                                            </span>
+                                          </div>
+                                          <div className="pl-[76px]">
+                                            {st.body ? (
+                                              <Disclosure label="body">
+                                                <pre className="ln-prose mt-2 whitespace-pre-wrap text-[12px] text-ink-cream-2">
+                                                  {st.body}
+                                                </pre>
+                                              </Disclosure>
+                                            ) : (
+                                              <span className="font-mono text-[10px] uppercase tracking-[0.14em] text-ink-faint">
+                                                body not captured
+                                              </span>
+                                            )}
+                                          </div>
+                                        </li>
+                                      ),
+                                    )}
                                   </ol>
                                 </div>
                               </>
@@ -1207,6 +1280,36 @@ function CadencesPage() {
           </table>
         )}
       </section>
+
+      <Modal
+        open={skipMailConfirmOpen}
+        onClose={() => setSkipMailConfirmOpen(false)}
+        title={`Skip the letter for ${mailWaiting.length} cadence${mailWaiting.length === 1 ? "" : "s"}`}
+        footer={
+          <>
+            <Button variant="ghost" onClick={() => setSkipMailConfirmOpen(false)}>
+              Cancel
+            </Button>
+            <Button
+              onClick={() =>
+                skipMailBatch.mutate(
+                  mailWaiting.map((c) => ({ prospectId: c.prospectId, playName: c.playName })),
+                )
+              }
+              disabled={skipMailBatch.isPending || mailWaiting.length === 0}
+              {...readOnly}
+            >
+              {skipMailBatch.isPending ? "Skipping…" : `Skip ${mailWaiting.length}`}
+            </Button>
+          </>
+        }
+      >
+        <div className="text-[12px] text-ink-muted">
+          Each cadence continues with its next email on the normal delay, and the skip is recorded
+          as “letter skipped” in its history. A mailpiece already submitted to the printer is left
+          alone; recover it in the mail review.
+        </div>
+      </Modal>
 
       <Modal
         open={bulkSendConfirmOpen}

--- a/apps/web/src/routes/cadences.tsx
+++ b/apps/web/src/routes/cadences.tsx
@@ -1305,9 +1305,10 @@ function CadencesPage() {
         }
       >
         <div className="text-[12px] text-ink-muted">
-          Each cadence continues with its next email on the normal delay, and the skip is recorded
-          as “letter skipped” in its history. A mailpiece already submitted to the printer is left
-          alone; recover it in the mail review.
+          Each cadence moves past the letter: on to its next email on the normal delay, or to
+          completed when the letter was the last step. The skip is recorded as “letter skipped” in
+          its history. A mailpiece already submitted to the printer is left alone; recover it in the
+          mail review.
         </div>
       </Modal>
 

--- a/apps/web/src/routes/plays.tsx
+++ b/apps/web/src/routes/plays.tsx
@@ -478,13 +478,23 @@ function MotionMailEditor({ play }: { play: PlayDescriptor }) {
         </Select>
       </label>
       <p className="w-full text-ink-faint">
-        {mode === "automatic"
-          ? play.mailRecommendation
-          : mode === "off"
-            ? "Direct mail is off for this motion."
-            : "Every eligible active prospect gets a mail step; missing addresses pause it."}{" "}
-        Each letter still requires individual approval. Follow-ups allow at least eight business
-        days for printing and transit, plus two days to read.
+        {mode === "off" ? (
+          <>
+            Direct mail is off for this motion: new enrollments plan no letter, and a letter not yet
+            prepared on an active cadence is dropped from its plan. A letter already in review stays
+            until you skip or send it on Cadences.
+          </>
+        ) : (
+          <>
+            {mode === "automatic"
+              ? play.mailRecommendation
+              : "Every eligible active prospect gets a mail step; missing addresses pause it."}{" "}
+            A letter is planned as step {position} for new enrollments that qualify. Each letter
+            still requires individual approval; skip it from Cadences when you would rather not send
+            post. Follow-ups allow at least eight business days for printing and transit, plus two
+            days to read.
+          </>
+        )}
       </p>
       {enabled && (
         <>


### PR DESCRIPTION
Closes #611. Part 2 of "skip the direct-mail step" — **stacked on #612**, retargets to `main` once it lands.

## What
- /cadences: "Skip mail" on every direct-mail row and in its sheet's letter bar (no confirm). Toolbar action "Skip mail for the N cadences waiting on a letter" behind a one-line confirm, driven by `mailWaitingRows(list)` (those rows are unselectable for email batches by design).
- Sent-so-far shows a skipped step as "step N · letter skipped"; `cadenceStateLabel`'s last send ignores skipped steps.
- `api.skipCadenceMail` / `api.skipCadenceMailBatch` against #612's routes.
- /plays: the direct-mail switch copy says what on/off actually do (new enrollments; an unprepared letter on active plans is dropped too; a letter in review stays until skipped or sent).

## Verification
`bun run test`: **3758 / 285 green**; typecheck, oxlint, oxfmt clean. Browser pass against a copy of the live ledger: single skip from a row (toast, next step becomes the email, "letter skipped" in the sheet), the bulk confirm → "skipped 8 letters", the Plays copy.

https://claude.ai/code/session_011meFPo97LhmTcoNRwyPQeS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added options to skip individual or multiple pending direct-mail letters and continue cadences.
  * Added confirmation prompts, success/failure summaries, and clearer indicators for skipped letters.
* **Bug Fixes**
  * Skipped letters no longer count as the most recent send.
  * Cadence views now correctly identify active cadences waiting for direct mail.
* **Documentation**
  * Clarified direct-mail policy guidance, including enrollment, approval, printing, transit, and reading timelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->