### PR TITLE
fix: issue #618: Extract cache persistence from Ledger

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -51,6 +51,8 @@ The ICP filter currently judges each candidate cold — `icpFilter` in `packages
       _Progress (#452):_ fresh-install schema construction + inline migrations extracted to `packages/core/src/ledger-schema.ts`; `Ledger.migrate()` now delegates to it. Byte-identical fresh-install schema verified (sqlite_master + schema_version snapshot in `ledger.test.ts`); domain methods (receipts, prospects, queue, cadence, inbox, bounces, canaries, caches) remain in `ledger.ts` for a follow-up slice.
       **Progress (#616):** receipt reads, writes, attribution and aggregation extracted to `packages/core/src/ledger-receipts.ts` as a `ReceiptStore` constructed from the migrated `Database` handle; `Ledger` delegates every receipt method to it with signatures, return values and transaction boundaries unchanged. Prospects, queue, cadence, inbox, bounces, canaries and caches remain in `ledger.ts` for further slices (bounces/canaries tracked as issue #617).
 
+      _Progress (#618):_ cache get/set/expiry/invalidation extracted to `packages/core/src/ledger-cache.ts`; `Ledger` delegates to a `LedgerCache` instance, keeping identical public method signatures and TTL constants. Receipts, prospects, queue, cadence, inbox, bounces and canaries remain in `ledger.ts` for further slices.
+
 ## Launch assets
 
 Not code — these need capture, not commits. `demo seed` + `demo ui` now stand up a populated, fictional install to record against, so neither is blocked on having something to point a camera at.

--- a/packages/core/__tests__/ledger-cache.test.ts
+++ b/packages/core/__tests__/ledger-cache.test.ts
@@ -142,8 +142,15 @@ describe("enrichment cache (delegated to SharedDb) — hits, misses, replacement
 });
 
 describe("LinkedIn cache (delegated to SharedDb) — hits, misses, replacement", () => {
+  // `getCachedLinkedIn`/`setCachedLinkedIn` are delegated to the process-wide
+  // `getSharedDb()` singleton, whose tables are never truncated between
+  // tests (unlike `dbPath`, which is recreated per test in beforeEach). Every
+  // case below therefore needs its own unique query key — reusing a key
+  // across cases makes assertions order-dependent on stale rows written by
+  // an earlier case, the same footgun ledger.test.ts already avoids for the
+  // enrichment cache by giving each case its own email.
   it("is a miss (null row) for a query key never searched", () => {
-    expect(ledger.getCachedLinkedIn("ada acme.dev")).toBeNull();
+    expect(ledger.getCachedLinkedIn("quinn nobody.dev")).toBeNull();
   });
 
   it("is a hit with status 'hit' when a URL was found", () => {
@@ -162,11 +169,11 @@ describe("LinkedIn cache (delegated to SharedDb) — hits, misses, replacement",
   });
 
   it("replacement: a later hit overwrites an earlier miss for the same query key", () => {
-    ledger.setCachedLinkedIn("ada acme.dev", null);
-    expect(ledger.getCachedLinkedIn("ada acme.dev")?.status).toBe("miss");
-    ledger.setCachedLinkedIn("ada acme.dev", "https://linkedin.com/in/ada");
-    expect(ledger.getCachedLinkedIn("ada acme.dev")).toMatchObject({
-      url: "https://linkedin.com/in/ada",
+    ledger.setCachedLinkedIn("grace flux.dev", null);
+    expect(ledger.getCachedLinkedIn("grace flux.dev")?.status).toBe("miss");
+    ledger.setCachedLinkedIn("grace flux.dev", "https://linkedin.com/in/grace");
+    expect(ledger.getCachedLinkedIn("grace flux.dev")).toMatchObject({
+      url: "https://linkedin.com/in/grace",
       status: "hit",
     });
   });

--- a/packages/core/__tests__/ledger-cache.test.ts
+++ b/packages/core/__tests__/ledger-cache.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { Ledger } from "../src/ledger.ts";
+
+/**
+ * Focused coverage for the cache persistence extracted to `ledger-cache.ts`
+ * (#618): hits, misses, expiry boundaries, replacement and invalidation,
+ * exercised entirely through the public `Ledger` surface so this file also
+ * proves the extraction changed nothing observable. `ledger.test.ts` already
+ * covers the enrichment-cache negative-entry (failure/success) transitions
+ * and a basic product-research hit/expiry pair — this file goes deeper on
+ * boundary conditions and the LinkedIn cache, without duplicating those.
+ */
+
+let dbPath: string;
+let ledger: Ledger;
+
+beforeEach(() => {
+  dbPath = join(
+    tmpdir(),
+    `oneshot-gtm-ledger-cache-${Date.now()}-${Math.random().toString(36).slice(2)}.sqlite`,
+  );
+  ledger = new Ledger(dbPath);
+});
+
+afterEach(() => {
+  ledger.close();
+  for (const suffix of ["", "-wal", "-shm"]) {
+    try {
+      rmSync(`${dbPath}${suffix}`);
+    } catch {
+      // ignore
+    }
+  }
+});
+
+/** Direct access to the underlying db to backdate a row's fetched_at, same pattern used elsewhere in this suite. */
+function backdateProductResearchCache(cacheKey: string, fetchedAtIso: string): void {
+  (ledger as unknown as { db: { prepare(s: string): { run(...a: unknown[]): unknown } } }).db
+    .prepare("UPDATE product_research_cache SET fetched_at = ? WHERE cache_key = ?")
+    .run(fetchedAtIso, cacheKey);
+}
+
+describe("product research cache — hits, misses, expiry boundaries, replacement", () => {
+  it("is a miss for a key that was never written", () => {
+    expect(ledger.getProductResearchCache("https://never-set.dev", 60_000)).toBeNull();
+  });
+
+  it("is a hit immediately after a write, within the TTL", () => {
+    ledger.setProductResearchCache("https://acme.dev", '{"version":1}');
+    expect(ledger.getProductResearchCache("https://acme.dev", 60_000)).toBe('{"version":1}');
+  });
+
+  it("is a miss once the row is older than maxAgeMs", () => {
+    ledger.setProductResearchCache("https://acme.dev", '{"version":1}');
+    backdateProductResearchCache("https://acme.dev", new Date(Date.now() - 120_000).toISOString());
+    expect(ledger.getProductResearchCache("https://acme.dev", 60_000)).toBeNull();
+  });
+
+  it("expiry boundary: a row exactly at the cutoff is still a hit (>=, not >)", () => {
+    vi.useFakeTimers();
+    try {
+      const now = Date.now();
+      const maxAgeMs = 60_000;
+      ledger.setProductResearchCache("https://boundary.dev", '{"version":1}');
+      // Row fetched exactly maxAgeMs ago: cutoff = now - maxAgeMs = fetchedAt.
+      backdateProductResearchCache("https://boundary.dev", new Date(now - maxAgeMs).toISOString());
+      expect(ledger.getProductResearchCache("https://boundary.dev", maxAgeMs)).toBe(
+        '{"version":1}',
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("expiry boundary: a row one millisecond past the cutoff is a miss", () => {
+    vi.useFakeTimers();
+    try {
+      const now = Date.now();
+      const maxAgeMs = 60_000;
+      ledger.setProductResearchCache("https://boundary2.dev", '{"version":1}');
+      // Row fetched one millisecond before the cutoff.
+      backdateProductResearchCache(
+        "https://boundary2.dev",
+        new Date(now - maxAgeMs - 1).toISOString(),
+      );
+      expect(ledger.getProductResearchCache("https://boundary2.dev", maxAgeMs)).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("a negative maxAgeMs always misses, even right after a write", () => {
+    ledger.setProductResearchCache("https://acme.dev", '{"version":1}');
+    expect(ledger.getProductResearchCache("https://acme.dev", -1)).toBeNull();
+  });
+
+  it("replacement: a second write for the same key overwrites the dossier and refreshes fetched_at", () => {
+    ledger.setProductResearchCache("https://acme.dev", '{"version":1}');
+    backdateProductResearchCache("https://acme.dev", new Date(Date.now() - 120_000).toISOString());
+    // Stale by the old write's timestamp...
+    expect(ledger.getProductResearchCache("https://acme.dev", 60_000)).toBeNull();
+    // ...but a fresh write replaces both the payload and the freshness.
+    ledger.setProductResearchCache("https://acme.dev", '{"version":2}');
+    expect(ledger.getProductResearchCache("https://acme.dev", 60_000)).toBe('{"version":2}');
+  });
+
+  it("distinct cache keys never collide", () => {
+    ledger.setProductResearchCache("https://a.dev", '{"co":"a"}');
+    ledger.setProductResearchCache("https://b.dev", '{"co":"b"}');
+    expect(ledger.getProductResearchCache("https://a.dev", 60_000)).toBe('{"co":"a"}');
+    expect(ledger.getProductResearchCache("https://b.dev", 60_000)).toBe('{"co":"b"}');
+  });
+});
+
+describe("enrichment cache (delegated to SharedDb) — hits, misses, replacement, invalidation", () => {
+  it("is a miss for an email that was never enriched", () => {
+    expect(ledger.getCachedEnrichment("nobody@acme.dev")).toBeNull();
+  });
+
+  it("is a hit after a successful enrichment write", () => {
+    ledger.setCachedEnrichment("ada@acme.dev", '{"title":"CTO"}');
+    expect(ledger.getCachedEnrichment("ada@acme.dev")).toMatchObject({
+      result_json: '{"title":"CTO"}',
+      status: null,
+    });
+  });
+
+  it("replacement: a later success overwrites the earlier payload", () => {
+    ledger.setCachedEnrichment("ada@acme.dev", '{"title":"CTO"}');
+    ledger.setCachedEnrichment("ada@acme.dev", '{"title":"Founder"}');
+    expect(ledger.getCachedEnrichment("ada@acme.dev")?.result_json).toBe('{"title":"Founder"}');
+  });
+
+  it("invalidation: a failure write marks the entry failed, suppressing the prior success", () => {
+    ledger.setCachedEnrichment("ada@acme.dev", '{"title":"CTO"}');
+    ledger.setCachedEnrichmentFailure("ada@acme.dev", "SDK outage");
+    expect(ledger.getCachedEnrichment("ada@acme.dev")?.status).toBe("failed");
+  });
+});
+
+describe("LinkedIn cache (delegated to SharedDb) — hits, misses, replacement", () => {
+  it("is a miss (null row) for a query key never searched", () => {
+    expect(ledger.getCachedLinkedIn("ada acme.dev")).toBeNull();
+  });
+
+  it("is a hit with status 'hit' when a URL was found", () => {
+    ledger.setCachedLinkedIn("ada acme.dev", "https://linkedin.com/in/ada");
+    expect(ledger.getCachedLinkedIn("ada acme.dev")).toMatchObject({
+      url: "https://linkedin.com/in/ada",
+      status: "hit",
+    });
+  });
+
+  it("records a genuine miss (searched, not found) as status 'miss' with a null url — distinct from never having been queried", () => {
+    ledger.setCachedLinkedIn("ghost person", null);
+    const row = ledger.getCachedLinkedIn("ghost person");
+    expect(row).toMatchObject({ url: null, status: "miss" });
+    expect(row).not.toBeNull();
+  });
+
+  it("replacement: a later hit overwrites an earlier miss for the same query key", () => {
+    ledger.setCachedLinkedIn("ada acme.dev", null);
+    expect(ledger.getCachedLinkedIn("ada acme.dev")?.status).toBe("miss");
+    ledger.setCachedLinkedIn("ada acme.dev", "https://linkedin.com/in/ada");
+    expect(ledger.getCachedLinkedIn("ada acme.dev")).toMatchObject({
+      url: "https://linkedin.com/in/ada",
+      status: "hit",
+    });
+  });
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,7 @@
 export * from "./oneshot.ts";
 export * from "./inflight.ts";
 export * from "./ledger.ts";
+export * from "./ledger-cache.ts";
 export * from "./config.ts";
 export * from "./demo.ts";
 export * from "./shared-db.ts";

--- a/packages/core/src/ledger-cache.ts
+++ b/packages/core/src/ledger-cache.ts
@@ -1,0 +1,116 @@
+import type { Database } from "bun:sqlite";
+import { getSharedDb } from "./shared-db.ts";
+
+/**
+ * Cache persistence extracted from `Ledger` (#618) — the second slice of the
+ * ledger split tracked in ROADMAP.md, after the fresh-install schema/inline
+ * migrations moved to `ledger-schema.ts` (#452). Covers every cache `Ledger`
+ * exposes: the product-research dossier cache, which owns its rows directly
+ * in this ledger's own SQLite file, and the paid-lookup enrichment/LinkedIn
+ * caches, which `Ledger` merely forwards to the cross-workspace `SharedDb`
+ * (shared-db.ts) so the same person is never bought twice across products.
+ *
+ * `Ledger` keeps its exact public method names/signatures and constructs one
+ * `LedgerCache` per instance, delegating every cache method to it — an
+ * observer of the public surface sees no difference.
+ */
+
+/** How long a SUCCESSFUL enrichment is reused before refetching (profiles are stable). */
+export const ENRICH_CACHE_TTL_MS = 30 * 24 * 3600 * 1000;
+/** How long a FAILED enrichment suppresses retries — long enough to ride out an SDK outage, short enough to self-heal. */
+export const ENRICH_FAILURE_TTL_MS = 3 * 24 * 3600 * 1000;
+/**
+ * Hard ceiling on waiting for one enrichProfile call. The platform's enrich
+ * tool has been observed HANGING (no error, no result, 5+ min) rather than
+ * failing — callers race against this and treat a deadline as a failure.
+ */
+export const ENRICH_DEADLINE_MS = 120_000;
+
+/**
+ * How long a SUCCESSFUL person dossier (deepResearchPerson) is reused. Longer
+ * than the enrich TTL: a person's org history and profiles change slowly, and
+ * the call costs 10x as much (~$0.05 vs ~$0.005).
+ */
+export const RESEARCH_CACHE_TTL_MS = 90 * 24 * 3600 * 1000;
+/**
+ * Hard ceiling on one deepResearchPerson call. Its own doc comment puts it at
+ * 2-5 minutes, so this sits above that rather than at the enrich ceiling — the
+ * call is legitimately slow, and racing it at 120s would abandon work we paid for.
+ */
+export const RESEARCH_DEADLINE_MS = 360_000;
+
+/** How long a FOUND LinkedIn URL is reused. Profile URLs effectively never change. */
+export const LINKEDIN_CACHE_TTL_MS = 30 * 24 * 3600 * 1000;
+/**
+ * How long a genuine MISS ("we searched, this person has no findable profile")
+ * suppresses re-searching. Longer than the enrich failure TTL because a miss is
+ * a real answer rather than an outage — but not permanent, since people do
+ * create profiles. Every re-search costs ~$0.01, so this directly caps the
+ * spend of repeatedly running finders over the same candidate pool.
+ */
+export const LINKEDIN_MISS_TTL_MS = 14 * 24 * 3600 * 1000;
+
+export class LedgerCache {
+  constructor(
+    private db: Database,
+    private path: string,
+  ) {}
+
+  /**
+   * Paid-lookup caches live in the cross-workspace SHARED DB (shared-db.ts) —
+   * the same person must never be bought twice across products. These methods
+   * keep their contracts and delegate; this ledger's legacy cache rows are
+   * copied across once on first use.
+   */
+  private shared(): ReturnType<typeof getSharedDb> {
+    const shared = getSharedDb();
+    shared.ensureImported(this.db, this.path);
+    return shared;
+  }
+
+  getCachedEnrichment(
+    email: string,
+  ): { result_json: string; fetched_at: string; status: string | null } | null {
+    return this.shared().getCachedEnrichment(email);
+  }
+
+  getCachedLinkedIn(
+    queryKey: string,
+  ): { url: string | null; status: string; fetched_at: string } | null {
+    return this.shared().getCachedLinkedIn(queryKey);
+  }
+
+  setCachedLinkedIn(queryKey: string, url: string | null): void {
+    this.shared().setCachedLinkedIn(queryKey, url);
+  }
+
+  setCachedEnrichment(email: string, resultJson: string): void {
+    this.shared().setCachedEnrichment(email, resultJson);
+  }
+
+  setCachedEnrichmentFailure(email: string, message: string): void {
+    this.shared().setCachedEnrichmentFailure(email, message);
+  }
+
+  getProductResearchCache(cacheKey: string, maxAgeMs: number): string | null {
+    const cutoff = new Date(Date.now() - maxAgeMs).toISOString();
+    const row = this.db
+      .query(
+        "SELECT dossier_json FROM product_research_cache WHERE cache_key = ? AND fetched_at >= ?",
+      )
+      .get(cacheKey, cutoff) as { dossier_json: string } | undefined;
+    return row?.dossier_json ?? null;
+  }
+
+  setProductResearchCache(cacheKey: string, dossierJson: string): void {
+    this.db
+      .prepare(
+        `INSERT INTO product_research_cache(cache_key, dossier_json, fetched_at)
+         VALUES(?, ?, ?)
+         ON CONFLICT(cache_key) DO UPDATE SET
+           dossier_json = excluded.dossier_json,
+           fetched_at = excluded.fetched_at`,
+      )
+      .run(cacheKey, dossierJson, new Date().toISOString());
+  }
+}

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -11,6 +11,7 @@ import {
   type ProductResearchDossier,
 } from "./dossier.ts";
 import { humanDecisionWhereSql } from "./labels.ts";
+import { LedgerCache } from "./ledger-cache.ts";
 import { migrateLedgerSchema } from "./ledger-schema.ts";
 import { ReceiptStore } from "./ledger-receipts.ts";
 import { getSharedDb } from "./shared-db.ts";
@@ -73,40 +74,19 @@ function icpExampleCandidate(payload: unknown): Record<string, unknown> {
 
 const DEFAULT_DB_PATH = join(configDir(), "ledger.sqlite");
 
-/** How long a SUCCESSFUL enrichment is reused before refetching (profiles are stable). */
-export const ENRICH_CACHE_TTL_MS = 30 * 24 * 3600 * 1000;
-/** How long a FAILED enrichment suppresses retries — long enough to ride out an SDK outage, short enough to self-heal. */
-export const ENRICH_FAILURE_TTL_MS = 3 * 24 * 3600 * 1000;
-/**
- * Hard ceiling on waiting for one enrichProfile call. The platform's enrich
- * tool has been observed HANGING (no error, no result, 5+ min) rather than
- * failing — callers race against this and treat a deadline as a failure.
- */
-export const ENRICH_DEADLINE_MS = 120_000;
-
-/**
- * How long a SUCCESSFUL person dossier (deepResearchPerson) is reused. Longer
- * than the enrich TTL: a person's org history and profiles change slowly, and
- * the call costs 10x as much (~$0.05 vs ~$0.005).
- */
-export const RESEARCH_CACHE_TTL_MS = 90 * 24 * 3600 * 1000;
-/**
- * Hard ceiling on one deepResearchPerson call. Its own doc comment puts it at
- * 2-5 minutes, so this sits above that rather than at the enrich ceiling — the
- * call is legitimately slow, and racing it at 120s would abandon work we paid for.
- */
-export const RESEARCH_DEADLINE_MS = 360_000;
-
-/** How long a FOUND LinkedIn URL is reused. Profile URLs effectively never change. */
-export const LINKEDIN_CACHE_TTL_MS = 30 * 24 * 3600 * 1000;
-/**
- * How long a genuine MISS ("we searched, this person has no findable profile")
- * suppresses re-searching. Longer than the enrich failure TTL because a miss is
- * a real answer rather than an outage — but not permanent, since people do
- * create profiles. Every re-search costs ~$0.01, so this directly caps the
- * spend of repeatedly running finders over the same candidate pool.
- */
-export const LINKEDIN_MISS_TTL_MS = 14 * 24 * 3600 * 1000;
+// Cache TTL/deadline constants and all cache get/set/expiry/invalidation
+// implementations live in ledger-cache.ts (#618) — re-exported here so every
+// existing `import { ENRICH_CACHE_TTL_MS, ... } from "./ledger.ts"` (and the
+// package's `export * from "./ledger.ts"` barrel) keeps resolving unchanged.
+export {
+  ENRICH_CACHE_TTL_MS,
+  ENRICH_DEADLINE_MS,
+  ENRICH_FAILURE_TTL_MS,
+  LINKEDIN_CACHE_TTL_MS,
+  LINKEDIN_MISS_TTL_MS,
+  RESEARCH_CACHE_TTL_MS,
+  RESEARCH_DEADLINE_MS,
+} from "./ledger-cache.ts";
 
 const QUEUE_STATUSES: readonly QueueStatus[] = [
   "pending",
@@ -288,6 +268,7 @@ export class Ledger {
   private db: Database;
   private path: string;
   private receipts: ReceiptStore;
+  private cache: LedgerCache;
 
   constructor(path: string = DEFAULT_DB_PATH) {
     this.path = path;
@@ -306,6 +287,8 @@ export class Ledger {
     // tracked in ROADMAP.md, following the schema extraction in #452.
     // Constructed AFTER migrate() so the receipts table already exists.
     this.receipts = new ReceiptStore(this.db);
+    // Same slice, same reason: the cache tables exist only after migrate().
+    this.cache = new LedgerCache(this.db, this.path);
   }
 
   getDirectMail(id: string): DirectMailDraft | null {
@@ -1470,38 +1453,31 @@ export class Ledger {
 
   /**
    * Paid-lookup caches live in the cross-workspace SHARED DB (shared-db.ts) —
-   * the same person must never be bought twice across products. These methods
-   * keep their contracts and delegate; this ledger's legacy cache rows are
-   * copied across once on first use.
+   * the same person must never be bought twice across products. Delegated to
+   * `LedgerCache` (ledger-cache.ts, #618), which keeps the same contracts.
    */
-  private shared(): ReturnType<typeof getSharedDb> {
-    const shared = getSharedDb();
-    shared.ensureImported(this.db, this.path);
-    return shared;
-  }
-
   getCachedEnrichment(
     email: string,
   ): { result_json: string; fetched_at: string; status: string | null } | null {
-    return this.shared().getCachedEnrichment(email);
+    return this.cache.getCachedEnrichment(email);
   }
 
   getCachedLinkedIn(
     queryKey: string,
   ): { url: string | null; status: string; fetched_at: string } | null {
-    return this.shared().getCachedLinkedIn(queryKey);
+    return this.cache.getCachedLinkedIn(queryKey);
   }
 
   setCachedLinkedIn(queryKey: string, url: string | null): void {
-    this.shared().setCachedLinkedIn(queryKey, url);
+    this.cache.setCachedLinkedIn(queryKey, url);
   }
 
   setCachedEnrichment(email: string, resultJson: string): void {
-    this.shared().setCachedEnrichment(email, resultJson);
+    this.cache.setCachedEnrichment(email, resultJson);
   }
 
   setCachedEnrichmentFailure(email: string, message: string): void {
-    this.shared().setCachedEnrichmentFailure(email, message);
+    this.cache.setCachedEnrichmentFailure(email, message);
   }
 
   recordReceipt(input: {
@@ -4475,25 +4451,11 @@ export class Ledger {
   }
 
   getProductResearchCache(cacheKey: string, maxAgeMs: number): string | null {
-    const cutoff = new Date(Date.now() - maxAgeMs).toISOString();
-    const row = this.db
-      .query(
-        "SELECT dossier_json FROM product_research_cache WHERE cache_key = ? AND fetched_at >= ?",
-      )
-      .get(cacheKey, cutoff) as { dossier_json: string } | undefined;
-    return row?.dossier_json ?? null;
+    return this.cache.getProductResearchCache(cacheKey, maxAgeMs);
   }
 
   setProductResearchCache(cacheKey: string, dossierJson: string): void {
-    this.db
-      .prepare(
-        `INSERT INTO product_research_cache(cache_key, dossier_json, fetched_at)
-         VALUES(?, ?, ?)
-         ON CONFLICT(cache_key) DO UPDATE SET
-           dossier_json = excluded.dossier_json,
-           fetched_at = excluded.fetched_at`,
-      )
-      .run(cacheKey, dossierJson, new Date().toISOString());
+    this.cache.setProductResearchCache(cacheKey, dossierJson);
   }
 
   /**


### PR DESCRIPTION
Closes #618.

Agent-authored via the dev-runner kanban loop; independently verified before egress:
```
baseline: 073f957258e2 (merge-base with origin base)
✓ bun run typecheck: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run lint: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run fmt:check: worktree ok (0 errs) vs base ok (0 errs)
✓ bun run test: worktree ok (2 errs) vs base ok (2 errs)
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved cache handling for research, enrichment, and LinkedIn lookups while preserving existing public interfaces and expiration behavior.
  * Cache replacement and failure invalidation behavior remain supported.

* **Tests**
  * Added coverage for cache hits and misses, expiration boundaries, replacement behavior, failure invalidation, and key isolation across supported lookup types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->