### PR TITLE
fix: use current finder edges when generating queued drafts

### DIFF
--- a/apps/server/__tests__/regenerate-route.test.ts
+++ b/apps/server/__tests__/regenerate-route.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 interface RowSnapshot {
   id: number;
+  source?: string;
   play_name: string;
   payload_json: string;
   status: string;
@@ -28,6 +29,9 @@ let dispatchPlayImpl: () => Promise<
   Array<{ subject: string; body: string; flags: string[] }>
 > = async () => [{ subject: "subj", body: "body", flags: [] }];
 
+const getTrigger = vi.fn();
+const dispatchCalls: unknown[] = [];
+
 const setQueueDraftCalls: Array<{ id: number; sent: boolean }> = [];
 
 vi.mock("@oneshot-gtm/core", async () => {
@@ -37,6 +41,7 @@ vi.mock("@oneshot-gtm/core", async () => {
     isDraining: () => false,
     getLedger: () => ({
       getQueueRow: () => ({ ...row }),
+      getTrigger,
       setQueueDraft: (input: { id: number; draft: { sent: boolean } }) => {
         setQueueDraftCalls.push({ id: input.id, sent: input.draft.sent });
       },
@@ -45,7 +50,10 @@ vi.mock("@oneshot-gtm/core", async () => {
 });
 
 vi.mock("../src/api/_play-dispatch.ts", () => ({
-  dispatchPlay: () => dispatchPlayImpl(),
+  dispatchPlay: (_name: string, body: unknown) => {
+    dispatchCalls.push(body);
+    return dispatchPlayImpl();
+  },
 }));
 
 const { regenerateDraftRoute } = await import("../src/api/queue.ts");
@@ -59,6 +67,8 @@ beforeEach(() => {
     send_started_at: null,
   };
   setQueueDraftCalls.length = 0;
+  dispatchCalls.length = 0;
+  getTrigger.mockReset();
   dispatchPlayImpl = async () => [{ subject: "subj", body: "body", flags: [] }];
 });
 
@@ -120,4 +130,32 @@ describe("regenerateDraftRoute — TOCTOU guards", () => {
     expect(setQueueDraftCalls).toHaveLength(1);
     expect(setQueueDraftCalls[0]?.sent).toBe(false);
   });
+});
+
+it("regenerates from current trigger edges without changing saved context", async () => {
+  row.source = "find:luma-events";
+  row.payload_json = JSON.stringify({
+    email: "a@b.dev",
+    yourEdge: "LinkedIn versus email",
+    dossier: "facts",
+  });
+  const original = row.payload_json;
+  getTrigger.mockReturnValue({
+    config_json: JSON.stringify({ yourEdge: "the product is the playbook" }),
+  });
+  const res = await regenerateDraftRoute(req(), { id: "1" });
+  expect(res.status).toBe(200);
+  expect(dispatchCalls[0]).toEqual({
+    dryRun: true,
+    targets: [{ email: "a@b.dev", yourEdge: "the product is the playbook", dossier: "facts" }],
+  });
+  expect(row.payload_json).toBe(original);
+});
+it("rejects malformed trigger config before dispatching", async () => {
+  row.source = "find:luma-events";
+  getTrigger.mockReturnValue({ config_json: "{" });
+  const res = await regenerateDraftRoute(req(), { id: "1" });
+  expect(res.status).toBe(400);
+  expect(dispatchCalls).toHaveLength(0);
+  expect(setQueueDraftCalls).toHaveLength(0);
 });

--- a/apps/server/src/api/queue.ts
+++ b/apps/server/src/api/queue.ts
@@ -12,7 +12,7 @@ import {
   type QueueStatus,
   type TelemetryOutcome,
 } from "@oneshot-gtm/core";
-import { drainQueue, rankPendingRows } from "@oneshot-gtm/find";
+import { drainQueue, rankPendingRows, resolveQueueTarget } from "@oneshot-gtm/find";
 import {
   MANUAL_PLAYS,
   enrollInCadence,
@@ -484,14 +484,14 @@ export async function regenerateDraftRoute(
 
   let target: unknown;
   try {
-    target = JSON.parse(row.payload_json);
-  } catch {
-    return jsonResponse({ error: "row payload is not valid JSON" }, 400, req);
+    target = resolveQueueTarget(row);
+  } catch (err) {
+    const error =
+      err instanceof SyntaxError ? "row payload is not valid JSON" : (err as Error).message;
+    return jsonResponse({ error }, 400, req);
   }
 
-  // Every finder row is self-contained (its pitch angle is stamped on at
-  // enqueue time), so the payload IS the target and there are no run-level
-  // extras to carry through.
+  // The target retains queued prospect facts with current trigger edges.
   const body: RunPlayRequest = {
     dryRun: true,
     targets: [target],

--- a/docs/prompt-inputs.md
+++ b/docs/prompt-inputs.md
@@ -22,7 +22,7 @@ On top of that:
 | Founder-authored input                                                | First touch              | Cadence follow-up | Reply                                        |
 | --------------------------------------------------------------------- | ------------------------ | ----------------- | -------------------------------------------- |
 | `founderName`, `productOneLiner`                                      | yes                      | yes               | yes                                          |
-| `yourEdge` / `yourClaim` (trigger config, stamped onto the row)       | yes                      | no                | no                                           |
+| `yourEdge` / `yourClaim` (current trigger config for queued drafts)   | yes                      | no                | no                                           |
 | Social proof — `founderCredentials` / `productPortfolio` / `partners` | yes                      | yes               | no                                           |
 | `founderAdmission`                                                    | yes (~1 in 3)            | no                | no                                           |
 | `icpOneLiner`                                                         | no [^icp]                | no                | yes                                          |
@@ -116,3 +116,17 @@ sed -n '/buildFollowUpEmail/,/^}/p' packages/plays/src/_cadence.ts
 grep -n "const user = \[" -A 20 packages/plays/src/reply.ts
 grep -rn "socialProofBlock\|admissionBlock" packages/plays/src
 ```
+
+## Edge edits and queued prospects
+
+Queue drafting and regeneration refresh `yourEdge` and `yourClaim` from the
+originating trigger immediately before generation, including prospects queued
+before the edit. Prospect facts and the original queue payload remain intact.
+An explicitly empty or null edge clears the saved edge for that generation.
+Missing triggers or absent fields retain the saved value; malformed trigger
+configuration fails generation with an error so it can be corrected.
+Manual/imported targets without finder provenance keep their supplied edges.
+
+Editing an edge does not rewrite an existing draft or sent email. Regenerate a
+draft to use the new edge; sending a saved draft still sends the reviewed text.
+Once this behavior is installed, edge edits require no server restart.

--- a/packages/find/__tests__/drain.test.ts
+++ b/packages/find/__tests__/drain.test.ts
@@ -32,6 +32,7 @@ function row(id: number, payload: Record<string, unknown> = {}): QueueRow {
 }
 
 const ledgerStub = {
+  getTrigger: vi.fn(),
   dequeueApproved: vi.fn<(opts: { playName: string; limit?: number }) => QueueRow[]>(),
   setQueueDraft: vi.fn(),
   setQueueStatus: vi.fn(),
@@ -79,6 +80,7 @@ const { drainQueue, idsForSentDrafts } = await import("../src/drain.ts");
 const { tryReserveDailySpend: tryReserveDailySpendMock } = await import("@oneshot-gtm/core");
 
 beforeEach(() => {
+  ledgerStub.getTrigger.mockReset();
   ledgerStub.dequeueApproved.mockReset();
   ledgerStub.setQueueDraft.mockReset();
   ledgerStub.setQueueStatus.mockReset();
@@ -343,4 +345,24 @@ describe("drainQueue per-target dispatch + persistence", () => {
     expect(ledgerStub.setQueueStatus).not.toHaveBeenCalled();
     expect(out.sent).toBe(0);
   });
+});
+
+it("drains with current source edges without rewriting the queue payload", async () => {
+  const queued = row(91);
+  queued.source = "find:github-topics";
+  const original = queued.payload_json;
+  ledgerStub.dequeueApproved.mockReturnValue([queued]);
+  ledgerStub.getTrigger.mockReturnValue({
+    config_json: JSON.stringify({ yourEdge: "the product is the playbook" }),
+  });
+  runStackConsolidationMock.mockResolvedValue({
+    drafted: [{ subject: "s", body: "b", flags: [], sent: false, receiptIds: [] }],
+  });
+  const result = await drainQueue({ playName: "stack-consolidation", dryRun: true });
+  expect(result.errors).toEqual([]);
+  expect(runStackConsolidationMock).toHaveBeenCalledWith({
+    dryRun: true,
+    targets: [{ ...JSON.parse(original), yourEdge: "the product is the playbook" }],
+  });
+  expect(queued.payload_json).toBe(original);
 });

--- a/packages/find/__tests__/queue-target.test.ts
+++ b/packages/find/__tests__/queue-target.test.ts
@@ -63,7 +63,7 @@ it.each([null, { config_json: null }, { config_json: "{}" }])(
   },
 );
 
-it.each(["{", "[]", "null", '{"yourEdge":123}'])(
+it.each(["", "{", "[]", "null", '{"yourEdge":123}'])(
   "rejects malformed configuration (%s)",
   (config_json) => {
     getTrigger.mockReturnValue({ config_json });

--- a/packages/find/__tests__/queue-target.test.ts
+++ b/packages/find/__tests__/queue-target.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, expect, it, vi } from "vitest";
+
+const getTrigger = vi.fn();
+vi.mock("@oneshot-gtm/core", () => ({ getLedger: () => ({ getTrigger }) }));
+const { resolveQueueTarget } = await import("../src/queue-target.ts");
+const payload_json = JSON.stringify({
+  email: "a@example.com",
+  yourEdge: "old comparison",
+  dossier: "facts",
+});
+beforeEach(() => getTrigger.mockReset());
+
+it("refreshes edges on each generation while preserving saved facts and payload", () => {
+  const row = { source: "find:luma-events", payload_json };
+  getTrigger.mockReturnValue({
+    config_json: JSON.stringify({ yourEdge: "the product is the playbook" }),
+  });
+  expect(resolveQueueTarget(row)).toEqual({
+    email: "a@example.com",
+    yourEdge: "the product is the playbook",
+    dossier: "facts",
+  });
+  getTrigger.mockReturnValue({ config_json: JSON.stringify({ yourEdge: "new angle" }) });
+  expect(resolveQueueTarget(row)).toHaveProperty("yourEdge", "new angle");
+  expect(row.payload_json).toBe(payload_json);
+});
+
+it.each(["", null])("honors a cleared edge (%s)", (yourEdge) => {
+  getTrigger.mockReturnValue({ config_json: JSON.stringify({ yourEdge }) });
+  expect(resolveQueueTarget({ source: "find:luma-events", payload_json })).toHaveProperty(
+    "yourEdge",
+    "",
+  );
+});
+
+it("resolves source suffixes and does not conflate finders sharing a play", () => {
+  getTrigger.mockImplementation((name: string) => ({
+    config_json: JSON.stringify({ yourEdge: name }),
+  }));
+  for (const name of ["github-stars", "github-topics", "accelerator-batch"]) {
+    expect(resolveQueueTarget({ source: `find:${name}:owner/repo`, payload_json })).toHaveProperty(
+      "yourEdge",
+      name,
+    );
+  }
+});
+
+it("refreshes yourClaim", () => {
+  getTrigger.mockReturnValue({ config_json: JSON.stringify({ yourClaim: "current claim" }) });
+  expect(resolveQueueTarget({ source: "find:hiring-signal", payload_json })).toHaveProperty(
+    "yourClaim",
+    "current claim",
+  );
+});
+
+it.each([null, { config_json: null }, { config_json: "{}" }])(
+  "retains saved edges when unavailable (%j)",
+  (trigger) => {
+    getTrigger.mockReturnValue(trigger);
+    expect(resolveQueueTarget({ source: "find:luma-events", payload_json })).toEqual(
+      JSON.parse(payload_json),
+    );
+  },
+);
+
+it.each(["{", "[]", "null", '{"yourEdge":123}'])(
+  "rejects malformed configuration (%s)",
+  (config_json) => {
+    getTrigger.mockReturnValue({ config_json });
+    expect(() => resolveQueueTarget({ source: "find:luma-events", payload_json })).toThrow(
+      /Invalid/,
+    );
+  },
+);
+
+it.each(["csv:import", "manual", ""])(
+  "preserves targets without finder provenance (%s)",
+  (source) => {
+    expect(resolveQueueTarget({ source, payload_json })).toEqual(JSON.parse(payload_json));
+    expect(getTrigger).not.toHaveBeenCalled();
+  },
+);

--- a/packages/find/src/drain.ts
+++ b/packages/find/src/drain.ts
@@ -7,6 +7,7 @@ import {
   type QueueRow,
 } from "@oneshot-gtm/core";
 import { type DraftedRow, isSupportedPlay, MANUAL_PLAYS, PLAYS } from "@oneshot-gtm/plays";
+import { resolveQueueTarget } from "./queue-target.ts";
 
 export interface DrainOpts {
   playName: string;
@@ -66,9 +67,8 @@ export async function drainQueue(opts: DrainOpts): Promise<DrainOutcome> {
   // but before checking whether rows are empty, so an unknown play adds an error
   // to the outcome (exit 1 when the CLI sees it) instead of returning an empty
   // outcome (exit 2 under --fail-on-empty), regardless of queue state.
-  // No per-play drain-level options: every finder row is self-contained
-  // (the angle is stamped on at enqueue time), and anything about the SENDER
-  // is read from config by the play itself.
+  // Prospect facts stay on the queue row; sender edges are refreshed from
+  // its originating trigger immediately before generation.
   if (!isSupportedPlay(opts.playName)) {
     outcome.errors.push({ id: -1, message: `drain: unsupported play '${opts.playName}'` });
     return outcome;
@@ -183,7 +183,7 @@ export async function drainQueue(opts: DrainOpts): Promise<DrainOutcome> {
 async function dispatchOneTarget(opts: DrainOpts, row: QueueRow): Promise<DraftedRow> {
   const play = PLAYS[opts.playName];
   if (!play) throw new Error(`drain: unsupported play '${opts.playName}'`);
-  const target = JSON.parse(row.payload_json) as unknown;
+  const target = resolveQueueTarget(row);
   const result = await play.run({
     dryRun: opts.dryRun,
     targets: [target],

--- a/packages/find/src/index.ts
+++ b/packages/find/src/index.ts
@@ -51,3 +51,4 @@ export * from "./_sdk-safe.ts";
 export * from "./csv-import.ts";
 export * from "./_profile-url.ts";
 export * from "./angle.ts";
+export * from "./queue-target.ts";

--- a/packages/find/src/queue-target.ts
+++ b/packages/find/src/queue-target.ts
@@ -1,0 +1,31 @@
+import { getLedger, type QueueRow } from "@oneshot-gtm/core";
+
+/** Refresh sender-authored edges at generation time without rewriting queue history. */
+export function resolveQueueTarget(row: Pick<QueueRow, "payload_json" | "source">): unknown {
+  const target: unknown = JSON.parse(row.payload_json);
+  if (!target || typeof target !== "object" || Array.isArray(target)) return target;
+  const name = /^find:([^:]+)(?::|$)/.exec(row.source ?? "")?.[1];
+  if (!name) return target;
+  const trigger = getLedger().getTrigger(name === "post-funding" ? "post-funding-auto" : name);
+  if (!trigger?.config_json) return target;
+  let config: Record<string, unknown>;
+  try {
+    const parsed: unknown = JSON.parse(trigger.config_json);
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) throw new Error();
+    config = parsed as Record<string, unknown>;
+  } catch {
+    throw new Error(
+      `Invalid configuration for trigger '${name}'; fix its config before generating.`,
+    );
+  }
+  const resolved = { ...target } as Record<string, unknown>;
+  for (const key of ["yourEdge", "yourClaim"] as const) {
+    if (!Object.hasOwn(config, key)) continue;
+    const value = config[key];
+    if (value !== null && typeof value !== "string") {
+      throw new Error(`Invalid ${key} for trigger '${name}'; use text or clear the field.`);
+    }
+    resolved[key] = value ?? "";
+  }
+  return resolved;
+}

--- a/packages/find/src/queue-target.ts
+++ b/packages/find/src/queue-target.ts
@@ -7,7 +7,7 @@ export function resolveQueueTarget(row: Pick<QueueRow, "payload_json" | "source"
   const name = /^find:([^:]+)(?::|$)/.exec(row.source ?? "")?.[1];
   if (!name) return target;
   const trigger = getLedger().getTrigger(name === "post-funding" ? "post-funding-auto" : name);
-  if (!trigger?.config_json) return target;
+  if (!trigger || trigger.config_json == null) return target;
   let config: Record<string, unknown>;
   try {
     const parsed: unknown = JSON.parse(trigger.config_json);


### PR DESCRIPTION
Editing a finder’s edge previously left queued prospects using the old pitch, even after regeneration. Queue drafting and regeneration now load the originating trigger’s current `yourEdge` / `yourClaim` immediately before building the target, including source suffixes and explicitly cleared values.

Prospect research and saved queue payloads remain intact. Missing trigger fields retain their saved values; malformed configuration returns an actionable error. Existing draft text changes only when regenerated, and sent records retain their existing protections.

Validation: full suite passed (3,804 tests across 289 files), including 36 focused resolver, regeneration, and drain tests; typechecking and formatting passed; lint completed with warnings and no errors. Includes regression coverage for changed and cleared edges, finder provenance, malformed config, and preservation of saved context.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Queued prospects now use the latest trigger edge and claim settings when drafted or regenerated.
  * Editing trigger edges no longer requires a server restart and does not alter existing drafts or sent emails.
  * Cleared edge settings are applied correctly, while unavailable trigger settings preserve saved values.
  * Manually imported targets retain their supplied edge information.

* **Bug Fixes**
  * Invalid trigger configurations now stop generation with a clear error before dispatch or draft updates occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->