### PR TITLE
feat(inbox): receive and reply to Smartlead mailbox threads

### DIFF
--- a/apps/cli/src/commands/smartlead.ts
+++ b/apps/cli/src/commands/smartlead.ts
@@ -135,6 +135,6 @@ export async function commandSmartleadConnect(): Promise<void> {
     }
   }
   note(
-    "Send-only for now: replies to Smartlead-sent mail appear in Smartlead's inbox, not /inbox.",
+    "Incoming mail and threaded replies connect automatically in /inbox while this workspace's server runs. Check mailbox connection status there.",
   );
 }

--- a/apps/server/__tests__/inbox-route.test.ts
+++ b/apps/server/__tests__/inbox-route.test.ts
@@ -28,7 +28,9 @@ let knownProspect: { id: number } | null = null;
 const archiveConversationMock = vi.fn();
 const restoreConversationMock = vi.fn();
 const inboxArchivesMock = vi.fn(() => new Map<number, string>());
+const mailboxGetMock = vi.fn();
 const ledger = {
+  mailboxes: { get: mailboxGetMock, all: () => [] },
   listInboxArchives: inboxArchivesMock,
   archiveInboxConversation: archiveConversationMock,
   restoreInboxConversation: restoreConversationMock,
@@ -812,4 +814,106 @@ describe("archive origin validation", () => {
       expect(restoreConversationMock).toHaveBeenCalledWith(42);
     },
   );
+});
+
+describe("mailbox draft context binding", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mailboxGetMock.mockReturnValue({
+      id: "mailbox:inbound",
+      direction: "inbound",
+      threadKey: "mailbox:correct-thread",
+      from: "stored@example.com",
+      replyTo: null,
+      subject: "Stored subject",
+      body: "Stored inbound",
+      prospectId: null,
+      kind: "human",
+      identityId: "smartlead:me@example.com",
+    });
+    getProspectByEmailMock.mockReturnValue(null);
+    getInboxThreadsMock.mockReturnValue(new Map());
+    gatherReplyContextMock.mockResolvedValue({
+      dossier: null,
+      threadSent: [],
+      priorInbound: [],
+      costUsd: 0,
+      researched: false,
+    });
+    draftInboxReplyMock.mockResolvedValue({ body: "Safe draft", flags: [] });
+  });
+
+  it.each([draftReplyRoute, steerRoute])(
+    "uses stored thread and message content for research and drafting",
+    async (route) => {
+      const res = await route(
+        post("/api/inbox/test", {
+          id: "mailbox:inbound",
+          threadId: "wrong-thread",
+          threadKey: "wrong-thread",
+          fromEmail: "wrong@example.com",
+          subject: "Wrong subject",
+          body: "Wrong body",
+          steer: "Be brief",
+        }),
+      );
+      expect(res.status).toBe(200);
+      expect(gatherReplyContextMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fromEmail: "stored@example.com",
+          threadKey: "mailbox:correct-thread",
+          excludeId: "mailbox:inbound",
+        }),
+      );
+      expect(draftInboxReplyMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fromEmail: "stored@example.com",
+          subject: "Stored subject",
+          body: "Stored inbound",
+        }),
+      );
+      if (route === steerRoute)
+        expect(setInboxDraftSteerMock).toHaveBeenCalledWith("mailbox:correct-thread", "Be brief");
+    },
+  );
+
+  it.each([draftReplyRoute, steerRoute])(
+    "rejects missing stored mailbox messages before research or persistence",
+    async (route) => {
+      mailboxGetMock.mockReturnValue(null);
+      const res = await route(
+        post("/api/inbox/test", {
+          id: "mailbox:missing",
+          threadKey: "mailbox:thread",
+          fromEmail: "wrong@example.com",
+          subject: "Wrong",
+          body: "Wrong",
+          steer: "Be brief",
+        }),
+      );
+      expect(res.status).toBe(400);
+      expect(gatherReplyContextMock).not.toHaveBeenCalled();
+      expect(upsertInboxDraftMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it("persists edited drafts under the stored inbound thread", async () => {
+    const res = await saveDraftRoute(
+      post("/api/inbox/draft", {
+        inboundEmailId: "mailbox:inbound",
+        threadKey: "wrong-thread",
+        toEmail: "wrong@example.com",
+        body: "Edited answer",
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(upsertInboxDraftMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadKey: "mailbox:correct-thread",
+        toEmail: "stored@example.com",
+        subject: "Stored subject",
+        body: "Edited answer",
+      }),
+    );
+  });
 });

--- a/apps/server/__tests__/mailboxes-route.test.ts
+++ b/apps/server/__tests__/mailboxes-route.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { Ledger } from "../../../packages/core/src/ledger.ts";
+import type { MailboxMessage } from "../../../packages/core/src/mailbox-store.ts";
+
+let ledger: Ledger;
+vi.mock("@oneshot-gtm/core", async (original) => ({
+  ...(await original<typeof import("@oneshot-gtm/core")>()),
+  getLedger: () => ledger,
+  mailboxHealth: () => [
+    {
+      identityId: "smartlead:me@example.com",
+      address: "me@example.com",
+      status: "connected",
+      lastSyncAt: "2026-09-11T00:00:00Z",
+      error: null,
+      backfillRemaining: false,
+      messages: 1,
+    },
+  ],
+}));
+const { mailboxInboxView, mailboxStateRoute, mailboxMatchRoute } =
+  await import("../src/api/mailboxes.ts");
+const message: MailboxMessage = {
+  id: "mailbox:message",
+  identityId: "smartlead:me@example.com",
+  threadKey: "mailbox:thread",
+  messageId: "<inbound@example.com>",
+  references: [],
+  gmailThreadId: null,
+  from: "sender@example.org",
+  to: ["me@example.com"],
+  replyTo: null,
+  subject: "Question",
+  body: "Tell me more",
+  at: "2026-09-11T00:00:00Z",
+  direction: "inbound",
+  kind: "human",
+  autoSubmitted: null,
+  prospectId: null,
+};
+function request(body: unknown, origin = "http://localhost:3031") {
+  return new Request("http://localhost/api/inbox/thread-state", {
+    method: "POST",
+    headers: { origin, "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+beforeEach(() => {
+  ledger = new Ledger(":memory:");
+  ledger.mailboxes.put(message);
+});
+afterEach(() => ledger.close());
+
+it("returns durable unmatched threads, drafts, and receiving health", () => {
+  ledger.upsertInboxDraft({
+    threadKey: message.threadKey,
+    inboundEmailId: message.id,
+    toEmail: message.from,
+    subject: message.subject,
+    identityId: message.identityId,
+    body: "draft",
+  });
+  const view = mailboxInboxView();
+  expect(view.mailboxThreads?.[0]).toMatchObject({
+    prospectId: null,
+    unread: true,
+    reply: { thread: { draftBody: "draft" }, sourceProvider: "smartlead" },
+  });
+  expect(view.mailboxes?.[0]?.status).toBe("connected");
+  expect(JSON.stringify(view)).not.toContain("password");
+});
+
+it("archives and restores an unmatched thread without needing a prospect", async () => {
+  const archive = await mailboxStateRoute(
+    request({
+      threadKey: message.threadKey,
+      observedReplyIds: [message.id],
+      read: true,
+      archived: true,
+    }),
+  );
+  expect(archive.status).toBe(200);
+  expect(ledger.mailboxes.threadState(message.threadKey)).toMatchObject({
+    unread: false,
+    archivedAt: expect.any(String),
+  });
+  const restore = await mailboxStateRoute(
+    request({ threadKey: message.threadKey, observedReplyIds: [], archived: false }),
+  );
+  expect(restore.status).toBe(200);
+  expect(ledger.mailboxes.threadState(message.threadKey).archivedAt).toBeNull();
+});
+
+it("blocks cross-origin state changes and rejects stale archive snapshots", async () => {
+  expect(
+    (
+      await mailboxStateRoute(
+        request(
+          { threadKey: message.threadKey, observedReplyIds: [message.id], archived: true },
+          "https://evil.example",
+        ),
+      )
+    ).status,
+  ).toBe(403);
+  expect(
+    (
+      await mailboxStateRoute(
+        request({ threadKey: message.threadKey, observedReplyIds: [], archived: true }),
+      )
+    ).status,
+  ).toBe(409);
+  expect(ledger.mailboxes.threadState(message.threadKey).archivedAt).toBeNull();
+});
+
+it("matches a thread to an existing workspace prospect and rejects unknown prospects", async () => {
+  const id = ledger.upsertProspect({ email: "known@example.org", name: "Known" });
+  expect(
+    (await mailboxMatchRoute(request({ threadKey: message.threadKey, email: "KNOWN@example.org" })))
+      .status,
+  ).toBe(200);
+  expect(mailboxInboxView().mailboxThreads?.[0]?.prospectId).toBe(id);
+  expect(
+    (
+      await mailboxMatchRoute(
+        request({ threadKey: message.threadKey, email: "foreign@example.org" }),
+      )
+    ).status,
+  ).toBe(400);
+});

--- a/apps/server/__tests__/reply-research.test.ts
+++ b/apps/server/__tests__/reply-research.test.ts
@@ -6,6 +6,7 @@ import type { Ledger } from "@oneshot-gtm/core";
 // degrade instead of blocking the draft.
 
 const ledger = {
+  mailboxes: { thread: vi.fn<Ledger["mailboxes"]["thread"]>(() => []) },
   getProspectById: vi.fn(),
   getInboxThreads: vi.fn(() => new Map()),
   listInboxRepliesForProspect: vi.fn(() => []),
@@ -55,6 +56,38 @@ beforeEach(() => {
 });
 
 describe("gatherReplyContext", () => {
+  it("uses the mailbox thread's inbound and external sent history for drafts", async () => {
+    const base = {
+      identityId: "smartlead:me@example.com",
+      threadKey: "mailbox:thread",
+      messageId: null,
+      references: [],
+      gmailThreadId: null,
+      from: "person@example.org",
+      to: ["me@example.com"],
+      replyTo: null,
+      subject: "Hi",
+      at: "2026-09-11T00:00:00Z",
+      kind: "human" as const,
+      autoSubmitted: null,
+      prospectId: null,
+    };
+    ledger.mailboxes.thread.mockReturnValueOnce([
+      { ...base, id: "older", direction: "inbound", body: "Earlier question" },
+      { ...base, id: "external", direction: "outbound", body: "Answer from my email client" },
+      { ...base, id: "current", direction: "inbound", body: "Current question" },
+    ]);
+    const context = await gatherReplyContext({
+      fromEmail: base.from,
+      prospectId: null,
+      threadKey: base.threadKey,
+      excludeId: "current",
+      skipPaid: true,
+    });
+    expect(context.priorInbound.map((m) => m.body)).toEqual(["Earlier question"]);
+    expect(context.threadSent.map((m) => m.body)).toEqual(["Answer from my email client"]);
+    expect(safeEnrichMock).not.toHaveBeenCalled();
+  });
   it("uses the stored prospect dossier for free — no paid calls", async () => {
     ledger.getProspectById.mockReturnValue({ dossier_json: '{"title":"CTO","hook":"x402"}' });
     const ctx = await gatherReplyContext({

--- a/apps/server/__tests__/scheduler.test.ts
+++ b/apps/server/__tests__/scheduler.test.ts
@@ -49,6 +49,8 @@ vi.mock("@oneshot-gtm/plays", () => ({
 }));
 
 vi.mock("@oneshot-gtm/core", () => ({
+  loadConfig: () => ({}),
+  resolveIdentities: () => (smartleadEnabled ? [{ provider: "smartlead" }] : []),
   logEvent: (kind: string) => {
     calls.eventKinds.push(kind);
   },
@@ -64,11 +66,23 @@ vi.mock("@oneshot-gtm/core", () => ({
 }));
 
 let demoModeValue = false;
+let smartleadEnabled = false;
 let bouncePollCleanValue = true;
 let replyPollCleanValue = true;
 let postDailySendSummaryIfDueOpts: Array<{ sweepClean?: boolean }> = [];
 
 const { startScheduler } = await import("../src/scheduler.ts");
+
+it("polls Smartlead workspaces at most a minute after a completed tick", async () => {
+  smartleadEnabled = true;
+  nextSleepValue = 600_000;
+  const handle = startScheduler();
+  await vi.advanceTimersByTimeAsync(5_000);
+  expect(calls.pollInboxReplies).toBe(1);
+  await vi.advanceTimersByTimeAsync(60_000);
+  expect(calls.pollInboxReplies).toBe(2);
+  handle.stop();
+});
 
 beforeEach(() => {
   vi.useFakeTimers();
@@ -83,6 +97,7 @@ beforeEach(() => {
   throwOnNextRun = null;
   runDueTriggersGate = null;
   demoModeValue = false;
+  smartleadEnabled = false;
   bouncePollCleanValue = true;
   replyPollCleanValue = true;
   postDailySendSummaryIfDueOpts = [];

--- a/apps/server/__tests__/workspace-route.test.ts
+++ b/apps/server/__tests__/workspace-route.test.ts
@@ -87,6 +87,7 @@ describe("POST /api/workspace/launch", () => {
   });
 
   it("spawns the target bound to its registered home + port, browser suppressed", async () => {
+    vi.stubEnv("SMARTLEAD_API_KEY", "parent-workspace-key");
     const spawns: Array<{ binPath: string; env: Record<string, string | undefined> }> = [];
     _setLaunchSpawn((opts) => spawns.push(opts));
 
@@ -104,6 +105,8 @@ describe("POST /api/workspace/launch", () => {
     // A dev-mode parent must not leak its vite URL — the child would 302 the
     // whole UI to the wrong workspace's dev server.
     expect(env["VITE_DEV_SERVER_URL"]).toBeUndefined();
+    expect(env["SMARTLEAD_API_KEY"]).toBeUndefined();
+    vi.unstubAllEnvs();
   });
 
   it("reports already-running instead of double-spawning when the probe succeeds", async () => {

--- a/apps/server/src/api/_reply-research.ts
+++ b/apps/server/src/api/_reply-research.ts
@@ -60,19 +60,31 @@ export async function gatherReplyContext(input: {
 }): Promise<ReplyContext> {
   const ledger = getLedger();
 
-  const threadSent = input.threadKey
+  let threadSent = input.threadKey
     ? (ledger.getInboxThreads().get(input.threadKey)?.sent ?? [])
     : [];
 
   // Tier 0 (free): the prospect's earlier inbound messages from the ledger —
   // the drafter should see the whole exchange, not just the newest email.
-  const priorInbound =
+  let priorInbound =
     input.prospectId != null
       ? ledger
           .listInboxRepliesForProspect(input.prospectId)
           .filter((r) => r.id !== input.excludeId)
           .map((r) => ({ body: r.body, subject: r.subject, receivedAt: r.received_at }))
       : [];
+
+  if (input.threadKey?.startsWith("mailbox:")) {
+    const messages = ledger.mailboxes.thread(input.threadKey);
+    // The durable mailbox timeline includes replies sent outside this app,
+    // and keeps separate conversations with the same prospect separate.
+    threadSent = messages
+      .filter((m) => m.direction === "outbound")
+      .map((m) => ({ body: m.body, sentAt: m.at }));
+    priorInbound = messages
+      .filter((m) => m.direction === "inbound" && m.id !== input.excludeId)
+      .map((m) => ({ body: m.body, subject: m.subject, receivedAt: m.at }));
+  }
 
   const parts: string[] = [];
   let costUsd = 0;

--- a/apps/server/src/api/inbox.ts
+++ b/apps/server/src/api/inbox.ts
@@ -35,6 +35,7 @@ import {
 } from "@oneshot-gtm/shared-types";
 import { isLoopbackOrigin, jsonResponse } from "../server.ts";
 import { gatherReplyContext } from "./_reply-research.ts";
+import { mailboxInboxView } from "./mailboxes.ts";
 
 /**
  * Classification of the inbound being answered: the persisted kind when the
@@ -47,6 +48,10 @@ function inboundReplyKind(
   subject: string,
   inboundBody: string,
 ): ReplyKind {
+  if (typeof body.id === "string" && body.id.startsWith("mailbox:")) {
+    const stored = ledger.mailboxes.get(body.id);
+    if (stored) return stored.kind;
+  }
   if (prospectId != null && typeof body.id === "string") {
     const stored = ledger.listInboxRepliesForProspect(prospectId).find((r) => r.id === body.id);
     if (stored?.kind) return stored.kind as ReplyKind;
@@ -183,6 +188,7 @@ export async function listInboxRoute(req: Request): Promise<Response> {
       // degraded twice over — return the error state alone.
     }
     const out: InboxResult = {
+      ...mailboxInboxView(),
       replies: [],
       conversations,
       hasMore: false,
@@ -277,6 +283,9 @@ export async function listInboxRoute(req: Request): Promise<Response> {
   // didn't triage (see _cadence.ts's isNewReply-or-untriaged check).
   try {
     for (const r of visible) {
+      // Direct mailbox capture/classification goes through the background poll,
+      // including explicit matches where the sender differs from the prospect.
+      if (r.sourceProvider === "smartlead") continue;
       if (!r.matched) continue;
       const p = ledger.findProspectByEmail(r.fromEmail);
       if (!p) continue;
@@ -352,7 +361,19 @@ export async function listInboxRoute(req: Request): Promise<Response> {
     );
   }
 
-  const out: InboxResult = { replies: visible, conversations, hasMore };
+  // Mailbox threads have their own durable view; do not duplicate them in the
+  // legacy per-prospect timeline when a prospect also has Gmail/OneShot mail.
+  const out: InboxResult = {
+    replies: visible,
+    conversations: conversations
+      .map((c) => ({
+        ...c,
+        items: c.items.filter((i) => i.kind !== "reply" || !i.id.startsWith("mailbox:")),
+      }))
+      .filter((c) => c.items.some((i) => i.kind === "reply")),
+    hasMore,
+    ...mailboxInboxView(),
+  };
   return jsonResponse(out, 200, req);
 }
 
@@ -510,7 +531,11 @@ export async function draftReplyRoute(req: Request): Promise<Response> {
   }
 
   const ledger = getLedger();
-  const prospect = ledger.getProspectByEmail(fromEmail);
+  const mailboxMessage = body.id?.startsWith("mailbox:") ? ledger.mailboxes.get(body.id) : null;
+  const prospect =
+    mailboxMessage?.prospectId != null
+      ? ledger.getProspectById(mailboxMessage.prospectId)
+      : ledger.getProspectByEmail(fromEmail);
   let matched: Parameters<typeof draftInboxReply>[0]["matched"] = null;
   if (prospect) {
     // Same ranking as the list route's badge (cadenceRank).
@@ -681,7 +706,11 @@ export async function steerRoute(req: Request): Promise<Response> {
   }
 
   const ledger = getLedger();
-  const prospect = ledger.getProspectByEmail(fromEmail);
+  const mailboxMessage = body.id?.startsWith("mailbox:") ? ledger.mailboxes.get(body.id) : null;
+  const prospect =
+    mailboxMessage?.prospectId != null
+      ? ledger.getProspectById(mailboxMessage.prospectId)
+      : ledger.getProspectByEmail(fromEmail);
   let matched: Parameters<typeof draftInboxReply>[0]["matched"] = null;
   if (prospect) {
     const cadences = ledger.listCadencesForProspect(prospect.id);
@@ -792,6 +821,8 @@ export async function steerRoute(req: Request): Promise<Response> {
  * are a best-effort fresh send (the platform has no threading API).
  */
 export async function sendReplyRoute(req: Request): Promise<Response> {
+  if (!isLoopbackOrigin(req.headers.get("origin") ?? ""))
+    return jsonResponse({ error: "forbidden origin" }, 403, req);
   if (isDraining()) {
     return jsonResponse({ error: "server restarting — retry in a moment" }, 503, req);
   }
@@ -801,8 +832,27 @@ export async function sendReplyRoute(req: Request): Promise<Response> {
   } catch {
     return jsonResponse({ error: "invalid JSON body" }, 400, req);
   }
-  const to = (body.to ?? "").trim();
-  const subject = (body.subject ?? "").trim();
+  const stored = body.inboundEmailId ? getLedger().mailboxes.get(body.inboundEmailId) : null;
+  if (
+    body.inboundEmailId &&
+    (!stored ||
+      stored.direction !== "inbound" ||
+      stored.identityId !== body.identityId ||
+      stored.threadKey !== body.threadKey)
+  ) {
+    return jsonResponse(
+      { error: "Inbound message does not match this workspace thread and sender." },
+      400,
+      req,
+    );
+  }
+  if (
+    stored &&
+    (typeof body.sendRequestId !== "string" || !/^[a-zA-Z0-9-]{16,100}$/.test(body.sendRequestId))
+  )
+    return jsonResponse({ error: "A valid send request ID is required." }, 400, req);
+  const to = stored ? stored.replyTo || stored.from : (body.to ?? "").trim();
+  const subject = stored ? stored.subject : (body.subject ?? "").trim();
   const replyBody = (body.body ?? "").trim();
   const identityId = (body.identityId ?? "").trim();
   const threadKey = (body.threadKey ?? "").trim();
@@ -837,6 +887,7 @@ export async function sendReplyRoute(req: Request): Promise<Response> {
           to,
           subject,
           body: replyBody,
+          ...(stored ? { inboundEmailId: stored.id, sendRequestId: body.sendRequestId } : {}),
           ...(body.threadId ? { threadId: body.threadId } : {}),
           ...(body.inReplyTo ? { inReplyTo: body.inReplyTo } : {}),
           ...(body.replyToEmailId ? { replyToEmailId: body.replyToEmailId } : {}),
@@ -858,7 +909,10 @@ export async function sendReplyRoute(req: Request): Promise<Response> {
     // last resort when the background poll misses. Idempotent, and never
     // allowed to fail a send that already happened.
     try {
-      const prospect = ledger.findProspectByEmail(to);
+      const prospect =
+        stored?.prospectId != null
+          ? ledger.getProspectById(stored.prospectId)
+          : ledger.findProspectByEmail(to);
       if (prospect) ledger.recordProspectReply(prospect.id, { subject });
     } catch (err) {
       logEvent(

--- a/apps/server/src/api/inbox.ts
+++ b/apps/server/src/api/inbox.ts
@@ -519,6 +519,20 @@ export async function draftReplyRoute(req: Request): Promise<Response> {
   } catch {
     return jsonResponse({ error: "invalid JSON body" }, 400, req);
   }
+  const ledger = getLedger();
+  const mailboxRequest = body.id?.startsWith("mailbox:") || body.threadId?.startsWith("mailbox:");
+  const mailboxMessage = mailboxRequest && body.id ? ledger.mailboxes.get(body.id) : null;
+  if (mailboxRequest) {
+    if (!mailboxMessage || mailboxMessage.direction !== "inbound")
+      return jsonResponse({ error: "Stored inbound mailbox message is required" }, 400, req);
+    body = {
+      ...body,
+      fromEmail: mailboxMessage.from,
+      subject: mailboxMessage.subject,
+      body: mailboxMessage.body,
+      threadId: mailboxMessage.threadKey,
+    };
+  }
   const fromEmail = (body.fromEmail ?? "").trim().toLowerCase();
   const subject = (body.subject ?? "").trim();
   const inboundBody = (body.body ?? "").trim();
@@ -530,8 +544,6 @@ export async function draftReplyRoute(req: Request): Promise<Response> {
     return jsonResponse({ error: "this email has no body to draft a reply from" }, 400, req);
   }
 
-  const ledger = getLedger();
-  const mailboxMessage = body.id?.startsWith("mailbox:") ? ledger.mailboxes.get(body.id) : null;
   const prospect =
     mailboxMessage?.prospectId != null
       ? ledger.getProspectById(mailboxMessage.prospectId)
@@ -650,6 +662,19 @@ export async function saveDraftRoute(req: Request): Promise<Response> {
   } catch {
     return jsonResponse({ error: "invalid JSON body" }, 400, req);
   }
+  const ledger = getLedger();
+  if (body.inboundEmailId?.startsWith("mailbox:") || body.threadKey?.startsWith("mailbox:")) {
+    const message = body.inboundEmailId ? ledger.mailboxes.get(body.inboundEmailId) : null;
+    if (!message || message.direction !== "inbound")
+      return jsonResponse({ error: "Stored inbound mailbox message is required" }, 400, req);
+    body = {
+      ...body,
+      threadKey: message.threadKey,
+      toEmail: message.replyTo ?? message.from,
+      subject: message.subject,
+      identityId: message.identityId,
+    };
+  }
   const threadKey = (body.threadKey ?? "").trim();
   const inboundEmailId = (body.inboundEmailId ?? "").trim();
   const toEmail = (body.toEmail ?? "").trim();
@@ -657,7 +682,6 @@ export async function saveDraftRoute(req: Request): Promise<Response> {
     return jsonResponse({ error: "threadKey, inboundEmailId and toEmail are required" }, 400, req);
   }
 
-  const ledger = getLedger();
   const draftBody = body.body ?? "";
   let status: "needs_decision" | null = null;
   // An emptied composer clears the draft so a refresh can't resurrect it.
@@ -693,6 +717,20 @@ export async function steerRoute(req: Request): Promise<Response> {
   } catch {
     return jsonResponse({ error: "invalid JSON body" }, 400, req);
   }
+  const ledger = getLedger();
+  const mailboxRequest = body.id?.startsWith("mailbox:") || body.threadKey?.startsWith("mailbox:");
+  const mailboxMessage = mailboxRequest && body.id ? ledger.mailboxes.get(body.id) : null;
+  if (mailboxRequest) {
+    if (!mailboxMessage || mailboxMessage.direction !== "inbound")
+      return jsonResponse({ error: "Stored inbound mailbox message is required" }, 400, req);
+    body = {
+      ...body,
+      fromEmail: mailboxMessage.from,
+      subject: mailboxMessage.subject,
+      body: mailboxMessage.body,
+      threadKey: mailboxMessage.threadKey,
+    };
+  }
   const fromEmail = (body.fromEmail ?? "").trim().toLowerCase();
   const subject = (body.subject ?? "").trim();
   const inboundBody = (body.body ?? "").trim();
@@ -705,8 +743,6 @@ export async function steerRoute(req: Request): Promise<Response> {
     return jsonResponse({ error: "this email has no body to draft a reply from" }, 400, req);
   }
 
-  const ledger = getLedger();
-  const mailboxMessage = body.id?.startsWith("mailbox:") ? ledger.mailboxes.get(body.id) : null;
   const prospect =
     mailboxMessage?.prospectId != null
       ? ledger.getProspectById(mailboxMessage.prospectId)

--- a/apps/server/src/api/mailboxes.ts
+++ b/apps/server/src/api/mailboxes.ts
@@ -18,6 +18,7 @@ import type {
 } from "@oneshot-gtm/shared-types";
 import { isLoopbackOrigin, jsonResponse } from "../server.ts";
 
+/** Build the workspace-local mailbox health and threaded inbox view. */
 export function mailboxInboxView(): Pick<InboxResult, "mailboxes" | "mailboxThreads"> {
   const health = mailboxHealth();
   const ledger = getLedger();
@@ -112,10 +113,12 @@ export function mailboxInboxView(): Pick<InboxResult, "mailboxes" | "mailboxThre
   };
 }
 
+/** Restrict credential and mailbox mutations to the local workspace UI. */
 function allowed(req: Request): boolean {
   return isLoopbackOrigin(req.headers.get("origin") ?? "");
 }
 
+/** Update read or archive state for the messages visible to the caller. */
 export async function mailboxStateRoute(req: Request): Promise<Response> {
   if (!allowed(req)) return jsonResponse({ error: "forbidden origin" }, 403, req);
   try {
@@ -139,6 +142,7 @@ export async function mailboxStateRoute(req: Request): Promise<Response> {
   }
 }
 
+/** Associate a mailbox thread with an existing workspace prospect. */
 export async function mailboxMatchRoute(req: Request): Promise<Response> {
   if (!allowed(req)) return jsonResponse({ error: "forbidden origin" }, 403, req);
   try {
@@ -160,6 +164,7 @@ export async function mailboxMatchRoute(req: Request): Promise<Response> {
   }
 }
 
+/** Import the remaining provider history for one mailbox thread. */
 export async function mailboxHistoryRoute(req: Request): Promise<Response> {
   if (!allowed(req)) return jsonResponse({ error: "forbidden origin" }, 403, req);
   try {
@@ -176,12 +181,14 @@ export async function mailboxHistoryRoute(req: Request): Promise<Response> {
   }
 }
 
+/** Force a mailbox sync and return the refreshed mailbox inbox view. */
 export async function mailboxRefreshRoute(req: Request): Promise<Response> {
   if (!allowed(req)) return jsonResponse({ error: "forbidden origin" }, 403, req);
   await syncSmartleadMailboxes(true);
   return jsonResponse(mailboxInboxView(), 200, req);
 }
 
+/** Verify and save IMAP/SMTP settings for a workspace mailbox identity. */
 export async function mailboxConnectRoute(req: Request): Promise<Response> {
   if (!allowed(req)) return jsonResponse({ error: "forbidden origin" }, 403, req);
   try {

--- a/apps/server/src/api/mailboxes.ts
+++ b/apps/server/src/api/mailboxes.ts
@@ -1,0 +1,206 @@
+import {
+  getLedger,
+  hydrateMailboxThread,
+  mailboxHealth,
+  syncSmartleadMailboxes,
+  verifyMailboxConnection,
+} from "@oneshot-gtm/core";
+import {
+  saveMailboxConnection,
+  validateMailboxConnection,
+} from "../../../../packages/core/src/mailbox-config.ts";
+import type {
+  MailboxConnectionRequest,
+  MailboxStateRequest,
+  MailboxThreadView,
+  InboxResult,
+  ConversationItem,
+} from "@oneshot-gtm/shared-types";
+import { isLoopbackOrigin, jsonResponse } from "../server.ts";
+
+export function mailboxInboxView(): Pick<InboxResult, "mailboxes" | "mailboxThreads"> {
+  const health = mailboxHealth();
+  const ledger = getLedger();
+  const store = ledger.mailboxes;
+  if (!health.length && !store?.all().length) return {};
+  const identities = new Map(health.map((h) => [h.identityId, h.address]));
+  const groups = new Map<string, ReturnType<typeof store.all>>();
+  for (const message of store.all()) {
+    const group = groups.get(message.threadKey) ?? [];
+    group.push(message);
+    groups.set(message.threadKey, group);
+  }
+  const drafts = ledger.getInboxThreads();
+  const views: MailboxThreadView[] = [];
+  for (const [threadKey, messages] of groups) {
+    messages.sort((a, b) => a.at.localeCompare(b.at) || a.id.localeCompare(b.id));
+    const latest = messages.findLast((m) => m.direction === "inbound");
+    if (!latest) continue;
+    const prospect = latest.prospectId == null ? null : ledger.getProspectById(latest.prospectId);
+    const cadence = prospect
+      ? (ledger.listCadencesForProspect(prospect.id).find((c) => c.status === "replied") ??
+        ledger.listCadencesForProspect(prospect.id)[0])
+      : null;
+    const intents = ledger.listInboxReplyIntents(messages.map((m) => m.id));
+    const draft = drafts.get(threadKey);
+    const intent = intents.get(latest.id);
+    const items: ConversationItem[] = messages.map((m) =>
+      m.direction === "outbound"
+        ? { kind: "sent", at: m.at, subject: m.subject, body: m.body }
+        : {
+            kind: "reply",
+            at: m.at,
+            subject: m.subject,
+            body: m.body,
+            id: m.id,
+            threadKey,
+            sourceIdentityId: m.identityId,
+            threadId: threadKey,
+            messageId: m.messageId,
+            replyKind: m.kind,
+            intent: (intents.get(m.id)?.intent as MailboxThreadView["reply"]["intent"]) ?? null,
+          },
+    );
+    views.push({
+      threadKey,
+      identityId: latest.identityId,
+      mailboxAddress:
+        identities.get(latest.identityId) ?? latest.identityId.replace(/^smartlead:/, ""),
+      prospectId: prospect?.id ?? null,
+      name: prospect?.name ?? null,
+      company: prospect?.company ?? null,
+      email: latest.from,
+      ...store.threadState(threadKey),
+      lastActivityAt: messages.at(-1)!.at,
+      items,
+      reply: {
+        bounceKind: latest.bounces?.[0]?.kind ?? null,
+        id: latest.id,
+        fromEmail: latest.from,
+        fromRaw: latest.from,
+        subject: latest.subject,
+        receivedAt: latest.at,
+        body: latest.body,
+        kind: latest.kind,
+        intent: (intent?.intent as MailboxThreadView["reply"]["intent"]) ?? null,
+        intentReason: intent?.intentReason ?? null,
+        // Removed identities retain history but cannot send.
+        sourceIdentityId: identities.has(latest.identityId) ? latest.identityId : null,
+        sourceProvider: "smartlead",
+        threadId: threadKey,
+        messageId: latest.messageId,
+        matched: prospect
+          ? {
+              name: prospect.name,
+              company: prospect.company,
+              playName: cadence?.play_name ?? prospect.source,
+              cadenceStatus: cadence?.status ?? null,
+            }
+          : null,
+        thread: {
+          draftBody: draft?.draftBody ?? null,
+          steer: draft?.steer ?? null,
+          status: draft?.status ?? null,
+          sent: [],
+        },
+      },
+    });
+  }
+  return {
+    mailboxes: health,
+    mailboxThreads: views.toSorted((a, b) => b.lastActivityAt.localeCompare(a.lastActivityAt)),
+  };
+}
+
+function allowed(req: Request): boolean {
+  return isLoopbackOrigin(req.headers.get("origin") ?? "");
+}
+
+export async function mailboxStateRoute(req: Request): Promise<Response> {
+  if (!allowed(req)) return jsonResponse({ error: "forbidden origin" }, 403, req);
+  try {
+    const b = (await req.json()) as MailboxStateRequest;
+    if (
+      typeof b.threadKey !== "string" ||
+      !Array.isArray(b.observedReplyIds) ||
+      !b.observedReplyIds.every((id) => typeof id === "string") ||
+      (b.read !== undefined && typeof b.read !== "boolean") ||
+      (b.archived !== undefined && typeof b.archived !== "boolean")
+    )
+      throw new Error("Invalid thread state request.");
+    getLedger().mailboxes.changeState(b.threadKey, b.observedReplyIds, b);
+    return jsonResponse({ ok: true }, 200, req);
+  } catch (err) {
+    return jsonResponse(
+      { error: err instanceof Error ? err.message : "Invalid thread state request." },
+      409,
+      req,
+    );
+  }
+}
+
+export async function mailboxMatchRoute(req: Request): Promise<Response> {
+  if (!allowed(req)) return jsonResponse({ error: "forbidden origin" }, 403, req);
+  try {
+    const b = (await req.json()) as { threadKey?: string; email?: string };
+    if (typeof b.threadKey !== "string" || typeof b.email !== "string")
+      throw new Error("Thread and prospect email are required.");
+    const ledger = getLedger();
+    const prospect = ledger.getProspectByEmail(b.email.trim().toLowerCase());
+    if (!prospect) throw new Error("No existing prospect has that email address.");
+    if (!ledger.mailboxes.thread(b.threadKey).length) throw new Error("Conversation not found.");
+    ledger.mailboxes.associate(b.threadKey, prospect.id);
+    return jsonResponse({ ok: true }, 200, req);
+  } catch (err) {
+    return jsonResponse(
+      { error: err instanceof Error ? err.message : "Could not match conversation." },
+      400,
+      req,
+    );
+  }
+}
+
+export async function mailboxHistoryRoute(req: Request): Promise<Response> {
+  if (!allowed(req)) return jsonResponse({ error: "forbidden origin" }, 403, req);
+  try {
+    const b = (await req.json()) as { threadKey?: string };
+    if (typeof b.threadKey !== "string") throw new Error("Thread is required.");
+    await hydrateMailboxThread(b.threadKey);
+    return jsonResponse({ ok: true }, 200, req);
+  } catch (err) {
+    return jsonResponse(
+      { error: err instanceof Error ? err.message : "Could not load history." },
+      400,
+      req,
+    );
+  }
+}
+
+export async function mailboxRefreshRoute(req: Request): Promise<Response> {
+  if (!allowed(req)) return jsonResponse({ error: "forbidden origin" }, 403, req);
+  await syncSmartleadMailboxes(true);
+  return jsonResponse(mailboxInboxView(), 200, req);
+}
+
+export async function mailboxConnectRoute(req: Request): Promise<Response> {
+  if (!allowed(req)) return jsonResponse({ error: "forbidden origin" }, 403, req);
+  try {
+    const b = (await req.json()) as MailboxConnectionRequest;
+    const identity = mailboxHealth().find(
+      (h) => h.identityId === b.identityId && h.address.toLowerCase() === b.address?.toLowerCase(),
+    );
+    if (!identity) throw new Error("Mailbox is not registered in this workspace.");
+    const connection = validateMailboxConnection(b);
+    await verifyMailboxConnection(connection);
+    saveMailboxConnection(b.identityId, connection);
+    await syncSmartleadMailboxes(true);
+    return jsonResponse({ ok: true }, 200, req);
+  } catch {
+    // Never forward credential-bearing transport errors or arbitrary input to the browser.
+    return jsonResponse(
+      { error: "Could not connect this mailbox. Check both IMAP and SMTP settings and try again." },
+      400,
+      req,
+    );
+  }
+}

--- a/apps/server/src/api/workspace.ts
+++ b/apps/server/src/api/workspace.ts
@@ -81,7 +81,7 @@ export type LaunchSpawn = (opts: {
 }) => void;
 
 const realSpawn: LaunchSpawn = ({ binPath, env }) => {
-  const proc = Bun.spawn([process.execPath, "run", binPath], {
+  const proc = Bun.spawn([process.execPath, "--no-env-file", "run", binPath], {
     env,
     stdout: "ignore",
     stderr: "ignore",
@@ -142,6 +142,11 @@ export async function workspaceLaunch(req: Request): Promise<Response> {
   // The parent may be running in dev mode; the child has no vite of its own
   // and must serve its static build instead of 302ing to the parent's.
   delete env["VITE_DEV_SERVER_URL"];
+  // A sibling workspace must resolve its own Smartlead account. Otherwise
+  // applySecretsToEnv's fill-blanks rule keeps the parent's key and silently
+  // lists/sends against the wrong account. --no-env-file also prevents Bun
+  // from reintroducing the repository's Smartlead key before config loads.
+  delete env["SMARTLEAD_API_KEY"];
 
   // fileURLToPath, not .pathname: a repo path with a space or non-ASCII char
   // would arrive percent-encoded and the child would die on a missing file.

--- a/apps/server/src/scheduler.ts
+++ b/apps/server/src/scheduler.ts
@@ -1,5 +1,7 @@
 import {
   demoMode,
+  loadConfig,
+  resolveIdentities,
   logEvent,
   type TelemetryOutcome,
   postDailySendSummaryIfDue,
@@ -118,17 +120,6 @@ export function startScheduler(): SchedulerHandle {
             mailBackfillRunning = false;
           });
       }
-      const outcomes = await runDueTriggers();
-      const fired = outcomes.filter((o) => o.fired).length;
-      // Telemetry per fired trigger — detached, must not delay the tick.
-      for (const o of outcomes) {
-        if (!o.fired) continue;
-        void reportServerExecution(`server.trigger.${o.name}`, {
-          outcome: triggerOutcome(o),
-          durationMs: o.duration_ms ?? 0,
-          flags: ["scheduled"],
-        });
-      }
       // Reply detection is isolated: an inbox outage must not skip trigger
       // scheduling (or vice-versa), and it never sends, so it can't double-spend.
       let repliesDetected = 0;
@@ -175,7 +166,10 @@ export function startScheduler(): SchedulerHandle {
         lastBouncePollAt > 0 &&
         new Date(lastBouncePollAt).toISOString().slice(0, 10) !==
           new Date().toISOString().slice(0, 10);
-      if (Date.now() - lastBouncePollAt >= BOUNCE_POLL_INTERVAL_MS || dayRolledOver) {
+      const bounceInterval = resolveIdentities(loadConfig()).some((i) => i.provider === "smartlead")
+        ? 60_000
+        : BOUNCE_POLL_INTERVAL_MS;
+      if (Date.now() - lastBouncePollAt >= bounceInterval || dayRolledOver) {
         // Stamped before the await, not after: a slow or failing sweep must not
         // let ticks queue up behind it and then all fire at once.
         lastBouncePollAt = Date.now();
@@ -191,6 +185,17 @@ export function startScheduler(): SchedulerHandle {
             "warn",
           );
         }
+      }
+      const outcomes = await runDueTriggers();
+      const fired = outcomes.filter((o) => o.fired).length;
+      // Telemetry per fired trigger — detached, must not delay the tick.
+      for (const o of outcomes) {
+        if (!o.fired) continue;
+        void reportServerExecution(`server.trigger.${o.name}`, {
+          outcome: triggerOutcome(o),
+          durationMs: o.duration_ms ?? 0,
+          flags: ["scheduled"],
+        });
       }
       // Drain outage-deferred candidates (time-windowed finders) now the
       // backend may be healthy again. Isolated like the reply poll — its
@@ -261,7 +266,10 @@ export function startScheduler(): SchedulerHandle {
         source: "server",
       });
       if (cancelled) return;
-      const sleepMs = Math.min(nextSleepMs(outcomes), REPLY_POLL_MAX_MS);
+      const replyInterval = resolveIdentities(loadConfig()).some((i) => i.provider === "smartlead")
+        ? 60_000
+        : REPLY_POLL_MAX_MS;
+      const sleepMs = Math.min(nextSleepMs(outcomes), replyInterval);
       timer = setTimeout(() => void tick(), sleepMs);
     } catch (err) {
       logEvent(

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1,4 +1,11 @@
 import { directMailRoute } from "./api/direct-mail.ts";
+import {
+  mailboxStateRoute,
+  mailboxMatchRoute,
+  mailboxHistoryRoute,
+  mailboxRefreshRoute,
+  mailboxConnectRoute,
+} from "./api/mailboxes.ts";
 import { existsSync, statSync } from "node:fs";
 import { isAbsolute, join, relative, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -117,6 +124,11 @@ const routes: RouteEntry[] = [
   route("GET", "/api/receipts", listReceipts),
   route("GET", "/api/receipts/:id", getReceipt),
   route("GET", "/api/inbox", listInboxRoute),
+  route("POST", "/api/inbox/thread-state", mailboxStateRoute),
+  route("POST", "/api/inbox/thread-match", mailboxMatchRoute),
+  route("POST", "/api/inbox/thread-history", mailboxHistoryRoute),
+  route("POST", "/api/inbox/mailbox-refresh", mailboxRefreshRoute),
+  route("POST", "/api/inbox/mailbox-connect", mailboxConnectRoute),
   route("POST", "/api/inbox/archive", archiveInboxConversationRoute),
   route("POST", "/api/inbox/draft-reply", draftReplyRoute),
   route("POST", "/api/inbox/draft", saveDraftRoute),

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -183,6 +183,16 @@ export const api = {
     return getJson<{ receipts: ReceiptView[] }>(`/receipts${qs ? `?${qs}` : ""}`);
   },
   inbox: () => getJson<InboxResult>("/inbox"),
+  mailboxState: (req: import("@oneshot-gtm/shared-types").MailboxStateRequest) =>
+    postJson<{ ok: boolean }>("/inbox/thread-state", req),
+  mailboxMatch: (threadKey: string, email: string) =>
+    postJson<{ ok: boolean }>("/inbox/thread-match", { threadKey, email }),
+  mailboxHistory: (threadKey: string) =>
+    postJson<{ ok: boolean }>("/inbox/thread-history", { threadKey }),
+  mailboxRefresh: () =>
+    postJson<Pick<InboxResult, "mailboxThreads" | "mailboxes">>("/inbox/mailbox-refresh", {}),
+  mailboxConnect: (req: import("@oneshot-gtm/shared-types").MailboxConnectionRequest) =>
+    postJson<{ ok: boolean }>("/inbox/mailbox-connect", req),
   archiveInboxConversation: (req: InboxArchiveRequest) =>
     postJson<InboxArchiveResult>("/inbox/archive", req),
   draftInboxReply: (req: InboxDraftReplyRequest) =>

--- a/apps/web/src/components/MailboxInbox.tsx
+++ b/apps/web/src/components/MailboxInbox.tsx
@@ -1,0 +1,288 @@
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { ChevronDown, ChevronRight, Loader2 } from "lucide-react";
+import { toast } from "sonner";
+import type {
+  MailboxConnectionRequest,
+  MailboxHealthView,
+  MailboxThreadView,
+} from "@oneshot-gtm/shared-types";
+import { api } from "../api/client.ts";
+import { Button } from "./primitives/Button.tsx";
+import { Input } from "./primitives/Field.tsx";
+import { Badge } from "./primitives/Badge.tsx";
+import { timeAgo } from "../lib/cn.ts";
+import { readOnly } from "../lib/readOnly.ts";
+import { IS_DEMO } from "../api/demo.ts";
+
+export function MailboxConnections({ mailboxes }: { mailboxes: MailboxHealthView[] }) {
+  const [editing, setEditing] = useState<string | null>(null);
+  if (!mailboxes.length) return null;
+  return (
+    <details
+      className="border-b border-ink-rule/60 px-6 py-3"
+      open={mailboxes.some((m) => m.status === "error")}
+    >
+      <summary className="cursor-pointer font-mono text-[12px] text-ink-muted">
+        {mailboxes.filter((m) => m.status === "connected").length} of {mailboxes.length} receiving
+        mailboxes connected
+        {mailboxes.some((m) => m.backfillRemaining) ? " · importing history" : ""}
+      </summary>
+      <div className="mt-3 space-y-3">
+        {mailboxes.map((m) => (
+          <div key={m.identityId} className="text-[12px] text-ink-muted">
+            <div className="flex flex-wrap items-center gap-2">
+              <span>{m.address}</span>
+              <Badge tone={m.status === "error" ? "blocked" : "neutral"}>{m.status}</Badge>
+              <span>
+                {m.lastSyncAt ? `synced ${timeAgo(m.lastSyncAt)}` : "waiting for first sync"}
+              </span>
+              {m.backfillRemaining && <span>history import incomplete</span>}
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => setEditing(editing === m.identityId ? null : m.identityId)}
+                {...readOnly}
+              >
+                Connection settings
+              </Button>
+            </div>
+            {m.error && <p className="mt-1 text-[color:var(--ink-blocked-2)]">{m.error}</p>}
+            {editing === m.identityId && (
+              <MailboxConnectionForm mailbox={m} onDone={() => setEditing(null)} />
+            )}
+          </div>
+        ))}
+      </div>
+    </details>
+  );
+}
+
+function MailboxConnectionForm({
+  mailbox,
+  onDone,
+}: {
+  mailbox: MailboxHealthView;
+  onDone: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const [form, setForm] = useState<MailboxConnectionRequest>({
+    identityId: mailbox.identityId,
+    address: mailbox.address,
+    imap: { host: "", port: 993, secure: true, user: mailbox.address, pass: "" },
+    smtp: { host: "", port: 587, secure: false, user: mailbox.address, pass: "" },
+  });
+  const save = useMutation({
+    mutationFn: () => api.mailboxConnect(form),
+    onSuccess: () => {
+      toast.success("Mailbox connected");
+      void queryClient.invalidateQueries({ queryKey: ["inbox"] });
+      onDone();
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+  return (
+    <form
+      className="mt-3 space-y-3 border border-ink-rule/60 p-3"
+      onSubmit={(e) => {
+        e.preventDefault();
+        save.mutate();
+      }}
+    >
+      <p>
+        Use an app password or the credentials supplied by your mailbox provider. Saved privately
+        for this workspace.
+      </p>
+      {(["imap", "smtp"] as const).map((kind) => (
+        <fieldset key={kind} className="grid gap-2 sm:grid-cols-2">
+          <legend className="mb-2 uppercase">{kind}</legend>
+          {(["host", "port", "user", "pass"] as const).map((field) => (
+            <label key={field}>
+              <span className="mb-1 block">
+                {field === "pass" ? "App password" : field === "user" ? "Username" : field}
+              </span>
+              <Input
+                required
+                type={field === "pass" ? "password" : field === "port" ? "number" : "text"}
+                autoComplete={field === "pass" ? "new-password" : "off"}
+                value={form[kind][field]}
+                onChange={(e) =>
+                  setForm({
+                    ...form,
+                    [kind]: {
+                      ...form[kind],
+                      [field]: field === "port" ? Number(e.target.value) : e.target.value,
+                    },
+                  })
+                }
+              />
+            </label>
+          ))}
+          <label className="flex items-center gap-2">
+            <input
+              type="checkbox"
+              checked={form[kind].secure}
+              onChange={(e) =>
+                setForm({ ...form, [kind]: { ...form[kind], secure: e.target.checked } })
+              }
+            />
+            TLS from connection start (otherwise require STARTTLS)
+          </label>
+        </fieldset>
+      ))}
+      <Button type="submit" size="sm" disabled={save.isPending} {...readOnly}>
+        {save.isPending ? "Checking connections…" : "Verify and connect"}
+      </Button>
+    </form>
+  );
+}
+
+export function MailboxThreadRow({
+  thread: t,
+  children,
+}: {
+  thread: MailboxThreadView;
+  children: ReactNode;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const [matchEmail, setMatchEmail] = useState("");
+  const queryClient = useQueryClient();
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: ["inbox"] });
+  const ids = t.items.filter((i) => i.kind === "reply").map((i) => i.id);
+  const state = useMutation({
+    mutationFn: (change: { read?: boolean; archived?: boolean }) =>
+      api.mailboxState({ threadKey: t.threadKey, observedReplyIds: ids, ...change }),
+    onSuccess: invalidate,
+    onError: (e: Error) => {
+      toast.error(e.message);
+      void invalidate();
+    },
+  });
+  const history = useMutation({
+    mutationFn: () => api.mailboxHistory(t.threadKey),
+    onSuccess: invalidate,
+    onError: (e: Error) => toast.error(e.message),
+  });
+  const match = useMutation({
+    mutationFn: () => api.mailboxMatch(t.threadKey, matchEmail),
+    onSuccess: invalidate,
+    onError: (e: Error) => toast.error(e.message),
+  });
+  // Mark only the snapshot displayed on opening. New arrivals remain unread,
+  // and explicitly marking an open thread unread does not immediately undo it.
+  const opened = useRef(false);
+  useEffect(() => {
+    if (expanded && !opened.current && !IS_DEMO) {
+      if (t.unread) state.mutate({ read: true });
+      if (!t.historyComplete) history.mutate();
+    }
+    opened.current = expanded;
+  }, [expanded, t.historyComplete, t.unread, state, history]);
+  return (
+    <div className="border-b border-ink-rule/60">
+      <div className="flex flex-wrap items-center gap-2 pr-6">
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          className="flex min-w-0 flex-1 items-center gap-3 px-6 py-3 text-left hover:bg-ink-surface/60"
+        >
+          {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+          <span className="min-w-0 flex-1">
+            <span
+              className={`block truncate text-[13px] text-ink-cream ${t.unread ? "font-semibold" : ""}`}
+            >
+              {t.unread ? "● " : ""}
+              {t.name ?? t.email}
+              {t.company ? ` · ${t.company}` : ""}
+            </span>
+            <span className="block truncate text-[12px] text-ink-muted">
+              {t.reply.subject || "(no subject)"}
+            </span>
+            <span className="block font-mono text-[10px] text-ink-faint">
+              {t.mailboxAddress} · {timeAgo(t.lastActivityAt)}
+            </span>
+          </span>
+          {t.reply.bounceKind ? (
+            <Badge tone="blocked">delivery failure · {t.reply.bounceKind}</Badge>
+          ) : t.reply.kind !== "human" ? (
+            <Badge tone={t.reply.kind === "auto" ? "neutral" : "blocked"}>
+              {t.reply.kind === "unsubscribe"
+                ? "opted out"
+                : t.reply.kind === "auto_permanent"
+                  ? "mailbox unavailable"
+                  : "automatic reply"}
+            </Badge>
+          ) : (
+            t.reply.intent && <Badge tone="neutral">{t.reply.intent}</Badge>
+          )}
+          {!t.prospectId && <Badge tone="neutral">no match</Badge>}
+        </button>
+        <Button
+          size="sm"
+          variant="ghost"
+          disabled={state.isPending}
+          {...readOnly}
+          onClick={() => state.mutate({ read: t.unread })}
+        >
+          {t.unread ? "Mark read" : "Mark unread"}
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          disabled={state.isPending}
+          {...readOnly}
+          onClick={() => state.mutate({ archived: !t.archivedAt })}
+        >
+          {t.archivedAt ? "Restore" : "Archive"}
+        </Button>
+      </div>
+      {expanded && (
+        <div className="space-y-3 bg-ink-bg-deep/50 px-6 py-3">
+          <div className="flex flex-wrap items-center gap-2 text-[12px] text-ink-muted">
+            <Input
+              value={matchEmail}
+              onChange={(e) => setMatchEmail(e.target.value)}
+              placeholder="Existing prospect’s email"
+              aria-label="Match to prospect email"
+              className="max-w-xs"
+            />
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={!matchEmail.trim() || match.isPending}
+              {...readOnly}
+              onClick={() => match.mutate()}
+            >
+              {t.prospectId ? "Change match" : "Match prospect"}
+            </Button>
+          </div>
+          {t.items.map((item, index) => (
+            <div
+              key={item.kind === "reply" ? item.id : `${item.at}:${index}`}
+              className="rounded-sm border border-ink-rule/60 bg-ink-surface/20 px-3 py-2"
+            >
+              <div className="mb-1 font-mono text-[10px] uppercase text-ink-faint">
+                {item.kind === "reply" ? t.email : "You"} · {timeAgo(item.at)}
+              </div>
+              <pre className="max-h-[360px] overflow-auto whitespace-pre-wrap text-[12px] leading-relaxed text-ink-cream-2">
+                {item.body || "(No text body)"}
+              </pre>
+            </div>
+          ))}
+          {!t.historyComplete && (
+            <Button
+              size="sm"
+              variant="ghost"
+              disabled={history.isPending}
+              onClick={() => history.mutate()}
+            >
+              {history.isPending && <Loader2 size={12} className="animate-spin" />}
+              {history.isPending ? "Loading full history…" : "Load more history"}
+            </Button>
+          )}
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/MailboxInbox.tsx
+++ b/apps/web/src/components/MailboxInbox.tsx
@@ -15,6 +15,7 @@ import { timeAgo } from "../lib/cn.ts";
 import { readOnly } from "../lib/readOnly.ts";
 import { IS_DEMO } from "../api/demo.ts";
 
+/** Render connection health and settings for the workspace's receiving mailboxes. */
 export function MailboxConnections({ mailboxes }: { mailboxes: MailboxHealthView[] }) {
   const [editing, setEditing] = useState<string | null>(null);
   if (!mailboxes.length) return null;
@@ -58,6 +59,7 @@ export function MailboxConnections({ mailboxes }: { mailboxes: MailboxHealthView
   );
 }
 
+/** Collect and submit IMAP/SMTP credentials for one mailbox identity. */
 function MailboxConnectionForm({
   mailbox,
   onDone,
@@ -137,6 +139,7 @@ function MailboxConnectionForm({
   );
 }
 
+/** Render an expandable mailbox conversation with local state controls. */
 export function MailboxThreadRow({
   thread: t,
   children,

--- a/apps/web/src/routes/__root.tsx
+++ b/apps/web/src/routes/__root.tsx
@@ -140,9 +140,11 @@ function RootLayout() {
     // Round-2 correction (#480): `awaitingReply` (not a bare `intent` check)
     // — it clears once the founder replies to the thread or records a deal
     // outcome, so the dot doesn't stay lit forever after the first use.
-    "inbox-positive": (inboxAlertQuery.data?.conversations ?? []).some(
-      (c) => !c.archivedAt && c.awaitingReply,
-    ),
+    "inbox-positive":
+      (inboxAlertQuery.data?.conversations ?? []).some((c) => !c.archivedAt && c.awaitingReply) ||
+      (inboxAlertQuery.data?.mailboxThreads ?? []).some(
+        (t) => !t.archivedAt && t.unread && t.reply.kind === "human" && t.prospectId != null,
+      ),
     "meetings-pending": (meetingsAlertQuery.data?.awaitingOutcome.length ?? 0) > 0,
   };
 

--- a/apps/web/src/routes/inbox.tsx
+++ b/apps/web/src/routes/inbox.tsx
@@ -17,6 +17,7 @@ import { cn, timeAgo } from "../lib/cn.ts";
 import { matchesReplyFilter, type ReplyMatchFilter } from "../lib/replyFilter.ts";
 import { readOnly } from "../lib/readOnly.ts";
 import { IS_DEMO } from "../api/demo.ts";
+import { MailboxConnections, MailboxThreadRow } from "../components/MailboxInbox.tsx";
 
 const MATCH_FILTERS: Array<{ key: ReplyMatchFilter; label: string }> = [
   { key: "all", label: "all" },
@@ -59,10 +60,19 @@ function InboxPage() {
     refetchInterval: 60_000,
   });
 
-  const replies = inbox.data?.replies ?? [];
+  const replies = (inbox.data?.replies ?? []).filter((r) => r.sourceProvider !== "smartlead");
+  const mailboxThreads = inbox.data?.mailboxThreads ?? [];
+  const mailboxVisible = mailboxThreads.filter(
+    (t) =>
+      Boolean(t.archivedAt) === archiveView &&
+      (matchFilter === "all" ||
+        (matchFilter === "matched" ? t.prospectId != null : t.prospectId == null)),
+  );
   // Ledger-backed threaded view — complete regardless of the live window.
   const conversations = inbox.data?.conversations ?? [];
-  const archivedCount = conversations.filter((c) => c.archivedAt).length;
+  const archivedCount =
+    conversations.filter((c) => c.archivedAt).length +
+    mailboxThreads.filter((t) => t.archivedAt).length;
   const displayedConversations = inboxConversations(conversations, archiveView);
   const error = inbox.data?.error;
   // The server fetches a clamped window (newest 200 across all identities).
@@ -70,13 +80,29 @@ function InboxPage() {
   // page never presents the window as the whole mailbox. `matched` is exact —
   // it comes from the ledger, not the window.
   const windowSuffix = inbox.data?.hasMore ? "+" : "";
-  const noMatchCount = replies.filter((r) => r.matched == null).length;
+  const noMatchCount =
+    replies.filter((r) => r.matched == null).length +
+    mailboxThreads.filter((t) => t.prospectId == null).length;
   const countFor = (key: ReplyMatchFilter): number =>
-    key === "matched" ? conversations.length : key === "no-match" ? noMatchCount : replies.length;
+    key === "matched"
+      ? conversations.length + mailboxThreads.filter((t) => t.prospectId != null).length
+      : key === "no-match"
+        ? noMatchCount
+        : replies.length + mailboxThreads.length;
   const suffixFor = (key: ReplyMatchFilter): string => (key === "matched" ? "" : windowSuffix);
   const visible = replies.filter((r) => matchesReplyFilter(r, matchFilter));
   const showConversations = matchFilter === "matched";
-  const needsDecisionCount = conversations.filter(inboxNeedsAttention).length;
+  const needsDecisionCount =
+    conversations.filter(inboxNeedsAttention).length +
+    mailboxThreads.filter((t) => !t.archivedAt && t.reply.thread?.status === "needs_decision")
+      .length;
+  const refresh = useMutation({
+    mutationFn: async () => {
+      if (inbox.data?.mailboxes?.length) await api.mailboxRefresh();
+      await inbox.refetch();
+    },
+    onError: (err: Error) => toast.error(err.message),
+  });
 
   return (
     <div className="-mx-6 -my-6 flex flex-col">
@@ -106,7 +132,7 @@ function InboxPage() {
             {!inbox.data
               ? "…"
               : showConversations
-                ? `${displayedConversations.length} conversation${displayedConversations.length === 1 ? "" : "s"}`
+                ? `${displayedConversations.length + mailboxVisible.length} conversations`
                 : matchFilter === "all"
                   ? `${replies.length}${windowSuffix} repl${replies.length === 1 && !windowSuffix ? "y" : "ies"}`
                   : `${visible.length} of ${replies.length}${windowSuffix}`}
@@ -114,8 +140,8 @@ function InboxPage() {
           <Button
             variant="ghost"
             size="sm"
-            disabled={inbox.isFetching}
-            onClick={() => void inbox.refetch()}
+            disabled={inbox.isFetching || refresh.isPending}
+            onClick={() => refresh.mutate()}
           >
             {inbox.isFetching ? (
               <Loader2 size={12} className="animate-spin" />
@@ -158,7 +184,8 @@ function InboxPage() {
         ))}
       </div>
 
-      {showConversations && (
+      <MailboxConnections mailboxes={inbox.data?.mailboxes ?? []} />
+      {(showConversations || mailboxThreads.length > 0) && (
         <div className="flex gap-2 border-b border-ink-rule/60 px-6 py-3">
           <Button
             size="sm"
@@ -168,7 +195,10 @@ function InboxPage() {
               setExpanded(null);
             }}
           >
-            Inbox <span className="ml-1 opacity-60">{conversations.length - archivedCount}</span>
+            Inbox{" "}
+            <span className="ml-1 opacity-60">
+              {conversations.length + mailboxThreads.length - archivedCount}
+            </span>
           </Button>
           <Button
             size="sm"
@@ -188,19 +218,26 @@ function InboxPage() {
         </section>
       )}
 
+      {mailboxVisible.map((t) => (
+        <MailboxThreadRow key={t.threadKey} thread={t}>
+          <ReplyComposer key={t.reply.id} reply={t.reply} prospectId={t.prospectId ?? undefined} />
+        </MailboxThreadRow>
+      ))}
       {inbox.isLoading ? (
         Array.from({ length: 5 }, (_, i) => <SkeletonRow key={i} />)
       ) : showConversations ? (
         displayedConversations.length === 0 ? (
-          <div className="p-5">
-            <EmptyNote
-              note={
-                archiveView
-                  ? "No archived conversations."
-                  : "No active conversations. New replies appear here; handled conversations are in Archived."
-              }
-            />
-          </div>
+          mailboxVisible.length > 0 ? null : (
+            <div className="p-5">
+              <EmptyNote
+                note={
+                  archiveView
+                    ? "No archived conversations."
+                    : "No active conversations. New replies appear here; handled conversations are in Archived."
+                }
+              />
+            </div>
+          )
         ) : (
           <div>
             {displayedConversations.map((c, i) => (
@@ -217,13 +254,17 @@ function InboxPage() {
           </div>
         )
       ) : replies.length === 0 ? (
-        <div className="p-5">
-          <EmptyNote note="No replies yet. When a prospect writes back, it shows here." />
-        </div>
+        mailboxVisible.length > 0 ? null : (
+          <div className="p-5">
+            <EmptyNote note="No replies yet. When a prospect writes back, it shows here." />
+          </div>
+        )
       ) : visible.length === 0 ? (
-        <div className="p-5">
-          <EmptyNote note="No unmatched replies — every reply here matches a prospect." />
-        </div>
+        mailboxVisible.length > 0 ? null : (
+          <div className="p-5">
+            <EmptyNote note="No unmatched replies — every reply here matches a prospect." />
+          </div>
+        )
       ) : (
         <div>
           {visible.map((r, i) => (
@@ -592,6 +633,7 @@ function ReplyComposer({
   const draftRef = useRef(draft);
   draftRef.current = draft;
   const identityId = reply.sourceIdentityId;
+  const sendRequest = useRef<{ body: string; id: string } | null>(null);
   // needs-decision state (issue #480): starts from the persisted status, then
   // tracks whatever the last draft/generate/steer call actually verified —
   // never trusted from the textarea's raw content (the client can't run the
@@ -673,8 +715,13 @@ function ReplyComposer({
   });
 
   const send = useMutation({
-    mutationFn: () =>
-      api.sendInboxReply({
+    mutationFn: () => {
+      if (!sendRequest.current || sendRequest.current.body !== draft)
+        sendRequest.current = { body: draft, id: crypto.randomUUID() };
+      return api.sendInboxReply({
+        ...(reply.sourceProvider === "smartlead"
+          ? { inboundEmailId: reply.id, sendRequestId: sendRequest.current.id }
+          : {}),
         to: reply.fromEmail,
         subject: reply.subject,
         body: draft,
@@ -685,18 +732,23 @@ function ReplyComposer({
         // OneShot-source rows: reply.id is the OneShot inbox id the platform
         // threads on. Ignored server-side for Gmail rows.
         replyToEmailId: reply.sourceProvider === "oneshot" ? reply.id : null,
-      }),
+      });
+    },
     onSuccess: (res) => {
       // Server appended to the sent history and cleared the draft. Reflect that
       // locally (clear the box, mark nothing-to-save) and refetch so the sent
       // reply shows up.
       lastSaved.current = "";
+      sendRequest.current = null;
       setDraft("");
       setNeedsDecision(false);
       void queryClient.invalidateQueries({ queryKey: ["inbox"] });
       toast.success(res.costUsd > 0 ? `reply sent · $${res.costUsd.toFixed(2)}` : "reply sent");
     },
-    onError: (err) => toast.error(`couldn't send · ${err.message}`),
+    onError: (err) => {
+      if (/was not sent|Previous send failed/.test(err.message)) sendRequest.current = null;
+      toast.error(`couldn't send · ${err.message}`);
+    },
   });
 
   const logOutcome = useMutation({

--- a/apps/web/src/routes/inbox.tsx
+++ b/apps/web/src/routes/inbox.tsx
@@ -88,7 +88,7 @@ function InboxPage() {
       ? conversations.length + mailboxThreads.filter((t) => t.prospectId != null).length
       : key === "no-match"
         ? noMatchCount
-        : replies.length + mailboxThreads.length;
+        : replies.length + (inbox.data?.mailboxThreads?.length ?? 0);
   const suffixFor = (key: ReplyMatchFilter): string => (key === "matched" ? "" : windowSuffix);
   const visible = replies.filter((r) => matchesReplyFilter(r, matchFilter));
   const showConversations = matchFilter === "matched";
@@ -134,8 +134,8 @@ function InboxPage() {
               : showConversations
                 ? `${displayedConversations.length + mailboxVisible.length} conversations`
                 : matchFilter === "all"
-                  ? `${replies.length}${windowSuffix} repl${replies.length === 1 && !windowSuffix ? "y" : "ies"}`
-                  : `${visible.length} of ${replies.length}${windowSuffix}`}
+                  ? `${replies.length + mailboxVisible.length}${windowSuffix} repl${replies.length + mailboxVisible.length === 1 && !windowSuffix ? "y" : "ies"}`
+                  : `${visible.length + mailboxVisible.length} of ${replies.length + (inbox.data?.mailboxThreads?.length ?? 0)}${windowSuffix}`}
           </span>
           <Button
             variant="ghost"

--- a/bun.lock
+++ b/bun.lock
@@ -97,7 +97,14 @@
       "version": "0.8.0",
       "dependencies": {
         "@oneshot-agent/sdk": "file:../../vendor/oneshot-agent-sdk-0.32.0.tgz",
+        "imapflow": "^2.0.2",
+        "mailparser": "^3.9.24",
+        "nodemailer": "^10.0.3",
         "pdf-lib": "^1.17.1",
+      },
+      "devDependencies": {
+        "@types/mailparser": "^3.4.6",
+        "@types/nodemailer": "^8.0.1",
       },
     },
     "packages/doctor": {
@@ -395,6 +402,8 @@
 
     "@pdf-lib/upng": ["@pdf-lib/upng@1.0.1", "", { "dependencies": { "pako": "^1.0.10" } }, "sha512-dQK2FUMQtowVP00mtIksrlZhdFXQZPC+taih1q4CvPZ5vqdxR/LKBaFg0oAfzd1GlHZXXSPdQfzQnt+ViGvEIQ=="],
 
+    "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
+
     "@quansync/fs": ["@quansync/fs@1.0.0", "", { "dependencies": { "quansync": "^1.0.0" } }, "sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.1", "", {}, "sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g=="],
@@ -549,6 +558,8 @@
 
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-rc.7", "", {}, "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA=="],
 
+    "@selderee/plugin-htmlparser2": ["@selderee/plugin-htmlparser2@0.12.0", "", { "dependencies": { "domelementtype": "~2.3.0", "domhandler": "~5.0.3" }, "peerDependencies": { "selderee": "~0.12.0" } }, "sha512-oELmoyA6ML9jDRMV3kgcMQFKxUfBU0yFVn6yTctVaLT5ygXnxH52I3TZEgV9EhXJC68/uFvE5Daj1/25c0Xa/A=="],
+
     "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@tailwindcss/node": ["@tailwindcss/node@4.2.4", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.4" } }, "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA=="],
@@ -627,7 +638,11 @@
 
     "@types/jsesc": ["@types/jsesc@2.5.1", "", {}, "sha512-9VN+6yxLOPLOav+7PwjZbxiID2bVaeq0ED4qSQmdQTdjnXJSaCVKTR58t15oqH1H5t8Ng2ZX1SabJVoN9Q34bw=="],
 
+    "@types/mailparser": ["@types/mailparser@3.4.6", "", { "dependencies": { "@types/node": "*", "iconv-lite": "^0.6.3" } }, "sha512-wVV3cnIKzxTffaPH8iRnddX1zahbYB1ZEoAxyhoBo3TBCBuK6nZ8M8JYO/RhsCuuBVOw/DEN/t/ENbruwlxn6Q=="],
+
     "@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
+
+    "@types/nodemailer": ["@types/nodemailer@8.0.1", "", { "dependencies": { "@types/node": "*" } }, "sha512-PxpaInm8V1JQDd4j0ds5HfvWQk8JupS1C0Picb96QJsrrRDjBH+DlK7L4ZdNSqNULhiZRQHc40nLVShaGxXAMw=="],
 
     "@types/prompts": ["@types/prompts@2.4.9", "", { "dependencies": { "@types/node": "*", "kleur": "^3.0.3" } }, "sha512-qTxFi6Buiu8+50/+3DGIWLHM6QuWsEKugJnnP6iv2Mc4ncxE4A/OJkjuVOA+5X0X1S/nq5VJRa8Lu+nwcvbrKA=="],
 
@@ -651,6 +666,8 @@
 
     "@vitest/utils": ["@vitest/utils@4.1.5", "", { "dependencies": { "@vitest/pretty-format": "4.1.5", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug=="],
 
+    "@zone-eu/mailsplit": ["@zone-eu/mailsplit@5.4.16", "", { "dependencies": { "libbase64": "1.3.0", "libmime": "5.4.3", "libqp": "2.1.1" } }, "sha512-zQ9iXvlT3Wi/hazeC1MdI4rQc1UJwJ6IQ6QzSZ5KDxLZZWQSazWLOzImLFluXadKShJ9WJvI1xH+AyVS8b9azg=="],
+
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "aes-js": ["aes-js@4.0.0-beta.5", "", {}, "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="],
@@ -668,6 +685,8 @@
     "assistant-stream": ["assistant-stream@0.3.11", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "nanoid": "^5.1.7", "secure-json-parse": "^4.1.0" } }, "sha512-ufnCsZOSXqSbwmJ1w4NaUJojyyqjmX0zh4q6DzdA+n7FVR8p9EvXuhB2HRzBL400eeGfleMsolfijDo90HTTTQ=="],
 
     "ast-kit": ["ast-kit@3.0.0-beta.1", "", { "dependencies": { "@babel/parser": "^8.0.0-beta.4", "estree-walker": "^3.0.3", "pathe": "^2.0.3" } }, "sha512-trmleAnZ2PxN/loHWVhhx1qeOHSRXq4TDsBBxq3GqeJitfk3+jTQ+v/C1km/KYq9M7wKqCewMh+/NAvVH7m+bw=="],
+
+    "atomic-sleep": ["atomic-sleep@1.0.0", "", {}, "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="],
 
     "babel-dead-code-elimination": ["babel-dead-code-elimination@1.0.12", "", { "dependencies": { "@babel/core": "^7.23.7", "@babel/parser": "^7.23.6", "@babel/traverse": "^7.23.7", "@babel/types": "^7.23.6" } }, "sha512-GERT7L2TiYcYDtYk1IpD+ASAYXjKbLTDPhBtYj7X1NuRMDTMtAx9kyBenub1Ev41lo91OHCKdmP+egTDmfQ7Ig=="],
 
@@ -709,6 +728,8 @@
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "deepmerge-ts": ["deepmerge-ts@8.0.2", "", {}, "sha512-uqbvqLUMrc6p0MO+WBRtTxY55hmyh94WRwI5a++PZe54X+bfVh59FSN7uWCBCW1CCVjzjnrwzfI8zidE2obMMw=="],
+
     "default-browser": ["default-browser@5.5.0", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw=="],
 
     "default-browser-id": ["default-browser-id@5.0.1", "", {}, "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q=="],
@@ -723,13 +744,25 @@
 
     "diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
     "dts-resolver": ["dts-resolver@2.1.3", "", { "peerDependencies": { "oxc-resolver": ">=11.0.0" }, "optionalPeers": ["oxc-resolver"] }, "sha512-bihc7jPC90VrosXNzK0LTE2cuLP6jr0Ro8jk+kMugHReJVLIpHz/xadeq3MhuwyO4TD4OA3L1Q8pBBFRc08Tsw=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.344", "", {}, "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg=="],
 
     "empathic": ["empathic@2.0.0", "", {}, "sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA=="],
 
+    "encoding-japanese": ["encoding-japanese@2.3.0", "", {}, "sha512-eQyh1vzHz13DUkZcJO+0IOAoKXRQwKV5IBffeuYsWZyRLGiSzfzXObCqWvqFXdX0UU8qOk+lBXbkUhMCpdJe4Q=="],
+
     "enhanced-resolve": ["enhanced-resolve@5.21.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA=="],
+
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "es-module-lexer": ["es-module-lexer@2.0.0", "", {}, "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw=="],
 
@@ -761,9 +794,21 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
+
     "hookable": ["hookable@6.1.1", "", {}, "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ=="],
 
+    "html-to-text": ["html-to-text@10.0.1", "", { "dependencies": { "@selderee/plugin-htmlparser2": "~0.12.0", "deepmerge-ts": "^8.0.1", "dom-serializer": "^2.0.0", "htmlparser2": "^10.1.0", "selderee": "~0.12.0" } }, "sha512-GiVhRI1BatGARSCmlXWNCjDT0cWrwBWoeduLoV0WSKAgaV/wa+hUWy5LiQLUs4UwiUrE52ZCMfBGiKD87TDPrg=="],
+
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "imapflow": ["imapflow@2.0.2", "", { "dependencies": { "@zone-eu/mailsplit": "5.4.16", "encoding-japanese": "2.3.0", "iconv-lite": "0.7.3", "libbase64": "1.3.0", "libmime": "5.4.3", "libqp": "2.1.1", "pino": "10.3.1", "socks": "2.8.10" } }, "sha512-jrWWecWFifN3Feum2MqaTUupNeYSAdPEltKuwGdr8IPdxW72NZXf7ObVUfTWoUH2MPrli0q7SZm9pRt8ob/9XQ=="],
+
     "import-without-cache": ["import-without-cache@0.3.3", "", {}, "sha512-bDxwDdF04gm550DfZHgffvlX+9kUlcz32UD0AeBTmVPFiWkrexF2XVmiuFFbDhiFuP8fQkrkvI2KdSNPYWAXkQ=="],
+
+    "ip-address": ["ip-address@10.7.0", "", {}, "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA=="],
 
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
 
@@ -793,6 +838,14 @@
 
     "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
 
+    "leac": ["leac@0.7.0", "", {}, "sha512-qMrZeyEekgdRQ9o6a4NAB2EQZrv827GJdn1vnapwSJ90hWRB4TzUSunvacPkxQ2TnNqHNI1/zSt0hlo0crG8Jw=="],
+
+    "libbase64": ["libbase64@1.3.0", "", {}, "sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg=="],
+
+    "libmime": ["libmime@5.4.3", "", { "dependencies": { "encoding-japanese": "2.3.0", "iconv-lite": "0.7.3", "libbase64": "1.3.0", "libqp": "2.1.1" } }, "sha512-di9BoDabBUMqjeD/wGj+hHpSgdqAph5ui7w6OdY6NpzU6O6VFLQsMOg9tqCjm/zf9OHzAM9EZxSOF7uIb8O8Hw=="],
+
+    "libqp": ["libqp@2.1.1", "", {}, "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow=="],
+
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
     "lightningcss-android-arm64": ["lightningcss-android-arm64@1.32.0", "", { "os": "android", "cpu": "arm64" }, "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg=="],
@@ -817,11 +870,15 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
+    "linkify-it": ["linkify-it@5.0.2", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q=="],
+
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "lucide-react": ["lucide-react@1.9.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-6qVAmbgCjcJz7sAGSPSSJ++RAwjlK2XCbRrZKv63Ciko1KT8jX0//CXxgI3jg2HlJu8tADqdYlNDebmYjeoruA=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "mailparser": ["mailparser@3.9.24", "", { "dependencies": { "@zone-eu/mailsplit": "5.4.16", "encoding-japanese": "2.3.0", "he": "1.2.0", "html-to-text": "10.0.1", "iconv-lite": "0.7.3", "libmime": "5.4.3", "linkify-it": "5.0.2", "nodemailer": "10.0.3", "punycode.js": "2.3.1", "tlds": "1.261.0" } }, "sha512-uK9B6Ynof9sh8fqHr5cclIN3q5/QL1LpEIrknLMp6UkrsOOxXW0Egt/o0COhkU0PuLZisn7l4ISpjGJTlA59sA=="],
 
     "motion": ["motion@12.38.0", "", { "dependencies": { "framer-motion": "^12.38.0", "tslib": "^2.4.0" }, "peerDependencies": { "@emotion/is-prop-valid": "*", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@emotion/is-prop-valid", "react", "react-dom"] }, "sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w=="],
 
@@ -835,9 +892,13 @@
 
     "node-releases": ["node-releases@2.0.38", "", {}, "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="],
 
+    "nodemailer": ["nodemailer@10.0.3", "", {}, "sha512-h5c8ypcMoOIh44bIcVROvTDbjRdOJX8AXTkxMht2C92HlSjkG+/8kjoqmNPypfjQaVNaUHWyZ3tqs5I3K91F3g=="],
+
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
     "obug": ["obug@2.1.1", "", {}, "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ=="],
+
+    "on-exit-leak-free": ["on-exit-leak-free@2.1.2", "", {}, "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA=="],
 
     "oneshot-gtm": ["oneshot-gtm@workspace:apps/cli"],
 
@@ -851,13 +912,23 @@
 
     "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
 
+    "parseley": ["parseley@0.13.1", "", { "dependencies": { "leac": "^0.7.0", "peberminta": "^0.10.0" } }, "sha512-uNBJZzmb60l6p6VWLTmevizNAGnE0xoSf1n0B4q3ntegDNzcS68NRCcBDZTcyXHxt2XhBChsCuqj4M+nChvE/A=="],
+
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "pdf-lib": ["pdf-lib@1.17.1", "", { "dependencies": { "@pdf-lib/standard-fonts": "^1.0.0", "@pdf-lib/upng": "^1.0.1", "pako": "^1.0.11", "tslib": "^1.11.1" } }, "sha512-V/mpyJAoTsN4cnP31vc0wfNA1+p20evqqnap0KLoRUN0Yk/p3wN52DOEsL4oBFcLdb76hlpKPtzJIgo67j/XLw=="],
 
+    "peberminta": ["peberminta@0.10.0", "", {}, "sha512-80B2AsU+I4Qdb0ZAPSfe9UwvGzwkM37IKIFEvdS3D/3Ndgv2bsuJ0bfG1+iEYO+l7Gfd4EUJmuRyq7efLgRMzQ=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
+
+    "pino": ["pino@10.3.1", "", { "dependencies": { "@pinojs/redact": "^0.4.0", "atomic-sleep": "^1.0.0", "on-exit-leak-free": "^2.1.0", "pino-abstract-transport": "^3.0.0", "pino-std-serializers": "^7.0.0", "process-warning": "^5.0.0", "quick-format-unescaped": "^4.0.3", "real-require": "^0.2.0", "safe-stable-stringify": "^2.3.1", "sonic-boom": "^4.0.1", "thread-stream": "^4.0.0" }, "bin": { "pino": "bin.js" } }, "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg=="],
+
+    "pino-abstract-transport": ["pino-abstract-transport@3.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg=="],
+
+    "pino-std-serializers": ["pino-std-serializers@7.1.0", "", {}, "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw=="],
 
     "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
@@ -865,9 +936,15 @@
 
     "prettier": ["prettier@3.8.3", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw=="],
 
+    "process-warning": ["process-warning@5.1.0", "", {}, "sha512-jQSaVHsPgtyw60e1rQ/A+/ArPEj/S8pS/vFnyGa/gYFXrKk/6RuDkoqVDQ5NI5MmS01698ltlAk0NoDBNLujRw=="],
+
     "prompts": ["prompts@2.4.2", "", { "dependencies": { "kleur": "^3.0.3", "sisteransi": "^1.0.5" } }, "sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q=="],
 
+    "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
+
     "quansync": ["quansync@1.0.0", "", {}, "sha512-5xZacEEufv3HSTPQuchrvV6soaiACMFnq1H8wkVioctoH3TRha9Sz66lOxRwPK/qZj7HPiSveih9yAyh98gvqA=="],
+
+    "quick-format-unescaped": ["quick-format-unescaped@4.0.4", "", {}, "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg=="],
 
     "radix-ui": ["radix-ui@1.4.3", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-accessible-icon": "1.1.7", "@radix-ui/react-accordion": "1.2.12", "@radix-ui/react-alert-dialog": "1.1.15", "@radix-ui/react-arrow": "1.1.7", "@radix-ui/react-aspect-ratio": "1.1.7", "@radix-ui/react-avatar": "1.1.10", "@radix-ui/react-checkbox": "1.3.3", "@radix-ui/react-collapsible": "1.1.12", "@radix-ui/react-collection": "1.1.7", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-context-menu": "2.2.16", "@radix-ui/react-dialog": "1.1.15", "@radix-ui/react-direction": "1.1.1", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-dropdown-menu": "2.1.16", "@radix-ui/react-focus-guards": "1.1.3", "@radix-ui/react-focus-scope": "1.1.7", "@radix-ui/react-form": "0.1.8", "@radix-ui/react-hover-card": "1.1.15", "@radix-ui/react-label": "2.1.7", "@radix-ui/react-menu": "2.1.16", "@radix-ui/react-menubar": "1.1.16", "@radix-ui/react-navigation-menu": "1.2.14", "@radix-ui/react-one-time-password-field": "0.1.8", "@radix-ui/react-password-toggle-field": "0.1.3", "@radix-ui/react-popover": "1.1.15", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-progress": "1.1.7", "@radix-ui/react-radio-group": "1.3.8", "@radix-ui/react-roving-focus": "1.1.11", "@radix-ui/react-scroll-area": "1.2.10", "@radix-ui/react-select": "2.2.6", "@radix-ui/react-separator": "1.1.7", "@radix-ui/react-slider": "1.3.6", "@radix-ui/react-slot": "1.2.3", "@radix-ui/react-switch": "1.2.6", "@radix-ui/react-tabs": "1.1.13", "@radix-ui/react-toast": "1.2.15", "@radix-ui/react-toggle": "1.1.10", "@radix-ui/react-toggle-group": "1.1.11", "@radix-ui/react-toolbar": "1.1.11", "@radix-ui/react-tooltip": "1.2.8", "@radix-ui/react-use-callback-ref": "1.1.1", "@radix-ui/react-use-controllable-state": "1.2.2", "@radix-ui/react-use-effect-event": "0.0.2", "@radix-ui/react-use-escape-keydown": "1.1.1", "@radix-ui/react-use-is-hydrated": "0.1.0", "@radix-ui/react-use-layout-effect": "1.1.1", "@radix-ui/react-use-size": "1.1.1", "@radix-ui/react-visually-hidden": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA=="],
 
@@ -885,6 +962,8 @@
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
+    "real-require": ["real-require@0.2.0", "", {}, "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg=="],
+
     "reselect": ["reselect@5.1.1", "", {}, "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w=="],
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
@@ -895,9 +974,15 @@
 
     "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
 
+    "safe-stable-stringify": ["safe-stable-stringify@2.5.0", "", {}, "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "secure-json-parse": ["secure-json-parse@4.1.0", "", {}, "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA=="],
+
+    "selderee": ["selderee@0.12.0", "", { "dependencies": { "parseley": "~0.13.1" } }, "sha512-b1YMh3+DHZp59DLna3qVwQ5iOla/nrI6mLBNW02XxU77M3046Df6VLkoaJyFz20VsGIG5kkp+FK0kg4K4HnUFw=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -909,9 +994,17 @@
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
+    "smart-buffer": ["smart-buffer@4.2.0", "", {}, "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="],
+
+    "socks": ["socks@2.8.10", "", { "dependencies": { "ip-address": "^10.1.1", "smart-buffer": "^4.2.0" } }, "sha512-e0VyvkVTwVYViNovRkZ9aodhxVlyoMn7eJhVUPxZ+eK9P/7CBkxvvsBOHqFPEH416726W8tLXXXjKwqgTErrCQ=="],
+
+    "sonic-boom": ["sonic-boom@4.2.1", "", { "dependencies": { "atomic-sleep": "^1.0.0" } }, "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q=="],
+
     "sonner": ["sonner@2.0.7", "", { "peerDependencies": { "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc", "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc" } }, "sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
@@ -923,6 +1016,8 @@
 
     "tapable": ["tapable@2.3.3", "", {}, "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A=="],
 
+    "thread-stream": ["thread-stream@4.2.0", "", { "dependencies": { "real-require": "^1.0.0" } }, "sha512-e2zZ96wSChazBsbENf/Pcm/4swHt2cEKQ92rhUjkL9GCKiTDJIaTBenjE/m9DXi0QBmTMDkFDdOomUy20A1tDQ=="],
+
     "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
 
     "tinyexec": ["tinyexec@1.1.1", "", {}, "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg=="],
@@ -932,6 +1027,8 @@
     "tinypool": ["tinypool@2.1.0", "", {}, "sha512-Pugqs6M0m7Lv1I7FtxN4aoyToKg1C4tu+/381vH35y8oENM/Ai7f7C4StcoK4/+BSw9ebcS8jRiVrORFKCALLw=="],
 
     "tinyrainbow": ["tinyrainbow@3.1.0", "", {}, "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw=="],
+
+    "tlds": ["tlds@1.261.0", "", { "bin": { "tlds": "bin.js" } }, "sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
@@ -946,6 +1043,8 @@
     "turbo": ["turbo@2.9.6", "", { "optionalDependencies": { "@turbo/darwin-64": "2.9.6", "@turbo/darwin-arm64": "2.9.6", "@turbo/linux-64": "2.9.6", "@turbo/linux-arm64": "2.9.6", "@turbo/windows-64": "2.9.6", "@turbo/windows-arm64": "2.9.6" }, "bin": { "turbo": "bin/turbo" } }, "sha512-+v2QJey7ZUeUiuigkU+uFfklvNUyPI2VO2vBpMYJA+a1hKFLFiKtUYlRHdb3P9CrAvMzi0upbjI4WT+zKtqkBg=="],
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
     "unconfig-core": ["unconfig-core@7.5.0", "", { "dependencies": { "@quansync/fs": "^1.0.0", "quansync": "^1.0.0" } }, "sha512-Su3FauozOGP44ZmKdHy2oE6LPjk51M/TRRjHv2HNCWiDvfvCoxC2lno6jevMA91MYAdCdwP05QnWdWpSbncX/w=="],
 
@@ -1179,6 +1278,14 @@
 
     "framer-motion/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
+    "imapflow/iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
+
+    "libmime/iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
+
+    "mailparser/iconv-lite": ["iconv-lite@0.7.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ=="],
+
     "motion/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
     "oneshot-gtm-server/@oneshot-agent/sdk": ["@oneshot-agent/sdk@0.32.0", "", { "dependencies": { "ethers": "6.16.0" }, "peerDependencies": { "@coinbase/cdp-sdk": ">=1.0.0", "typescript": ">=5.0.0" }, "optionalPeers": ["@coinbase/cdp-sdk", "typescript"] }, "sha512-FpF7ALp5yxCva5VHY8x235fykor7JxIg+N+Ss//iWiYE54mPHzZdtclwHWs9nXEqOQhPahx+3FGybJRZvNREvA=="],
@@ -1210,6 +1317,8 @@
     "rolldown-plugin-dts/@babel/parser": ["@babel/parser@8.0.0-rc.3", "", { "dependencies": { "@babel/types": "^8.0.0-rc.3" }, "bin": "./bin/babel-parser.js" }, "sha512-B20dvP3MfNc/XS5KKCHy/oyWl5IA6Cn9YjXRdDlCjNmUFrjvLXMNUfQq/QUy9fnG2gYkKKcrto2YaF9B32ToOQ=="],
 
     "rolldown-plugin-dts/@babel/types": ["@babel/types@8.0.0-rc.3", "", { "dependencies": { "@babel/helper-string-parser": "^8.0.0-rc.3", "@babel/helper-validator-identifier": "^8.0.0-rc.3" } }, "sha512-mOm5ZrYmphGfqVWoH5YYMTITb3cDXsFgmvFlvkvWDMsR9X8RFnt7a0Wb6yNIdoFsiMO9WjYLq+U/FMtqIYAF8Q=="],
+
+    "thread-stream/real-require": ["real-require@1.0.0", "", {}, "sha512-P4nbQYQfePJxRSmY+v/KINxVucm4NF3p3s7pJveMTtom52FR4YGltUQLB8idDXwDDWW+eYrWDFbuzUnjoWHF7g=="],
 
     "use-callback-ref/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 

--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -29,4 +29,35 @@ A masthead chip names the workspace and its port; each name gets a stable colour
 
 ## Background services
 
+### Smartlead inboxes
+
+Every workspace automatically receives mail for its registered Smartlead identities
+while its dashboard server runs. Smartlead continues handling outreach and warmup;
+the dashboard reads IMAP and sends threaded replies over SMTP from the receiving
+mailbox. Newly registered identities join the next sync automatically.
+
+Open **Replies** to see mailbox connection status, the last successful sync, and
+history import progress. The first import covers 30 days and older recorded
+outreach; opening a conversation loads its available full history. Partial imports
+and disconnected mailboxes are shown explicitly. A typical clean sync runs about
+once a minute; a stopped dashboard does not receive mail in the background.
+
+Use **Connection settings** when Smartlead does not expose working IMAP/SMTP
+credentials. Both connections are verified before saving. Explicit credentials
+live in the workspace's private `mailbox-connections.json` (mode `0600`), never in
+the ledger or browser responses. OAuth-only accounts may require an app password
+or another supported mailbox connection from the provider.
+
+Threads match existing prospects by outreach references or email address; unmatched
+mail stays under **No match**, where it can be associated with an existing prospect.
+Read/unread, drafts, and archive state belong to this workspace. Reading or archiving
+here does not change Smartlead or provider mailbox flags. A new inbound message
+reopens an archived thread. Replies preserve email threading headers and remain
+manually sent. If a send times out after submission, GTM checks Sent mail before
+allowing another attempt to avoid duplicate responses.
+
+Removing an identity stops its sync and sending but retains saved conversations.
+Connecting one mailbox in two workspaces gives both access to that mailbox; their
+prospect matches, read states, drafts, and archives remain independent.
+
 `find watch --install-service` embeds the active home, so `--workspace acme find watch --install-service` pins the generated service to that workspace. See [background monitoring](./background-monitoring.md).

--- a/packages/core/__tests__/__snapshots__/ledger.test.ts.snap
+++ b/packages/core/__tests__/__snapshots__/ledger.test.ts.snap
@@ -236,6 +236,24 @@ exports[`Ledger schema migration > fresh-install schema (tables, columns, indexe
       "type": "index",
     },
     {
+      "name": "mailbox_attempts_inbound",
+      "sql": "CREATE INDEX mailbox_attempts_inbound ON mailbox_attempts(inbound_id, status)",
+      "tbl_name": "mailbox_attempts",
+      "type": "index",
+    },
+    {
+      "name": "mailbox_messages_rfc",
+      "sql": "CREATE INDEX mailbox_messages_rfc ON mailbox_messages(identity_id, message_id)",
+      "tbl_name": "mailbox_messages",
+      "type": "index",
+    },
+    {
+      "name": "mailbox_messages_thread",
+      "sql": "CREATE INDEX mailbox_messages_thread ON mailbox_messages(thread_key, at)",
+      "tbl_name": "mailbox_messages",
+      "type": "index",
+    },
+    {
       "name": "bounces",
       "sql": "CREATE TABLE bounces (
         message_id  TEXT NOT NULL,
@@ -454,6 +472,47 @@ exports[`Ledger schema migration > fresh-install schema (tables, columns, indexe
     PRIMARY KEY(prospect_id,play_name,enrollment,step_index)
   )",
       "tbl_name": "mail_preparations",
+      "type": "table",
+    },
+    {
+      "name": "mailbox_attempts",
+      "sql": "CREATE TABLE mailbox_attempts (
+        id TEXT PRIMARY KEY, inbound_id TEXT NOT NULL, status TEXT NOT NULL, data TEXT NOT NULL
+      )",
+      "tbl_name": "mailbox_attempts",
+      "type": "table",
+    },
+    {
+      "name": "mailbox_messages",
+      "sql": "CREATE TABLE mailbox_messages (
+        id TEXT PRIMARY KEY, identity_id TEXT NOT NULL, thread_key TEXT NOT NULL,
+        message_id TEXT, prospect_id INTEGER, direction TEXT NOT NULL,
+        at TEXT NOT NULL, data TEXT NOT NULL, is_read INTEGER NOT NULL DEFAULT 0
+      , needs_processing INTEGER NOT NULL DEFAULT 1)",
+      "tbl_name": "mailbox_messages",
+      "type": "table",
+    },
+    {
+      "name": "mailbox_references",
+      "sql": "CREATE TABLE mailbox_references (
+        identity_id TEXT NOT NULL, reference_id TEXT NOT NULL, message_id TEXT NOT NULL,
+        PRIMARY KEY(identity_id, reference_id, message_id)
+      )",
+      "tbl_name": "mailbox_references",
+      "type": "table",
+    },
+    {
+      "name": "mailbox_state",
+      "sql": "CREATE TABLE mailbox_state (key TEXT PRIMARY KEY, data TEXT NOT NULL)",
+      "tbl_name": "mailbox_state",
+      "type": "table",
+    },
+    {
+      "name": "mailbox_threads",
+      "sql": "CREATE TABLE mailbox_threads (
+        thread_key TEXT PRIMARY KEY, archived_at TEXT, history_complete INTEGER NOT NULL DEFAULT 0
+      , last_read_at TEXT)",
+      "tbl_name": "mailbox_threads",
       "type": "table",
     },
     {

--- a/packages/core/__tests__/contact-optout.test.ts
+++ b/packages/core/__tests__/contact-optout.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, expect, it } from "vitest";
+import { Database } from "bun:sqlite";
+import { contactAllowedClause, isProspectOptedOut } from "../src/contact-optout.ts";
+
+let db: Database;
+beforeEach(() => {
+  db = new Database(":memory:");
+  db.exec(`
+    CREATE TABLE prospects (id INTEGER PRIMARY KEY, email TEXT);
+    INSERT INTO prospects VALUES (1, 'person@example.com'), (2, 'other@example.com');
+    CREATE TABLE inbox_replies (prospect_id INTEGER, from_email TEXT, kind TEXT);
+    CREATE TABLE cadence_state (prospect_id INTEGER, status TEXT);
+    CREATE TABLE mailbox_messages (prospect_id INTEGER, direction TEXT, data TEXT);
+  `);
+});
+afterEach(() => db.close());
+
+it("an opt-out vetoes a previous human reply in enrollment selection", () => {
+  db.exec(
+    `INSERT INTO inbox_replies VALUES (1, 'person@example.com', 'human'), (1, 'alternate@example.com', 'unsubscribe')`,
+  );
+  expect(isProspectOptedOut(db, 1)).toBe(true);
+  expect(db.query(`SELECT p.id FROM prospects p WHERE ${contactAllowedClause(db)}`).all()).toEqual([
+    { id: 2 },
+  ]);
+});
+
+it("matches opt-outs by email when the reply is not yet associated", () => {
+  db.exec(`INSERT INTO inbox_replies VALUES (NULL, 'PERSON@example.com', 'unsubscribe')`);
+  expect(isProspectOptedOut(db, 1)).toBe(true);
+});
+
+it("blocks a synced opt-out before the cadence poll processes it", () => {
+  db.query("INSERT INTO mailbox_messages VALUES (1, 'inbound', ?)").run(
+    JSON.stringify({ kind: "unsubscribe", from: "alternate@example.com" }),
+  );
+  expect(isProspectOptedOut(db, 1)).toBe(true);
+  expect(isProspectOptedOut(db, 2)).toBe(false);
+});
+
+it("retains suppression through the terminal cadence status", () => {
+  db.exec(`INSERT INTO cadence_state VALUES (1, 'unsubscribed')`);
+  expect(isProspectOptedOut(db, 1)).toBe(true);
+});
+
+it("does not interpret ordinary human replies or auto replies as opt-outs", () => {
+  db.exec(
+    `INSERT INTO inbox_replies VALUES (1, 'person@example.com', 'human'), (1, 'person@example.com', 'auto')`,
+  );
+  expect(isProspectOptedOut(db, 1)).toBe(false);
+});
+
+it("supports older ledgers without reply classification tables", () => {
+  db.exec("DROP TABLE inbox_replies; DROP TABLE mailbox_messages; DROP TABLE cadence_state");
+  expect(isProspectOptedOut(db, 1)).toBe(false);
+});

--- a/packages/core/__tests__/inbox-replies.test.ts
+++ b/packages/core/__tests__/inbox-replies.test.ts
@@ -140,6 +140,11 @@ describe("inbox_replies.kind (v23)", () => {
 });
 
 describe("contactSuppressionFor", () => {
+  it("suppresses the matched prospect when an opt-out comes from an alternate address", () => {
+    const id = ledger.upsertProspect({ email: "primary@example.org" });
+    record({ prospectId: id, fromEmail: "alternate@example.org", kind: "unsubscribe" });
+    expect(ledger.contactSuppressionFor("primary@example.org")?.kind).toBe("unsubscribe");
+  });
   it("returns the newest unsubscribe / dead-mailbox verdict for an address", () => {
     record({ kind: "auto" }); // temporary OOO never suppresses
     expect(ledger.contactSuppressionFor("jane@prospect.example")).toBeNull();

--- a/packages/core/__tests__/ledger.test.ts
+++ b/packages/core/__tests__/ledger.test.ts
@@ -1190,6 +1190,44 @@ describe("Ledger outcomes + cold prospects", () => {
     expect(show?.lost).toBe(0);
   });
 
+  it("never selects an unsubscribed prospect for revival", () => {
+    const pid = ledger.upsertProspect({
+      name: "Opt Out",
+      email: "optout@example.com",
+      source: "test",
+    });
+    ledger.recordSequenceEvent({
+      prospectId: pid,
+      playName: "test",
+      stepIndex: 0,
+      channel: "email",
+      status: "sent",
+    });
+    const window = { minDaysSinceLastEvent: 0, maxDaysSinceLastEvent: 90 };
+    expect(ledger.listColdProspects(window).map((p) => p.id)).toContain(pid);
+    ledger.enrollCadence({
+      prospectId: pid,
+      playName: "test",
+      nextDueAt: new Date().toISOString(),
+    });
+    ledger.setCadenceStatus({ prospectId: pid, playName: "test", status: "unsubscribed" });
+    expect(ledger.listColdProspects(window).map((p) => p.id)).not.toContain(pid);
+    ledger.setCadenceStatus({ prospectId: pid, playName: "test", status: "active" });
+
+    ledger.recordInboxReply({
+      id: "optout-revival",
+      threadKey: "optout-revival",
+      prospectId: pid,
+      playName: "test",
+      fromEmail: "alternate@example.com",
+      subject: "stop",
+      body: "Don't email me again",
+      receivedAt: new Date().toISOString(),
+      kind: "unsubscribe",
+    });
+    expect(ledger.listColdProspects(window).map((p) => p.id)).not.toContain(pid);
+  });
+
   it("listColdProspects respects the day window", () => {
     const pid = ledger.upsertProspect({ name: "D", email: "d@x.com", source: "t" });
     // Manually backdate a sequence event to 75 days ago by inserting one then UPDATE.

--- a/packages/core/__tests__/mailbox-config.test.ts
+++ b/packages/core/__tests__/mailbox-config.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, afterEach, expect, it, vi } from "vitest";
+import { mkdtempSync, statSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let home: string;
+let ids: { id: string; provider: string; address: string }[];
+vi.mock("../src/config.ts", () => ({
+  configDir: () => home,
+  loadConfig: () => ({ emailIdentities: ids }),
+}));
+vi.mock("../src/identities.ts", () => ({
+  resolveIdentities: (cfg: { emailIdentities: unknown[] }) => cfg.emailIdentities,
+}));
+const { mailboxConnection, saveMailboxConnection, resetMailboxConnections } =
+  await import("../src/mailbox-config.ts");
+const fetchMock = vi.fn();
+const row = (address: string) => ({
+  from_email: address,
+  imap_host: "imap.example.com",
+  imap_port: 993,
+  smtp_host: "smtp.example.com",
+  smtp_port: 587,
+  password: Buffer.from("app-secret").toString("base64"),
+});
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "mailbox-config-"));
+  ids = [{ id: "smartlead:a@example.com", provider: "smartlead", address: "a@example.com" }];
+  resetMailboxConnections();
+  fetchMock.mockReset();
+  vi.stubGlobal("fetch", fetchMock);
+  vi.stubEnv("SMARTLEAD_API_KEY", "workspace-a-key");
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+  rmSync(home, { recursive: true, force: true });
+});
+
+it("decodes credentials only for a registered mailbox and requires encrypted transports", async () => {
+  fetchMock.mockResolvedValue(
+    new Response(JSON.stringify([row("other@example.com"), row("a@example.com")])),
+  );
+  const connection = await mailboxConnection(ids[0]!.id);
+  expect(connection.address).toBe("a@example.com");
+  expect(connection.imap.pass).toBe("app-secret");
+  expect(connection.imap.secure).toBe(true);
+  expect(connection.smtp.secure).toBe(false); // Requires STARTTLS in the transport.
+  await expect(mailboxConnection("smartlead:other@example.com")).rejects.toThrow(
+    /no longer connected/,
+  );
+});
+
+it("invalidates the account cache when the workspace API key changes", async () => {
+  fetchMock.mockImplementation(async () => new Response(JSON.stringify([row("a@example.com")])));
+  await mailboxConnection(ids[0]!.id);
+  await mailboxConnection(ids[0]!.id);
+  expect(fetchMock).toHaveBeenCalledTimes(1);
+  vi.stubEnv("SMARTLEAD_API_KEY", "workspace-b-key");
+  await mailboxConnection(ids[0]!.id);
+  expect(fetchMock).toHaveBeenCalledTimes(2);
+  expect(new URL(fetchMock.mock.calls[1]![0]).searchParams.get("api_key")).toBe("workspace-b-key");
+});
+
+it("offers connection setup for accounts with no usable direct credentials", async () => {
+  fetchMock.mockResolvedValue(new Response(JSON.stringify([{ from_email: "a@example.com" }])));
+  await expect(mailboxConnection(ids[0]!.id)).rejects.toThrow(/Connect IMAP and SMTP/);
+});
+
+it("stores explicit connection credentials privately and never accepts another workspace identity", async () => {
+  const connection = {
+    address: "a@example.com",
+    imap: { host: "imap.example.com", port: 993, secure: true, user: "a", pass: "imap-secret" },
+    smtp: { host: "smtp.example.com", port: 587, secure: false, user: "a", pass: "smtp-secret" },
+  };
+  saveMailboxConnection(ids[0]!.id, connection);
+  expect(statSync(join(home, "mailbox-connections.json")).mode & 0o777).toBe(0o600);
+  expect(await mailboxConnection(ids[0]!.id)).toEqual(connection);
+  expect(fetchMock).not.toHaveBeenCalled();
+  expect(() => saveMailboxConnection("smartlead:other@example.com", connection)).toThrow(
+    /does not belong/,
+  );
+});
+
+it("does not expose an upstream error body or API key", async () => {
+  fetchMock.mockResolvedValue(
+    new Response("password=secret api_key=workspace-a-key", { status: 401 }),
+  );
+  await expect(mailboxConnection(ids[0]!.id)).rejects.toThrow(
+    "Smartlead connection lookup failed (HTTP 401). Reconnect in Setup.",
+  );
+});

--- a/packages/core/__tests__/mailbox.test.ts
+++ b/packages/core/__tests__/mailbox.test.ts
@@ -1,0 +1,370 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Ledger } from "../src/ledger.ts";
+import { simpleParser } from "mailparser";
+
+const mocks = vi.hoisted(() => ({
+  identities: [
+    { id: "smartlead:me@example.com", address: "me@example.com", provider: "smartlead" },
+  ],
+  uidValidity: 1n,
+  open: vi.fn(),
+  failUser: "",
+  mails: [] as { uid: number; source: Buffer; threadId?: string }[],
+  smtp: { verify: vi.fn(), sendMail: vi.fn(), close: vi.fn() },
+}));
+let ledger: Ledger;
+vi.mock("../src/ledger.ts", async (original) => ({
+  ...(await original<typeof import("../src/ledger.ts")>()),
+  getLedger: () => ledger,
+}));
+vi.mock("../src/mailbox-config.ts", () => ({
+  smartleadMailboxIdentities: () => mocks.identities,
+  resetMailboxConnections: vi.fn(),
+  mailboxConnection: async (id: string) => {
+    const identity = mocks.identities.find((i) => i.id === id);
+    if (!identity) throw new Error("This mailbox was removed.");
+    return {
+      address: identity.address,
+      imap: {
+        host: "imap.gmail.com",
+        port: 993,
+        secure: true,
+        user: identity.address,
+        pass: "secret",
+      },
+      smtp: {
+        host: "smtp.gmail.com",
+        port: 465,
+        secure: true,
+        user: identity.address,
+        pass: "secret",
+      },
+    };
+  },
+}));
+vi.mock("imapflow", () => ({
+  ImapFlow: class {
+    constructor(private options: { auth: { user: string } }) {}
+    on() {}
+    async connect() {
+      if (this.options.auth.user === mocks.failUser) throw new Error("secret auth error");
+    }
+    close() {}
+    async list() {
+      return [{ path: "INBOX", flags: new Set(), specialUse: "\\Inbox" }];
+    }
+    async mailboxOpen(path: string, options: unknown) {
+      mocks.open(path, options);
+      return { uidValidity: mocks.uidValidity };
+    }
+    async search(query: { uid?: string }) {
+      const min = query.uid ? Number(query.uid.split(":")[0]) : 0;
+      return mocks.mails.filter((m) => m.uid >= min).map((m) => m.uid);
+    }
+    async fetchAll(uids: number[]) {
+      return mocks.mails.filter((m) => uids.includes(m.uid));
+    }
+  },
+}));
+vi.mock("nodemailer", async (original) => {
+  const actual = await original<typeof import("nodemailer")>();
+  return {
+    default: {
+      createTransport: (options: { streamTransport?: boolean }) =>
+        options.streamTransport ? actual.default.createTransport(options) : mocks.smtp,
+    },
+  };
+});
+
+const {
+  parseMailboxMessage,
+  mailboxReplyMessage,
+  sendMailboxReply,
+  syncSmartleadMailboxes,
+  mailboxHealth,
+  listMailboxInbox,
+  listMailboxBounces,
+} = await import("../src/mailbox.ts");
+const identityId = "smartlead:me@example.com";
+const source = (id: string, headers = "", from = "prospect@example.org") =>
+  Buffer.from(
+    `From: ${from}\r\nTo: me@example.com\r\nMessage-ID: <${id}@example.org>\r\nSubject: Hello\r\nDate: Wed, 9 Sep 2026 10:00:00 +0000\r\n${headers}\r\nThanks for reaching out.`,
+  );
+async function parsed(id: string, headers = "", from?: string) {
+  return parseMailboxMessage(
+    source(id, headers, from),
+    { identityId, address: "me@example.com", fallbackId: id },
+    ledger,
+  );
+}
+async function put(id = "first", headers = "") {
+  const m = await parsed(id, headers);
+  ledger.mailboxes.put(m);
+  return m;
+}
+
+beforeEach(() => {
+  ledger = new Ledger(":memory:");
+  mocks.identities = [{ id: identityId, address: "me@example.com", provider: "smartlead" }];
+  mocks.mails = [];
+  mocks.uidValidity = 1n;
+  mocks.failUser = "";
+  vi.clearAllMocks();
+  mocks.smtp.verify.mockResolvedValue(true);
+  mocks.smtp.sendMail.mockResolvedValue({ accepted: ["prospect@example.org"] });
+});
+afterEach(() => ledger.close());
+
+describe("durable mailbox threads", () => {
+  it("keeps identical messages and organization isolated across workspaces", async () => {
+    const other = new Ledger(":memory:");
+    try {
+      const m = await put();
+      other.mailboxes.put(m);
+      ledger.mailboxes.changeState(m.threadKey, [m.id], { read: true, archived: true });
+      expect(ledger.mailboxes.threadState(m.threadKey)).toMatchObject({
+        unread: false,
+        archivedAt: expect.any(String),
+      });
+      expect(other.mailboxes.threadState(m.threadKey)).toMatchObject({
+        unread: true,
+        archivedAt: null,
+      });
+    } finally {
+      other.close();
+    }
+  });
+  it("deduplicates folder copies and does not reopen archived threads on re-fetch", async () => {
+    const m = await put();
+    ledger.mailboxes.changeState(m.threadKey, [m.id], { archived: true });
+    expect(ledger.mailboxes.put(m)).toBe(false);
+    expect(ledger.mailboxes.threadState(m.threadKey).archivedAt).not.toBeNull();
+    expect(ledger.mailboxes.all()).toHaveLength(1);
+  });
+  it("rejects stale archives, keeps unseen arrivals unread, and reopens on new mail", async () => {
+    const first = await put();
+    ledger.mailboxes.changeState(first.threadKey, [first.id], { archived: true, read: true });
+    const next = {
+      ...(await parsed("second", "In-Reply-To: <first@example.org>\r\n")),
+      at: new Date(Date.now() + 1000).toISOString(),
+    };
+    ledger.mailboxes.put(next);
+    expect(next.threadKey).toBe(first.threadKey);
+    expect(() =>
+      ledger.mailboxes.changeState(first.threadKey, [first.id], { archived: true }),
+    ).toThrow(/changed/);
+    ledger.mailboxes.changeState(first.threadKey, [first.id], { read: true });
+    expect(ledger.mailboxes.threadState(first.threadKey)).toMatchObject({
+      unread: true,
+      archivedAt: null,
+    });
+  });
+  it("matches referenced outreach when the reply uses another address", async () => {
+    const prospectId = ledger.upsertProspect({ email: "prospect@example.org" });
+    const outbound = { ...(await parsed("outbound")), direction: "outbound" as const, prospectId };
+    ledger.mailboxes.put(outbound);
+    const reply = await parsed(
+      "reply",
+      "References: <outbound@example.org>\r\n",
+      "alternate@example.org",
+    );
+    expect(reply.prospectId).toBe(prospectId);
+    expect(reply.threadKey).toBe(outbound.threadKey);
+  });
+  it("never merges same-subject threads or two sending identities", async () => {
+    const first = await put();
+    const second = await put("different");
+    expect(first.threadKey).not.toBe(second.threadKey);
+    const another = await parseMailboxMessage(
+      source("first"),
+      {
+        identityId: "smartlead:other@example.com",
+        address: "other@example.com",
+        fallbackId: "first",
+      },
+      ledger,
+    );
+    expect(another.threadKey).not.toBe(first.threadKey);
+    expect(another.id).not.toBe(first.id);
+  });
+  it("keeps a partial-reference thread together when older ancestors arrive later", async () => {
+    const child = await put("child", "In-Reply-To: <parent@example.org>\r\n");
+    const parent = await put("parent", "In-Reply-To: <root@example.org>\r\n");
+    const root = await put("root");
+    expect(parent.threadKey).toBe(child.threadKey);
+    expect(root.threadKey).toBe(child.threadKey);
+  });
+  it("does not mark a read thread unread when loading older history", async () => {
+    const recent = await put();
+    ledger.mailboxes.changeState(recent.threadKey, [recent.id], { read: true });
+    ledger.mailboxes.put({ ...recent, id: "older", at: "2026-09-01T00:00:00Z" });
+    expect(ledger.mailboxes.threadState(recent.threadKey).unread).toBe(false);
+  });
+  it("keeps manually matched old messages available behind the global watermark", async () => {
+    const m = await put();
+    const prospectId = ledger.upsertProspect({ email: "different@example.org" });
+    ledger.mailboxes.associate(m.threadKey, prospectId);
+    expect(ledger.mailboxes.inbound(identityId, "2099-01-01T00:00:00Z")).toHaveLength(1);
+  });
+  it("classifies auto replies using headers and decodes HTML-only mail", async () => {
+    const m = await parseMailboxMessage(
+      Buffer.from(
+        "From: bot@example.org\r\nTo: me@example.com\r\nAuto-Submitted: auto-replied\r\nContent-Type: text/html; charset=utf-8\r\n\r\n<p>Out of office</p>",
+      ),
+      { identityId, address: "me@example.com", fallbackId: "auto" },
+      ledger,
+    );
+    expect(m.kind).toBe("auto");
+    expect(m.body).toContain("Out of office");
+    expect(() => mailboxReplyMessage(m, "me@example.com", "Hi")).toThrow(/Message-ID/);
+  });
+});
+
+describe("mailbox sync", () => {
+  it("extracts structured delivery failures and exposes them to the bounce pipeline", async () => {
+    const prospectId = ledger.upsertProspect({ email: "prospect@example.org" });
+    ledger.recordSequenceEvent({
+      prospectId,
+      playName: "outreach",
+      stepIndex: 0,
+      channel: "email",
+      status: "sent",
+    });
+    const raw = Buffer.from(
+      "From: mailer-daemon@example.com\r\nTo: me@example.com\r\nMessage-ID: <dsn@example.com>\r\nSubject: Delivery Status Notification (Failure)\r\nMIME-Version: 1.0\r\nContent-Type: multipart/report; boundary=dsn; report-type=delivery-status\r\n\r\n--dsn\r\nContent-Type: text/plain\r\n\r\nAddress not found\r\n--dsn\r\nContent-Type: message/delivery-status\r\n\r\nReporting-MTA: dns; example.com\r\n\r\nFinal-Recipient: rfc822; prospect@example.org\r\nAction: failed\r\nStatus: 5.1.1\r\nDiagnostic-Code: smtp; 550 No such user\r\n\r\n--dsn--\r\n",
+    );
+    const m = await parseMailboxMessage(
+      raw,
+      { identityId, address: "me@example.com", fallbackId: "dsn" },
+      ledger,
+    );
+    expect(m.kind).toBe("auto");
+    expect(m.bounces?.[0]).toMatchObject({
+      recipient: "prospect@example.org",
+      kind: "hard",
+      statusCode: "5.1.1",
+    });
+    ledger.mailboxes.put(m);
+    expect(listMailboxBounces().bounces[0]).toMatchObject({
+      recipient: "prospect@example.org",
+      identityId,
+      messageId: m.id,
+    });
+    ledger.mailboxes.put({
+      ...m,
+      id: "warmup-dsn",
+      bounces: [
+        {
+          recipient: "warmup@example.net",
+          kind: "hard",
+          statusCode: "5.1.1",
+          diagnostic: "No such user",
+        },
+      ],
+    });
+    expect(listMailboxBounces().bounces).toHaveLength(1);
+  });
+  it("reclassifies a previously imported explicit opt-out for cadence processing", async () => {
+    const m = {
+      ...(await parsed("unsubscribe")),
+      body: "Don’t ever email me again.",
+      kind: "human" as const,
+    };
+    ledger.mailboxes.put(m);
+    await syncSmartleadMailboxes(true);
+    expect(ledger.mailboxes.get(m.id)?.kind).toBe("unsubscribe");
+  });
+  it("pages imports, resumes checkpoints, and opens folders read-only", async () => {
+    mocks.mails = Array.from({ length: 105 }, (_, i) => ({
+      uid: i + 1,
+      source: source(String(i + 1)),
+    }));
+    await syncSmartleadMailboxes(true);
+    expect(ledger.mailboxes.all()).toHaveLength(105); // Includes newest tail while backfilling.
+    expect(mailboxHealth()[0]?.backfillRemaining).toBe(true);
+    await syncSmartleadMailboxes(true);
+    expect(ledger.mailboxes.all()).toHaveLength(105);
+    expect(mailboxHealth()[0]?.backfillRemaining).toBe(false);
+    expect(mocks.open).toHaveBeenCalledWith("INBOX", { readOnly: true });
+    mocks.uidValidity = 2n;
+    await syncSmartleadMailboxes(true);
+    expect(ledger.mailboxes.all()).toHaveLength(105);
+  });
+  it("reports partial failures without hiding other connected mailboxes", async () => {
+    mocks.identities.push({
+      id: "smartlead:bad@example.com",
+      address: "bad@example.com",
+      provider: "smartlead",
+    });
+    mocks.failUser = "bad@example.com";
+    mocks.mails = [{ uid: 1, source: source("first") }];
+    await syncSmartleadMailboxes(true);
+    expect(mailboxHealth().map((h) => h.status)).toEqual(["connected", "error"]);
+    expect(JSON.stringify(mailboxHealth())).not.toContain("secret");
+    expect((await listMailboxInbox("smartlead:bad@example.com")).failed_sources).toEqual([
+      "smartlead:bad@example.com",
+    ]);
+  });
+  it("discovers newly registered identities without fixed workspace names", async () => {
+    mocks.identities = [];
+    await syncSmartleadMailboxes(true);
+    expect(mocks.open).not.toHaveBeenCalled();
+    mocks.identities = [
+      { id: "smartlead:new@another.org", address: "new@another.org", provider: "smartlead" },
+    ];
+    await syncSmartleadMailboxes(true);
+    expect(mailboxHealth()[0]?.address).toBe("new@another.org");
+  });
+});
+
+describe("threaded replies", () => {
+  it("uses stored routing, real reply headers, and a stable send attempt", async () => {
+    const inbound = await put();
+    const message = await sendMailboxReply(inbound.id, "Here is my answer.", "send-request-one");
+    const raw = mocks.smtp.sendMail.mock.calls[0]![0].raw as Buffer;
+    const wire = await simpleParser(raw);
+    expect(wire.inReplyTo).toBe(inbound.messageId);
+    expect(wire.references).toContain(inbound.messageId);
+    expect(wire.from?.value[0]?.address).toBe("me@example.com");
+    expect(wire.subject).toBe("Re: Hello");
+    expect(message.threadKey).toBe(inbound.threadKey);
+    expect(
+      (await sendMailboxReply(inbound.id, "Here is my answer.", "send-request-one")).messageId,
+    ).toBe(message.messageId);
+    expect(mocks.smtp.sendMail).toHaveBeenCalledTimes(1);
+  });
+  it("does not resend after a timeout, even if the client supplies a new request ID", async () => {
+    const inbound = await put();
+    mocks.smtp.sendMail.mockRejectedValue(new Error("connection lost after DATA"));
+    await expect(sendMailboxReply(inbound.id, "answer", "send-unknown")).rejects.toThrow(/unknown/);
+    expect(ledger.mailboxes.attempt("send-unknown")?.status).toBe("uncertain");
+    await expect(sendMailboxReply(inbound.id, "answer edited", "send-another")).rejects.toThrow(
+      /reconciled/,
+    );
+    expect(mocks.smtp.sendMail).toHaveBeenCalledTimes(1);
+  });
+  it("reconciles an uncertain send when its Sent copy arrives", async () => {
+    const inbound = await put();
+    mocks.smtp.sendMail.mockRejectedValue(new Error("lost response"));
+    await expect(sendMailboxReply(inbound.id, "answer", "send-reconcile")).rejects.toThrow();
+    const attempt = ledger.mailboxes.attempt("send-reconcile")!;
+    ledger.mailboxes.put(attempt.message);
+    await syncSmartleadMailboxes(true);
+    expect(ledger.mailboxes.attempt(attempt.id)?.status).toBe("sent");
+    await sendMailboxReply(inbound.id, "answer", attempt.id);
+    expect(mocks.smtp.sendMail).toHaveBeenCalledTimes(1);
+  });
+  it("keeps failed sends out of sent history and rejects removed identities", async () => {
+    const inbound = await put();
+    mocks.smtp.verify.mockRejectedValue(new Error("bad password"));
+    await expect(sendMailboxReply(inbound.id, "answer", "failed-request")).rejects.toThrow(
+      /not sent/,
+    );
+    expect(ledger.mailboxes.attempt("failed-request")?.status).toBe("failed");
+    expect(ledger.mailboxes.thread(inbound.threadKey)).toHaveLength(1);
+    mocks.identities = [];
+    await expect(sendMailboxReply(inbound.id, "answer", "removed-request")).rejects.toThrow(
+      /removed/,
+    );
+  });
+});

--- a/packages/core/__tests__/mailbox.test.ts
+++ b/packages/core/__tests__/mailbox.test.ts
@@ -116,6 +116,33 @@ beforeEach(() => {
 afterEach(() => ledger.close());
 
 describe("durable mailbox threads", () => {
+  it.each(["delivered", "replied"] as const)(
+    "retains %s outreach in the backfill watermark",
+    (status) => {
+      const id = ledger.upsertProspect({ email: "person@example.com", source: "test" });
+      ledger.recordSequenceEvent({
+        prospectId: id,
+        playName: "test",
+        stepIndex: 0,
+        channel: "email",
+        status,
+      });
+      expect(ledger.mailboxes.oldestOutreach()).not.toBeNull();
+    },
+  );
+
+  it("allows retry after SMTP explicitly accepts no recipients", async () => {
+    const inbound = await put();
+    mocks.smtp.sendMail.mockResolvedValueOnce({ accepted: [] });
+    await expect(sendMailboxReply(inbound.id, "answer", "rejected-all")).rejects.toThrow(
+      /not sent/,
+    );
+    expect(ledger.mailboxes.attempt("rejected-all")?.status).toBe("failed");
+    await sendMailboxReply(inbound.id, "answer", "retry-rejected-all");
+    expect(mocks.smtp.sendMail).toHaveBeenCalledTimes(2);
+    expect(ledger.mailboxes.attempt("retry-rejected-all")?.status).toBe("sent");
+  });
+
   it("keeps identical messages and organization isolated across workspaces", async () => {
     const other = new Ledger(":memory:");
     try {

--- a/packages/core/__tests__/oneshot-smartlead-dispatch.test.ts
+++ b/packages/core/__tests__/oneshot-smartlead-dispatch.test.ts
@@ -145,7 +145,7 @@ describe("replyEmail with a smartlead identity", () => {
         },
         { playName: "inbox" },
       ),
-    ).rejects.toThrow(/aren't supported yet/);
+    ).rejects.toThrow(/stored inbound message/);
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/__tests__/reply-classify.test.ts
+++ b/packages/core/__tests__/reply-classify.test.ts
@@ -2,6 +2,10 @@ import { describe, expect, test } from "vitest";
 import { classifyReply, stripQuotedChain } from "../src/reply-classify.ts";
 
 describe("classifyReply", () => {
+  test("explicit opt-outs with curly apostrophes and ever are unsubscribe requests", () => {
+    expect(classifyReply({ body: "Don’t ever email me again." })).toBe("unsubscribe");
+    expect(classifyReply({ body: "Do not ever contact me again." })).toBe("unsubscribe");
+  });
   test("plain human reply is human", () => {
     expect(
       classifyReply({

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,6 +16,13 @@
   },
   "dependencies": {
     "@oneshot-agent/sdk": "file:../../vendor/oneshot-agent-sdk-0.32.0.tgz",
+    "imapflow": "^2.0.2",
+    "mailparser": "^3.9.24",
+    "nodemailer": "^10.0.3",
     "pdf-lib": "^1.17.1"
+  },
+  "devDependencies": {
+    "@types/mailparser": "^3.4.6",
+    "@types/nodemailer": "^8.0.1"
   }
 }

--- a/packages/core/src/contact-optout.ts
+++ b/packages/core/src/contact-optout.ts
@@ -1,0 +1,40 @@
+import type { Database } from "bun:sqlite";
+
+function hasTable(db: Database, name: string): boolean {
+  return db.query("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?").get(name) != null;
+}
+
+/** Opt-outs override every campaign, including historical human/replied signals. */
+export function contactAllowedClause(db: Database): string {
+  const clauses: string[] = [];
+  if (hasTable(db, "cadence_state"))
+    clauses.push(`NOT EXISTS (
+    SELECT 1 FROM cadence_state c WHERE c.prospect_id = p.id AND c.status = 'unsubscribed')`);
+  if (
+    hasTable(db, "inbox_replies") &&
+    (db.query("PRAGMA table_info(inbox_replies)").all() as Array<{ name: string }>).some(
+      (c) => c.name === "kind",
+    )
+  )
+    clauses.push(`NOT EXISTS (
+    SELECT 1 FROM inbox_replies ir WHERE ir.kind = 'unsubscribe'
+      AND (ir.prospect_id = p.id OR lower(ir.from_email) = lower(p.email)))`);
+  // Sync may have persisted a verdict before the cadence poll consumes it.
+  if (
+    db.query("SELECT 1 FROM sqlite_master WHERE type='table' AND name='mailbox_messages'").get()
+  ) {
+    clauses.push(`NOT EXISTS (SELECT 1 FROM mailbox_messages m
+      WHERE m.direction = 'inbound' AND json_extract(m.data, '$.kind') = 'unsubscribe'
+        AND (m.prospect_id = p.id OR lower(json_extract(m.data, '$.from')) = lower(p.email)))`);
+  }
+  return clauses.length ? clauses.join(" AND ") : "1=1";
+}
+
+/** Cross-channel enrollment guard. The SQL clause expects the prospect alias `p`. */
+export function isProspectOptedOut(db: Database, prospectId: number): boolean {
+  return (
+    db
+      .query(`SELECT 1 FROM prospects p WHERE p.id = ? AND NOT (${contactAllowedClause(db)})`)
+      .get(prospectId) != null
+  );
+}

--- a/packages/core/src/contact-optout.ts
+++ b/packages/core/src/contact-optout.ts
@@ -1,5 +1,6 @@
 import type { Database } from "bun:sqlite";
 
+/** Check whether an optional ledger table is available to an opt-out query. */
 function hasTable(db: Database, name: string): boolean {
   return db.query("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?").get(name) != null;
 }

--- a/packages/core/src/delivery-health.ts
+++ b/packages/core/src/delivery-health.ts
@@ -104,10 +104,11 @@ export function contactSuppressionFor(
     (db
       .query(
         `SELECT kind, received_at FROM inbox_replies
-         WHERE from_email = ? AND kind IN ('unsubscribe', 'auto_permanent')
+         WHERE (from_email = ? OR prospect_id IN (SELECT id FROM prospects WHERE email = ?))
+           AND kind IN ('unsubscribe', 'auto_permanent')
          ORDER BY received_at DESC LIMIT 1`,
       )
-      .get(canonEmail(email)) as { kind: string; received_at: string }) ?? null
+      .get(canonEmail(email), canonEmail(email)) as { kind: string; received_at: string }) ?? null
   );
 }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -41,3 +41,5 @@ export * from "./mail-pdf.ts";
 export * from "./mail-policy.ts";
 
 export * from "./mail-enrichment.ts";
+
+export { isProspectOptedOut } from "./contact-optout.ts";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export * from "./gmail.ts";
 export * from "./gcal.ts";
 export * from "./freemail.ts";
 export * from "./smartlead.ts";
+export * from "./mailbox.ts";
 export * from "./canary.ts";
 export * from "./identities.ts";
 export * from "./send-routing.ts";

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -25,6 +25,7 @@ import {
 import { humanDecisionWhereSql } from "./labels.ts";
 import { LedgerCache } from "./ledger-cache.ts";
 import { migrateLedgerSchema } from "./ledger-schema.ts";
+import { MailboxStore } from "./mailbox-store.ts";
 import { ReceiptStore } from "./ledger-receipts.ts";
 import { getSharedDb } from "./shared-db.ts";
 import type { ReplyKind } from "./reply-classify.ts";
@@ -277,6 +278,7 @@ function publicIntent(intent: string | null): string | null {
 }
 
 export class Ledger {
+  readonly mailboxes: MailboxStore;
   private db: Database;
   private path: string;
   private receipts: ReceiptStore;
@@ -301,6 +303,7 @@ export class Ledger {
     this.receipts = new ReceiptStore(this.db);
     // Same slice, same reason: the cache tables exist only after migrate().
     this.cache = new LedgerCache(this.db, this.path);
+    this.mailboxes = new MailboxStore(this.db);
   }
 
   getDirectMail(id: string): DirectMailDraft | null {
@@ -905,6 +908,13 @@ export class Ledger {
     requestId: string | null;
   }): void {
     this.db.transaction(() => {
+      if (
+        input.requestId &&
+        this.db
+          .query("SELECT 1 FROM inbox_sent WHERE request_id=? AND identity_id IS ? LIMIT 1")
+          .get(input.requestId, input.identityId)
+      )
+        return;
       this.db
         .prepare(
           `INSERT INTO inbox_sent(thread_key, to_email, subject, body, identity_id, request_id, sent_at)

--- a/packages/core/src/ledger.ts
+++ b/packages/core/src/ledger.ts
@@ -1,3 +1,4 @@
+import { contactAllowedClause } from "./contact-optout.ts";
 import { extractBusinessAddress } from "./mail-address.ts";
 import type { DirectMailDraft, PostalAddress } from "./direct-mail.ts";
 import { Database } from "bun:sqlite";
@@ -2292,7 +2293,7 @@ export class Ledger {
       FROM prospects p
       LEFT JOIN sequence_events s ON s.prospect_id = p.id
       LEFT JOIN cadence_state c ON c.prospect_id = p.id
-      WHERE NOT EXISTS (
+      WHERE ${contactAllowedClause(this.db)} AND NOT EXISTS (
         SELECT 1 FROM cadence_state blocked
         WHERE blocked.prospect_id = p.id AND blocked.status = 'stopped'
           AND blocked.stop_reason IN ('not_a_fit', 'do_not_contact')

--- a/packages/core/src/mailbox-config.ts
+++ b/packages/core/src/mailbox-config.ts
@@ -1,0 +1,133 @@
+import { chmodSync, existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { configDir, loadConfig } from "./config.ts";
+import { resolveIdentities } from "./identities.ts";
+import { smartleadApiKey } from "./smartlead.ts";
+import { mailboxHash } from "./mailbox-store.ts";
+
+export interface MailboxConnection {
+  address: string;
+  imap: { host: string; port: number; secure: boolean; user: string; pass: string };
+  smtp: { host: string; port: number; secure: boolean; user: string; pass: string };
+}
+
+export function smartleadMailboxIdentities() {
+  return resolveIdentities(loadConfig()).filter((i) => i.provider === "smartlead");
+}
+
+let cached: { key: string; at: number; rows: Record<string, unknown>[] } | null = null;
+
+const str = (v: unknown): string => (typeof v === "string" ? v.trim() : "");
+const decode = (v: unknown): string => (v ? Buffer.from(str(v), "base64").toString("utf8") : "");
+
+/** This module is deliberately not re-exported by the public core barrel. */
+async function accounts(): Promise<Record<string, unknown>[]> {
+  const apiKey = smartleadApiKey();
+  if (!apiKey) throw new Error("Smartlead API key is missing. Reconnect Smartlead in Setup.");
+  const key = mailboxHash(`${configDir()}:${apiKey}`);
+  if (cached?.key === key && Date.now() - cached.at < 5 * 60_000) return cached.rows;
+  const rows: Record<string, unknown>[] = [];
+  for (let page = 0; page < 50; page++) {
+    const query = new URLSearchParams({
+      api_key: apiKey,
+      limit: "100",
+      offset: String(page * 100),
+    });
+    let response: Response;
+    try {
+      response = await fetch(`https://server.smartlead.ai/api/v1/email-accounts/?${query}`, {
+        signal: AbortSignal.timeout(15_000),
+      });
+    } catch {
+      throw new Error("Could not reach Smartlead to resolve mailbox connections.");
+    }
+    if (!response.ok)
+      throw new Error(
+        `Smartlead connection lookup failed (HTTP ${response.status}). Reconnect in Setup.`,
+      );
+    const data: unknown = await response.json();
+    if (!Array.isArray(data)) throw new Error("Smartlead returned an invalid mailbox list.");
+    rows.push(...data);
+    if (data.length < 100) {
+      cached = { key, at: Date.now(), rows };
+      return rows;
+    }
+  }
+  throw new Error("Smartlead mailbox listing is incomplete.");
+}
+
+export function resetMailboxConnections(): void {
+  cached = null;
+}
+
+export function validateMailboxConnection(input: MailboxConnection): MailboxConnection {
+  if (!input || typeof input.address !== "string") throw new Error("Mailbox address is required.");
+  for (const transport of [input.imap, input.smtp]) {
+    if (
+      !transport ||
+      !transport.host?.trim() ||
+      !transport.user?.trim() ||
+      !transport.pass ||
+      !Number.isInteger(transport.port) ||
+      transport.port < 1 ||
+      transport.port > 65535 ||
+      typeof transport.secure !== "boolean"
+    ) {
+      throw new Error("Both IMAP and SMTP need a host, port, username, password, and TLS mode.");
+    }
+  }
+  return input;
+}
+
+function overrides(): Record<string, MailboxConnection> {
+  const path = join(configDir(), "mailbox-connections.json");
+  return existsSync(path) ? JSON.parse(readFileSync(path, "utf8")) : {};
+}
+
+export function saveMailboxConnection(identityId: string, input: MailboxConnection): void {
+  const identity = smartleadMailboxIdentities().find((i) => i.id === identityId);
+  if (!identity?.address || identity.address.toLowerCase() !== input.address?.toLowerCase())
+    throw new Error("Mailbox does not belong to this workspace identity.");
+  const next = { ...overrides(), [identityId]: validateMailboxConnection(input) };
+  const path = join(configDir(), "mailbox-connections.json");
+  const temp = `${path}.${process.pid}.tmp`;
+  writeFileSync(temp, JSON.stringify(next), { mode: 0o600 });
+  renameSync(temp, path);
+  chmodSync(path, 0o600);
+  resetMailboxConnections();
+}
+
+export async function mailboxConnection(identityId: string): Promise<MailboxConnection> {
+  const identity = smartleadMailboxIdentities().find((i) => i.id === identityId);
+  if (!identity?.address)
+    throw new Error("This mailbox identity is no longer connected to this workspace.");
+  const address = identity.address.toLowerCase();
+  const override = overrides()[identityId];
+  if (override && override.address.toLowerCase() === address)
+    return validateMailboxConnection(override);
+  const row = (await accounts()).find((a) => str(a["from_email"]).toLowerCase() === address);
+  if (!row) throw new Error("This mailbox is missing from this workspace's Smartlead account.");
+  const pass = decode(row["password"]);
+  const user = str(row["username"] ?? row["user_name"]) || address;
+  const imapPass = decode(row["imap_password"]) || pass;
+  const imapPort = Number(row["imap_port"]) || 993;
+  const smtpPort = Number(row["smtp_port"]) || 587;
+  const connection: MailboxConnection = {
+    address,
+    imap: {
+      host: str(row["imap_host"]),
+      port: imapPort,
+      secure: imapPort === 993,
+      user: str(row["imap_username"]) || user,
+      pass: imapPass,
+    },
+    smtp: { host: str(row["smtp_host"]), port: smtpPort, secure: smtpPort === 465, user, pass },
+  };
+  try {
+    return validateMailboxConnection(connection);
+  } catch {
+    throw new Error(
+      "Direct mailbox credentials are unavailable. Connect IMAP and SMTP in the inbox's mailbox settings.",
+    );
+  }
+}

--- a/packages/core/src/mailbox-config.ts
+++ b/packages/core/src/mailbox-config.ts
@@ -10,6 +10,7 @@ export interface MailboxConnection {
   smtp: { host: string; port: number; secure: boolean; user: string; pass: string };
 }
 
+/** Return Smartlead identities configured in the active workspace. */
 export function smartleadMailboxIdentities() {
   return resolveIdentities(loadConfig()).filter((i) => i.provider === "smartlead");
 }
@@ -21,7 +22,9 @@ let cached: {
   rows: Record<string, unknown>[];
 } | null = null;
 
+/** Normalize an unknown provider field to a trimmed string. */
 const str = (v: unknown): string => (typeof v === "string" ? v.trim() : "");
+/** Decode a provider's optional base64-encoded credential field. */
 const decode = (v: unknown): string => (v ? Buffer.from(str(v), "base64").toString("utf8") : "");
 
 /** This module is deliberately not re-exported by the public core barrel. */
@@ -65,10 +68,12 @@ async function accounts(): Promise<Record<string, unknown>[]> {
   throw new Error("Smartlead mailbox listing is incomplete.");
 }
 
+/** Clear the workspace-scoped Smartlead account cache. */
 export function resetMailboxConnections(): void {
   cached = null;
 }
 
+/** Validate the required IMAP and SMTP connection fields. */
 export function validateMailboxConnection(input: MailboxConnection): MailboxConnection {
   if (!input || typeof input.address !== "string") throw new Error("Mailbox address is required.");
   for (const transport of [input.imap, input.smtp]) {
@@ -88,11 +93,13 @@ export function validateMailboxConnection(input: MailboxConnection): MailboxConn
   return input;
 }
 
+/** Read manually configured mailbox connections for the active workspace. */
 function overrides(): Record<string, MailboxConnection> {
   const path = join(configDir(), "mailbox-connections.json");
   return existsSync(path) ? JSON.parse(readFileSync(path, "utf8")) : {};
 }
 
+/** Persist a verified mailbox connection with owner-only permissions. */
 export function saveMailboxConnection(identityId: string, input: MailboxConnection): void {
   const identity = smartleadMailboxIdentities().find((i) => i.id === identityId);
   if (!identity?.address || identity.address.toLowerCase() !== input.address?.toLowerCase())
@@ -106,6 +113,7 @@ export function saveMailboxConnection(identityId: string, input: MailboxConnecti
   resetMailboxConnections();
 }
 
+/** Resolve a mailbox connection from workspace overrides or Smartlead. */
 export async function mailboxConnection(identityId: string): Promise<MailboxConnection> {
   const identity = smartleadMailboxIdentities().find((i) => i.id === identityId);
   if (!identity?.address)

--- a/packages/core/src/mailbox-config.ts
+++ b/packages/core/src/mailbox-config.ts
@@ -3,7 +3,6 @@ import { join } from "node:path";
 import { configDir, loadConfig } from "./config.ts";
 import { resolveIdentities } from "./identities.ts";
 import { smartleadApiKey } from "./smartlead.ts";
-import { mailboxHash } from "./mailbox-store.ts";
 
 export interface MailboxConnection {
   address: string;
@@ -15,7 +14,12 @@ export function smartleadMailboxIdentities() {
   return resolveIdentities(loadConfig()).filter((i) => i.provider === "smartlead");
 }
 
-let cached: { key: string; at: number; rows: Record<string, unknown>[] } | null = null;
+let cached: {
+  workspace: string;
+  apiKey: string;
+  at: number;
+  rows: Record<string, unknown>[];
+} | null = null;
 
 const str = (v: unknown): string => (typeof v === "string" ? v.trim() : "");
 const decode = (v: unknown): string => (v ? Buffer.from(str(v), "base64").toString("utf8") : "");
@@ -24,8 +28,13 @@ const decode = (v: unknown): string => (v ? Buffer.from(str(v), "base64").toStri
 async function accounts(): Promise<Record<string, unknown>[]> {
   const apiKey = smartleadApiKey();
   if (!apiKey) throw new Error("Smartlead API key is missing. Reconnect Smartlead in Setup.");
-  const key = mailboxHash(`${configDir()}:${apiKey}`);
-  if (cached?.key === key && Date.now() - cached.at < 5 * 60_000) return cached.rows;
+  const workspace = configDir();
+  if (
+    cached?.workspace === workspace &&
+    cached.apiKey === apiKey &&
+    Date.now() - cached.at < 5 * 60_000
+  )
+    return cached.rows;
   const rows: Record<string, unknown>[] = [];
   for (let page = 0; page < 50; page++) {
     const query = new URLSearchParams({
@@ -49,7 +58,7 @@ async function accounts(): Promise<Record<string, unknown>[]> {
     if (!Array.isArray(data)) throw new Error("Smartlead returned an invalid mailbox list.");
     rows.push(...data);
     if (data.length < 100) {
-      cached = { key, at: Date.now(), rows };
+      cached = { workspace, apiKey, at: Date.now(), rows };
       return rows;
     }
   }

--- a/packages/core/src/mailbox-store.ts
+++ b/packages/core/src/mailbox-store.ts
@@ -50,11 +50,13 @@ export interface MailboxAttempt {
   error: string | null;
 }
 
+/** Produce the stable, non-reversible key used in workspace mailbox IDs. */
 export const mailboxHash = (value: string): string =>
   createHash("sha256").update(value).digest("hex").slice(0, 32);
 
 /** Workspace-local storage. No credentials and no global/shared database. */
 export class MailboxStore {
+  /** Initialize the workspace-local mailbox tables and compatibility columns. */
   constructor(private db: Database) {
     db.exec(`
       CREATE TABLE IF NOT EXISTS mailbox_messages (
@@ -81,6 +83,7 @@ export class MailboxStore {
     addColumnIfMissing(db, "mailbox_messages", "needs_processing", "INTEGER NOT NULL DEFAULT 1");
   }
 
+  /** Look up a persisted mailbox message by its workspace ID. */
   get(id: string): MailboxMessage | null {
     const row = this.db.query("SELECT data FROM mailbox_messages WHERE id=?").get(id) as {
       data: string;
@@ -88,6 +91,7 @@ export class MailboxStore {
     return row ? JSON.parse(row.data) : null;
   }
 
+  /** Look up a message by mailbox identity and RFC Message-ID. */
   byMessageId(identityId: string, messageId: string): MailboxMessage | null {
     const row = this.db
       .query("SELECT data FROM mailbox_messages WHERE identity_id=? AND message_id=?")
@@ -95,6 +99,7 @@ export class MailboxStore {
     return row ? JSON.parse(row.data) : null;
   }
 
+  /** Find the earliest stored message that references an RFC Message-ID. */
   referencing(identityId: string, messageId: string): MailboxMessage | null {
     const row = this.db
       .query(`SELECT m.data FROM mailbox_messages m JOIN mailbox_references r ON r.message_id=m.id
@@ -103,6 +108,7 @@ export class MailboxStore {
     return row ? JSON.parse(row.data) : null;
   }
 
+  /** Persist a message once and update its thread association and state. */
   put(message: MailboxMessage): boolean {
     return this.db
       .transaction(() => {
@@ -175,6 +181,7 @@ export class MailboxStore {
       .immediate();
   }
 
+  /** Return one thread's messages in chronological order. */
   thread(key: string): MailboxMessage[] {
     return (
       this.db
@@ -183,6 +190,7 @@ export class MailboxStore {
     ).map((r) => JSON.parse(r.data));
   }
 
+  /** Return all stored mailbox messages with the newest first. */
   all(): MailboxMessage[] {
     return (
       this.db.query("SELECT data FROM mailbox_messages ORDER BY at DESC,id").all() as {
@@ -203,6 +211,7 @@ export class MailboxStore {
     ).map((row) => JSON.parse(row.data));
   }
 
+  /** List inbound messages eligible for an identity's inbox processing window. */
   inbound(identityId: string, since?: string, until?: string): MailboxMessage[] {
     return (
       this.db
@@ -217,6 +226,7 @@ export class MailboxStore {
     ).map((r) => JSON.parse(r.data));
   }
 
+  /** Read JSON state associated with an internal mailbox key. */
   state<T>(key: string): T | null {
     const row = this.db.query("SELECT data FROM mailbox_state WHERE key=?").get(key) as {
       data: string;
@@ -224,6 +234,7 @@ export class MailboxStore {
     return row ? JSON.parse(row.data) : null;
   }
 
+  /** Upsert JSON state associated with an internal mailbox key. */
   setState(key: string, data: unknown): void {
     this.db
       .query(
@@ -232,6 +243,7 @@ export class MailboxStore {
       .run(key, JSON.stringify(data));
   }
 
+  /** Read the user-visible state derived for a mailbox thread. */
   threadState(key: string): {
     unread: boolean;
     archivedAt: string | null;
@@ -252,6 +264,7 @@ export class MailboxStore {
     };
   }
 
+  /** Mark a thread's provider-history import as complete. */
   markHistoryComplete(key: string): void {
     this.db.query("UPDATE mailbox_threads SET history_complete=1 WHERE thread_key=?").run(key);
   }
@@ -294,6 +307,7 @@ export class MailboxStore {
       .immediate();
   }
 
+  /** Associate every message in a thread with a workspace prospect. */
   associate(key: string, prospectId: number): void {
     this.db
       .transaction(() => {
@@ -308,12 +322,14 @@ export class MailboxStore {
       .immediate();
   }
 
+  /** Mark a matched inbound message as processed by cadence polling. */
   acknowledge(id: string, prospectId: number): void {
     this.db
       .query("UPDATE mailbox_messages SET needs_processing=0 WHERE id=? AND prospect_id=?")
       .run(id, prospectId);
   }
 
+  /** Persist an updated reply classification and parsed bounce details. */
   reclassify(message: MailboxMessage, kind: ReplyKind, bounces?: ParsedBounce[]): void {
     if (message.kind === kind && message.bounces != null) return;
     this.db
@@ -332,6 +348,7 @@ export class MailboxStore {
       .immediate();
   }
 
+  /** Return the earliest recorded email outreach timestamp for backfill. */
   oldestOutreach(): string | null {
     const row = this.db
       .query(
@@ -343,6 +360,7 @@ export class MailboxStore {
       : null;
   }
 
+  /** Look up a persisted SMTP send attempt by request ID. */
   attempt(id: string): MailboxAttempt | null {
     const row = this.db.query("SELECT data FROM mailbox_attempts WHERE id=?").get(id) as {
       data: string;
@@ -350,6 +368,7 @@ export class MailboxStore {
     return row ? JSON.parse(row.data) : null;
   }
 
+  /** Return send attempts that still need Sent-folder reconciliation. */
   attempts(): MailboxAttempt[] {
     return (
       this.db
@@ -358,6 +377,7 @@ export class MailboxStore {
     ).map((r) => JSON.parse(r.data));
   }
 
+  /** Atomically claim an idempotent send attempt or return its prior result. */
   claimAttempt(attempt: MailboxAttempt): MailboxAttempt {
     return this.db
       .transaction(() => {
@@ -378,6 +398,7 @@ export class MailboxStore {
       .immediate();
   }
 
+  /** Persist the latest status and payload for an SMTP send attempt. */
   saveAttempt(attempt: MailboxAttempt): void {
     this.db
       .query(

--- a/packages/core/src/mailbox-store.ts
+++ b/packages/core/src/mailbox-store.ts
@@ -192,6 +192,17 @@ export class MailboxStore {
   }
 
   /** Includes unprocessed old matches even after a newer global poll watermark. */
+  /** Read only potential delivery notices, including legacy rows awaiting classification. */
+  bounceCandidates(since?: string): MailboxMessage[] {
+    return (
+      this.db
+        .query(`SELECT data FROM mailbox_messages WHERE direction='inbound'
+      AND (? IS NULL OR at >= ?) AND (json_extract(data, '$.bounces') IS NULL
+      OR json_array_length(data, '$.bounces') > 0)`)
+        .all(since ?? null, since ?? null) as { data: string }[]
+    ).map((row) => JSON.parse(row.data));
+  }
+
   inbound(identityId: string, since?: string, until?: string): MailboxMessage[] {
     return (
       this.db
@@ -324,7 +335,7 @@ export class MailboxStore {
   oldestOutreach(): string | null {
     const row = this.db
       .query(
-        "SELECT min(created_at) AS at FROM sequence_events WHERE channel='email' AND status='sent'",
+        "SELECT min(created_at) AS at FROM sequence_events WHERE channel='email' AND status IN ('sent','delivered','replied')",
       )
       .get() as { at: string | null };
     return row.at

--- a/packages/core/src/mailbox-store.ts
+++ b/packages/core/src/mailbox-store.ts
@@ -1,0 +1,377 @@
+import type { Database } from "bun:sqlite";
+import { createHash } from "node:crypto";
+import type { ReplyKind } from "./reply-classify.ts";
+import { addColumnIfMissing } from "./ledger-schema.ts";
+import type { ParsedBounce } from "./gmail.ts";
+
+export interface MailboxMessage {
+  id: string;
+  identityId: string;
+  threadKey: string;
+  messageId: string | null;
+  references: string[];
+  gmailThreadId: string | null;
+  from: string;
+  to: string[];
+  replyTo: string | null;
+  subject: string;
+  body: string;
+  at: string;
+  direction: "inbound" | "outbound";
+  kind: ReplyKind;
+  autoSubmitted: string | null;
+  prospectId: number | null;
+  bounces?: ParsedBounce[];
+}
+
+export interface MailboxHealth {
+  identityId: string;
+  address: string;
+  lastSyncAt: string | null;
+  status: "syncing" | "connected" | "error" | "disconnected";
+  error: string | null;
+  backfillRemaining: boolean;
+  messages: number;
+}
+
+export interface MailboxCheckpoint {
+  uidValidity: string;
+  lastUid: number;
+  /** Initial scan includes the workspace's earliest email outreach. */
+  since: string;
+  complete: boolean;
+}
+
+export interface MailboxAttempt {
+  id: string;
+  inboundId: string;
+  message: MailboxMessage;
+  status: "sending" | "uncertain" | "sent" | "failed";
+  error: string | null;
+}
+
+export const mailboxHash = (value: string): string =>
+  createHash("sha256").update(value).digest("hex").slice(0, 32);
+
+/** Workspace-local storage. No credentials and no global/shared database. */
+export class MailboxStore {
+  constructor(private db: Database) {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS mailbox_messages (
+        id TEXT PRIMARY KEY, identity_id TEXT NOT NULL, thread_key TEXT NOT NULL,
+        message_id TEXT, prospect_id INTEGER, direction TEXT NOT NULL,
+        at TEXT NOT NULL, data TEXT NOT NULL, is_read INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE INDEX IF NOT EXISTS mailbox_messages_thread ON mailbox_messages(thread_key, at);
+      CREATE INDEX IF NOT EXISTS mailbox_messages_rfc ON mailbox_messages(identity_id, message_id);
+      CREATE TABLE IF NOT EXISTS mailbox_references (
+        identity_id TEXT NOT NULL, reference_id TEXT NOT NULL, message_id TEXT NOT NULL,
+        PRIMARY KEY(identity_id, reference_id, message_id)
+      );
+      CREATE TABLE IF NOT EXISTS mailbox_threads (
+        thread_key TEXT PRIMARY KEY, archived_at TEXT, history_complete INTEGER NOT NULL DEFAULT 0
+      );
+      CREATE TABLE IF NOT EXISTS mailbox_state (key TEXT PRIMARY KEY, data TEXT NOT NULL);
+      CREATE TABLE IF NOT EXISTS mailbox_attempts (
+        id TEXT PRIMARY KEY, inbound_id TEXT NOT NULL, status TEXT NOT NULL, data TEXT NOT NULL
+      );
+      CREATE INDEX IF NOT EXISTS mailbox_attempts_inbound ON mailbox_attempts(inbound_id, status);
+    `);
+    addColumnIfMissing(db, "mailbox_threads", "last_read_at", "TEXT");
+    addColumnIfMissing(db, "mailbox_messages", "needs_processing", "INTEGER NOT NULL DEFAULT 1");
+  }
+
+  get(id: string): MailboxMessage | null {
+    const row = this.db.query("SELECT data FROM mailbox_messages WHERE id=?").get(id) as {
+      data: string;
+    } | null;
+    return row ? JSON.parse(row.data) : null;
+  }
+
+  byMessageId(identityId: string, messageId: string): MailboxMessage | null {
+    const row = this.db
+      .query("SELECT data FROM mailbox_messages WHERE identity_id=? AND message_id=?")
+      .get(identityId, messageId) as { data: string } | null;
+    return row ? JSON.parse(row.data) : null;
+  }
+
+  referencing(identityId: string, messageId: string): MailboxMessage | null {
+    const row = this.db
+      .query(`SELECT m.data FROM mailbox_messages m JOIN mailbox_references r ON r.message_id=m.id
+      WHERE r.identity_id=? AND r.reference_id=? ORDER BY m.at,m.id LIMIT 1`)
+      .get(identityId, messageId) as { data: string } | null;
+    return row ? JSON.parse(row.data) : null;
+  }
+
+  put(message: MailboxMessage): boolean {
+    return this.db
+      .transaction(() => {
+        const existingMessage = this.get(message.id);
+        if (existingMessage) {
+          if (existingMessage.bounces == null && message.bounces != null) {
+            this.db
+              .query("UPDATE mailbox_messages SET data=? WHERE id=?")
+              .run(JSON.stringify({ ...existingMessage, bounces: message.bounces }), message.id);
+          }
+          return false;
+        }
+        // Inherit an explicit thread association before looking at the latest sender.
+        const linked = this.thread(message.threadKey).find((m) => m.prospectId != null);
+        if (linked) message = { ...message, prospectId: linked.prospectId };
+        const readState = this.db
+          .query("SELECT last_read_at FROM mailbox_threads WHERE thread_key=?")
+          .get(message.threadKey) as { last_read_at: string | null } | null;
+        this.db
+          .query(`INSERT INTO mailbox_messages
+        (id,identity_id,thread_key,message_id,prospect_id,direction,at,data,is_read)
+        VALUES(?,?,?,?,?,?,?,?,?)`)
+          .run(
+            message.id,
+            message.identityId,
+            message.threadKey,
+            message.messageId,
+            message.prospectId,
+            message.direction,
+            message.at,
+            JSON.stringify(message),
+            message.direction === "outbound" ||
+              (readState?.last_read_at && message.at < readState.last_read_at)
+              ? 1
+              : 0,
+          );
+        for (const reference of message.references)
+          this.db
+            .query(
+              "INSERT OR IGNORE INTO mailbox_references(identity_id,reference_id,message_id) VALUES(?,?,?)",
+            )
+            .run(message.identityId, reference, message.id);
+        const existing = this.db
+          .query("SELECT archived_at FROM mailbox_threads WHERE thread_key=?")
+          .get(message.threadKey);
+        if (!existing) {
+          // Preserve a previous prospect archive only for messages older than it.
+          const archive =
+            message.prospectId == null
+              ? null
+              : (this.db
+                  .query("SELECT archived_at FROM inbox_archives WHERE prospect_id=?")
+                  .get(message.prospectId) as { archived_at: string } | null);
+          this.db
+            .query("INSERT INTO mailbox_threads(thread_key,archived_at) VALUES(?,?)")
+            .run(
+              message.threadKey,
+              archive && message.at <= archive.archived_at ? archive.archived_at : null,
+            );
+        } else if (message.direction === "inbound") {
+          // Historical backfill must not reopen a conversation already handled later.
+          this.db
+            .query(
+              "UPDATE mailbox_threads SET archived_at=NULL WHERE thread_key=? AND archived_at < ?",
+            )
+            .run(message.threadKey, message.at);
+        }
+        return true;
+      })
+      .immediate();
+  }
+
+  thread(key: string): MailboxMessage[] {
+    return (
+      this.db
+        .query("SELECT data FROM mailbox_messages WHERE thread_key=? ORDER BY at,id")
+        .all(key) as { data: string }[]
+    ).map((r) => JSON.parse(r.data));
+  }
+
+  all(): MailboxMessage[] {
+    return (
+      this.db.query("SELECT data FROM mailbox_messages ORDER BY at DESC,id").all() as {
+        data: string;
+      }[]
+    ).map((r) => JSON.parse(r.data));
+  }
+
+  /** Includes unprocessed old matches even after a newer global poll watermark. */
+  inbound(identityId: string, since?: string, until?: string): MailboxMessage[] {
+    return (
+      this.db
+        .query(`SELECT m.data FROM mailbox_messages m
+      LEFT JOIN inbox_replies r ON r.id=m.id
+      WHERE m.identity_id=? AND m.direction='inbound'
+      AND (? IS NULL OR m.at >= ? OR (m.prospect_id IS NOT NULL AND (r.id IS NULL OR m.needs_processing=1)))
+      AND (? IS NULL OR m.at < ?) ORDER BY m.at DESC,m.id`)
+        .all(identityId, since ?? null, since ?? null, until ?? null, until ?? null) as {
+        data: string;
+      }[]
+    ).map((r) => JSON.parse(r.data));
+  }
+
+  state<T>(key: string): T | null {
+    const row = this.db.query("SELECT data FROM mailbox_state WHERE key=?").get(key) as {
+      data: string;
+    } | null;
+    return row ? JSON.parse(row.data) : null;
+  }
+
+  setState(key: string, data: unknown): void {
+    this.db
+      .query(
+        "INSERT INTO mailbox_state(key,data) VALUES(?,?) ON CONFLICT(key) DO UPDATE SET data=excluded.data",
+      )
+      .run(key, JSON.stringify(data));
+  }
+
+  threadState(key: string): {
+    unread: boolean;
+    archivedAt: string | null;
+    historyComplete: boolean;
+  } {
+    const row = this.db
+      .query("SELECT archived_at,history_complete FROM mailbox_threads WHERE thread_key=?")
+      .get(key) as { archived_at: string | null; history_complete: number } | null;
+    const unread = this.db
+      .query(
+        "SELECT 1 FROM mailbox_messages WHERE thread_key=? AND direction='inbound' AND is_read=0 LIMIT 1",
+      )
+      .get(key);
+    return {
+      unread: Boolean(unread),
+      archivedAt: row?.archived_at ?? null,
+      historyComplete: Boolean(row?.history_complete),
+    };
+  }
+
+  markHistoryComplete(key: string): void {
+    this.db.query("UPDATE mailbox_threads SET history_complete=1 WHERE thread_key=?").run(key);
+  }
+
+  /** Snapshot-based mutations never hide or read a newly arrived message. */
+  changeState(
+    key: string,
+    observedIds: string[],
+    change: { read?: boolean; archived?: boolean },
+  ): void {
+    this.db
+      .transaction(() => {
+        const inbound = this.thread(key).filter((m) => m.direction === "inbound");
+        if (!inbound.length) throw new Error("conversation not found");
+        const observed = new Set(observedIds);
+        if (change.archived && inbound.some((m) => !observed.has(m.id)))
+          throw new Error("The conversation changed. Review the new reply before archiving.");
+        if (change.read != null) {
+          for (const m of inbound)
+            if (observed.has(m.id))
+              this.db
+                .query("UPDATE mailbox_messages SET is_read=? WHERE id=?")
+                .run(change.read ? 1 : 0, m.id);
+          const cutoff = change.read
+            ? (inbound
+                .filter((m) => observed.has(m.id))
+                .map((m) => m.at)
+                .toSorted()
+                .at(-1) ?? null)
+            : null;
+          this.db
+            .query("UPDATE mailbox_threads SET last_read_at=? WHERE thread_key=?")
+            .run(cutoff, key);
+        }
+        if (change.archived != null)
+          this.db
+            .query("UPDATE mailbox_threads SET archived_at=? WHERE thread_key=?")
+            .run(change.archived ? new Date().toISOString() : null, key);
+      })
+      .immediate();
+  }
+
+  associate(key: string, prospectId: number): void {
+    this.db
+      .transaction(() => {
+        for (const m of this.thread(key)) {
+          m.prospectId = prospectId;
+          this.db
+            .query("UPDATE mailbox_messages SET prospect_id=?,data=?,needs_processing=1 WHERE id=?")
+            .run(prospectId, JSON.stringify(m), m.id);
+          this.db.query("UPDATE inbox_replies SET prospect_id=? WHERE id=?").run(prospectId, m.id);
+        }
+      })
+      .immediate();
+  }
+
+  acknowledge(id: string, prospectId: number): void {
+    this.db
+      .query("UPDATE mailbox_messages SET needs_processing=0 WHERE id=? AND prospect_id=?")
+      .run(id, prospectId);
+  }
+
+  reclassify(message: MailboxMessage, kind: ReplyKind, bounces?: ParsedBounce[]): void {
+    if (message.kind === kind && message.bounces != null) return;
+    this.db
+      .transaction(() => {
+        this.db
+          .query(
+            "UPDATE mailbox_messages SET data=?,needs_processing=CASE WHEN ? THEN 1 ELSE needs_processing END WHERE id=?",
+          )
+          .run(
+            JSON.stringify({ ...message, kind, bounces: bounces ?? message.bounces }),
+            message.kind !== kind ? 1 : 0,
+            message.id,
+          );
+        this.db.query("UPDATE inbox_replies SET kind=? WHERE id=?").run(kind, message.id);
+      })
+      .immediate();
+  }
+
+  oldestOutreach(): string | null {
+    const row = this.db
+      .query(
+        "SELECT min(created_at) AS at FROM sequence_events WHERE channel='email' AND status='sent'",
+      )
+      .get() as { at: string | null };
+    return row.at
+      ? new Date(row.at.replace(" ", "T") + (row.at.endsWith("Z") ? "" : "Z")).toISOString()
+      : null;
+  }
+
+  attempt(id: string): MailboxAttempt | null {
+    const row = this.db.query("SELECT data FROM mailbox_attempts WHERE id=?").get(id) as {
+      data: string;
+    } | null;
+    return row ? JSON.parse(row.data) : null;
+  }
+
+  attempts(): MailboxAttempt[] {
+    return (
+      this.db
+        .query("SELECT data FROM mailbox_attempts WHERE status IN ('sending','uncertain')")
+        .all() as { data: string }[]
+    ).map((r) => JSON.parse(r.data));
+  }
+
+  claimAttempt(attempt: MailboxAttempt): MailboxAttempt {
+    return this.db
+      .transaction(() => {
+        const existing = this.attempt(attempt.id);
+        if (existing) return existing;
+        const pending = this.db
+          .query(
+            "SELECT data FROM mailbox_attempts WHERE inbound_id=? AND status IN ('sending','uncertain') LIMIT 1",
+          )
+          .get(attempt.inboundId) as { data: string } | null;
+        if (pending)
+          throw new Error(
+            "A previous send is still being reconciled. Refresh the thread before retrying.",
+          );
+        this.saveAttempt(attempt);
+        return attempt;
+      })
+      .immediate();
+  }
+
+  saveAttempt(attempt: MailboxAttempt): void {
+    this.db
+      .query(
+        "INSERT INTO mailbox_attempts(id,inbound_id,status,data) VALUES(?,?,?,?) ON CONFLICT(id) DO UPDATE SET status=excluded.status,data=excluded.data",
+      )
+      .run(attempt.id, attempt.inboundId, attempt.status, JSON.stringify(attempt));
+  }
+}

--- a/packages/core/src/mailbox.ts
+++ b/packages/core/src/mailbox.ts
@@ -1,0 +1,619 @@
+import { ImapFlow, type ListResponse } from "imapflow";
+import { simpleParser } from "mailparser";
+import nodemailer from "nodemailer";
+import { randomUUID } from "node:crypto";
+import { parseBounce } from "./gmail.ts";
+import { getLedger, type Ledger } from "./ledger.ts";
+import { classifyReply } from "./reply-classify.ts";
+import { parallelMap } from "./parallel.ts";
+import {
+  mailboxConnection,
+  resetMailboxConnections,
+  smartleadMailboxIdentities,
+  type MailboxConnection,
+} from "./mailbox-config.ts";
+import {
+  mailboxHash,
+  type MailboxMessage,
+  type MailboxHealth,
+  type MailboxCheckpoint,
+  type MailboxAttempt,
+} from "./mailbox-store.ts";
+import type { AnnotatedInboxListResult, BounceListResult } from "./oneshot.ts";
+
+export type { MailboxMessage, MailboxHealth } from "./mailbox-store.ts";
+const DAY = 86_400_000;
+const syncs = new Map<string, { started: number; pending: Promise<void> | null }>();
+const liveSends = new Set<string>();
+const reclassifiedStores = new WeakSet<object>();
+
+function parseMailboxBounces(from: string, subject: string, body: string, deliveryStatus?: Buffer) {
+  return parseBounce({
+    id: "",
+    threadId: "",
+    internalDate: "0",
+    payload: {
+      headers: [
+        { name: "From", value: from },
+        { name: "Subject", value: subject },
+      ],
+      parts: [
+        { mimeType: "text/plain", body: { data: Buffer.from(body).toString("base64url") } },
+        ...(deliveryStatus
+          ? [
+              {
+                mimeType: "message/delivery-status",
+                body: { data: deliveryStatus.toString("base64url") },
+              },
+            ]
+          : []),
+      ],
+    },
+  });
+}
+
+export function listMailboxBounces(opts?: { since?: string }): BounceListResult {
+  const identities = new Set(smartleadMailboxIdentities().map((i) => i.id));
+  if (!identities.size) return { bounces: [], failedSources: [] };
+  const ledger = getLedger();
+  const bounces = ledger.mailboxes
+    .all()
+    .filter(
+      (m) =>
+        identities.has(m.identityId) &&
+        m.direction === "inbound" &&
+        (!opts?.since || m.at >= opts.since),
+    )
+    .flatMap((m) =>
+      (m.bounces ?? parseMailboxBounces(m.from, m.subject, m.body))
+        // Smartlead warmup uses the same mailbox. Those delivery reports must
+        // not inflate this workspace's outreach bounce rate or notifications.
+        .filter((b) => ledger.hasPriorEmailSend(b.recipient))
+        .map((b) => ({
+          recipient: b.recipient,
+          kind: b.kind,
+          statusCode: b.statusCode,
+          diagnostic: b.diagnostic,
+          messageId: m.id,
+          identityId: m.identityId,
+          bouncedAt: m.at,
+        })),
+    );
+  return {
+    bounces,
+    failedSources: mailboxHealth()
+      .filter((h) => h.status !== "connected" || h.backfillRemaining)
+      .map((h) => h.identityId),
+  };
+}
+
+export function mailboxClient(connection: MailboxConnection): ImapFlow {
+  const c = new ImapFlow({
+    host: connection.imap.host,
+    port: connection.imap.port,
+    secure: connection.imap.secure,
+    doSTARTTLS: connection.imap.secure ? undefined : true,
+    auth: { user: connection.imap.user, pass: connection.imap.pass },
+    logger: false,
+    connectionTimeout: 15_000,
+    greetingTimeout: 15_000,
+    socketTimeout: 30_000,
+    disableAutoIdle: true,
+  });
+  // Socket errors are reported through the active operation. Never log protocol data.
+  c.on("error", () => {});
+  return c;
+}
+
+function smtpTransport(connection: MailboxConnection) {
+  return nodemailer.createTransport({
+    host: connection.smtp.host,
+    port: connection.smtp.port,
+    secure: connection.smtp.secure,
+    requireTLS: !connection.smtp.secure,
+    auth: { user: connection.smtp.user, pass: connection.smtp.pass },
+    connectionTimeout: 15_000,
+    greetingTimeout: 15_000,
+    socketTimeout: 30_000,
+    logger: false,
+    debug: false,
+    disableFileAccess: true,
+    disableUrlAccess: true,
+  });
+}
+
+export async function verifyMailboxConnection(connection: MailboxConnection): Promise<void> {
+  const imap = mailboxClient(connection);
+  const smtp = smtpTransport(connection);
+  try {
+    await imap.connect();
+    await imap.mailboxOpen("INBOX", { readOnly: true });
+    await smtp.verify();
+  } catch {
+    throw new Error(
+      "Mailbox login failed. Check IMAP/SMTP credentials, TLS settings, and account access.",
+    );
+  } finally {
+    imap.close();
+    smtp.close();
+  }
+}
+
+export function mailboxFolders(folders: ListResponse[]): ListResponse[] {
+  const selectable = folders.filter((f) => !f.flags.has("\\Noselect"));
+  const all = selectable.find((f) => f.specialUse === "\\All");
+  const sent = selectable.find((f) => f.specialUse === "\\Sent");
+  const inbox = selectable.find((f) => f.path.toUpperCase() === "INBOX");
+  const spam = selectable.find((f) => f.specialUse === "\\Junk");
+  return [
+    ...new Map(
+      (all ? [all, spam] : [sent, inbox, spam])
+        .filter((f): f is ListResponse => Boolean(f))
+        .map((f) => [f.path, f]),
+    ).values(),
+  ];
+}
+
+export async function parseMailboxMessage(
+  raw: Buffer,
+  meta: { identityId: string; address: string; fallbackId: string; threadId?: string; at?: Date },
+  ledger: Ledger,
+): Promise<MailboxMessage> {
+  const parseOptions = { skipImageLinks: true, skipTextToHtml: true, keepDeliveryStatus: true };
+  const parsed = await simpleParser(raw, parseOptions);
+  const from = parsed.from?.value[0]?.address?.toLowerCase() ?? "";
+  const to = (Array.isArray(parsed.to) ? parsed.to : parsed.to ? [parsed.to] : [])
+    .flatMap((v) => v.value.map((a) => a.address?.toLowerCase() ?? ""))
+    .filter(Boolean);
+  const messageId = parsed.messageId ?? null;
+  const references = [
+    ...new Set([
+      ...(Array.isArray(parsed.references)
+        ? parsed.references
+        : parsed.references
+          ? [parsed.references]
+          : []),
+      ...(parsed.inReplyTo ? [parsed.inReplyTo] : []),
+    ]),
+  ];
+  const direction = from === meta.address.toLowerCase() ? "outbound" : "inbound";
+  const parents = references
+    .map((id) => ledger.mailboxes.byMessageId(meta.identityId, id))
+    .filter((m): m is MailboxMessage => Boolean(m));
+  const root = references[0] ?? messageId ?? meta.fallbackId;
+  const child = messageId ? ledger.mailboxes.referencing(meta.identityId, messageId) : null;
+  const threadKey = meta.threadId
+    ? `mailbox:${meta.identityId}:${mailboxHash(`gmail:${meta.threadId}`)}`
+    : (parents[0]?.threadKey ??
+      child?.threadKey ??
+      `mailbox:${meta.identityId}:${mailboxHash(root)}`);
+  const peer = direction === "inbound" ? from : to.find((a) => a !== meta.address.toLowerCase());
+  const prospect = peer ? ledger.findProspectByEmail(peer) : null;
+  const body = parsed.text?.trim() ?? "";
+  const bounces = parseMailboxBounces(
+    from,
+    parsed.subject ?? "",
+    body,
+    parsed.attachments.find((a) => a.contentType === "message/delivery-status")?.content,
+  );
+  const autoSubmitted = String(parsed.headers.get("auto-submitted") ?? "");
+  const auto = Boolean(autoSubmitted && autoSubmitted.toLowerCase() !== "no");
+  return {
+    id: `mailbox:${meta.identityId}:${mailboxHash(messageId ?? meta.fallbackId)}`,
+    identityId: meta.identityId,
+    threadKey,
+    messageId,
+    references,
+    gmailThreadId: meta.threadId ?? null,
+    from,
+    to,
+    replyTo: parsed.replyTo?.value[0]?.address?.toLowerCase() ?? null,
+    subject: parsed.subject ?? "",
+    body,
+    at: (
+      meta.at ?? (parsed.date && Number.isFinite(parsed.date.getTime()) ? parsed.date : new Date())
+    ).toISOString(),
+    direction,
+    kind: bounces.length
+      ? "auto"
+      : classifyReply({ subject: parsed.subject, body, autoSubmitted: auto }),
+    autoSubmitted: bounces.length ? "auto-generated" : auto ? autoSubmitted : null,
+    bounces,
+    prospectId: parents.find((m) => m.prospectId != null)?.prospectId ?? prospect?.id ?? null,
+  };
+}
+
+async function capture(
+  client: ImapFlow,
+  uids: number[],
+  identityId: string,
+  address: string,
+  folder: string,
+  validity: string,
+  ledger: Ledger,
+): Promise<void> {
+  for (let i = 0; i < uids.length; i += 20) {
+    const batch = await client.fetchAll(
+      uids.slice(i, i + 20),
+      { uid: true, source: true, internalDate: true, threadId: true },
+      { uid: true },
+    );
+    for (const m of batch) {
+      if (!m.source) throw new Error("Mailbox returned a message without its body.");
+      const message = await parseMailboxMessage(
+        m.source,
+        {
+          identityId,
+          address,
+          fallbackId: `${folder}:${validity}:${m.uid}`,
+          threadId: m.threadId,
+          at: m.internalDate instanceof Date ? m.internalDate : undefined,
+        },
+        ledger,
+      );
+      ledger.mailboxes.put(message);
+    }
+  }
+}
+
+async function syncIdentity(identityId: string, address: string, ledger: Ledger): Promise<void> {
+  const store = ledger.mailboxes;
+  const prior = store.state<MailboxHealth>(`health:${identityId}`);
+  const health: MailboxHealth = {
+    identityId,
+    address,
+    lastSyncAt: prior?.lastSyncAt ?? null,
+    status: "syncing",
+    error: null,
+    backfillRemaining: false,
+    messages: prior?.messages ?? 0,
+  };
+  store.setState(`health:${identityId}`, health);
+  let client: ImapFlow | null = null;
+  try {
+    const connection = await mailboxConnection(identityId);
+    client = mailboxClient(connection);
+    await client.connect();
+    const folders = mailboxFolders(await client.list());
+    if (!folders.length) throw new Error("No readable inbox folder found.");
+    const oldest = store.oldestOutreach();
+    const initialSince = new Date(
+      Math.min(Date.now() - 30 * DAY, oldest ? new Date(oldest).getTime() : Infinity),
+    ).toISOString();
+    for (const folder of folders) {
+      // Re-read identity configuration before each folder, so a removal takes effect mid-sync.
+      if (!smartleadMailboxIdentities().some((i) => i.id === identityId)) return;
+      const box = await client.mailboxOpen(folder.path, { readOnly: true });
+      const validity = String(box.uidValidity);
+      const key = `checkpoint:${identityId}:${folder.path}`;
+      const saved = store.state<MailboxCheckpoint>(key);
+      const cp =
+        saved?.uidValidity === validity
+          ? saved
+          : { uidValidity: validity, lastUid: 0, since: initialSince, complete: false };
+      const found = await client.search(
+        cp.lastUid ? { uid: `${cp.lastUid + 1}:*` } : { since: new Date(cp.since) },
+        { uid: true },
+      );
+      // IMAP n:* can return the last UID even when n is beyond it.
+      const uids = (found || []).filter((uid) => uid > cp.lastUid).toSorted((a, b) => a - b);
+      const page = uids.slice(0, 100);
+      // Backfill walks forward for resumable checkpoints, but fresh replies
+      // must not wait behind weeks of warmup mail. Sweep the newest tail too;
+      // its IDs deduplicate when the historical cursor catches up.
+      if (uids.length > page.length) {
+        await capture(client, uids.slice(-25), identityId, address, folder.path, validity, ledger);
+      }
+      await capture(client, page, identityId, address, folder.path, validity, ledger);
+      cp.lastUid = page.at(-1) ?? cp.lastUid;
+      cp.complete = page.length === uids.length;
+      store.setState(key, cp);
+      health.backfillRemaining ||= !cp.complete;
+    }
+    // Sent copies are authoritative evidence for a crashed/timed-out send.
+    for (const attempt of store.attempts().filter((a) => a.message.identityId === identityId)) {
+      if (
+        !liveSends.has(attempt.id) &&
+        attempt.message.messageId &&
+        store.byMessageId(identityId, attempt.message.messageId)
+      ) {
+        store.saveAttempt({ ...attempt, status: "sent", error: null });
+        ledger.clearInboxDraft(attempt.message.threadKey);
+      }
+    }
+    health.status = "connected";
+    health.lastSyncAt = new Date().toISOString();
+    health.messages = store.all().filter((m) => m.identityId === identityId).length;
+  } catch (err) {
+    resetMailboxConnections();
+    health.status = "error";
+    // Connection library errors may include credentials or protocol responses.
+    health.error =
+      err instanceof Error &&
+      /^(Smartlead|Direct mailbox|This mailbox|No readable)/.test(err.message)
+        ? err.message
+        : "Mailbox sync failed. Check the connection settings and retry.";
+  } finally {
+    client?.close();
+    store.setState(`health:${identityId}`, health);
+  }
+}
+
+/** Shared by the background poll and all inbox requests in this workspace process. */
+export async function syncSmartleadMailboxes(force = false): Promise<void> {
+  const ledger = getLedger();
+  const identities = smartleadMailboxIdentities();
+  if (!reclassifiedStores.has(ledger.mailboxes)) {
+    const active = new Set(identities.map((i) => i.id));
+    for (const m of ledger.mailboxes.all()) {
+      if (m.direction === "inbound" && active.has(m.identityId)) {
+        const bounces = m.bounces ?? parseMailboxBounces(m.from, m.subject, m.body);
+        ledger.mailboxes.reclassify(
+          m,
+          bounces.length
+            ? "auto"
+            : classifyReply({
+                subject: m.subject,
+                body: m.body,
+                autoSubmitted: Boolean(m.autoSubmitted),
+              }),
+          bounces,
+        );
+      }
+    }
+    reclassifiedStores.add(ledger.mailboxes);
+  }
+  await parallelMap(identities, 3, async (identity) => {
+    const previous = syncs.get(identity.id);
+    if (previous?.pending) return previous.pending;
+    if (!force && previous && Date.now() - previous.started < 60_000) return;
+    const entry = { started: Date.now(), pending: null as Promise<void> | null };
+    entry.pending = syncIdentity(identity.id, identity.address ?? "", ledger).finally(() => {
+      entry.pending = null;
+    });
+    syncs.set(identity.id, entry);
+    return entry.pending;
+  });
+}
+
+export function mailboxHealth(): MailboxHealth[] {
+  const store = getLedger().mailboxes;
+  return smartleadMailboxIdentities().map(
+    (i) =>
+      store.state<MailboxHealth>(`health:${i.id}`) ?? {
+        identityId: i.id,
+        address: i.address ?? "",
+        lastSyncAt: null,
+        status: "disconnected",
+        error: null,
+        backfillRemaining: true,
+        messages: 0,
+      },
+  );
+}
+
+export async function listMailboxInbox(
+  identityId: string,
+  opts?: { since?: string; until?: string; limit?: number },
+): Promise<AnnotatedInboxListResult> {
+  await syncSmartleadMailboxes();
+  const ledger = getLedger();
+  const health = mailboxHealth().find((h) => h.identityId === identityId);
+  const messages = ledger.mailboxes.inbound(identityId, opts?.since, opts?.until);
+  const selected = messages.slice(0, opts?.limit ?? 200);
+  return {
+    agent_id: identityId,
+    emails: selected.map((m) => ({
+      id: m.id,
+      from: m.from,
+      to: m.to[0] ?? "",
+      subject: m.subject,
+      body: m.body,
+      received_at: m.at,
+      thread_id: m.threadKey,
+      message_id: m.messageId ?? undefined,
+      source_identity_id: m.identityId,
+      auto_submitted: Boolean(m.autoSubmitted),
+      matched_prospect_id: m.prospectId ?? undefined,
+    })),
+    count: selected.length,
+    has_more: selected.length < messages.length,
+    ...(health?.status !== "connected" || health.backfillRemaining
+      ? { failed_sources: [identityId] }
+      : {}),
+  };
+}
+
+export async function hydrateMailboxThread(threadKey: string): Promise<void> {
+  const ledger = getLedger();
+  const store = ledger.mailboxes;
+  if (store.threadState(threadKey).historyComplete) return;
+  const messages = store.thread(threadKey);
+  const seed = messages.find((m) => m.direction === "inbound") ?? messages[0];
+  if (!seed) throw new Error("conversation not found");
+  const connection = await mailboxConnection(seed.identityId);
+  const client = mailboxClient(connection);
+  try {
+    await client.connect();
+    let complete = true;
+    for (const folder of mailboxFolders(await client.list())) {
+      const box = await client.mailboxOpen(folder.path, { readOnly: true });
+      const peer = seed.direction === "inbound" ? seed.from : seed.to[0];
+      const found = await client.search(
+        seed.gmailThreadId
+          ? { threadId: seed.gmailThreadId }
+          : { or: [{ from: peer }, { to: peer }] },
+        { uid: true },
+      );
+      const uids = found || [];
+      // Cache progress so long histories can be resumed without refetching the same page.
+      const progressKey = `history:${threadKey}:${folder.path}:${box.uidValidity}`;
+      const done = new Set(store.state<number[]>(progressKey) ?? []);
+      const remaining = uids.filter((uid) => !done.has(uid));
+      const page = remaining.slice(0, 200);
+      await capture(
+        client,
+        page,
+        seed.identityId,
+        connection.address,
+        folder.path,
+        String(box.uidValidity),
+        ledger,
+      );
+      store.setState(progressKey, [...done, ...page]);
+      complete &&= remaining.length <= page.length;
+    }
+    if (complete) store.markHistoryComplete(threadKey);
+  } catch {
+    throw new Error(
+      "Could not load complete mailbox history. Your saved messages are still available; retry to continue.",
+    );
+  } finally {
+    client.close();
+  }
+}
+
+export function mailboxReplyMessage(
+  inbound: MailboxMessage,
+  address: string,
+  body: string,
+): MailboxMessage {
+  if (!inbound.messageId)
+    throw new Error("This message has no Message-ID; a threaded reply cannot be sent safely.");
+  const messageId = `<${randomUUID()}@${address.split("@")[1]}>`;
+  return {
+    ...inbound,
+    id: `mailbox:${inbound.identityId}:${mailboxHash(messageId)}`,
+    messageId,
+    references: [...new Set([...inbound.references, inbound.messageId])],
+    from: address,
+    to: [inbound.replyTo || inbound.from],
+    replyTo: null,
+    subject: /^re:/i.test(inbound.subject) ? inbound.subject : `Re: ${inbound.subject}`,
+    body,
+    at: new Date().toISOString(),
+    direction: "outbound",
+    kind: "human",
+    autoSubmitted: null,
+  };
+}
+
+/** Uses only stored routing metadata, never client-supplied From/To/thread headers. */
+export async function sendMailboxReply(
+  inboundId: string,
+  body: string,
+  requestId: string,
+): Promise<MailboxMessage> {
+  const ledger = getLedger();
+  const store = ledger.mailboxes;
+  const inbound = store.get(inboundId);
+  if (!inbound || inbound.direction !== "inbound")
+    throw new Error("Inbound message not found in this workspace.");
+  const connection = await mailboxConnection(inbound.identityId);
+  const prior = store.attempt(requestId);
+  if (prior && (prior.inboundId !== inboundId || prior.message.body !== body))
+    throw new Error("Send request does not match the saved attempt.");
+  if (prior?.status === "sent") return prior.message;
+  if (prior && prior.status !== "failed") {
+    await syncSmartleadMailboxes(true);
+    if (store.attempt(requestId)?.status === "sent") return prior.message;
+    throw new Error(
+      "Previous send has an unknown outcome. It will be reconciled against Sent mail; do not resend it yet.",
+    );
+  }
+  if (prior?.status === "failed")
+    throw new Error("Previous send failed. Start a new send attempt.");
+  const message = mailboxReplyMessage(inbound, connection.address, body);
+  const fresh: MailboxAttempt = {
+    id: requestId,
+    inboundId,
+    message,
+    status: "sending",
+    error: null,
+  };
+  const claimed = store.claimAttempt(fresh);
+  if (claimed !== fresh)
+    throw new Error("This reply is already being sent. Refresh before retrying.");
+  liveSends.add(requestId);
+  const smtp = smtpTransport(connection);
+  let submitted = false;
+  try {
+    // Authentication/connect failures are definitive: no DATA was submitted.
+    await smtp.verify();
+    const mime = await nodemailer
+      .createTransport({ streamTransport: true, buffer: true, newline: "windows" })
+      .sendMail({
+        from: connection.address,
+        to: message.to,
+        subject: message.subject,
+        text: body,
+        messageId: message.messageId!,
+        inReplyTo: inbound.messageId!,
+        references: message.references,
+        date: new Date(message.at),
+        disableFileAccess: true,
+        disableUrlAccess: true,
+      });
+    submitted = true;
+    const accepted = await smtp.sendMail({
+      envelope: { from: connection.address, to: message.to },
+      raw: mime.message,
+    });
+    if (!accepted.accepted?.length) throw new Error("SMTP did not accept the reply.");
+    store.put(message);
+    store.saveAttempt({ ...fresh, status: "sent" });
+    ledger.clearInboxDraft(message.threadKey);
+    // Gmail stores SMTP sends automatically. Other IMAP providers need an explicit Sent copy.
+    if (!/gmail\.com$/i.test(connection.smtp.host)) {
+      const client = mailboxClient(connection);
+      try {
+        await client.connect();
+        const sent = (await client.list()).find((f) => f.specialUse === "\\Sent");
+        if (sent) {
+          await client.mailboxOpen(sent.path, { readOnly: true });
+          const existing = await client.search(
+            { header: { "message-id": message.messageId! } },
+            { uid: true },
+          );
+          if (!existing || !existing.length)
+            await client.append(
+              sent.path,
+              mime.message as Buffer,
+              ["\\Seen"],
+              new Date(message.at),
+            );
+        }
+      } catch {
+        // Submission succeeded. A Sent-copy failure must never turn into a retry of DATA.
+        store.setState(`sent-copy:${requestId}`, {
+          messageId: message.messageId,
+          error: "Reply sent; mailbox Sent copy could not be saved.",
+        });
+      } finally {
+        client.close();
+      }
+    }
+    return message;
+  } catch (err) {
+    // An explicit SMTP rejection is definitive; a disconnect after DATA is not.
+    const code = (err as { responseCode?: number }).responseCode;
+    const definite = !submitted || (code != null && code >= 400 && code < 600);
+    store.saveAttempt({
+      ...fresh,
+      status: definite ? "failed" : "uncertain",
+      error: definite
+        ? "SMTP rejected the reply. Check your connection and retry."
+        : "Send outcome unknown; checking Sent mail before retry.",
+    });
+    // Transport exceptions can contain authentication details; do not attach them as causes.
+    // oxlint-disable-next-line preserve-caught-error
+    throw new Error(
+      definite
+        ? "Reply was not sent. Check mailbox settings and retry."
+        : "Send outcome unknown. Refresh to reconcile Sent mail before retrying.",
+    );
+  } finally {
+    liveSends.delete(requestId);
+    smtp.close();
+  }
+}

--- a/packages/core/src/mailbox.ts
+++ b/packages/core/src/mailbox.ts
@@ -27,6 +27,7 @@ const syncs = new Map<string, { started: number; pending: Promise<void> | null }
 const liveSends = new Set<string>();
 const reclassifiedStores = new WeakSet<object>();
 
+/** Adapt a parsed mailbox message to the shared delivery-failure parser. */
 function parseMailboxBounces(from: string, subject: string, body: string, deliveryStatus?: Buffer) {
   return parseBounce({
     id: "",
@@ -52,6 +53,7 @@ function parseMailboxBounces(from: string, subject: string, body: string, delive
   });
 }
 
+/** List delivery failures captured from active Smartlead mailboxes. */
 export function listMailboxBounces(opts?: { since?: string }): BounceListResult {
   const identities = new Set(smartleadMailboxIdentities().map((i) => i.id));
   if (!identities.size) return { bounces: [], failedSources: [] };
@@ -85,6 +87,7 @@ export function listMailboxBounces(opts?: { since?: string }): BounceListResult 
   };
 }
 
+/** Create a bounded, non-logging IMAP client for a mailbox connection. */
 export function mailboxClient(connection: MailboxConnection): ImapFlow {
   const c = new ImapFlow({
     host: connection.imap.host,
@@ -103,6 +106,7 @@ export function mailboxClient(connection: MailboxConnection): ImapFlow {
   return c;
 }
 
+/** Create a bounded, non-logging SMTP transport for a mailbox connection. */
 function smtpTransport(connection: MailboxConnection) {
   return nodemailer.createTransport({
     host: connection.smtp.host,
@@ -120,6 +124,7 @@ function smtpTransport(connection: MailboxConnection) {
   });
 }
 
+/** Verify that both IMAP inbox access and SMTP authentication succeed. */
 export async function verifyMailboxConnection(connection: MailboxConnection): Promise<void> {
   const imap = mailboxClient(connection);
   const smtp = smtpTransport(connection);
@@ -137,6 +142,7 @@ export async function verifyMailboxConnection(connection: MailboxConnection): Pr
   }
 }
 
+/** Select the minimal useful set of readable folders for mailbox sync. */
 export function mailboxFolders(folders: ListResponse[]): ListResponse[] {
   const selectable = folders.filter((f) => !f.flags.has("\\Noselect"));
   const all = selectable.find((f) => f.specialUse === "\\All");
@@ -152,6 +158,7 @@ export function mailboxFolders(folders: ListResponse[]): ListResponse[] {
   ];
 }
 
+/** Parse a raw provider message into the workspace's normalized mailbox record. */
 export async function parseMailboxMessage(
   raw: Buffer,
   meta: { identityId: string; address: string; fallbackId: string; threadId?: string; at?: Date },
@@ -221,6 +228,7 @@ export async function parseMailboxMessage(
   };
 }
 
+/** Fetch and persist a bounded batch of provider messages. */
 async function capture(
   client: ImapFlow,
   uids: number[],
@@ -254,6 +262,7 @@ async function capture(
   }
 }
 
+/** Resume incremental folder sync and reconcile sends for one identity. */
 async function syncIdentity(identityId: string, address: string, ledger: Ledger): Promise<void> {
   const store = ledger.mailboxes;
   const prior = store.state<MailboxHealth>(`health:${identityId}`);
@@ -374,6 +383,7 @@ export async function syncSmartleadMailboxes(force = false): Promise<void> {
   });
 }
 
+/** Return persisted connection and sync health for active mailbox identities. */
 export function mailboxHealth(): MailboxHealth[] {
   const store = getLedger().mailboxes;
   return smartleadMailboxIdentities().map(
@@ -390,6 +400,7 @@ export function mailboxHealth(): MailboxHealth[] {
   );
 }
 
+/** Sync and list one identity's normalized inbound mailbox window. */
 export async function listMailboxInbox(
   identityId: string,
   opts?: { since?: string; until?: string; limit?: number },
@@ -422,6 +433,7 @@ export async function listMailboxInbox(
   };
 }
 
+/** Import provider history for a thread until its resumable scan completes. */
 export async function hydrateMailboxThread(threadKey: string): Promise<void> {
   const ledger = getLedger();
   const store = ledger.mailboxes;
@@ -471,6 +483,7 @@ export async function hydrateMailboxThread(threadKey: string): Promise<void> {
   }
 }
 
+/** Build a threaded outbound mailbox record from a stored inbound message. */
 export function mailboxReplyMessage(
   inbound: MailboxMessage,
   address: string,

--- a/packages/core/src/mailbox.ts
+++ b/packages/core/src/mailbox.ts
@@ -57,28 +57,26 @@ export function listMailboxBounces(opts?: { since?: string }): BounceListResult 
   if (!identities.size) return { bounces: [], failedSources: [] };
   const ledger = getLedger();
   const bounces = ledger.mailboxes
-    .all()
-    .filter(
-      (m) =>
-        identities.has(m.identityId) &&
-        m.direction === "inbound" &&
-        (!opts?.since || m.at >= opts.since),
-    )
-    .flatMap((m) =>
-      (m.bounces ?? parseMailboxBounces(m.from, m.subject, m.body))
-        // Smartlead warmup uses the same mailbox. Those delivery reports must
-        // not inflate this workspace's outreach bounce rate or notifications.
-        .filter((b) => ledger.hasPriorEmailSend(b.recipient))
-        .map((b) => ({
-          recipient: b.recipient,
-          kind: b.kind,
-          statusCode: b.statusCode,
-          diagnostic: b.diagnostic,
-          messageId: m.id,
-          identityId: m.identityId,
-          bouncedAt: m.at,
-        })),
-    );
+    .bounceCandidates(opts?.since)
+    .filter((m) => identities.has(m.identityId))
+    .flatMap((m) => {
+      const parsed = m.bounces ?? parseMailboxBounces(m.from, m.subject, m.body);
+      if (m.bounces == null) ledger.mailboxes.reclassify(m, m.kind, parsed);
+      return (
+        parsed
+          // Smartlead warmup shares the mailbox but is not workspace outreach.
+          .filter((b) => ledger.hasPriorEmailSend(b.recipient))
+          .map((b) => ({
+            recipient: b.recipient,
+            kind: b.kind,
+            statusCode: b.statusCode,
+            diagnostic: b.diagnostic,
+            messageId: m.id,
+            identityId: m.identityId,
+            bouncedAt: m.at,
+          }))
+      );
+    });
   return {
     bounces,
     failedSources: mailboxHealth()
@@ -559,7 +557,10 @@ export async function sendMailboxReply(
       envelope: { from: connection.address, to: message.to },
       raw: mime.message,
     });
-    if (!accepted.accepted?.length) throw new Error("SMTP did not accept the reply.");
+    if (!accepted.accepted?.length) {
+      submitted = false; // SMTP explicitly accepted no recipients; retry is safe.
+      throw new Error("SMTP did not accept the reply.");
+    }
     store.put(message);
     store.saveAttempt({ ...fresh, status: "sent" });
     ledger.clearInboxDraft(message.threadKey);

--- a/packages/core/src/oneshot.ts
+++ b/packages/core/src/oneshot.ts
@@ -41,6 +41,7 @@ import {
   sendGmailMessage,
 } from "./gmail.ts";
 import { gmailAccountFor, resolveIdentities } from "./identities.ts";
+import { listMailboxInbox, listMailboxBounces, sendMailboxReply } from "./mailbox.ts";
 import { sendViaSmartlead, smartleadApiKey } from "./smartlead.ts";
 import { parallelMap, withDeadline } from "./parallel.ts";
 import {
@@ -491,6 +492,9 @@ export async function sendEmail(input: SendEmailInput, ctx: CallContext) {
 }
 
 export interface ReplyEmailInput {
+  /** Direct mailbox: persisted inbound ID and idempotent client send request. */
+  inboundEmailId?: string;
+  sendRequestId?: string;
   /** Sender identity that RECEIVED the inbound email; the reply goes out from it. */
   identityId: string;
   to: string;
@@ -579,13 +583,39 @@ export async function replyEmail(input: ReplyEmailInput, ctx: CallContext) {
     return { result, receiptId };
   }
 
-  // Send-only v1: Smartlead identities produce no inbox rows, so no UI path
-  // reaches here — this guard exists so a future inbox source can't silently
-  // route a "reply" through the paid OneShot wallet from the wrong domain.
   if (identity.provider === "smartlead") {
-    throw new Error(
-      `replies from Smartlead identity '${identity.id}' aren't supported yet — reply in Smartlead's own inbox`,
-    );
+    if (!input.inboundEmailId || !input.sendRequestId)
+      throw new Error(
+        "A stored inbound message and send request ID are required for a threaded mailbox reply.",
+      );
+    const inbound = getLedger().mailboxes.get(input.inboundEmailId);
+    if (inbound?.identityId !== identity.id)
+      throw new Error("Inbound message does not belong to this sender identity.");
+    const sent = await sendMailboxReply(input.inboundEmailId, input.body, input.sendRequestId);
+    const result: EmailResult = {
+      status: "sent",
+      request_id: sent.messageId!,
+      cost: 0,
+      email: { id: sent.id, provider_message_id: sent.messageId!, status: "sent" },
+    };
+    const receiptId = recordCallReceipt({
+      ctx,
+      callType: "email.reply",
+      signedReceipt: {
+        provider: "smartlead",
+        transport: "smtp",
+        message_id: sent.messageId,
+        thread_id: sent.threadKey,
+        from: sent.from,
+        to: sent.to[0],
+        subject: sent.subject,
+      },
+      costUsd: 0,
+      oneshotRequestId: sent.messageId!,
+      senderIdentity: identity.id,
+    });
+    recordContactTouch(sent.to[0]!, ctx.playName);
+    return { result, receiptId };
   }
   if (identity.provider !== "oneshot") {
     throw new Error(`unknown email provider '${identity.provider}' for identity '${identity.id}'`);
@@ -1126,6 +1156,8 @@ async function listOneShotInbox(opts?: {
  * consumers (stop-on-reply reads `from` only) are unaffected.
  */
 export type AnnotatedInboxEmail = InboxEmail & {
+  /** Workspace-local association established from references or an explicit match. */
+  matched_prospect_id?: number;
   message_id?: string;
   source_identity_id?: string;
   /** Header-level autoresponder verdict (Gmail sources only — RFC 3834 et al.). */
@@ -1189,7 +1221,7 @@ export async function listInbox(opts?: {
   const sources: Array<{
     label: string;
     identityId: string;
-    fetch: () => Promise<InboxListResult>;
+    fetch: () => Promise<AnnotatedInboxListResult>;
   }> = [];
   const oneshotIdentity = identities.find((i) => i.provider === "oneshot");
   if (oneshotIdentity) {
@@ -1197,6 +1229,13 @@ export async function listInbox(opts?: {
       label: "oneshot",
       identityId: oneshotIdentity.id,
       fetch: () => listOneShotInbox(opts),
+    });
+  }
+  for (const identity of identities.filter((i) => i.provider === "smartlead")) {
+    sources.push({
+      label: identity.id,
+      identityId: identity.id,
+      fetch: () => listMailboxInbox(identity.id, opts),
     });
   }
   for (const identity of identities.filter((i) => i.provider === "gmail")) {
@@ -1252,7 +1291,12 @@ export async function listInbox(opts?: {
   if (ok.length === 0) {
     throw new Error("all inbox sources failed — check doctor for identity auth status");
   }
-  const failed = sources.filter((_, i) => results[i] == null).map((s) => s.label);
+  const failed = [
+    ...new Set([
+      ...sources.filter((_, i) => results[i] == null).map((s) => s.label),
+      ...ok.flatMap((r) => r.failed_sources ?? []),
+    ]),
+  ];
   return {
     ...mergeInboxWindow(ok, opts?.limit),
     ...(failed.length ? { failed_sources: failed } : {}),
@@ -1343,6 +1387,9 @@ function mergeInboxWindow(
     count: emails.length,
     has_more: results.some((r) => r.has_more) || all.length > max,
     agent_id: results.map((r) => r.agent_id).join("+"),
+    ...(results.some((r) => r.failed_sources?.length)
+      ? { failed_sources: [...new Set(results.flatMap((r) => r.failed_sources ?? []))] }
+      : {}),
   };
 }
 
@@ -1405,7 +1452,11 @@ export async function listBounces(opts?: {
       return [];
     }
   });
-  return { bounces: results.flat(), failedSources };
+  const mailbox = listMailboxBounces(opts);
+  return {
+    bounces: [...results.flat(), ...mailbox.bounces],
+    failedSources: [...failedSources, ...mailbox.failedSources],
+  };
 }
 
 export interface BuildSiteInput {

--- a/packages/core/src/reply-classify.ts
+++ b/packages/core/src/reply-classify.ts
@@ -112,8 +112,8 @@ const UNSUBSCRIBE_RE = new RegExp(
     "\\bremove me\\b",
     "\\btake me off\\b",
     "\\bstop (?:emailing|contacting|messaging)\\b",
-    "\\bdo not (?:contact|email) me\\b",
-    "\\bdon'?t (?:contact|email) me\\b",
+    "\\bdo not (?:ever )?(?:contact|email) me\\b",
+    "\\bdon'?t (?:ever )?(?:contact|email) me\\b",
     "\\bopt me out\\b",
     "\\bnot interested\\b.{0,80}\\b(?:stop|remove|unsubscribe|don'?t)\\b",
   ].join("|"),
@@ -135,8 +135,8 @@ export function classifyReply(input: {
   body?: string | null;
   autoSubmitted?: boolean;
 }): ReplyKind {
-  const subject = input.subject ?? "";
-  const stripped = stripQuotedChain(input.body ?? "");
+  const subject = (input.subject ?? "").replace(/[’‘]/g, "'");
+  const stripped = stripQuotedChain(input.body ?? "").replace(/[’‘]/g, "'");
   const head = stripped.slice(0, BODY_HEAD_CHARS);
   const permanent = PERMANENT_RE.test(subject) || PERMANENT_RE.test(head);
 

--- a/packages/plays/__tests__/cadence-reply.test.ts
+++ b/packages/plays/__tests__/cadence-reply.test.ts
@@ -13,6 +13,7 @@ let inboxEmails: Array<{
   received_at?: string;
   body?: string;
   auto_submitted?: boolean;
+  matched_prospect_id?: number;
 }> = [];
 let lookupArgs: string[] = [];
 let listInboxArgs: Array<Record<string, unknown>> = [];
@@ -94,6 +95,7 @@ vi.mock("@oneshot-gtm/core", async () => {
       };
     },
     getLedger: () => ({
+      mailboxes: { acknowledge: () => {} },
       findDirectMail: () => null,
       listAllCadences: () => rows,
       listActiveCadences: ({ dueByIso }: { dueByIso: string }) =>
@@ -321,6 +323,30 @@ describe("advanceCadence — reply detection", () => {
 });
 
 describe("pollInboxReplies — standalone background detection (no sends)", () => {
+  it("stops the matched prospect's cadence when a mailbox reply comes from an alternate address", async () => {
+    rows = [
+      {
+        prospect_id: 1,
+        play_name: "test",
+        status: "active",
+        next_due_at: null,
+        prospect_email: STORED_EMAIL,
+      },
+    ];
+    inboxEmails = [
+      {
+        id: "mailbox:alternate",
+        from: "alternate@example.org",
+        subject: "Re: hello",
+        body: "Interested",
+        matched_prospect_id: 1,
+      },
+    ];
+    const result = await pollInboxReplies();
+    expect(rows[0]?.status).toBe("replied");
+    expect(result.cadencesStopped).toBe(1);
+    expect(calls.sendEmail).toBe(0);
+  });
   it("flips a matching active cadence to replied and records the reply event", async () => {
     inboxEmails = [{ from: "Sophia <sophia@agenticarchitect.ai>", subject: "re: stack" }];
 

--- a/packages/plays/src/_cadence.ts
+++ b/packages/plays/src/_cadence.ts
@@ -507,7 +507,10 @@ async function walkInboxWindow(
         if (pageOldest == null || e.received_at < pageOldest) pageOldest = e.received_at;
       }
       const from = normalizeEmail(e.from);
-      const prospect = ledger.findProspectByEmail(from);
+      const prospect =
+        e.matched_prospect_id != null
+          ? ledger.getProspectById(e.matched_prospect_id)
+          : ledger.findProspectByEmail(from);
       if (!prospect) continue;
       // Autoresponders (OOO, "no longer here") and unsubscribe requests are
       // NOT replies: they must not stop cadences as engagement, move the reply
@@ -622,6 +625,7 @@ async function walkInboxWindow(
             out.cadencesStopped++;
           }
         }
+        if (e.id.startsWith("mailbox:")) ledger.mailboxes.acknowledge(e.id, prospect.id);
         continue;
       }
       // Sentiment/intent classification (issue #480), via the existing
@@ -686,6 +690,7 @@ async function walkInboxWindow(
           valueTag: { type: "engagement", label: "reply" },
         });
       }
+      if (e.id.startsWith("mailbox:")) ledger.mailboxes.acknowledge(e.id, prospect.id);
     }
     if (pageOldest && (res.oldest == null || pageOldest < res.oldest)) res.oldest = pageOldest;
 

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -900,6 +900,7 @@ export const POSITIVE_REPLY_INTENTS: readonly ReplyIntent[] = [
 
 /** A single inbox email (reply to outreach), with prospect/play context when matched. */
 export interface InboxReplyView {
+  bounceKind?: "hard" | "block" | "soft" | null;
   id: string;
   /** What this inbound actually is — only `human` counts as a reply anywhere. */
   kind: InboundReplyKind;
@@ -1021,6 +1022,9 @@ export interface ConversationView {
 }
 
 export interface InboxResult {
+  /** Durable direct-mailbox threads, separate from legacy per-prospect conversations. */
+  mailboxThreads?: MailboxThreadView[];
+  mailboxes?: MailboxHealthView[];
   replies: InboxReplyView[];
   /** Threaded matched view: one entry per prospect with a recorded reply. */
   conversations?: ConversationView[];
@@ -1093,6 +1097,8 @@ export type InboxSteerResult = InboxDraftReplyResult;
 
 /** POST /api/inbox/reply — send a (possibly edited) reply. */
 export interface InboxSendReplyRequest {
+  inboundEmailId?: string;
+  sendRequestId?: string;
   to: string;
   subject: string;
   body: string;
@@ -1109,6 +1115,46 @@ export interface InboxSendReplyResult {
   sent: boolean;
   id: string;
   costUsd: number;
+}
+
+export interface MailboxHealthView {
+  identityId: string;
+  address: string;
+  lastSyncAt: string | null;
+  status: "syncing" | "connected" | "error" | "disconnected";
+  error: string | null;
+  backfillRemaining: boolean;
+  messages: number;
+}
+
+export interface MailboxThreadView {
+  threadKey: string;
+  identityId: string;
+  mailboxAddress: string;
+  prospectId: number | null;
+  name: string | null;
+  company: string | null;
+  email: string;
+  unread: boolean;
+  archivedAt: string | null;
+  historyComplete: boolean;
+  lastActivityAt: string;
+  reply: InboxReplyView;
+  items: ConversationItem[];
+}
+
+export interface MailboxStateRequest {
+  threadKey: string;
+  observedReplyIds: string[];
+  read?: boolean;
+  archived?: boolean;
+}
+
+export interface MailboxConnectionRequest {
+  identityId: string;
+  address: string;
+  imap: { host: string; port: number; secure: boolean; user: string; pass: string };
+  smtp: { host: string; port: number; secure: boolean; user: string; pass: string };
 }
 
 export interface QueueCounts {


### PR DESCRIPTION
Smartlead identities previously sent outreach without receiving replies in the workspace inbox. This adds workspace-scoped IMAP sync and SMTP replies so connected mailboxes show complete conversations and preserve the original threading headers.

- Discover Smartlead identities per workspace, import recent history and recorded outreach, and poll every minute with persistent checkpoints and connection health.
- Add drafts, prospect matching, read/unread, archive/restore, and reopening on new inbound mail. Draft generation and persistence use stored inbound context. Thread organization stays local to the workspace.
- Persist send attempts to prevent duplicate replies, reconcile uncertain SMTP sends against Sent mail, and allow new attempts after definite rejection.
- Classify opt-outs and delivery failures, exclude opted-out prospects from revival selection, and keep warmup delivery notices out of outreach bounce metrics.
- Expose a cross-channel opt-out guard that overrides historical reply signals and catches mailbox verdicts before cadence processing. The maintainer-local LinkedIn sync uses this guard for selection and before enrollment; its private adapter remains outside this public repository.

Validation: all 3,928 tests across 298 files pass, alongside typecheck, formatting, lint (no errors), and web/server builds. The maintainer-local LinkedIn suite also passes (76 tests). Live verification connected all six GTM mailboxes, confirmed a threaded roundtrip between two user-owned test mailboxes, and confirmed the opted-out prospect is excluded from both LinkedIn audiences.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Smartlead mailbox support with automatic inbox syncing while the workspace server is running.
  * View, read, archive, restore, and match mailbox threads to prospects.
  * Connect mailboxes using IMAP/SMTP settings and monitor connection health.
  * Send threaded replies directly from the inbox with reliable retry handling.
  * Inbox alerts now include unread human replies.

* **Bug Fixes**
  * Improved unsubscribe detection, including alternate sender addresses and curly apostrophes.
  * Prevented workspace launches from inheriting another workspace’s Smartlead credentials.

* **Documentation**
  * Added guidance for configuring Smartlead inboxes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->