### PR TITLE
feat(plays): one tighter redraft when a first-touch body is over the word cap

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 67 CLI commands, 23 plays, 15 finders, ten dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-11** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3928 tests / 298 files** · typecheck + oxlint + oxfmt pass (40 lint warnings, 0 errors).
+Last verified **2026-09-11** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3935 tests / 299 files** · typecheck + oxlint + oxfmt pass (40 lint warnings, 0 errors).
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/packages/plays/__tests__/draft-length-retry.test.ts
+++ b/packages/plays/__tests__/draft-length-retry.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// A draft that comes back over the play's body cap earns exactly one redraft
+// with a tighter budget stated in the message; the shorter draft wins; a
+// failed redraft returns the original. Motivated by kimi-k3/k2.6 writing
+// ~135-160 words against a 150 cap where gemini wrote ~106 (2026-09-11).
+
+const responses: string[] = [];
+const calls: Array<Array<{ role: string; content: string }>> = [];
+const events: Array<{ kind: string; ctx: Record<string, unknown> }> = [];
+
+vi.mock("@oneshot-gtm/core", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/core")>("@oneshot-gtm/core");
+  return {
+    ...actual,
+    loadConfig: () => ({
+      llmProvider: "anthropic",
+      llmModel: "test",
+      founderName: "Founder",
+      productOneLiner: "thing",
+      productDomain: null,
+      founderCredentials: null,
+      productPortfolio: null,
+      partners: null,
+      founderCohort: null,
+      mobileSignature: false,
+      clientId: "test",
+    }),
+    logEvent: (kind: string, ctx: Record<string, unknown>) => {
+      events.push({ kind, ctx });
+    },
+  };
+});
+vi.mock("@oneshot-gtm/intel", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/intel")>("@oneshot-gtm/intel");
+  return {
+    ...actual,
+    loadPrompt: () => "write an email",
+    complete: async (input: { messages: Array<{ role: string; content: string }> }) => {
+      calls.push(input.messages.map((m) => ({ ...m })));
+      const next = responses.shift();
+      if (next === undefined) throw new Error("no more responses");
+      if (next === "THROW") throw new Error("provider down");
+      return { content: next, provider: "t", model: "t" };
+    },
+  };
+});
+
+const { draftEmailFromPrompt, LENGTH_RETRY_RATIO } = await import("../src/_lib.ts");
+
+const words = (n: number): string => Array.from({ length: n }, (_, i) => `w${i}`).join(" ");
+const json = (body: string): string => JSON.stringify({ subject: "subject", body });
+
+beforeEach(() => {
+  responses.length = 0;
+  calls.length = 0;
+  events.length = 0;
+});
+
+describe("draftEmailFromPrompt length retry", () => {
+  it("makes no second call when the body is within the cap", async () => {
+    responses.push(json(words(120)));
+    const d = await draftEmailFromPrompt({ promptName: "p", inputBlock: "x", maxBodyWords: 150 });
+    expect(d.body.split(" ")).toHaveLength(120);
+    expect(calls).toHaveLength(1);
+    expect(events.map((e) => e.kind)).not.toContain("email.draft.too_long_retry");
+  });
+
+  it("makes no second call at all when no cap is given (legacy callers)", async () => {
+    responses.push(json(words(400)));
+    await draftEmailFromPrompt({ promptName: "p", inputBlock: "x" });
+    expect(calls).toHaveLength(1);
+  });
+
+  it("over the cap: one redraft asking for three quarters of it, in the same conversation", async () => {
+    responses.push(json(words(163)), json(words(118)));
+    const d = await draftEmailFromPrompt({ promptName: "p", inputBlock: "x", maxBodyWords: 150 });
+    expect(calls).toHaveLength(2);
+    expect(d.body.split(" ")).toHaveLength(118);
+    const second = calls[1]!;
+    // The first draft is on the record as the assistant turn, then the ask.
+    expect(second.at(-2)?.role).toBe("assistant");
+    expect(second.at(-2)?.content).toContain("w162");
+    const ask = second.at(-1)!;
+    expect(ask.role).toBe("user");
+    expect(ask.content).toContain("163 words");
+    expect(ask.content).toContain(`at most ${Math.floor(150 * LENGTH_RETRY_RATIO)} words`);
+    expect(ask.content).toMatch(/Cut whole sentences/);
+    const ev = events.find((e) => e.kind === "email.draft.too_long_retry")!;
+    expect(ev.ctx).toMatchObject({ words: 163, cap: 150, retry_words: 118, kept: "retry" });
+  });
+
+  it("keeps the shorter draft even when the redraft is still over the cap — lint decides", async () => {
+    responses.push(json(words(170)), json(words(155)));
+    const d = await draftEmailFromPrompt({ promptName: "p", inputBlock: "x", maxBodyWords: 150 });
+    expect(d.body.split(" ")).toHaveLength(155);
+    expect(calls).toHaveLength(2);
+  });
+
+  it("keeps the original when the redraft is not shorter", async () => {
+    responses.push(json(words(160)), json(words(165)));
+    const d = await draftEmailFromPrompt({ promptName: "p", inputBlock: "x", maxBodyWords: 150 });
+    expect(d.body.split(" ")).toHaveLength(160);
+    const ev = events.find((e) => e.kind === "email.draft.too_long_retry")!;
+    expect(ev.ctx.kept).toBe("original");
+  });
+
+  it("a failed redraft returns the original draft, never throws", async () => {
+    responses.push(json(words(160)), "THROW");
+    const d = await draftEmailFromPrompt({ promptName: "p", inputBlock: "x", maxBodyWords: 150 });
+    expect(d.body.split(" ")).toHaveLength(160);
+    expect(events.map((e) => e.kind)).toContain("email.draft.too_long_retry_failed");
+  });
+
+  it("never runs more than one redraft", async () => {
+    responses.push(json(words(160)), json(words(158)), json(words(50)));
+    const d = await draftEmailFromPrompt({ promptName: "p", inputBlock: "x", maxBodyWords: 150 });
+    expect(calls).toHaveLength(2);
+    expect(d.body.split(" ")).toHaveLength(158);
+  });
+});

