### PR TITLE
fix(reject): prefill from the dossier and company facts, not the finder's provenance line

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 67 CLI commands, 23 plays, 15 finders, ten dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-11** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3949 tests / 300 files** · typecheck + oxlint + oxfmt pass (41 lint warnings, 0 errors).
+Last verified **2026-09-11** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3960 tests / 301 files** · typecheck + oxlint + oxfmt pass (41 lint warnings, 0 errors).
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/apps/server/__tests__/reject-route.test.ts
+++ b/apps/server/__tests__/reject-route.test.ts
@@ -24,13 +24,27 @@ vi.mock("@oneshot-gtm/core", async () => {
     }),
   };
 });
+const enrichMock = vi.fn();
+vi.mock("@oneshot-gtm/find", async () => {
+  const actual = await vi.importActual<typeof import("@oneshot-gtm/find")>("@oneshot-gtm/find");
+  return {
+    ...actual,
+    safeEnrichCompany: enrichMock,
+    isDudDomain: (d: string | null | undefined) => d === "gmail.com",
+  };
+});
 vi.mock("@oneshot-gtm/plays", async () => {
   const actual = await vi.importActual<typeof import("@oneshot-gtm/plays")>("@oneshot-gtm/plays");
   return { ...actual, generateRejectReason: generateMock };
 });
 
