### PR TITLE
feat(queue): "ungrounded" is a soft review flag, so Send anyway works

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,7 +2,7 @@
 
 **Assume green.** The 67 CLI commands, 23 plays, 15 finders, ten dashboard pages plus the run form, and the server's REST + SSE routes are all covered by the test suite — and verified end to end against the live OneShot API: every paid call type has made the live round trip, including the voice and SMS legs (`motion concierge` / `motion demo-no-show`), the PMF survey pair, reply triage, bounce harvesting, and `gmail placement`.
 
-Last verified **2026-09-11** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3960 tests / 301 files** · typecheck + oxlint + oxfmt pass (41 lint warnings, 0 errors).
+Last verified **2026-09-11** · Bun 1.3.13 · OneShot SDK 0.32.0 · **3961 tests / 301 files** · typecheck + oxlint + oxfmt pass (41 lint warnings, 0 errors).
 
 **What the gate covers.** `apps/web` is now inside `bun run typecheck` — the dashboard source is
 type-checked in CI, and a deliberate error under `apps/web/src` fails the root script. As of

--- a/apps/web/__tests__/flagLabels.test.ts
+++ b/apps/web/__tests__/flagLabels.test.ts
@@ -12,6 +12,9 @@ describe("humanizeFlag", () => {
     expect(humanizeFlag("hard-ban:discount-offer")).toBe("hard ban: discount offer");
     expect(humanizeFlag("stale-event")).toBe("the event has passed");
     expect(humanizeFlag("contacted-elsewhere")).toBe("another workspace emailed them this week");
+    expect(humanizeFlag("ungrounded")).toBe(
+      "research found nothing on them; the draft leans on the company name",
+    );
   });
 
   it("degrades an unknown label to its words instead of hiding it", () => {
@@ -40,5 +43,11 @@ describe("heldSummary", () => {
 
   it("a soft flag beside a lint flag is still a lint hold", () => {
     expect(heldSummary(["stale-event", "em-dash"])?.kind).toBe("lint");
+    // ungrounded alone is a review hold with a send-anyway, not a lint block.
+    expect(heldSummary(["ungrounded"])).toEqual({
+      kind: "review",
+      text: "1 flag: research found nothing on them; the draft leans on the company name",
+      next: "read it once more, then send as-is",
+    });
   });
 });

--- a/apps/web/src/lib/flagLabels.ts
+++ b/apps/web/src/lib/flagLabels.ts
@@ -31,6 +31,7 @@ const NAMED: Record<string, string> = {
   "banned-cta:time-slots": "time-slot ask",
   "stale-event": "the event has passed",
   "contacted-elsewhere": "another workspace emailed them this week",
+  ungrounded: "research found nothing on them; the draft leans on the company name",
   "already-enrolled": "already in a cadence",
   "already-contacted": "already contacted",
   "off-icp": "off ICP",

--- a/apps/web/src/routes/queue.tsx
+++ b/apps/web/src/routes/queue.tsx
@@ -1398,7 +1398,9 @@ function DraftSection({
   const softHold = cleanDraft && draft != null && draft.flags.length > 0;
   const softHoldDetail = draft?.flags.includes("contacted-elsewhere")
     ? "Held — another workspace emailed this person in the last 7 days. Send the reviewed draft as-is to override."
-    : "Held for review (event has passed) — send the reviewed draft as-is";
+    : draft?.flags.includes("ungrounded")
+      ? "Held — research found nothing on this person, so the draft leans on the company name. Read it once more; send as-is if it still holds up."
+      : "Held for review (event has passed) — send the reviewed draft as-is";
   const showSend = !isManualPlay && status === "approved" && !(draft?.sent ?? false);
   const sendButton = showSend ? (
     <Button

--- a/packages/shared-types/__tests__/flags.test.ts
+++ b/packages/shared-types/__tests__/flags.test.ts
@@ -12,6 +12,12 @@ describe("blockingFlags", () => {
     expect(blockingFlags(["stale-event"])).toEqual([]);
   });
 
+  it("treats ungrounded as soft: regenerating cannot supply the missing research, the founder judges", () => {
+    expect(SOFT_REVIEW_FLAGS).toContain("ungrounded");
+    expect(blockingFlags(["ungrounded"])).toEqual([]);
+    expect(blockingFlags(["ungrounded", "contacted-elsewhere"])).toEqual([]);
+  });
+
   it("keeps lint/dedup flags blocking", () => {
     expect(blockingFlags(["em-dash"])).toEqual(["em-dash"]);
     expect(blockingFlags(["already-contacted", "rule-of-three"])).toEqual([

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -770,12 +770,21 @@ export type FitReasonSource = "company-gate" | "person-gate" | "generated" | "no
  * the founder either sends as-is or rejects.
  *
  * Currently: `stale-event` — a luma-events event >14 days past, where the
- * guest-list signal is old enough to want confirmation before sending; and
+ * guest-list signal is old enough to want confirmation before sending;
  * `contacted-elsewhere` — another WORKSPACE (another product of yours) emailed
  * this person inside the 7-day hold window, so two motions don't stack in one
- * inbox. Sending as-is is the founder saying "I know, do it anyway."
+ * inbox; and `ungrounded` — enrichment failed and the row carries no title or
+ * bio, so the draft could only lean on the company name (`lintGrounding`).
+ * Regenerating cannot clear that one either: the research is what is missing,
+ * and a founder who has read the draft is the only judge of whether it still
+ * says something true. Sending as-is is the founder saying "I know, do it
+ * anyway."
  */
-export const SOFT_REVIEW_FLAGS: readonly string[] = ["stale-event", "contacted-elsewhere"];
+export const SOFT_REVIEW_FLAGS: readonly string[] = [
+  "stale-event",
+  "contacted-elsewhere",
+  "ungrounded",
+];
 
 /**
  * The subset of a draft's flags that genuinely block sending (everything except


### PR DESCRIPTION
## Why

A held draft read "HELD · LINT · 1 flag: ungrounded · regenerate to clear it, then send", with the send button disabled. Regenerating cannot clear that flag: it means enrichment failed and the row carries no title or bio, so the research is what is missing. The founder who has just read the draft is the only judge of whether it still says something true, and the queue already has the mechanism for exactly that, the soft review flags with a "Send anyway" button.

## What

- **`packages/shared-types`**: `ungrounded` joins `SOFT_REVIEW_FLAGS` next to `stale-event` and `contacted-elsewhere`. The server send gate and the queue UI both read this list, so a manual "Send anyway" is accepted and auto-send (drain) still holds, since `sendDraftedEmail` only sends a flag-free draft.
- **Web**: a label for the flag ("research found nothing on them; the draft leans on the company name") and a send-anyway hint that says what to check before overriding.
- Tests pin the classification and the card wording. 3961 tests / 301 files.

## Not changed

Real lint flags (em dash, rule of three, banned openers, links outside the brief) stay blocking: regenerating clears them, so there is no reason to send around them. Dedup outcomes (already contacted, already enrolled) stay blocking too.

https://claude.ai/code/session_01CPweATEtibYbHW7CUBqbig
