### PR TITLE
fix: issue #616: Extract receipt persistence from Ledger

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -65,7 +65,6 @@ Not code — these need capture, not commits. `demo seed` + `demo ui` now stand 
 
 ## Approved, not yet started
 
-- [ ] **Extract receipt persistence from Ledger** — issue #616.
 - [ ] **Extract bounce and canary persistence from Ledger** — issue #617.
 
 ## Things we intentionally do NOT do

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -49,6 +49,7 @@ The ICP filter currently judges each candidate cold — `icpFilter` in `packages
 - [ ] **Split `packages/core/src/ledger.ts`** · L — 2967 lines covering receipts, prospects, queue, cadence, inbox, bounces, canaries and caches behind one class, with `migrate()` at 400 lines of inline DDL.
       _Done when:_ the file is split by domain with the exported class surface and every call site unchanged, `migrate()` still produces a byte-identical schema for a fresh install, and `packages/core/__tests__/ledger.test.ts` passes untouched.
       _Progress (#452):_ fresh-install schema construction + inline migrations extracted to `packages/core/src/ledger-schema.ts`; `Ledger.migrate()` now delegates to it. Byte-identical fresh-install schema verified (sqlite_master + schema_version snapshot in `ledger.test.ts`); domain methods (receipts, prospects, queue, cadence, inbox, bounces, canaries, caches) remain in `ledger.ts` for a follow-up slice.
+      **Progress (#616):** receipt reads, writes, attribution and aggregation extracted to `packages/core/src/ledger-receipts.ts` as a `ReceiptStore` constructed from the migrated `Database` handle; `Ledger` delegates every receipt method to it with signatures, return values and transaction boundaries unchanged. Prospects, queue, cadence, inbox, bounces, canaries and caches remain in `ledger.ts` for further slices (bounces/canaries tracked as issue #617).
 
 ## Launch assets
 

--- a/packages/core/__tests__/ledger-receipts.test.ts
+++ b/packages/core/__tests__/ledger-receipts.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { Database } from "bun:sqlite";
+import { Ledger } from "../src/ledger.ts";
+import { migrateLedgerSchema } from "../src/ledger-schema.ts";
+import { ReceiptStore } from "../src/ledger-receipts.ts";
+
+let dbPath: string;
+let ledger: Ledger;
+
+beforeEach(() => {
+  dbPath = join(
+    tmpdir(),
+    `oneshot-gtm-test-receipts-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`,
+  );
+  ledger = new Ledger(dbPath);
+});
+
+afterEach(() => {
+  ledger.close();
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      rmSync(`${dbPath}${suffix}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+describe("Ledger receipt methods delegate to ReceiptStore (issue #616)", () => {
+  it("recordReceipt/getReceipt/listReceipts round-trip through Ledger exactly as before extraction", () => {
+    const id = ledger.recordReceipt({
+      playName: "show-hn",
+      callType: "email.send",
+      costUsd: 0.05,
+      signedReceipt: { email: { id: "abc-123" } },
+      oneshotRequestId: "abc-123",
+      senderIdentity: "legacy-oneshot",
+      memo: "custom memo",
+      decisionContext: { goalId: "g-1", playName: "show-hn", callType: "email.send" },
+    });
+    expect(id).toBeGreaterThan(0);
+    const r = ledger.getReceipt(id);
+    expect(r?.play_name).toBe("show-hn");
+    expect(r?.cost_usd).toBe(0.05);
+    expect(r?.oneshot_request_id).toBe("abc-123");
+    expect(r?.sender_identity).toBe("legacy-oneshot");
+    expect(r?.memo).toBe("custom memo");
+    expect(r?.goal_id).toBe("g-1");
+    expect(ledger.listReceipts({ playName: "show-hn" }).map((row) => row.id)).toContain(id);
+  });
+
+  it("recordReceipt stays idempotent on a non-null oneshot_request_id after the move to ledger-receipts.ts", () => {
+    const first = ledger.recordReceipt({
+      playName: "inbox-reply",
+      callType: "email.reply",
+      costUsd: 0.01,
+      oneshotRequestId: "job-xyz-616",
+    });
+    const replay = ledger.recordReceipt({
+      playName: "inbox-reply",
+      callType: "email.reply",
+      costUsd: 0.01,
+      oneshotRequestId: "job-xyz-616",
+    });
+    expect(replay).toBe(first);
+    expect(ledger.countReceipts({ playName: "inbox-reply" })).toBe(1);
+  });
+
+  it("setReceiptValueTag/currentGoalValueTag/setReceiptValueTagByGoal/goalLabels delegate correctly", () => {
+    const idA = ledger.recordReceipt({
+      playName: "show-hn",
+      callType: "email.send",
+      decisionContext: { goalId: "goal-1", playName: "show-hn", prospectEmail: "a@x.dev" },
+    });
+    const idB = ledger.recordReceipt({
+      playName: "show-hn",
+      callType: "email.reply",
+      decisionContext: { goalId: "goal-1", playName: "show-hn", prospectEmail: "a@x.dev" },
+    });
+    expect(ledger.currentGoalValueTag("goal-1")).toBeNull();
+    const touched = ledger.setReceiptValueTagByGoal("goal-1", '{"type":"reply"}');
+    expect(touched).toBe(2);
+    expect(ledger.currentGoalValueTag("goal-1")).toBe('{"type":"reply"}');
+    ledger.setReceiptValueTag(idA, '{"type":"meeting"}');
+    expect(ledger.getReceipt(idA)?.value_tag).toBe('{"type":"meeting"}');
+    expect(ledger.getReceipt(idB)?.value_tag).toBe('{"type":"reply"}');
+    const labels = ledger.goalLabels(["goal-1", "missing-goal"]);
+    expect(labels.get("goal-1")).toEqual({ playName: "show-hn", prospect: "a@x.dev" });
+    expect(labels.has("missing-goal")).toBe(false);
+  });
+
+  it("spendByPlay/countReceipts/totalSpendUsd/spendSeriesByPlay/listValueTaggedReceipts delegate correctly", () => {
+    ledger.recordReceipt({ playName: "show-hn", callType: "email.send", costUsd: 0.1 });
+    ledger.recordReceipt({ playName: "show-hn", callType: "research.deep", costUsd: 0.4 });
+    ledger.recordReceipt({
+      playName: "job-change",
+      callType: "enrich.profile",
+      costUsd: 0.2,
+      decisionContext: { goalId: "goal-9" },
+    });
+    ledger.setReceiptValueTagByGoal("goal-9", '{"type":"qualified"}');
+
+    const byPlay = ledger.spendByPlay();
+    const showHn = byPlay.find((r) => r.play_name === "show-hn");
+    expect(showHn?.calls).toBe(2);
+    expect(showHn?.total_usd).toBeCloseTo(0.5);
+
+    expect(ledger.countReceipts()).toBe(3);
+    expect(ledger.countReceipts({ playName: "job-change" })).toBe(1);
+    expect(ledger.totalSpendUsd()).toBeCloseTo(0.7);
+    expect(ledger.totalSpendUsd({ playName: "show-hn" })).toBeCloseTo(0.5);
+
+    const series = ledger.spendSeriesByPlay({ days: 7 });
+    expect(series.some((row) => row.play_name === "show-hn")).toBe(true);
+
+    const tagged = ledger.listValueTaggedReceipts();
+    expect(tagged).toEqual([{ goal_id: "goal-9", value_tag: '{"type":"qualified"}' }]);
+  });
+
+  it("recordMailReceipt's transaction boundary is unchanged: dedupes on receipt_id and updates the signed receipt in place", () => {
+    const input = { playName: "direct-mail", callType: "mail.send", costUsd: 1.2 };
+    const first = ledger.recordMailReceipt("dm-receipt-1", input);
+    expect(ledger.countReceipts({ playName: "direct-mail" })).toBe(1);
+    // Re-recording the SAME direct-mail receipt id must not insert a second
+    // receipt row — the transaction reuses the existing local_id and just
+    // refreshes signed_receipt, exactly as before the extraction.
+    const second = ledger.recordMailReceipt("dm-receipt-1", {
+      ...input,
+      signedReceipt: { stamped: true },
+    });
+    expect(second).toBe(first);
+    expect(ledger.countReceipts({ playName: "direct-mail" })).toBe(1);
+    expect(ledger.getReceipt(first)?.signed_receipt).toBe(JSON.stringify({ stamped: true }));
+  });
+
+  it("recordMailReceipt rolls back BOTH the receipts insert and the direct_mail_receipts insert when the transaction fails partway", () => {
+    // Force the delegated ReceiptStore.recordReceipt call to throw AFTER
+    // recordMailReceipt's db.transaction() has started, to prove the whole
+    // transaction — spanning the receipts insert (now in ledger-receipts.ts)
+    // and the direct_mail_receipts insert (still in ledger.ts) — rolls back
+    // as one unit exactly like before the extraction, not just the
+    // ledger.ts-owned half.
+    const originalRecordReceipt = ledger.recordReceipt.bind(ledger);
+    let calls = 0;
+    ledger.recordReceipt = (input: Parameters<Ledger["recordReceipt"]>[0]) => {
+      calls += 1;
+      originalRecordReceipt(input);
+      throw new Error("simulated failure after the receipts insert");
+    };
+    expect(() => ledger.recordMailReceipt("dm-rollback", { playName: "x", callType: "y" })).toThrow(
+      "simulated failure after the receipts insert",
+    );
+    expect(calls).toBe(1);
+    ledger.recordReceipt = originalRecordReceipt;
+    // Neither half of the transaction may have persisted.
+    expect(ledger.countReceipts({ playName: "x" })).toBe(0);
+    const db = (ledger as unknown as { db: Database }).db;
+    const row = db
+      .query("SELECT * FROM direct_mail_receipts WHERE receipt_id = ?")
+      .get("dm-rollback");
+    expect(row).toBeNull();
+  });
+});
+
+describe("ReceiptStore is a pure function of a raw Database handle (issue #616)", () => {
+  let db: Database;
+
+  beforeEach(() => {
+    db = new Database(":memory:");
+    migrateLedgerSchema(db);
+  });
+
+  afterEach(() => {
+    db.close();
+  });
+
+  it("can be constructed and exercised standalone, without the Ledger class", () => {
+    const store = new ReceiptStore(db);
+    const id = store.recordReceipt({ playName: "p", callType: "c", costUsd: 0.03 });
+    expect(store.getReceipt(id)?.play_name).toBe("p");
+    expect(store.countReceipts()).toBe(1);
+    expect(store.totalSpendUsd()).toBeCloseTo(0.03);
+  });
+
+  it("shares the same underlying table as Ledger, so a row written via one is visible via the other", () => {
+    const store = new ReceiptStore(db);
+    const id = store.recordReceipt({ playName: "shared", callType: "c" });
+    const viaRaw = db.query("SELECT play_name FROM receipts WHERE id = ?").get(id) as {
+      play_name: string;
+    };
+    expect(viaRaw.play_name).toBe("shared");
+  });
+});