--- a/packages/plays/src/_lib.ts
+++ b/packages/plays/src/_lib.ts
@@ -712,17 +712,52 @@ export function meetingBlock(
   return lines.join("\n");
 }
 
+type DraftMessages = Array<{ role: "system" | "user" | "assistant"; content: string }>;
+
+interface DraftCallOpts {
+  promptName: string;
+  temperature?: number;
+  maxTokens?: number;
+}
+
+/**
+ * The redraft asks for this share of the cap, not the cap itself: a model
+ * that just wrote 160 words against "150" will land near 150 again if told
+ * "150". Measured 2026-09-11 on accelerator-batch (cap 150): gemini-3.8-flash
+ * averaged 106 words and never crossed; kimi-k3 crossed on 2 of 4, kimi-k2.6
+ * on 1 of 6, both by 10-16 words. Three quarters leaves room for that drift.
+ */
+export const LENGTH_RETRY_RATIO = 0.75;
+
 export async function draftEmailFromPrompt(opts: {
   promptName: string;
   inputBlock: string;
   temperature?: number;
   maxTokens?: number;
+  /**
+   * The play's body cap (what `lintEmail` will hold the draft at). When set,
+   * a draft that comes back over it earns ONE redraft with a tighter budget
+   * stated in the message, so a wordy model doesn't turn into a lint-held
+   * send. Absent → the draft is returned as written.
+   */
+  maxBodyWords?: number;
 }): Promise<DraftedEmail> {
   const system = loadPrompt(opts.promptName) + signatureDirective();
-  const messages: Array<{ role: "system" | "user" | "assistant"; content: string }> = [
+  const messages: DraftMessages = [
     { role: "system", content: system },
     { role: "user", content: opts.inputBlock },
   ];
+  const draft = await draftOnce(messages, opts);
+  if (opts.maxBodyWords === undefined) return draft;
+  return tightenIfTooLong(messages, draft, opts.maxBodyWords, opts);
+}
+
+/**
+ * One draft: up to two calls, the second only when the first could not be read
+ * as a subject/body JSON object. Appends to `messages` so a caller that wants
+ * to continue the conversation (the length redraft) has the real history.
+ */
+async function draftOnce(messages: DraftMessages, opts: DraftCallOpts): Promise<DraftedEmail> {
   for (let attempt = 0; attempt < 2; attempt++) {
     const res = await complete({
       messages,
@@ -749,6 +784,60 @@ export async function draftEmailFromPrompt(opts: {
   throw new Error(
     "Draft generation failed: the model returned invalid or empty subject/body twice. Try regenerating.",
   );
+}
+
+/**
+ * Over the cap → one redraft in the same conversation, asking for
+ * `LENGTH_RETRY_RATIO` of the cap and to cut sentences rather than compress
+ * them. The shorter of the two drafts wins, even when the redraft is still
+ * over — lint decides what is sendable, this only stops a model's house style
+ * from holding every other send. A failed redraft returns the original.
+ */
+async function tightenIfTooLong(
+  messages: DraftMessages,
+  draft: DraftedEmail,
+  maxBodyWords: number,
+  opts: DraftCallOpts,
+): Promise<DraftedEmail> {
+  const words = bodyWordsForLint(draft.body);
+  if (words <= maxBodyWords) return draft;
+  const target = Math.max(30, Math.floor(maxBodyWords * LENGTH_RETRY_RATIO));
+  messages.push(
+    { role: "assistant", content: JSON.stringify({ subject: draft.subject, body: draft.body }) },
+    {
+      role: "user",
+      content:
+        `That body is ${words} words; this email is held at ${maxBodyWords}. Rewrite it in at most ${target} words. ` +
+        "Keep the subject, the facts, the one argument and the closing question. Cut whole sentences rather than compressing them into longer ones. " +
+        'Return only the JSON object with "subject" and "body".',
+    },
+  );
+  let retry: DraftedEmail;
+  try {
+    retry = await draftOnce(messages, opts);
+  } catch (err) {
+    logEvent(
+      "email.draft.too_long_retry_failed",
+      {
+        promptName: opts.promptName,
+        words,
+        cap: maxBodyWords,
+        message_120: (err as Error).message.slice(0, 120),
+      },
+      "warn",
+    );
+    return draft;
+  }
+  const retryWords = bodyWordsForLint(retry.body);
+  logEvent("email.draft.too_long_retry", {
+    promptName: opts.promptName,
+    words,
+    cap: maxBodyWords,
+    target,
+    retry_words: retryWords,
+    kept: retryWords < words ? "retry" : "original",
+  });
+  return retryWords < words ? retry : draft;
 }
 
 function parseSubjectBody(raw: string): DraftedEmail | null {

--- a/packages/plays/src/_run-play.ts
+++ b/packages/plays/src/_run-play.ts
@@ -311,6 +311,9 @@ export async function runEmailPlay<T, X = Record<string, never>>(
         const draft = await draftEmailFromPrompt({
           promptName: def.promptName,
           inputBlock,
+          // The same cap lintEmail holds at, so an over-long first pass gets
+          // one tighter redraft instead of becoming a lint-held send.
+          maxBodyWords: def.maxBodyWords,
         });
 
         const flags = [


### PR DESCRIPTION
## Why

`body-too-long` blocks a send. With `llmModel` on `moonshotai/kimi-k2.6` (switched today; `reasoning.mandatory: false`, so no #586 truncation) drafts run ~135 words against gemini's ~106 on the same prompt, and cross the accelerator-batch cap of 150 about one time in six (kimi-k3: two in four). Every one of those is a held send.

## What

`draftEmailFromPrompt({ maxBodyWords })` — set by `_run-play.ts` from the play def — does **one** redraft when the body comes back over the cap: same conversation, the first draft on the record as the assistant turn, and an ask for `LENGTH_RETRY_RATIO` (0.75) of the cap, cutting whole sentences rather than compressing. The shorter of the two wins even if the redraft is still over (lint remains the judge); a failed redraft returns the original. Event `email.draft.too_long_retry` carries words / cap / target / retry_words / kept.

Not covered: cadence follow-ups (`_cadence.ts` calls `complete` directly).

## Verified

- 7 new tests in `packages/plays/__tests__/draft-length-retry.test.ts`: no call within cap; none without a cap (legacy callers); one redraft with the tighter ask and the first draft as prior turn; shorter-wins when still over; original kept when redraft is longer; failed redraft → original; never a second redraft.
- Live on the gtm server: 8 regenerations, one draft came back at 162 words → redraft asked for 112 → 114, `flags=[]`; all 8 under the cap.
- `bun run typecheck`, `lint`, `fmt:check`; `vitest` 3935 tests / 299 files (STATUS.md stamped).

https://claude.ai/code/session_011meFPo97LhmTcoNRwyPQeS


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Email drafts can now be checked against each play’s maximum body length.
  - When an initial draft is too long, the system may generate one shorter revision and keep the better result.
  - Draft generation preserves the original when a shorter revision cannot be produced.

- **Tests**
  - Added coverage for length limits, retry behavior, fallback handling, and retry event reporting.

- **Documentation**
  - Updated verification metrics to reflect 3,935 tests across 299 files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->