-const { parseRejectReason, rejectQueueRoute, suggestRejectReasonRoute, REJECT_REASON_MAX_CHARS } =
-  await import("../src/api/queue.ts");
+const {
+  parseRejectReason,
+  rejectLookupDomain,
+  rejectQueueRoute,
+  suggestRejectReasonRoute,
+  REJECT_REASON_MAX_CHARS,
+} = await import("../src/api/queue.ts");
 
 function post(id: string, body?: unknown): Request {
   return new Request(`http://x/api/queue/${id}/reject`, {
@@ -44,6 +58,7 @@ beforeEach(() => {
   prospectsById.clear();
   statusCalls.length = 0;
   generateMock.mockReset();
+  enrichMock.mockReset();
   queueRows.set(7, {
     id: 7,
     play_name: "luma-events",
@@ -131,21 +146,111 @@ describe("suggestRejectReasonRoute", () => {
     expect(await res.json()).toEqual({
       reason: "Recruiter, not the person who buys.",
       source: "llm",
+      researched: false,
     });
     expect(generateMock).toHaveBeenCalledWith(
       expect.objectContaining({
         playName: "luma-events",
         payload: expect.objectContaining({ company: "Acme" }),
         dossier: "dossier text",
+        company: null,
       }),
     );
+    // A stored dossier means no paid lookup.
+    expect(enrichMock).not.toHaveBeenCalled();
     expect(statusCalls).toHaveLength(0);
+  });
+
+  it("with no dossier, looks the company up by the address domain and hands the record to the generator", async () => {
+    queueRows.set(8, {
+      id: 8,
+      play_name: "luma-events",
+      status: "approved",
+      payload_json: JSON.stringify({ email: "bruno@magna.so", company: "Magna" }),
+      prospect_id: null,
+      notes: "Bruno going to a founders breakfast",
+    });
+    enrichMock.mockResolvedValue({
+      result: {
+        status: "ok",
+        company: {
+          name: "Magna",
+          employee_count: 80,
+          funding_stage: "series_b",
+          founded_year: 2014,
+        },
+        cost: 0.005,
+      },
+      receiptId: 1,
+    });
+    generateMock.mockResolvedValue(
+      "Founded 2014, ~80 employees, Series B: past founder-led sales.",
+    );
+    const res = await ask("8");
+    expect(await res.json()).toEqual({
+      reason: "Founded 2014, ~80 employees, Series B: past founder-led sales.",
+      source: "llm",
+      researched: true,
+    });
+    expect(enrichMock).toHaveBeenCalledWith(
+      { domain: "magna.so" },
+      expect.objectContaining({ playName: "luma-events" }),
+    );
+    expect(generateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        dossier: null,
+        company: expect.objectContaining({ founded_year: 2014, employee_count: 80 }),
+      }),
+    );
+  });
+
+  it("skips the lookup for a personal-provider address and on a failed record", async () => {
+    queueRows.set(9, {
+      id: 9,
+      play_name: "luma-events",
+      status: "approved",
+      payload_json: JSON.stringify({ email: "someone@gmail.com" }),
+      prospect_id: null,
+      notes: null,
+    });
+    generateMock.mockResolvedValue(null);
+    expect(await (await ask("9")).json()).toEqual({
+      reason: null,
+      source: null,
+      researched: false,
+    });
+    expect(enrichMock).not.toHaveBeenCalled();
+
+    queueRows.set(10, {
+      id: 10,
+      play_name: "show-hn",
+      status: "pending",
+      payload_json: JSON.stringify({ email: "x@acme.dev" }),
+      prospect_id: null,
+      notes: null,
+    });
+    enrichMock.mockResolvedValue({
+      result: { status: "error", company: {}, cost: 0 },
+      receiptId: 0,
+    });
+    expect(await (await ask("10")).json()).toEqual({
+      reason: null,
+      source: null,
+      researched: false,
+    });
+    expect(generateMock).toHaveBeenLastCalledWith(expect.objectContaining({ company: null }));
+  });
+
+  it("rejectLookupDomain prefers the address domain and falls back to the payload's own", () => {
+    expect(rejectLookupDomain({ email: "A@Magna.so" })).toBe("magna.so");
+    expect(rejectLookupDomain({ companyDomain: "https://www.acme.dev/about" })).toBe("acme.dev");
+    expect(rejectLookupDomain({ name: "nobody" })).toBeNull();
   });
 
   it("a null from the generator is a null to the box, not an error", async () => {
     generateMock.mockResolvedValue(null);
     const res = await ask("7");
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual({ reason: null, source: null });
+    expect(await res.json()).toEqual({ reason: null, source: null, researched: false });
   });
 });

--- a/apps/server/__tests__/reject-route.test.ts
+++ b/apps/server/__tests__/reject-route.test.ts
@@ -193,7 +193,7 @@ describe("suggestRejectReasonRoute", () => {
       researched: true,
     });
     expect(enrichMock).toHaveBeenCalledWith(
-      { domain: "magna.so" },
+      { domain: "magna.so", timeoutMs: expect.any(Number) },
       expect.objectContaining({ playName: "luma-events" }),
     );
     expect(generateMock).toHaveBeenCalledWith(
@@ -244,6 +244,8 @@ describe("suggestRejectReasonRoute", () => {
   it("rejectLookupDomain prefers the address domain and falls back to the payload's own", () => {
     expect(rejectLookupDomain({ email: "A@Magna.so" })).toBe("magna.so");
     expect(rejectLookupDomain({ companyDomain: "https://www.acme.dev/about" })).toBe("acme.dev");
+    expect(rejectLookupDomain({ companyDomain: " HTTPS://WWW.Acme.dev?ref=x " })).toBe("acme.dev");
+    expect(rejectLookupDomain({ domain: "acme.dev#team" })).toBe("acme.dev");
     expect(rejectLookupDomain({ name: "nobody" })).toBeNull();
   });
 

--- a/apps/server/src/api/queue.ts
+++ b/apps/server/src/api/queue.ts
@@ -470,12 +470,16 @@ export function rejectLookupDomain(payload: unknown): string | null {
       : typeof p.domain === "string"
         ? p.domain
         : "";
+  // Normalize first, then peel: scheme, www., and anything from the first
+  // path, query or fragment separator on. " HTTPS://WWW.Acme.dev?ref=x " is
+  // acme.dev, not "https:".
   const domain = (fromEmail || own)
+    .trim()
+    .toLowerCase()
     .replace(/^https?:\/\//, "")
     .replace(/^www\./, "")
-    .split("/")[0]!
-    .trim()
-    .toLowerCase();
+    .split(/[/?#]/)[0]!
+    .trim();
   return domain || null;
 }
 
@@ -517,17 +521,22 @@ export async function suggestRejectReasonRoute(
   let company: Record<string, unknown> | null = null;
   const domain = dossier?.trim() ? null : rejectLookupDomain(payload);
   if (domain && !isDudDomain(domain)) {
+    // The SDK gets the deadline too (totalTimeoutMs), so a slow lookup is
+    // cancelled end to end rather than merely released here.
+    let timer: ReturnType<typeof setTimeout> | undefined;
     const enriched = await Promise.race([
       safeEnrichCompany(
-        { domain },
+        { domain, timeoutMs: REJECT_ENRICH_DEADLINE_MS },
         {
           playName: row.play_name,
           memo: "company facts before prefilling a reject reason",
           decisionContext: { reason: "queue row has no dossier; reject box prefill", queueId: id },
         },
       ),
-      new Promise<null>((resolve) => setTimeout(() => resolve(null), REJECT_ENRICH_DEADLINE_MS)),
-    ]);
+      new Promise<null>((resolve) => {
+        timer = setTimeout(() => resolve(null), REJECT_ENRICH_DEADLINE_MS + 500);
+      }),
+    ]).finally(() => clearTimeout(timer));
     const record = enriched && enriched.result.status !== "error" ? enriched.result.company : null;
     if (record && Object.keys(record).length > 0) company = record as Record<string, unknown>;
   }

--- a/apps/server/src/api/queue.ts
+++ b/apps/server/src/api/queue.ts
@@ -13,7 +13,13 @@ import {
   type QueueStatus,
   type TelemetryOutcome,
 } from "@oneshot-gtm/core";
-import { drainQueue, rankPendingRows, resolveQueueTarget } from "@oneshot-gtm/find";
+import {
+  drainQueue,
+  isDudDomain,
+  rankPendingRows,
+  resolveQueueTarget,
+  safeEnrichCompany,
+} from "@oneshot-gtm/find";
 import {
   MANUAL_PLAYS,
   enrollInCadence,
@@ -450,12 +456,42 @@ export async function rejectQueueRoute(
   return jsonResponse({ ok: true }, 200, req);
 }
 
+/** How long the reject box waits on a company lookup before judging without it. */
+const REJECT_ENRICH_DEADLINE_MS = 12_000;
+
+/** The domain a company lookup can key on: the address's, else the payload's own. */
+export function rejectLookupDomain(payload: unknown): string | null {
+  const p = payload && typeof payload === "object" ? (payload as Record<string, unknown>) : {};
+  const email = typeof p.email === "string" ? p.email.trim().toLowerCase() : "";
+  const fromEmail = email.includes("@") ? email.split("@")[1]! : "";
+  const own =
+    typeof p.companyDomain === "string"
+      ? p.companyDomain
+      : typeof p.domain === "string"
+        ? p.domain
+        : "";
+  const domain = (fromEmail || own)
+    .replace(/^https?:\/\//, "")
+    .replace(/^www\./, "")
+    .split("/")[0]!
+    .trim()
+    .toLowerCase();
+  return domain || null;
+}
+
 /**
  * The reject box's LLM fallback: when the row carries neither a person-gate
- * verdict reason nor a finder note, the web asks for one sentence on why this
- * prospect might not fit. Preview only — nothing is written, nothing is
- * decided. A provider failure or a model that sees no mismatch both answer
- * `{ reason: null }`, and the box simply stays empty.
+ * verdict reason nor a machine-negative note, the web asks for one sentence
+ * on why this prospect might not fit. Preview only — nothing is written,
+ * nothing is decided. A provider failure or a model that sees no mismatch
+ * both answer `{ reason: null }`, and the box simply stays empty.
+ *
+ * A row with no stored dossier gets one bounded company lookup by domain
+ * (SDK enrichCompany, $0.005), so the facts a stage judgment turns on —
+ * founded year, headcount, funding stage — reach the model. Row #882
+ * (2026-09-11) was a ten-year-old company whose only evidence was the
+ * breakfast it attended. Best-effort: a personal-provider address, a
+ * failure, or a slow answer all leave the lookup out.
  */
 export async function suggestRejectReasonRoute(
   req: Request,
@@ -478,9 +514,28 @@ export async function suggestRejectReasonRoute(
     row.prospect_id != null
       ? (ledger.getProspectById(row.prospect_id)?.dossier_json ?? null)
       : null;
-  const reason = await generateRejectReason({ playName: row.play_name, payload, dossier });
+  let company: Record<string, unknown> | null = null;
+  const domain = dossier?.trim() ? null : rejectLookupDomain(payload);
+  if (domain && !isDudDomain(domain)) {
+    const enriched = await Promise.race([
+      safeEnrichCompany(
+        { domain },
+        {
+          playName: row.play_name,
+          memo: "company facts before prefilling a reject reason",
+          decisionContext: { reason: "queue row has no dossier; reject box prefill", queueId: id },
+        },
+      ),
+      new Promise<null>((resolve) => setTimeout(() => resolve(null), REJECT_ENRICH_DEADLINE_MS)),
+    ]);
+    const record = enriched && enriched.result.status !== "error" ? enriched.result.company : null;
+    if (record && Object.keys(record).length > 0) company = record as Record<string, unknown>;
+  }
+  const reason = await generateRejectReason({ playName: row.play_name, payload, dossier, company });
   return jsonResponse(
-    reason ? { reason, source: "llm" } : { reason: null, source: null },
+    reason
+      ? { reason, source: "llm", researched: company !== null }
+      : { reason: null, source: null, researched: company !== null },
     200,
     req,
   );

--- a/apps/web/__tests__/rejectReason.test.ts
+++ b/apps/web/__tests__/rejectReason.test.ts
@@ -43,7 +43,7 @@ describe("suggestRejectReason", () => {
     ).toBe("Role unclear from the bio.");
   });
 
-  it("falls back to the finder's note with the machine prefix stripped", () => {
+  it("falls back to a machine-negative note with the prefix stripped", () => {
     expect(
       suggestRejectReason({ payload: {}, notes: "auto: role — Recruiter, not a founder." }),
     ).toEqual({
@@ -54,9 +54,22 @@ describe("suggestRejectReason", () => {
       "Consumer app, no business buyer.",
     );
     expect(reasonFromNotes("auto: dedup — not re-sent")).toBe("not re-sent");
-    expect(reasonFromNotes("Wrong segment; already spoke last year.")).toBe(
-      "Wrong segment; already spoke last year.",
+  });
+
+  it("a note without the prefix is the finder's provenance, never a reason, so the dossier tier runs", () => {
+    // Row #882 (2026-09-11) opened with the event name below and the LLM
+    // fallback never ran; the company was ten years old.
+    expect(reasonFromNotes("Bruno Faviero going to Corgi Founders Breakfast Club with Rho")).toBe(
+      "",
     );
+    expect(reasonFromNotes("starred langchain/langchain 3d ago — owns acquisition")).toBe("");
+    expect(reasonFromNotes("Wrong segment; already spoke last year.")).toBe("");
+    expect(
+      suggestRejectReason({
+        payload: { icpVerdict: "pass", icpVerdictReason: "Co-founder, owns acquisition" },
+        notes: "Bruno Faviero going to Corgi Founders Breakfast Club with Rho",
+      }),
+    ).toEqual({ text: "", source: null });
   });
 
   it("never surfaces the gates' pass-throughs, CSV status strings, or a bare token", () => {

--- a/apps/web/src/lib/rejectReason.ts
+++ b/apps/web/src/lib/rejectReason.ts
@@ -7,7 +7,11 @@
  *  - the person gate's verdict reason, when the verdict was `reject` or
  *    `unclear` — that sentence is literally "why they don't fit", which is
  *    exactly why `stampFitReason` refuses to promote it to the fit line;
- *  - the finder's own note, once the machine prefix is gone.
+ *  - the finder's own note, once the machine prefix is gone — but only a
+ *    machine negative (`auto: …`). A finder note without the prefix is
+ *    provenance ("Bruno going to Corgi Founders Breakfast Club"), not a
+ *    reason, and prefilling it hid the one tier that reads the dossier:
+ *    the box opened with the event name and the LLM fallback never ran.
  *
  * The prefix matters: `auto:` is how `isAutoRejected` in score-prospects and
  * the pre-v26 `isHumanDecision` arm tell a machine negative from a human one,
@@ -59,13 +63,16 @@ function str(v: unknown): string {
   return typeof v === "string" ? v.replace(/\s+/g, " ").trim() : "";
 }
 
-/** A note with the machine prefix removed, or "" when nothing usable is left. */
+/**
+ * A machine negative with its prefix removed, or "" when the note is not one.
+ * Only `auto:` notes are reasons; anything else on a pending or approved row
+ * is the finder's provenance line, which the LLM tier reads as evidence
+ * instead of the founder reading it as a verdict.
+ */
 export function reasonFromNotes(notes: string | null | undefined): string {
   let s = str(notes);
-  if (!s) return "";
-  if (AUTO_PREFIX.test(s)) {
-    s = s.replace(AUTO_PREFIX, "").replace(COHORT_LABEL, "").trim();
-  }
+  if (!s || !AUTO_PREFIX.test(s)) return "";
+  s = s.replace(AUTO_PREFIX, "").replace(COHORT_LABEL, "").trim();
   if (s.length < MIN_REASON_CHARS || NOT_A_REASON.has(s.toLowerCase()) || DIAGNOSTIC.test(s)) {
     return "";
   }

--- a/docs/prompt-inputs.md
+++ b/docs/prompt-inputs.md
@@ -160,15 +160,21 @@ plays, including manual DMs; it is not added to run results or inbox replies.
 
 ## Reject reason
 
-The reject box on `/queue` and `/prospects` opens prefilled. Nothing reaches a
-model for that: the box takes the person gate's verdict reason when the verdict
-was _reject_ or _unclear_, else the finder's own note with its `auto:` prefix
-removed. Only when a row has neither — most approved rows, where the gate said
-_pass_ — does the `/queue` modal ask `reject-reason.md` for one sentence, from
-the same inputs as the fit line: the ICP one-liner, the play name and the
-prospect's own evidence (company, title, bio, event, repo, research excerpt).
-It never sees names, emails or URLs, may answer null, and its sentence is only
-a suggestion in the box until the founder submits. What is submitted is
+The reject box on `/queue` and `/prospects` opens prefilled. Two tiers are free:
+the person gate's verdict reason when the verdict was _reject_ or _unclear_,
+else a machine-negative note (`auto: …`) with its prefix removed. A finder note
+without the prefix is provenance ("going to the founders breakfast"), not a
+reason, and is never prefilled. Every other row — most approved rows, where the
+gate said _pass_ — has the `/queue` modal ask `reject-reason.md` for one
+sentence from the ICP one-liner, the play name, the prospect's own evidence
+(company, title, bio, event, repo), the stored dossier rendered as facts
+(title, summary, the experience history with periods), and, when the row has
+no dossier, one bounded company lookup by the address domain (SDK
+`enrichCompany`, $0.005: founded year, headcount, funding stage). The prompt
+reads company and dossier before the finder's line and is asked to name a
+stage mismatch with the fact that shows it. It never sees names, emails or
+URLs, may answer null, and its sentence is only a suggestion in the box until
+the founder submits. What is submitted is
 trimmed, capped at 300 characters, refused if it starts with `auto:` (the
 machine-decision marker), and stored on the row as the note the timeline
 shows. An emptied box clears an old note. The text is not forwarded to the

--- a/packages/core/src/oneshot.ts
+++ b/packages/core/src/oneshot.ts
@@ -886,6 +886,8 @@ export interface EnrichCompanyInput {
   name?: string;
   linkedinUrl?: string;
   ticker?: string;
+  /** End-to-end deadline for the SDK call (its `totalTimeoutMs`), for callers answering an interactive click. */
+  timeoutMs?: number;
 }
 
 /**
@@ -921,6 +923,7 @@ export async function enrichCompany(input: EnrichCompanyInput, ctx: CallContext)
   if (input.name) opts.name = input.name;
   if (input.linkedinUrl) opts.linkedin_url = input.linkedinUrl;
   if (input.ticker) opts.ticker = input.ticker;
+  if (input.timeoutMs) opts.totalTimeoutMs = input.timeoutMs;
 
   const result: EnrichCompanyResult = await agent.enrichCompany(opts);
   const receiptId = recordCallReceipt({

--- a/packages/plays/__tests__/reject-reason-prompt.test.ts
+++ b/packages/plays/__tests__/reject-reason-prompt.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+// Drift guard for reject-reason.md: the prefill must read the company and
+// dossier facts, treat the surfacing event as provenance, and name stage
+// mismatches with the fact that shows them.
+const here = dirname(fileURLToPath(import.meta.url));
+const prompt = readFileSync(join(here, "..", "..", "prompts", "reject-reason.md"), "utf8");
+
+describe("reject-reason.md", () => {
+  it("names COMPANY and DOSSIER as inputs read before the finder's line", () => {
+    expect(prompt).toContain("COMPANY (optional)");
+    expect(prompt).toContain("DOSSIER (optional)");
+    expect(prompt).toContain("Read COMPANY and DOSSIER before PROSPECT");
+  });
+
+  it("treats the surfacing event as provenance, never a reason", () => {
+    expect(prompt).toContain("is provenance, never a reason");
+  });
+
+  it("asks for the stage fact to be cited", () => {
+    expect(prompt).toContain("Stage is the most common mismatch");
+    expect(prompt).toContain("cite the fact");
+  });
+});

--- a/packages/plays/__tests__/reject-reason.test.ts
+++ b/packages/plays/__tests__/reject-reason.test.ts
@@ -21,7 +21,8 @@ vi.mock("@oneshot-gtm/intel", async () => {
   return { ...actual, loadPrompt: () => "system", complete: completeMock };
 });
 
-const { generateRejectReason } = await import("../src/_reject-reason.ts");
+const { generateRejectReason, describeCompanyForReject, describeDossierForReject } =
+  await import("../src/_reject-reason.ts");
 
 const payload = { company: "Acme", title: "Recruiter", productOneLiner: "Staffing for clinics" };
 
@@ -82,5 +83,74 @@ describe("generateRejectReason", () => {
       expect.objectContaining({ kind: "reject-reason", message_120: "upstream 503" }),
       "warn",
     );
+  });
+});
+
+describe("reject evidence", () => {
+  it("renders the company facts a stage judgment turns on, in a fixed order", () => {
+    expect(
+      describeCompanyForReject({
+        name: "Magna",
+        industry: "Insurance",
+        founded_year: 2014,
+        employee_count: 80,
+        funding_stage: "series_b",
+        description: "AI-native insurance for startups.",
+        linkedin_url: "https://linkedin.com/company/magna",
+      }),
+    ).toBe(
+      [
+        "company: Magna",
+        "industry: Insurance",
+        "founded: 2014",
+        "employees: 80",
+        "funding stage: series_b",
+        "description: AI-native insurance for startups.",
+      ].join("\n"),
+    );
+    expect(describeCompanyForReject(null)).toBe("");
+  });
+
+  it("turns a person-research dossier into facts, keeping the experience periods", () => {
+    const dossier = JSON.stringify({
+      status: "completed",
+      result: {
+        full_name: "Bruno F",
+        title: "Co-Founder & CEO",
+        company: "Magna",
+        summary: "Building insurance infrastructure.",
+        experience: [
+          { title: "Co-Founder & CEO", company: "Magna", period: "Jan 2014 - Present" },
+          { title: "Engineer", company: "Big Co", period: "2010 - 2013" },
+        ],
+        emails: ["bruno@magna.so"],
+      },
+    });
+    const text = describeDossierForReject(dossier);
+    expect(text).toContain("title: Co-Founder & CEO");
+    expect(text).toContain(
+      "experience: Co-Founder & CEO at Magna (Jan 2014 - Present); Engineer at Big Co (2010 - 2013)",
+    );
+    expect(text).not.toContain("bruno@magna.so");
+  });
+
+  it("passes plain-text research through, bounded", () => {
+    expect(describeDossierForReject("  Runs a   ten-year-old agency.  ")).toBe(
+      "Runs a ten-year-old agency.",
+    );
+    expect(describeDossierForReject("x".repeat(5000)).length).toBe(2500);
+    expect(describeDossierForReject("")).toBe("");
+  });
+
+  it("puts COMPANY and DOSSIER blocks in front of the model", async () => {
+    await generateRejectReason({
+      playName: "luma-events",
+      payload,
+      dossier: JSON.stringify({ result: { title: "CEO", company: "Magna" } }),
+      company: { name: "Magna", employee_count: 80 },
+    });
+    const user = completeMock.mock.calls[0]![0].messages[1].content as string;
+    expect(user).toContain("COMPANY:\ncompany: Magna\nemployees: 80");
+    expect(user).toContain("DOSSIER:\ntitle: CEO\ncompany: Magna");
   });
 });

--- a/packages/plays/src/_reject-reason.ts
+++ b/packages/plays/src/_reject-reason.ts
@@ -25,8 +25,94 @@ export interface GenerateRejectReasonInput {
   icp?: string | null;
   playName: string;
   payload: unknown;
-  /** The dossier `prepare` (or research) assembled, when there is one. */
+  /** The stored dossier (`prospects.dossier_json`, usually a person-research JSON), when there is one. */
   dossier?: string | null;
+  /** A company record (SDK `enrichCompany`) the route fetched when the row had no dossier. */
+  company?: Record<string, unknown> | null;
+}
+
+/** How much of a dossier the model sees. The 600-char `describeTargetForAngle` slice was written for angle selection; a stage judgment needs the experience history. */
+const DOSSIER_CHARS = 2500;
+
+function s(v: unknown): string {
+  return typeof v === "string" ? v.replace(/\s+/g, " ").trim() : "";
+}
+
+/** The company facts a stage judgment turns on, in a fixed order. */
+export function describeCompanyForReject(
+  company: Record<string, unknown> | null | undefined,
+): string {
+  if (!company) return "";
+  const lines: string[] = [];
+  const push = (label: string, v: unknown) => {
+    const t = typeof v === "number" ? String(v) : s(v);
+    if (t) lines.push(`${label}: ${t.slice(0, 240)}`);
+  };
+  push("company", company.name);
+  push("industry", company.industry);
+  push("founded", company.founded_year ?? company.founded ?? company.year_founded);
+  push("employees", company.employee_count ?? company.size);
+  push("funding stage", company.funding_stage);
+  push("total funding", company.total_funding ?? company.funding_total);
+  push("location", company.location);
+  push("description", company.description);
+  return lines.join("\n");
+}
+
+/**
+ * The dossier as evidence: a person-research JSON becomes its facts (title,
+ * company, summary, the experience history with periods — where "founded
+ * 2014, still CEO" lives), anything else is a bounded raw slice.
+ */
+export function describeDossierForReject(dossier: string | null | undefined): string {
+  const raw = dossier?.trim();
+  if (!raw) return "";
+  let parsed: unknown = null;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return raw.replace(/\s+/g, " ").slice(0, DOSSIER_CHARS);
+  }
+  if (!parsed || typeof parsed !== "object")
+    return raw.replace(/\s+/g, " ").slice(0, DOSSIER_CHARS);
+  const root = parsed as Record<string, unknown>;
+  const person = (
+    root.result && typeof root.result === "object"
+      ? root.result
+      : root.person && typeof root.person === "object"
+        ? root.person
+        : root
+  ) as Record<string, unknown>;
+  const lines: string[] = [];
+  const push = (label: string, v: unknown) => {
+    const t = s(v);
+    if (t) lines.push(`${label}: ${t.slice(0, 400)}`);
+  };
+  push("title", person.title ?? person.headline);
+  push("company", person.company);
+  push("location", person.location);
+  push("summary", person.summary ?? person.bio);
+  if (Array.isArray(person.experience)) {
+    const exp = person.experience
+      .filter((e): e is Record<string, unknown> => Boolean(e) && typeof e === "object")
+      .slice(0, 8)
+      .map((e) =>
+        [s(e.title), s(e.company) && `at ${s(e.company)}`, s(e.period) && `(${s(e.period)})`]
+          .filter(Boolean)
+          .join(" "),
+      )
+      .filter(Boolean);
+    if (exp.length) lines.push(`experience: ${exp.join("; ")}`);
+  }
+  if (Array.isArray(person.organizations)) {
+    const orgs = person.organizations
+      .filter((o): o is Record<string, unknown> => Boolean(o) && typeof o === "object")
+      .map((o) => [s(o.name), s(o.title) && `(${s(o.title)})`].filter(Boolean).join(" "))
+      .filter(Boolean);
+    if (orgs.length) lines.push(`organizations: ${orgs.join("; ")}`);
+  }
+  if (lines.length === 0) return raw.replace(/\s+/g, " ").slice(0, DOSSIER_CHARS);
+  return lines.join("\n").slice(0, DOSSIER_CHARS);
 }
 
 /**
@@ -39,10 +125,15 @@ export async function generateRejectReason(
 ): Promise<string | null> {
   const icp = input.icp?.trim() ?? loadConfig().icpOneLiner?.trim() ?? "";
   if (!icp) return null;
+  // Payload fields via the angle describer (it already knows which keys are
+  // evidence); the dossier and company are rendered here, in full enough
+  // form that "this business is ten years old" is visible.
   const evidence = describeTargetForAngle(
     (input.payload && typeof input.payload === "object" ? input.payload : {}) as object,
-    input.dossier ?? null,
+    null,
   );
+  const dossier = describeDossierForReject(input.dossier);
+  const company = describeCompanyForReject(input.company);
   try {
     const system = loadPrompt("reject-reason");
     const user = [
@@ -50,6 +141,8 @@ export async function generateRejectReason(
       `PLAY: ${input.playName}`,
       "PROSPECT:",
       evidence.trim() || "(nothing known beyond name and email)",
+      ...(company ? ["", "COMPANY:", company] : []),
+      ...(dossier ? ["", "DOSSIER:", dossier] : []),
     ].join("\n");
     const res = await complete({
       messages: [
@@ -57,7 +150,7 @@ export async function generateRejectReason(
         { role: "user", content: user },
       ],
       temperature: 0.1,
-      maxTokens: 120,
+      maxTokens: 160,
     });
     const parsed = tryParseJsonObject<{ rejectReason?: unknown }>(res.content, {});
     const reason = normalizeFitReason(parsed.rejectReason);

--- a/packages/prompts/reject-reason.md
+++ b/packages/prompts/reject-reason.md
@@ -4,11 +4,16 @@ You write ONE sentence naming the most likely reason a prospect in the founder's
 
 - ICP: the founder's one-line ideal customer profile.
 - PLAY: the motion that surfaced this prospect (an accelerator batch, an event, a starred repo, a funding round, a job change, a public notice).
-- PROSPECT: what is known — company, product one-liner, title, bio, event, repo, stack, industry, location, research excerpt.
+- PROSPECT: what the finder recorded — company, product one-liner, title, bio, event, repo, stack, industry, location.
+- COMPANY (optional): a company record — industry, founded year, employee count, funding stage, description.
+- DOSSIER (optional): research on the person — title, summary, and the experience history with periods.
 
 ## Rules
 
 - ONE sentence, at most 25 words. Name the concrete mismatch: wrong buyer, sells to consumers, not the decision-maker, no product yet, wrong stage, a role the ICP excludes, a company that is itself a vendor of the same thing.
+- Read COMPANY and DOSSIER before PROSPECT. The event, repo, or list that surfaced them is provenance, never a reason: "attending a founders breakfast" says nothing about fit.
+- Stage is the most common mismatch and the most often missed. When the founded year, the length of the CEO's tenure in the experience history, the employee count, or the funding stage says the business is past the stage the ICP names, say so and cite the fact: "Founded 2014, ~80 employees, Series B: a mature company past founder-led sales." A company that has existed for years with a stable team is not an early-stage prospect, whatever event they attended.
+- Where the ICP names a stage, size, or buyer and the facts contradict it, prefer that contradiction over anything softer.
 - Describe, never judge. No adjectives about the prospect's quality ("weak", "unimpressive"), no advice, no speculation about budget or intent.
 - Use only what the PROSPECT block contains. If nothing in it argues against fit, return null — never invent a mismatch to have something to say.
 - Plain words. No "leverage", "seamless", "robust", "landscape", "ecosystem", "journey", "unlock", "empower", "elevate", "cutting-edge".

--- a/packages/prompts/reject-reason.md
+++ b/packages/prompts/reject-reason.md
@@ -15,7 +15,7 @@ You write ONE sentence naming the most likely reason a prospect in the founder's
 - Stage is the most common mismatch and the most often missed. When the founded year, the length of the CEO's tenure in the experience history, the employee count, or the funding stage says the business is past the stage the ICP names, say so and cite the fact: "Founded 2014, ~80 employees, Series B: a mature company past founder-led sales." A company that has existed for years with a stable team is not an early-stage prospect, whatever event they attended.
 - Where the ICP names a stage, size, or buyer and the facts contradict it, prefer that contradiction over anything softer.
 - Describe, never judge. No adjectives about the prospect's quality ("weak", "unimpressive"), no advice, no speculation about budget or intent.
-- Use only what the PROSPECT block contains. If nothing in it argues against fit, return null — never invent a mismatch to have something to say.
+- Use only what the PROSPECT, COMPANY and DOSSIER blocks contain. If nothing in them argues against fit, return null — never invent a mismatch to have something to say.
 - Plain words. No "leverage", "seamless", "robust", "landscape", "ecosystem", "journey", "unlock", "empower", "elevate", "cutting-edge".
 - No names of people, no email addresses, no URLs in the sentence. Never start the sentence with "auto:".
 


### PR DESCRIPTION
## Why

Row #882 opened its reject box with "Bruno Faviero going to Corgi Founders Breakfast Club with Rho". That is where the finder found him, not why he does not fit. The real reason, a company founded years ago and well past founder-led sales, was never in front of anything: the prefill ladder's note tier counted a provenance note as a reason, so the one tier that reads the dossier (the LLM fallback) never ran. And that row had no dossier anyway, so even the fallback would have judged from an event title.

## What

- **Web ladder** (`apps/web/src/lib/rejectReason.ts`): only a machine negative (`auto: …`) prefills from notes. A finder note without the prefix is provenance and yields nothing, so the `/queue` modal asks the model. On pending and approved rows, notes are always machine-written, so no human reason is lost.
- **Reject route** (`apps/server/src/api/queue.ts`): a row with no stored dossier gets one bounded company lookup by the address domain (SDK `enrichCompany`, $0.005, 12 s deadline, skipped for personal-provider addresses, best-effort on failure). Founded year, headcount, funding stage and description reach the model. The response carries `researched`.
- **Generator** (`packages/plays/src/_reject-reason.ts`): the dossier is rendered as facts, title, summary and the experience history with periods, up to 2500 chars, instead of the 600-char slice meant for angle selection. A COMPANY block in a fixed order. `maxTokens` 120 → 160.
- **Prompt** (`packages/prompts/reject-reason.md`): reads COMPANY and DOSSIER before the finder's line, treats the surfacing event as provenance, and asks for a stage mismatch to be named with the fact that shows it ("Founded 2014, ~80 employees, Series B: a mature company past founder-led sales").
- **Docs**: the reject-reason section of `docs/prompt-inputs.md`.

## Tests

- `apps/web/__tests__/rejectReason.test.ts`: provenance notes yield nothing, machine negatives still prefill.
- `apps/server/__tests__/reject-route.test.ts`: lookup runs only without a dossier, keyed by the address domain, skipped for gmail and on a failed record; the record reaches the generator.
- `packages/plays/__tests__/reject-reason.test.ts` and a new prompt drift guard: company block order, dossier facts with periods, no emails leaked, bounded plain text.
- Full suite under `bun --bun run test`: 3960 tests / 301 files. STATUS.md updated.

## Cost

One $0.005 company lookup per reject click on a row without a dossier. Rows with a dossier pay nothing extra.

https://claude.ai/code/session_01CPweATEtibYbHW7CUBqbig


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Reject-reason suggestions can use stored prospect dossiers and, when unavailable, perform a bounded company lookup using the prospect’s domain.
  - Generated reasons include clearer company, dossier, and stage-related context.

- **Bug Fixes**
  - Finder notes without the machine-generated prefix are no longer prefilled as rejection reasons; they remain provenance information.
  - Domain matching now handles spaces, capitalization, URLs, paths, queries, and fragments more reliably.

- **Documentation**
  - Updated guidance describes the revised reject-reason inputs and prioritization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->