--- a/packages/core/src/ledger-receipts.ts
+++ b/packages/core/src/ledger-receipts.ts
@@ -1,0 +1,277 @@
+import type { Database } from "bun:sqlite";
+import type { ReceiptRecord } from "./types.ts";
+
+/**
+ * Receipt persistence for the ledger's `receipts` table: writes
+ * (`recordReceipt`), reads (`getReceipt`/`listReceipts`), attribution
+ * (`setReceiptValueTag`/`setReceiptValueTagByGoal`/`currentGoalValueTag`/
+ * `goalLabels`), and aggregation (`spendByPlay`/`countReceipts`/
+ * `spendSeriesByPlay`/`totalSpendUsd`/`listValueTaggedReceipts`). Extracted
+ * from `Ledger` (see ledger.ts) as the next slice of the split tracked in
+ * ROADMAP.md, following the schema extraction in #452.
+ *
+ * Pure wrapper around a raw `Database` handle — same shape as
+ * `migrateLedgerSchema` in ledger-schema.ts — so it can be constructed and
+ * exercised without the rest of Ledger's surface. `Ledger` owns exactly one
+ * instance (constructed after `migrate()` runs) and delegates every receipt
+ * method to it, preserving each method's existing signature, return value,
+ * transaction boundary, and caller.
+ */
+export class ReceiptStore {
+  constructor(private readonly db: Database) {}
+
+  recordReceipt(input: {
+    playName: string;
+    callType: string;
+    /** Per-call USD cost. Every wrapper in `oneshot.ts` reads `result.cost`
+     *  from the SDK response (declared on every result type in
+     *  `@oneshot-agent/sdk@0.15.2+`) and forwards it here. NULL in the
+     *  column when undefined — visible signal that the SDK omitted cost. */
+    costUsd?: number;
+    signedReceipt?: unknown;
+    oneshotRequestId?: string;
+    /** EmailIdentity id for email.send receipts — drives per-identity daily caps. */
+    senderIdentity?: string;
+    /** Call-time memo (the same value sent to OneShot); defaults to "{play} {callType}". */
+    memo?: string;
+    /** Call-time decisionContext blob; JSON-stringified into the column. */
+    decisionContext?: unknown;
+  }): number {
+    // Idempotent on the job id: the SDK's idempotency replay returns the
+    // ORIGINAL request_id when a timed-out/double-fired send is retried, and a
+    // Gmail message id is unique per send — so a non-null request_id already in
+    // the table means "same underlying send". Return the existing receipt
+    // instead of inserting a duplicate that would double-count spend and caps.
+    // Null request_ids (cache hits, SDK omissions) are distinct events and skip
+    // this — they must never collapse together.
+    if (input.oneshotRequestId) {
+      const existing = this.db
+        .query("SELECT id FROM receipts WHERE oneshot_request_id = ?")
+        .get(input.oneshotRequestId) as { id: number } | undefined;
+      if (existing) return existing.id;
+    }
+    // Number.isFinite guard rejects undefined / Infinity / NaN — those land
+    // as NULL in the column, NOT silently distorted into a number.
+    const costUsd =
+      typeof input.costUsd === "number" && Number.isFinite(input.costUsd) ? input.costUsd : null;
+    // Mirror what buildAuditOpts sends to OneShot so the stored memo/context
+    // match the platform receipt even at call sites that don't enrich.
+    const memo = input.memo ?? `${input.playName} ${input.callType}`;
+    const decisionContext = input.decisionContext ?? {
+      playName: input.playName,
+      callType: input.callType,
+    };
+    // Mirror the cadence correlation key (decisionContext.goalId) into its own
+    // column so an outcome can value-tag the whole goal in one UPDATE.
+    const goalId =
+      typeof (decisionContext as { goalId?: unknown }).goalId === "string"
+        ? (decisionContext as { goalId: string }).goalId
+        : null;
+    const stmt = this.db.prepare(`
+      INSERT INTO receipts(play_name, call_type, cost_usd, signed_receipt, oneshot_request_id, sender_identity, memo, decision_context, goal_id)
+      VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    const result = stmt.run(
+      input.playName,
+      input.callType,
+      costUsd,
+      input.signedReceipt ? JSON.stringify(input.signedReceipt) : null,
+      input.oneshotRequestId ?? null,
+      input.senderIdentity ?? null,
+      memo,
+      JSON.stringify(decisionContext),
+      goalId,
+    );
+    return Number(result.lastInsertRowid);
+  }
+
+  getReceipt(id: number): ReceiptRecord | null {
+    return (this.db.query("SELECT * FROM receipts WHERE id = ?").get(id) as ReceiptRecord) ?? null;
+  }
+
+  listReceipts(
+    opts: { playName?: string; sinceIso?: string; limit?: number } = {},
+  ): ReceiptRecord[] {
+    const where: string[] = [];
+    const args: unknown[] = [];
+    if (opts.playName) {
+      where.push("play_name = ?");
+      args.push(opts.playName);
+    }
+    if (opts.sinceIso) {
+      where.push("created_at >= ?");
+      args.push(opts.sinceIso);
+    }
+    const sql = `SELECT * FROM receipts ${where.length ? `WHERE ${where.join(" AND ")}` : ""} ORDER BY created_at DESC LIMIT ?`;
+    args.push(opts.limit ?? 200);
+    return this.db.query(sql).all(...(args as never[])) as ReceiptRecord[];
+  }
+
+  /** Persist the RoCS value tag (JSON `{type,amount?,label?}`) on a single receipt. */
+  setReceiptValueTag(receiptId: number, valueTagJson: string): void {
+    this.db
+      .prepare(`UPDATE receipts SET value_tag = ?, value_tagged_at = datetime('now') WHERE id = ?`)
+      .run(valueTagJson, receiptId);
+  }
+
+  /**
+   * Local mirror of a goal-level value tag: stamp every receipt in the cadence
+   * (matching `goal_id`) so the /receipts UI shows the value per row. Returns the
+   * number of receipts touched. The platform records the value once per goal via
+   * `tagReceiptValue({goalId})`; this just keeps the dashboard in sync.
+   */
+  setReceiptValueTagByGoal(goalId: string, valueTagJson: string): number {
+    const res = this.db
+      .prepare(
+        `UPDATE receipts SET value_tag = ?, value_tagged_at = datetime('now') WHERE goal_id = ?`,
+      )
+      .run(valueTagJson, goalId);
+    return res.changes;
+  }
+
+  /** Current local value tag for a goal (any one of its receipts), or null. */
+  currentGoalValueTag(goalId: string): string | null {
+    const row = this.db
+      .query(`SELECT value_tag FROM receipts WHERE goal_id = ? AND value_tag IS NOT NULL LIMIT 1`)
+      .get(goalId) as { value_tag: string } | undefined;
+    return row?.value_tag ?? null;
+  }
+
+  /**
+   * Human labels (play + prospect) for a set of goalIds, derived from the local
+   * receipts so the Measure page can render OneShot's opaque goal_id rollups as
+   * "{play} → {prospect}". First receipt per goal wins.
+   */
+  goalLabels(goalIds: string[]): Map<string, { playName: string | null; prospect: string | null }> {
+    const out = new Map<string, { playName: string | null; prospect: string | null }>();
+    if (goalIds.length === 0) return out;
+    const placeholders = goalIds.map(() => "?").join(",");
+    const rows = this.db
+      .query(
+        `SELECT goal_id, play_name, decision_context FROM receipts WHERE goal_id IN (${placeholders})`,
+      )
+      .all(...goalIds) as Array<{
+      goal_id: string;
+      play_name: string;
+      decision_context: string | null;
+    }>;
+    for (const r of rows) {
+      if (out.has(r.goal_id)) continue;
+      let prospect: string | null = null;
+      if (r.decision_context) {
+        try {
+          const dc = JSON.parse(r.decision_context) as {
+            prospectEmail?: string;
+            customerName?: string;
+          };
+          prospect = dc.prospectEmail ?? dc.customerName ?? null;
+        } catch {
+          prospect = null;
+        }
+      }
+      out.set(r.goal_id, { playName: r.play_name, prospect });
+    }
+    return out;
+  }
+
+  spendByPlay(
+    opts: { sinceIso?: string } = {},
+  ): Array<{ play_name: string; calls: number; total_usd: number }> {
+    const where: string[] = [];
+    const args: unknown[] = [];
+    if (opts.sinceIso) {
+      where.push("created_at >= ?");
+      args.push(opts.sinceIso);
+    }
+    const sql = `
+      SELECT play_name, COUNT(*) AS calls, COALESCE(SUM(cost_usd), 0) AS total_usd
+      FROM receipts
+      ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
+      GROUP BY play_name
+      ORDER BY total_usd DESC, calls DESC
+    `;
+    return this.db.query(sql).all(...(args as never[])) as Array<{
+      play_name: string;
+      calls: number;
+      total_usd: number;
+    }>;
+  }
+
+  /**
+   * How many receipts fall in the window.
+   *
+   * Callers wanting a count must not list the rows and measure the array: the
+   * Today page did exactly that behind a `limit: 1000`, so any install busy
+   * enough to exceed it reported precisely 1000 calls a week, for ever, with
+   * nothing in the response to say it had been truncated.
+   */
+  countReceipts(opts: { sinceIso?: string; playName?: string } = {}): number {
+    const where: string[] = [];
+    const args: unknown[] = [];
+    if (opts.playName) {
+      where.push("play_name = ?");
+      args.push(opts.playName);
+    }
+    if (opts.sinceIso) {
+      where.push("created_at >= ?");
+      args.push(opts.sinceIso);
+    }
+    const sql = `SELECT COUNT(*) AS n FROM receipts${where.length ? ` WHERE ${where.join(" AND ")}` : ""}`;
+    return (this.db.query(sql).get(...(args as never[])) as { n: number } | null)?.n ?? 0;
+  }
+
+  /**
+   * Daily signed spend per play, for the trend sparklines on Measure.
+   *
+   * Bucketed in SQL rather than by listing receipts and grouping in the
+   * browser. The page used to pull 500 rows and bucket them client-side, which
+   * silently became a five-hour window once an install carried tens of
+   * thousands of receipts; and `new Date("YYYY-MM-DD HH:MM:SS")` parses as
+   * local time, so the buckets drifted by the viewer's UTC offset. `date()`
+   * here has neither problem.
+   */
+  spendSeriesByPlay(opts: { days: number }): Array<{
+    play_name: string;
+    day: string;
+    total_usd: number;
+  }> {
+    const sql = `
+      SELECT play_name, date(created_at) AS day, COALESCE(SUM(cost_usd), 0) AS total_usd
+      FROM receipts
+      WHERE cost_usd IS NOT NULL AND date(created_at) >= date('now', ?)
+      GROUP BY play_name, day
+      ORDER BY day ASC
+    `;
+    return this.db.query(sql).all(`-${Math.max(1, Math.floor(opts.days))} days` as never) as never;
+  }
+
+  totalSpendUsd(opts: { sinceIso?: string; playName?: string } = {}): number {
+    const where: string[] = ["cost_usd IS NOT NULL"];
+    const args: unknown[] = [];
+    if (opts.playName) {
+      where.push("play_name = ?");
+      args.push(opts.playName);
+    }
+    if (opts.sinceIso) {
+      where.push("created_at >= ?");
+      args.push(opts.sinceIso);
+    }
+    const sql = `SELECT COALESCE(SUM(cost_usd), 0) AS total FROM receipts WHERE ${where.join(" AND ")}`;
+    return (this.db.query(sql).get(...(args as never[])) as { total: number } | null)?.total ?? 0;
+  }
+
+  /**
+   * The local funnel ladder: receipts value-tagged by outcome attribution
+   * (engagement < meeting < qualified < revenue). goal_id is a sha256 of
+   * (play, email) — not computable in SQLite, so the caller joins in JS via
+   * `cadenceGoalId`.
+   */
+  listValueTaggedReceipts(): Array<{ goal_id: string; value_tag: string }> {
+    return this.db
+      .query(
+        `SELECT goal_id, value_tag FROM receipts
+         WHERE value_tag IS NOT NULL AND goal_id IS NOT NULL`,
+      )
+      .all() as Array<{ goal_id: string; value_tag: string }>;
+  }
+}

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -12,6 +12,7 @@ import {
 } from "./dossier.ts";
 import { humanDecisionWhereSql } from "./labels.ts";
 import { migrateLedgerSchema } from "./ledger-schema.ts";
+import { ReceiptStore } from "./ledger-receipts.ts";
 import { getSharedDb } from "./shared-db.ts";
 import type { ReplyKind } from "./reply-classify.ts";
 import type {
@@ -286,6 +287,7 @@ function publicIntent(intent: string | null): string | null {
 export class Ledger {
   private db: Database;
   private path: string;
+  private receipts: ReceiptStore;
 
   constructor(path: string = DEFAULT_DB_PATH) {
     this.path = path;
@@ -299,6 +301,11 @@ export class Ledger {
     // / "no such table" mid-migration.
     this.db.exec("PRAGMA busy_timeout = 5000");
     this.migrate();
+    // Receipt reads/writes/attribution/aggregation live in ledger-receipts.ts
+    // (see its doc comment) — extracted as the next slice of the ledger split
+    // tracked in ROADMAP.md, following the schema extraction in #452.
+    // Constructed AFTER migrate() so the receipts table already exists.
+    this.receipts = new ReceiptStore(this.db);
   }
 
   getDirectMail(id: string): DirectMailDraft | null {
@@ -1514,52 +1521,7 @@ export class Ledger {
     /** Call-time decisionContext blob; JSON-stringified into the column. */
     decisionContext?: unknown;
   }): number {
-    // Idempotent on the job id: the SDK's idempotency replay returns the
-    // ORIGINAL request_id when a timed-out/double-fired send is retried, and a
-    // Gmail message id is unique per send — so a non-null request_id already in
-    // the table means "same underlying send". Return the existing receipt
-    // instead of inserting a duplicate that would double-count spend and caps.
-    // Null request_ids (cache hits, SDK omissions) are distinct events and skip
-    // this — they must never collapse together.
-    if (input.oneshotRequestId) {
-      const existing = this.db
-        .query("SELECT id FROM receipts WHERE oneshot_request_id = ?")
-        .get(input.oneshotRequestId) as { id: number } | undefined;
-      if (existing) return existing.id;
-    }
-    // Number.isFinite guard rejects undefined / Infinity / NaN — those land
-    // as NULL in the column, NOT silently distorted into a number.
-    const costUsd =
-      typeof input.costUsd === "number" && Number.isFinite(input.costUsd) ? input.costUsd : null;
-    // Mirror what buildAuditOpts sends to OneShot so the stored memo/context
-    // match the platform receipt even at call sites that don't enrich.
-    const memo = input.memo ?? `${input.playName} ${input.callType}`;
-    const decisionContext = input.decisionContext ?? {
-      playName: input.playName,
-      callType: input.callType,
-    };
-    // Mirror the cadence correlation key (decisionContext.goalId) into its own
-    // column so an outcome can value-tag the whole goal in one UPDATE.
-    const goalId =
-      typeof (decisionContext as { goalId?: unknown }).goalId === "string"
-        ? (decisionContext as { goalId: string }).goalId
-        : null;
-    const stmt = this.db.prepare(`
-      INSERT INTO receipts(play_name, call_type, cost_usd, signed_receipt, oneshot_request_id, sender_identity, memo, decision_context, goal_id)
-      VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `);
-    const result = stmt.run(
-      input.playName,
-      input.callType,
-      costUsd,
-      input.signedReceipt ? JSON.stringify(input.signedReceipt) : null,
-      input.oneshotRequestId ?? null,
-      input.senderIdentity ?? null,
-      memo,
-      JSON.stringify(decisionContext),
-      goalId,
-    );
-    return Number(result.lastInsertRowid);
+    return this.receipts.recordReceipt(input);
   }
 
   getSenderAssignment(email: string): string | null {
@@ -1940,25 +1902,13 @@ export class Ledger {
   }
 
   getReceipt(id: number): ReceiptRecord | null {
-    return (this.db.query("SELECT * FROM receipts WHERE id = ?").get(id) as ReceiptRecord) ?? null;
+    return this.receipts.getReceipt(id);
   }
 
   listReceipts(
     opts: { playName?: string; sinceIso?: string; limit?: number } = {},
   ): ReceiptRecord[] {
-    const where: string[] = [];
-    const args: unknown[] = [];
-    if (opts.playName) {
-      where.push("play_name = ?");
-      args.push(opts.playName);
-    }
-    if (opts.sinceIso) {
-      where.push("created_at >= ?");
-      args.push(opts.sinceIso);
-    }
-    const sql = `SELECT * FROM receipts ${where.length ? `WHERE ${where.join(" AND ")}` : ""} ORDER BY created_at DESC LIMIT ?`;
-    args.push(opts.limit ?? 200);
-    return this.db.query(sql).all(...(args as never[])) as ReceiptRecord[];
+    return this.receipts.listReceipts(opts);
   }
 
   upsertProspect(input: Partial<ProspectRecord> & { email?: string | null }): number {
@@ -2528,9 +2478,7 @@ export class Ledger {
 
   /** Persist the RoCS value tag (JSON `{type,amount?,label?}`) on a single receipt. */
   setReceiptValueTag(receiptId: number, valueTagJson: string): void {
-    this.db
-      .prepare(`UPDATE receipts SET value_tag = ?, value_tagged_at = datetime('now') WHERE id = ?`)
-      .run(valueTagJson, receiptId);
+    this.receipts.setReceiptValueTag(receiptId, valueTagJson);
   }
 
   /**
@@ -2540,20 +2488,12 @@ export class Ledger {
    * `tagReceiptValue({goalId})`; this just keeps the dashboard in sync.
    */
   setReceiptValueTagByGoal(goalId: string, valueTagJson: string): number {
-    const res = this.db
-      .prepare(
-        `UPDATE receipts SET value_tag = ?, value_tagged_at = datetime('now') WHERE goal_id = ?`,
-      )
-      .run(valueTagJson, goalId);
-    return res.changes;
+    return this.receipts.setReceiptValueTagByGoal(goalId, valueTagJson);
   }
 
   /** Current local value tag for a goal (any one of its receipts), or null. */
   currentGoalValueTag(goalId: string): string | null {
-    const row = this.db
-      .query(`SELECT value_tag FROM receipts WHERE goal_id = ? AND value_tag IS NOT NULL LIMIT 1`)
-      .get(goalId) as { value_tag: string } | undefined;
-    return row?.value_tag ?? null;
+    return this.receipts.currentGoalValueTag(goalId);
   }
 
   /**
@@ -2562,35 +2502,7 @@ export class Ledger {
    * "{play} → {prospect}". First receipt per goal wins.
    */
   goalLabels(goalIds: string[]): Map<string, { playName: string | null; prospect: string | null }> {
-    const out = new Map<string, { playName: string | null; prospect: string | null }>();
-    if (goalIds.length === 0) return out;
-    const placeholders = goalIds.map(() => "?").join(",");
-    const rows = this.db
-      .query(
-        `SELECT goal_id, play_name, decision_context FROM receipts WHERE goal_id IN (${placeholders})`,
-      )
-      .all(...goalIds) as Array<{
-      goal_id: string;
-      play_name: string;
-      decision_context: string | null;
-    }>;
-    for (const r of rows) {
-      if (out.has(r.goal_id)) continue;
-      let prospect: string | null = null;
-      if (r.decision_context) {
-        try {
-          const dc = JSON.parse(r.decision_context) as {
-            prospectEmail?: string;
-            customerName?: string;
-          };
-          prospect = dc.prospectEmail ?? dc.customerName ?? null;
-        } catch {
-          prospect = null;
-        }
-      }
-      out.set(r.goal_id, { playName: r.play_name, prospect });
-    }
-    return out;
+    return this.receipts.goalLabels(goalIds);
   }
 
   /**
@@ -2888,24 +2800,7 @@ export class Ledger {
   spendByPlay(
     opts: { sinceIso?: string } = {},
   ): Array<{ play_name: string; calls: number; total_usd: number }> {
-    const where: string[] = [];
-    const args: unknown[] = [];
-    if (opts.sinceIso) {
-      where.push("created_at >= ?");
-      args.push(opts.sinceIso);
-    }
-    const sql = `
-      SELECT play_name, COUNT(*) AS calls, COALESCE(SUM(cost_usd), 0) AS total_usd
-      FROM receipts
-      ${where.length ? `WHERE ${where.join(" AND ")}` : ""}
-      GROUP BY play_name
-      ORDER BY total_usd DESC, calls DESC
-    `;
-    return this.db.query(sql).all(...(args as never[])) as Array<{
-      play_name: string;
-      calls: number;
-      total_usd: number;
-    }>;
+    return this.receipts.spendByPlay(opts);
   }
 
   /**
@@ -2995,18 +2890,7 @@ export class Ledger {
    * nothing in the response to say it had been truncated.
    */
   countReceipts(opts: { sinceIso?: string; playName?: string } = {}): number {
-    const where: string[] = [];
-    const args: unknown[] = [];
-    if (opts.playName) {
-      where.push("play_name = ?");
-      args.push(opts.playName);
-    }
-    if (opts.sinceIso) {
-      where.push("created_at >= ?");
-      args.push(opts.sinceIso);
-    }
-    const sql = `SELECT COUNT(*) AS n FROM receipts${where.length ? ` WHERE ${where.join(" AND ")}` : ""}`;
-    return (this.db.query(sql).get(...(args as never[])) as { n: number } | null)?.n ?? 0;
+    return this.receipts.countReceipts(opts);
   }
 
   /**
@@ -3024,29 +2908,11 @@ export class Ledger {
     day: string;
     total_usd: number;
   }> {
-    const sql = `
-      SELECT play_name, date(created_at) AS day, COALESCE(SUM(cost_usd), 0) AS total_usd
-      FROM receipts
-      WHERE cost_usd IS NOT NULL AND date(created_at) >= date('now', ?)
-      GROUP BY play_name, day
-      ORDER BY day ASC
-    `;
-    return this.db.query(sql).all(`-${Math.max(1, Math.floor(opts.days))} days` as never) as never;
+    return this.receipts.spendSeriesByPlay(opts);
   }
 
   totalSpendUsd(opts: { sinceIso?: string; playName?: string } = {}): number {
-    const where: string[] = ["cost_usd IS NOT NULL"];
-    const args: unknown[] = [];
-    if (opts.playName) {
-      where.push("play_name = ?");
-      args.push(opts.playName);
-    }
-    if (opts.sinceIso) {
-      where.push("created_at >= ?");
-      args.push(opts.sinceIso);
-    }
-    const sql = `SELECT COALESCE(SUM(cost_usd), 0) AS total FROM receipts WHERE ${where.join(" AND ")}`;
-    return (this.db.query(sql).get(...(args as never[])) as { total: number } | null)?.total ?? 0;
+    return this.receipts.totalSpendUsd(opts);
   }
 
   // ── spend_reservations (issue #481: install-wide daily USD spend ceiling) ──
@@ -4737,12 +4603,7 @@ export class Ledger {
    * `cadenceGoalId`.
    */
   listValueTaggedReceipts(): Array<{ goal_id: string; value_tag: string }> {
-    return this.db
-      .query(
-        `SELECT goal_id, value_tag FROM receipts
-         WHERE value_tag IS NOT NULL AND goal_id IS NOT NULL`,
-      )
-      .all() as Array<{ goal_id: string; value_tag: string }>;
+    return this.receipts.listValueTaggedReceipts();
   }
 
   close(): void {


### PR DESCRIPTION
Closes #616.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 073f957258e2 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (2 errs) vs base ok (2 errs)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved receipt persistence reliability, including duplicate request handling and transaction rollback.
  * Preserved receipt retrieval, filtering, tagging, labeling, and spending analytics.
  * Improved handling of invalid costs and malformed decision-context data without disrupting related lookups.

* **Tests**
  * Added comprehensive coverage for receipt storage, ledger integration, spending queries, tagging, deduplication, rollback, and shared database visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->