### PR TITLE
ci(status): add the status-stamp workflow for #582

### DIFF
--- a/.github/workflows/status-stamp.yml
+++ b/.github/workflows/status-stamp.yml
@@ -1,0 +1,53 @@
+name: status-stamp
+
+# Keeps STATUS.md's "Last verified" line honest without hand-editing (#582).
+# `scripts/status-stamp.ts` measures the real test/file counts, Bun version
+# and OneShot SDK version and rewrites exactly that one line. Runs only on
+# push to main — branches leave the line alone and inherit whatever main
+# has, so two branches that each add tests never collide on this line
+# again. If the line is already current (the common case — most pushes to
+# main don't change test counts), the script no-ops and this job commits
+# nothing.
+
+on:
+  push:
+    branches: ["main"]
+
+# GITHUB_TOKEN-authored commits don't trigger new workflow runs, so this
+# can't recurse; the concurrency group still avoids two stamp commits
+# racing on rapid consecutive pushes.
+concurrency:
+  group: status-stamp-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  stamp:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.13" # match `packageManager` in root package.json
+
+      - name: Install workspace deps
+        run: bun install --frozen-lockfile
+
+      - name: Stamp STATUS.md
+        run: bun run status:stamp
+
+      - name: Commit stamp if changed
+        run: |
+          if git diff --quiet -- STATUS.md; then
+            echo "STATUS.md unchanged — nothing to commit."
+            exit 0
+          fi
+          COUNTS=$(grep -oE '[0-9,]+ tests / [0-9,]+ files' STATUS.md | head -1)
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add STATUS.md
+          git commit -m "chore(status): ${COUNTS}"
+          git push


### PR DESCRIPTION
The workflow half of #582, carried by hand.

The dev-runner's guard refuses any agent diff touching `.github/workflows/` — deliberately, so a merged agent PR can never rewrite CI. Issue #582 asked for a workflow anyway, so its branch has been sitting at the gate since yesterday. This PR takes that one file; the loop's own PR brings `scripts/status-stamp.ts`, the `status:stamp` package script and the README sentence.

**Merge order matters:** this job runs `bun run status:stamp`, which the loop's PR defines. Merge that one first, then this.

The file is the agent's, verbatim. It runs on push to `main` only, needs no secrets, and commits the stamp line as `github-actions[bot]` when the counts changed. `GITHUB_TOKEN`-authored commits do not trigger workflow runs, so it cannot recurse.

https://claude.ai/code/session_01StbUPZskK4D6qyQv2SSi8P

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - `STATUS.md` is now automatically refreshed after changes are pushed to the main branch.
  - Status information reflects current test counts, file counts, and version details.
  - Updates are committed only when the status information has changed, avoiding unnecessary revisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->